### PR TITLE
Auto-connect Claude Code via committed .mcp.json

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "ochakai": {
+      "type": "http",
+      "url": "http://localhost:8787/mcp"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ claude mcp add --transport http ochakai http://localhost:8080/mcp \
   --header "Authorization: Bearer <token>"
 ```
 
+Opening this repository in Claude Code connects automatically via the
+committed [.mcp.json](.mcp.json), which expects ochakai (or the Cloud Run
+proxy — see the [deploy guide](deploy/cloudrun/README.md)) on
+`localhost:8787`. On tokenless `cloudrun-iam` deployments no header is
+needed at all.
+
 ## MCP tools
 
 | Tool | Description |


### PR DESCRIPTION
Clone → run the Cloud Run proxy (or a local ochakai) on :8787 → open the repo in Claude Code → connected. No headers on tokenless cloudrun-iam deployments. README notes the flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)