### PR TITLE
Ship the sample web UI as its own Cloud Run service

### DIFF
--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -221,29 +221,55 @@ curl -H "Authorization: Bearer $AGENT_TOKEN" -X POST "$OCHAKAI_URL/api/v1/compil
   -d '{"metrics":["revenue"],"dimensions":["customers.region"],"dialect":"bigquery"}'
 ```
 
-## 5b. Host the sample web UI (separately, by design)
+## 5b. Deploy the sample web UI (separate service, by design)
 
 The sample UI ([examples/webui](../../examples/webui)) is **not** part of
-the container image — ochakai keeps its serving surface minimal. Host the
-single HTML file anywhere (any static host, or locally), then allow that
-origin to call the REST API from a browser:
+the ochakai image — the core keeps its serving surface minimal. It ships
+as its own tiny service: a static page plus a reverse proxy that attaches
+this service's identity token (`X-Serverless-Authorization`) to API
+calls, so **ochakai stays organization-restricted (§3b)** while the UI is
+reachable from any machine. The client's `Authorization` header (the
+ochakai token choosing the actor) passes through untouched.
+
+```sh
+# build & push (from the repository root)
+docker build --platform linux/amd64 -f examples/webui/Dockerfile \
+  -t $REGION-docker.pkg.dev/$PROJECT_ID/images/ochakai-webui:0.1 .
+docker push $REGION-docker.pkg.dev/$PROJECT_ID/images/ochakai-webui:0.1
+
+# dedicated identity, allowed to invoke ochakai only
+gcloud iam service-accounts create ochakai-webui
+gcloud run services add-iam-policy-binding ochakai --region=$REGION \
+  --member=serviceAccount:ochakai-webui@$PROJECT_ID.iam.gserviceaccount.com \
+  --role=roles/run.invoker
+
+gcloud run deploy ochakai-webui \
+  --image=$REGION-docker.pkg.dev/$PROJECT_ID/images/ochakai-webui:0.1 \
+  --region=$REGION --allow-unauthenticated \
+  --service-account=ochakai-webui@$PROJECT_ID.iam.gserviceaccount.com \
+  --min-instances=0 --max-instances=1 --cpu=1 --memory=256Mi \
+  --set-env-vars=OCHAKAI_URL=$OCHAKAI_URL
+```
+
+Open the webui service URL from any machine, paste a client token, and
+search. The UI and API are same-origin through the proxy, so no CORS
+setup is needed. Note the trade-off: the webui itself is public here
+(token-gated only) — anyone reaching it can attempt API calls, so treat
+it like the public-endpoint variant of §3. To require Google login in
+the browser too, put IAP in front of the webui service, or wait for
+first-class MCP OAuth (issue #5).
+
+Alternatively, host `index.html` on any static host (no container) and
+allow its origin to call the REST API directly from the browser:
 
 ```sh
 gcloud run services update ochakai --region=$REGION \
-  --update-env-vars=OCHAKAI_CORS_ORIGINS=http://localhost:8000
-
-# serve the UI locally
-python3 -m http.server 8000 -d examples/webui
+  --update-env-vars=OCHAKAI_CORS_ORIGINS=https://your-ui.example
 ```
 
-Open http://localhost:8000, set the base URL to your ochakai endpoint,
-and paste a client token. On an organization-restricted deployment
-(§3b), set the base URL to the Cloud Run proxy (`http://localhost:8787`)
-instead — the CORS origin is still the UI's own origin
-(`http://localhost:8000`).
-
-CORS is off unless `OCHAKAI_CORS_ORIGINS` is set, and origins are matched
-exactly — no wildcards.
+CORS is off unless `OCHAKAI_CORS_ORIGINS` is set, origins match exactly
+(no wildcards), and this path requires the browser to reach ochakai
+itself — combine with §3b's proxy on restricted deployments.
 
 ## 6. Troubleshooting in security-hardened organizations
 

--- a/examples/webui/Dockerfile
+++ b/examples/webui/Dockerfile
@@ -1,0 +1,14 @@
+# Sample web UI as its own Cloud Run service (kept out of the ochakai
+# core image by design). Build from the repository root:
+#   docker build -f examples/webui/Dockerfile -t ochakai-webui .
+FROM golang:1.26 AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY examples/webui/ examples/webui/
+RUN CGO_ENABLED=0 go build -trimpath -o /webui ./examples/webui
+
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=build /webui /webui
+USER nonroot
+ENTRYPOINT ["/webui"]

--- a/examples/webui/index.html
+++ b/examples/webui/index.html
@@ -21,7 +21,7 @@
 <body>
 <h1>ochakai</h1>
 <p>
