### PR TITLE
Fix vector search SQL ambiguity and /healthz unreachability on Cloud Run

### DIFF
--- a/cmd/ochakai/main.go
+++ b/cmd/ochakai/main.go
@@ -106,10 +106,15 @@ func serve(log *slog.Logger) error {
 	defer svc.Store.Close()
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
+	// /health is the canonical health endpoint. /healthz is kept for local
+	// use but is unreachable behind Google Frontends (Cloud Run's run.app
+	// intercepts the path and returns its own 404) — discovered the hard way.
+	health := func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
-	})
+	}
+	mux.HandleFunc("GET /health", health)
+	mux.HandleFunc("GET /healthz", health)
 	mux.Handle("/mcp", httpauth.Middleware(cfg, mcpserver.Handler(svc, version)))
 	mux.Handle("/api/v1/", httpauth.Middleware(cfg, restapi.Handler(svc)))
 

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -100,14 +100,16 @@ gcloud run deploy ochakai \
   --set-env-vars="^@^OCHAKAI_CLIENTS=$AGENT_TOKEN=agent:claude-code,$HUMAN_TOKEN=human:$(whoami)"
 
 export OCHAKAI_URL=$(gcloud run services describe ochakai --region=$REGION --format='value(status.url)')
-curl $OCHAKAI_URL/healthz
+curl $OCHAKAI_URL/health
 ```
 
 Notes:
 
 - `^@^` changes the env-var delimiter so `OCHAKAI_CLIENTS` may contain commas.
 - `--allow-unauthenticated` exposes the service publicly, protected by
-  ochakai's bearer tokens; every endpoint except `/healthz` requires one.
+  ochakai's bearer tokens; every endpoint except `/health` requires one.
+  Use `/health`, not `/healthz`: Google Frontends intercept `/healthz` on
+  `run.app` URLs and return their own 404 without ever reaching the app.
   For private networking, drop the flag and front it with IAM/IAP instead.
 - Container port defaults are fine: ochakai honors Cloud Run's `PORT`.
 - Environment variables are visible to project viewers in the console.
@@ -128,8 +130,11 @@ gcloud projects add-iam-policy-binding $PROJECT_ID \
   --member=serviceAccount:$SERVICE_ACCOUNT --role=roles/aiplatform.user
 
 gcloud run services update ochakai --region=$REGION \
-  --set-env-vars=OCHAKAI_EMBEDDING_PROVIDER=vertex,OCHAKAI_VERTEX_PROJECT=$PROJECT_ID
+  --update-env-vars=OCHAKAI_EMBEDDING_PROVIDER=vertex,OCHAKAI_VERTEX_PROJECT=$PROJECT_ID
 ```
+
+Use `--update-env-vars`, not `--set-env-vars`: the latter **replaces** all
+environment variables and would wipe `OCHAKAI_DATABASE_URL`.
 
 On the next start, ochakai creates the pgvector table and embeds new and
 updated knowledge with `gemini-embedding-001`. Search becomes hybrid
@@ -187,13 +192,18 @@ curl -H "Authorization: Bearer $AGENT_TOKEN" -X POST "$OCHAKAI_URL/api/v1/compil
   Google ID tokens (Cloud Run accepts the app's bearer token in
   `Authorization` and the Google ID token in `X-Serverless-Authorization`
   simultaneously).
