### PR TITLE
Serve the sample web UI at /ui

### DIFF
--- a/cmd/ochakai/main.go
+++ b/cmd/ochakai/main.go
@@ -26,6 +26,8 @@ import (
 	"github.com/na0fu3y/ochakai/internal/restapi"
 	"github.com/na0fu3y/ochakai/internal/service"
 	"github.com/na0fu3y/ochakai/internal/store"
+
+	"github.com/na0fu3y/ochakai/examples/webui"
 )
 
 // version is stamped by -ldflags at release; "dev" otherwise.
@@ -115,6 +117,15 @@ func serve(log *slog.Logger) error {
 	}
 	mux.HandleFunc("GET /health", health)
 	mux.HandleFunc("GET /healthz", health)
+	// Sample web UI (examples/webui), served same-origin so its REST calls
+	// need no CORS. The page is static; the API it calls stays token-authed.
+	mux.HandleFunc("GET /ui", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write(webui.Index)
+	})
+	mux.HandleFunc("GET /{$}", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/ui", http.StatusFound)
+	})
 	mux.Handle("/mcp", httpauth.Middleware(cfg, mcpserver.Handler(svc, version)))
 	mux.Handle("/api/v1/", httpauth.Middleware(cfg, restapi.Handler(svc)))
 

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -116,6 +116,44 @@ Notes:
   For production, store `OCHAKAI_DATABASE_URL` and `OCHAKAI_CLIENTS` in
   Secret Manager and use `--set-secrets` instead of `--set-env-vars`.
 
+## 3b. Recommended: restrict access to your organization
+
+`--allow-unauthenticated` leaves the URL reachable by anyone (protected
+only by ochakai's bearer tokens). To make the service unreachable from
+outside your Google Workspace / Cloud Identity organization, use Cloud Run
+IAM as a second, network-level layer:
+
+```sh
+gcloud run services remove-iam-policy-binding ochakai --region=$REGION \
+  --member=allUsers --role=roles/run.invoker
+gcloud run services add-iam-policy-binding ochakai --region=$REGION \
+  --member=domain:your-org.example --role=roles/run.invoker
+```
+
+Auth becomes two-layer: Cloud Run IAM decides **who can reach** the
+service (org members only; anonymous requests get Google's 401 without
+ever hitting the container), and `OCHAKAI_CLIENTS` decides **which actor**
+(human/agent) they act as for provenance.
+
+Clients with static headers (Claude Code MCP, curl) go through the
+[Cloud Run proxy](https://cloud.google.com/sdk/gcloud/reference/run/services/proxy),
+which handles the Google identity layer transparently and passes your
+`Authorization` header (the ochakai token) through untouched:
+
+```sh
+gcloud run services proxy ochakai --region=$REGION --port=8787
+claude mcp add --transport http ochakai http://localhost:8787/mcp \
+  --header "Authorization: Bearer $AGENT_TOKEN"
+```
+
+Server-to-server callers instead send the Google ID token in
+`X-Serverless-Authorization` (Cloud Run strips it before your app sees
+it), keeping `Authorization` free for the ochakai token.
+
+This setup never needs an `allUsers` grant, so it is compatible with —
+and a good reason to keep — the Domain Restricted Sharing org policy
+(`iam.allowedPolicyMemberDomains`).
+
 ## 4. Optional: enable hybrid semantic search (Vertex AI)
 
 Embeddings are off by default (trigram-only search, no external calls).

--- a/examples/webui/embed.go
+++ b/examples/webui/embed.go
@@ -1,0 +1,11 @@
+// Package webui embeds the sample web UI so the ochakai binary can serve
+// it at /ui. It is a single static HTML file — same origin as the REST API
+// (no CORS setup), and reachable through `gcloud run services proxy` when
+// the service is IAM-restricted. Users building their own UI can copy
+// index.html as a starting point or ignore it entirely.
+package webui
+
+import _ "embed"
+
+//go:embed index.html
+var Index []byte

--- a/examples/webui/index.html
+++ b/examples/webui/index.html
@@ -21,7 +21,7 @@
 <body>
 <h1>ochakai</h1>
 <p>
-  <input id="base" value="http://localhost:8080" size="24" title="ochakai base URL">
+  <input id="base" size="24" title="ochakai base URL">
   <input id="token" placeholder="bearer token (optional)" size="24">
 </p>
 <p>
@@ -68,6 +68,10 @@ async function search() {
 }
 function esc(s) { return String(s).replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c])); }
 document.getElementById('q').addEventListener('keydown', e => { if (e.key === 'Enter') search(); });
+// Same-origin default when served from ochakai itself (/ui); fall back to
+// localhost for file:// use.
+document.getElementById('base').value =
+  location.protocol.startsWith('http') ? location.origin : 'http://localhost:8080';
 </script>
 </body>
 </html>


### PR DESCRIPTION
Embeds examples/webui/index.html into the binary (go:embed) and serves it at `/ui` (`/` redirects there). Same-origin means no CORS machinery, and on organization-restricted deployments the UI is reachable through `gcloud run services proxy` like everything else. The page auto-fills its base URL from `location.origin`.

Verified locally: `/ui` 200, `/` → 302 `/ui`, tests/vet/fmt green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)