-  <input id="base" value="http://localhost:8080" size="24" title="ochakai base URL">
+  <input id="base" size="24" title="ochakai base URL">
   <input id="token" placeholder="bearer token (optional)" size="24">
 </p>
 <p>
@@ -68,6 +68,10 @@ async function search() {
 }
 function esc(s) { return String(s).replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c])); }
 document.getElementById('q').addEventListener('keydown', e => { if (e.key === 'Enter') search(); });
+// Same origin by default (works when served by main.go, which proxies
+// /api/v1 to ochakai); localhost fallback for file:// use.
+document.getElementById('base').value =
+  location.protocol.startsWith('http') ? location.origin : 'http://localhost:8080';
 </script>
 </body>
 </html>

--- a/examples/webui/main.go
+++ b/examples/webui/main.go
@@ -1,0 +1,125 @@
+// Sample web UI server for ochakai, deployable as its own Cloud Run
+// service. It serves the static UI and reverse-proxies /api/v1 (and /mcp)
+// to the ochakai service, attaching this service's identity token in
+// X-Serverless-Authorization for Cloud Run service-to-service auth. The
+// ochakai deployment can therefore stay IAM-restricted; the client's
+// Authorization header (the ochakai token deciding the actor) passes
+// through untouched.
+//
+// Without OCHAKAI_URL it serves the static UI only (the page then calls
+// whatever base URL the user enters, e.g. a local ochakai).
+package main
+
+import (
+	_ "embed"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+//go:embed index.html
+var index []byte
+
+func main() {
+	log := slog.New(slog.NewJSONHandler(os.Stderr, nil))
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("GET /{$}", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write(index)
+	})
+
+	if target := os.Getenv("OCHAKAI_URL"); target != "" {
+		u, err := url.Parse(target)
+		if err != nil {
+			log.Error("invalid OCHAKAI_URL", "error", err)
+			os.Exit(1)
+		}
+		proxy := newOchakaiProxy(u, log)
+		mux.Handle("/api/v1/", proxy)
+		mux.Handle("/mcp", proxy)
+		log.Info("proxying to ochakai", "target", target)
+	}
+
+	addr := ":" + envOr("PORT", "8080")
+	log.Info("webui listening", "addr", addr)
+	if err := http.ListenAndServe(addr, mux); err != nil {
+		log.Error("webui failed", "error", err)
+		os.Exit(1)
+	}
+}
+
+func newOchakaiProxy(target *url.URL, log *slog.Logger) *httputil.ReverseProxy {
+	tokens := &idTokenSource{audience: target.String()}
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	director := proxy.Director
+	proxy.Director = func(r *http.Request) {
+		director(r)
+		r.Host = target.Host
+		// Cloud Run service-to-service auth; harmless if unavailable
+		// (e.g. running locally against an unrestricted ochakai).
+		if tok, err := tokens.token(); err == nil {
+			r.Header.Set("X-Serverless-Authorization", "Bearer "+tok)
+		} else {
+			log.Warn("no service identity token; forwarding without it", "error", err)
+		}
+	}
+	return proxy
+}
+
+// idTokenSource fetches this service's Google-signed ID token from the
+// metadata server and caches it briefly (tokens live ~1h).
+type idTokenSource struct {
+	audience string
+
+	mu      sync.Mutex
+	token_  string
+	expires time.Time
+}
+
+func (s *idTokenSource) token() (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.token_ != "" && time.Now().Before(s.expires) {
+		return s.token_, nil
+	}
+	req, err := http.NewRequest(http.MethodGet,
+		"http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience="+url.QueryEscape(s.audience), nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Metadata-Flavor", "Google")
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("metadata identity token: %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+	s.token_ = strings.TrimSpace(string(body))
+	s.expires = time.Now().Add(50 * time.Minute)
+	return s.token_, nil
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}


### PR DESCRIPTION
Adds `examples/webui/main.go` (static page + reverse proxy with Cloud Run service-to-service auth via `X-Serverless-Authorization`) and a Dockerfile, so the sample UI deploys as its **own** Cloud Run service — the ochakai core image is untouched, and the ochakai service stays organization-restricted.

Verified on ochakai-example from a real browser over the internet: UI loads on the webui service URL, API calls flow webui → (SA id-token) → IAM-restricted ochakai, ochakai's token layer still enforced (401 without a client token, 200 with one; direct browser access to ochakai remains blocked). Cloud Run guide §5b rewritten for this pattern, with static-host + CORS as the alternative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)