-- **Every request to the `run.app` URL returns Google's HTML 404 even
-  though the service is Ready** (no request logs appear): the data plane
-  is being blocked upstream of your service — typically a VPC Service
-  Controls perimeter or another org-level control. Service/project
-  settings (ingress, IAM, org policies visible at project level) will all
-  look correct. Check Security → VPC Service Controls with an org admin,
-  or deploy to a project outside the perimeter.
+- **`run.app` returns Google's HTML 404 ("That's an error") even though
+  the service is Ready**: before suspecting infrastructure, test a real
+  application endpoint (e.g. `/api/v1/knowledge?q=x` with a token) and
+  check request logs. Two Google Frontend behaviors conspire to make a
+  healthy service look dead:
+  1. `/healthz` is intercepted by Google Frontends on `run.app` and 404s
+     without ever reaching the container (and without request logs). Use
+     `/health`.
+  2. Application-level 404 responses are dressed up as Google's branded
+     404 page, so an unhandled path looks like a routing failure.
+  A genuinely unknown service URL returns a much shorter 404 page
+  (~272 bytes vs ~1.5 KB) — comparing `content-length` tells them apart.
 
 ## 7. Teardown
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -177,7 +177,7 @@ func (s *Store) addRevision(ctx context.Context, tx pgx.Tx, k *domain.Knowledge,
 // SearchLexical ranks by trigram similarity with a substring-match floor
 // (trigram alone misses short Japanese terms), verified entries boosted.
 func (s *Store) SearchLexical(ctx context.Context, query string, f Filter, limit int) ([]domain.SearchHit, error) {
-	where, args := f.buildWhere()
+	where, args := f.buildWhere("")
 	args = append(args, query)
 	q := fmt.Sprintf(`
 		SELECT `+knowledgeCols+`, score FROM (
@@ -199,11 +199,12 @@ func (s *Store) SearchLexical(ctx context.Context, query string, f Filter, limit
 
 // SearchVector ranks by cosine distance against stored embeddings.
 func (s *Store) SearchVector(ctx context.Context, vec []float32, f Filter, limit int) ([]domain.SearchHit, error) {
-	where, args := f.buildWhere()
+	// Columns must be qualified: knowledge_embedding shares type/id/updated_at.
+	where, args := f.buildWhere("k.")
 	args = append(args, encodeVector(vec))
 	q := fmt.Sprintf(`
-		SELECT `+knowledgeCols+`, 1 - (e.embedding <=> $%d::vector) AS score
-		FROM knowledge k JOIN knowledge_embedding e USING (type, id)
+		SELECT `+qualifyCols("k")+`, 1 - (e.embedding <=> $%d::vector) AS score
+		FROM knowledge k JOIN knowledge_embedding e ON k.type = e.type AND k.id = e.id
 		WHERE %s
 		ORDER BY e.embedding <=> $%d::vector LIMIT %d`, len(args), where, len(args), limit)
 	rows, err := s.pool.Query(ctx, q, args...)
@@ -237,20 +238,22 @@ func scanHit(row pgx.CollectableRow) (domain.SearchHit, error) {
 	return h, nil
 }
 
-func (f Filter) buildWhere() (string, []any) {
-	conds := []string{"deleted_at IS NULL"}
+// buildWhere renders filter conditions; prefix qualifies columns (e.g. "k.")
+// for joined queries and may be empty.
+func (f Filter) buildWhere(prefix string) (string, []any) {
+	conds := []string{prefix + "deleted_at IS NULL"}
 	var args []any
 	if len(f.Types) > 0 {
 		args = append(args, f.Types)
-		conds = append(conds, fmt.Sprintf("type = ANY($%d)", len(args)))
+		conds = append(conds, fmt.Sprintf("%stype = ANY($%d)", prefix, len(args)))
 	}
 	if len(f.Statuses) > 0 {
 		args = append(args, f.Statuses)
-		conds = append(conds, fmt.Sprintf("status = ANY($%d)", len(args)))
+		conds = append(conds, fmt.Sprintf("%sstatus = ANY($%d)", prefix, len(args)))
 	}
 	if len(f.Tags) > 0 {
 		args = append(args, f.Tags)
-		conds = append(conds, fmt.Sprintf("tags && $%d", len(args)))
+		conds = append(conds, fmt.Sprintf("%stags && $%d", prefix, len(args)))
 	}
 	return strings.Join(conds, " AND "), args
 }
@@ -330,6 +333,15 @@ func marshalJSONFields(k *domain.Knowledge) (links, attrs []byte, err error) {
 		return nil, nil, err
 	}
 	return links, attrs, nil
+}
+
+// qualifyCols prefixes every column in knowledgeCols with a table alias.
+func qualifyCols(alias string) string {
+	cols := strings.Split(knowledgeCols, ",")
+	for i, c := range cols {
+		cols[i] = alias + "." + strings.TrimSpace(c)
+	}
+	return strings.Join(cols, ", ")
 }
 
 // encodeVector renders a pgvector literal like "[0.1,0.2]".

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -1,0 +1,63 @@
+package store
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/na0fu3y/ochakai/internal/domain"
+)
+
+// TestIntegration exercises the store against a real PostgreSQL with
+// pgvector. Skipped unless OCHAKAI_TEST_DATABASE_URL is set, e.g.:
+//
+//	docker run -d --rm -p 55433:5432 -e POSTGRES_PASSWORD=t -e POSTGRES_USER=t -e POSTGRES_DB=t pgvector/pgvector:pg17
+//	OCHAKAI_TEST_DATABASE_URL='postgres://t:t@localhost:55433/t?sslmode=disable' go test ./internal/store/
+func TestIntegration(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := New(ctx, dbURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.Migrate(ctx, 4); err != nil {
+		t.Fatal(err)
+	}
+
+	k := &domain.Knowledge{
+		Type: domain.TypeMetric, ID: "it-revenue", Title: "売上",
+		Description: "統合テスト用", Status: domain.StatusVerified,
+		CreatedBy: domain.Actor{Kind: "human", Name: "test"},
+	}
+	_ = s.SoftDelete(ctx, k.Type, k.ID, k.CreatedBy) // clean rerun
+	if err := s.Create(ctx, k); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UpsertEmbedding(ctx, k.Type, k.ID, "test-model", []float32{1, 0, 0, 0}); err != nil {
+		t.Fatal(err)
+	}
+
+	lex, err := s.SearchLexical(ctx, "売上", Filter{}, 5)
+	if err != nil {
+		t.Fatalf("SearchLexical: %v", err)
+	}
+	if len(lex) == 0 || lex[0].ID != "it-revenue" {
+		t.Errorf("lexical search missed the entry: %+v", lex)
+	}
+
+	// The joined vector query must not have ambiguous column references
+	// (knowledge_embedding shares type/id/updated_at with knowledge).
+	vec, err := s.SearchVector(ctx, []float32{1, 0, 0, 0}, Filter{
+		Types: []domain.Type{domain.TypeMetric}, Statuses: []domain.Status{domain.StatusVerified},
+	}, 5)
+	if err != nil {
+		t.Fatalf("SearchVector: %v", err)
+	}
+	if len(vec) == 0 || vec[0].ID != "it-revenue" || vec[0].Score < 0.99 {
+		t.Errorf("vector search wrong result: %+v", vec)
+	}
+}


### PR DESCRIPTION
Two bugs found by deploying to a real Cloud Run + Cloud SQL + Vertex AI environment:

1. **SearchVector ambiguous column**: the knowledge ⋈ knowledge_embedding join referenced `updated_at` unqualified — both tables have it, so hybrid search 500'd. Columns are now alias-qualified; added an opt-in integration test against real pgvector that would have caught it.
2. **/healthz is unreachable on run.app**: Google Frontends intercept the path and serve their own 404 before the container sees it. `/health` is now the canonical endpoint (`/healthz` kept for local use), and the deploy guide documents the gotcha (plus `--update-env-vars` vs `--set-env-vars`).

Verified: integration test green locally against pgvector/pg17; full E2E re-run on Cloud Run follows with the released image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)