### PR TITLE
Restructure Cloud Run guide: tokenless org-restricted deployment as the default path

### DIFF
--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -1,9 +1,10 @@
 # Deploying ochakai on Cloud Run + Cloud SQL
 
-The recommended initial setup: Cloud Run scales to zero and the smallest
-Cloud SQL instance carries the whole knowledge base. ochakai's only hard
-dependency is PostgreSQL, so everything below is one container image plus
-one database.
+The recommended setup: an **organization-restricted, tokenless** ochakai.
+Cloud Run IAM decides who can reach it; ochakai records who did what
+(provenance) and performs no authorization of its own. Cloud Run scales to
+zero and the smallest Cloud SQL instance carries the whole knowledge base —
+one container image plus one database.
 
 **Cost (approximate, us-central1):**
 
@@ -38,7 +39,7 @@ gcloud artifacts repositories create ghcr \
   --remote-docker-repo=https://ghcr.io \
   --location=$REGION
 
-export IMAGE=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:0.1.0
+export IMAGE=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:0.2.0
 ```
 
 ## 2. Create the database (cheapest viable instance)
@@ -62,13 +63,14 @@ gcloud sql users create ochakai --instance=ochakai --password=$DB_PASSWORD
 
 Notes:
 
+- Instance creation takes 10–15 minutes.
 - `--no-backup` keeps the example cheap; enable backups for anything you
   care about (`gcloud sql instances patch ochakai --backup`).
 - Users created through Cloud SQL get `cloudsqlsuperuser`, so ochakai can
   run `CREATE EXTENSION` (pg_trgm, and vector if you enable embeddings)
   during its automatic migration.
 
-## 3. Deploy Cloud Run
+## 3. Deploy Cloud Run (organization-restricted, tokenless)
 
 Grant the Cloud Run service account access to Cloud SQL. In projects
 created since 2024 the default compute service account has no roles, so
@@ -82,95 +84,74 @@ gcloud projects add-iam-policy-binding $PROJECT_ID \
   --member=serviceAccount:$SERVICE_ACCOUNT --role=roles/cloudsql.client
 ```
 
-ochakai authenticates clients with static bearer tokens that map to an
-actor (`human` or `agent`) for provenance. Generate one per client:
+Deploy privately with `OCHAKAI_AUTH=cloudrun-iam`, then allow your
+organization to invoke it:
 
 ```sh
-export AGENT_TOKEN=$(openssl rand -hex 24)
-export HUMAN_TOKEN=$(openssl rand -hex 24)
-
 gcloud run deploy ochakai \
   --image=$IMAGE \
   --region=$REGION \
-  --allow-unauthenticated \
+  --no-allow-unauthenticated \
   --min-instances=0 --max-instances=1 \
   --cpu=1 --memory=512Mi \
   --add-cloudsql-instances=$PROJECT_ID:$REGION:ochakai \
-  --set-env-vars="OCHAKAI_DATABASE_URL=postgres:///ochakai?host=/cloudsql/$PROJECT_ID:$REGION:ochakai&user=ochakai&password=$DB_PASSWORD" \
-  --set-env-vars="^@^OCHAKAI_CLIENTS=$AGENT_TOKEN=agent:claude-code,$HUMAN_TOKEN=human:$(whoami)"
+  --set-env-vars="OCHAKAI_AUTH=cloudrun-iam" \
+  --set-env-vars="OCHAKAI_DATABASE_URL=postgres:///ochakai?host=/cloudsql/$PROJECT_ID:$REGION:ochakai&user=ochakai&password=$DB_PASSWORD"
 
-export OCHAKAI_URL=$(gcloud run services describe ochakai --region=$REGION --format='value(status.url)')
-curl $OCHAKAI_URL/health
-```
-
-Notes:
-
-- `^@^` changes the env-var delimiter so `OCHAKAI_CLIENTS` may contain commas.
-- `--allow-unauthenticated` exposes the service publicly, protected by
-  ochakai's bearer tokens; every endpoint except `/health` requires one.
-  Use `/health`, not `/healthz`: Google Frontends intercept `/healthz` on
-  `run.app` URLs and return their own 404 without ever reaching the app.
-  For private networking, drop the flag and front it with IAM/IAP instead.
-- Container port defaults are fine: ochakai honors Cloud Run's `PORT`.
-- Environment variables are visible to project viewers in the console.
-  For production, store `OCHAKAI_DATABASE_URL` and `OCHAKAI_CLIENTS` in
-  Secret Manager and use `--set-secrets` instead of `--set-env-vars`.
-
-## 3b. Recommended: restrict access to your organization
-
-`--allow-unauthenticated` leaves the URL reachable by anyone (protected
-only by ochakai's bearer tokens). To make the service unreachable from
-outside your Google Workspace / Cloud Identity organization, use Cloud Run
-IAM as a second, network-level layer:
-
-```sh
-gcloud run services remove-iam-policy-binding ochakai --region=$REGION \
-  --member=allUsers --role=roles/run.invoker
 gcloud run services add-iam-policy-binding ochakai --region=$REGION \
   --member=domain:your-org.example --role=roles/run.invoker
+
+export OCHAKAI_URL=$(gcloud run services describe ochakai --region=$REGION --format='value(status.url)')
 ```
 
-Auth becomes two-layer: Cloud Run IAM decides **who can reach** the
-service (org members only; anonymous requests get Google's 401 without
-ever hitting the container), and `OCHAKAI_CLIENTS` decides **which actor**
-(human/agent) they act as for provenance.
+How this works:
 
-Clients with static headers (Claude Code MCP, curl) go through the
-[Cloud Run proxy](https://cloud.google.com/sdk/gcloud/reference/run/services/proxy),
-which handles the Google identity layer transparently and passes your
-`Authorization` header (the ochakai token) through untouched:
+- **Cloud Run IAM decides who can reach the service** (org members and
+  service accounts you grant `roles/run.invoker`; anonymous requests get
+  Google's 401 without hitting the container). ochakai performs no
+  authorization: whoever reaches it reads and writes.
+- **ochakai reads the Cloud-Run-verified caller identity for provenance**:
+  people are recorded as `human:<email>`, service accounts as
+  `agent:<sa-email>`. Nothing to issue, rotate, or revoke.
+- **Never combine `cloudrun-iam` with a public (`allUsers`) service** —
+  there the identity headers are unverified. For a public deployment use
+  the token variant (§3-alt).
+- No `allUsers` grant is needed anywhere, so this is compatible with —
+  and a good reason to keep — the Domain Restricted Sharing org policy
+  (`iam.allowedPolicyMemberDomains`).
+- Environment variables are visible to project viewers in the console.
+  For production, put `OCHAKAI_DATABASE_URL` in Secret Manager and use
+  `--set-secrets`.
+
+Verify through the
+[Cloud Run proxy](https://cloud.google.com/sdk/gcloud/reference/run/services/proxy)
+(direct `curl` is blocked by IAM, which is the point):
 
 ```sh
-gcloud run services proxy ochakai --region=$REGION --port=8787
-claude mcp add --transport http ochakai http://localhost:8787/mcp \
-  --header "Authorization: Bearer $AGENT_TOKEN"
+gcloud run services proxy ochakai --region=$REGION --port=8787 &
+curl http://localhost:8787/health
 ```
 
-Server-to-server callers instead send the Google ID token in
-`X-Serverless-Authorization` (Cloud Run strips it before your app sees
-it), keeping `Authorization` free for the ochakai token.
+Note: use `/health`, not `/healthz` — Google Frontends intercept
+`/healthz` on `run.app` URLs and return their own 404 without ever
+reaching the app.
 
-**Going tokenless (recommended once restricted):** ochakai can resolve
-the actor directly from the Cloud-Run-verified caller identity instead of
-bearer tokens — people become `human:<email>`, service accounts (like the
-sample webui) become `agent:<sa-email>`:
+### 3-alt. Public endpoint with bearer tokens
+
+If you cannot use Google identities (mixed IdPs, external partners) or
+must expose a public URL, deploy with `--allow-unauthenticated` and static
+tokens instead. Each token maps to an actor for provenance; whoever holds
+a token acts as that actor, so issue one per client and don't share them:
 
 ```sh
-gcloud run services update ochakai --region=$REGION \
-  --update-env-vars=OCHAKAI_AUTH=cloudrun-iam --remove-env-vars=OCHAKAI_CLIENTS
-
-claude mcp add --transport http ochakai http://localhost:8787/mcp  # no headers at all
+export AGENT_TOKEN=$(openssl rand -hex 24)
+gcloud run deploy ochakai ... --allow-unauthenticated \
+  --set-env-vars="^@^OCHAKAI_CLIENTS=$AGENT_TOKEN=agent:claude-code,$(openssl rand -hex 24)=human:$(whoami)"
 ```
 
-There is nothing to issue, rotate, or revoke, and provenance records the
-actual caller. ochakai performs no authorization — whoever can reach the
-service reads and writes, and every change records who made it.
-**Never enable `cloudrun-iam` on a public (`allUsers`) service**: there
-the identity headers are unverified.
-
-This setup never needs an `allUsers` grant, so it is compatible with —
-and a good reason to keep — the Domain Restricted Sharing org policy
-(`iam.allowedPolicyMemberDomains`).
+(`^@^` changes the env-var delimiter so the value may contain commas.
+Clients then send `Authorization: Bearer <token>`; every endpoint except
+`/health` requires it.)
 
 ## 4. Optional: enable hybrid semantic search (Vertex AI)
 
@@ -180,8 +161,6 @@ Enabling them uses the Cloud Run service identity via ADC — no API keys.
 ```sh
 gcloud services enable aiplatform.googleapis.com
 
-export SERVICE_ACCOUNT=$(gcloud run services describe ochakai --region=$REGION \
-  --format='value(spec.template.spec.serviceAccountName)')
 gcloud projects add-iam-policy-binding $PROJECT_ID \
   --member=serviceAccount:$SERVICE_ACCOUNT --role=roles/aiplatform.user
 
@@ -197,7 +176,7 @@ updated knowledge with `gemini-embedding-001`. Search becomes hybrid
 (trigram + vector, reciprocal rank fusion). If Vertex AI is ever
 unavailable, writes and searches degrade gracefully to trigram-only.
 
-## 5. Load a semantic model and connect an agent
+## 5. Load a semantic model and connect Claude Code
 
 Import Apache Ossie semantic models through the
 [Cloud SQL Auth Proxy](https://cloud.google.com/sql/docs/postgres/sql-proxy)
@@ -213,10 +192,10 @@ OCHAKAI_DATABASE_URL="postgres://ochakai:$DB_PASSWORD@localhost:55432/ochakai?ss
 ```
 
 No proxy installed? A temporary authorized network works with no extra
-tools — remember to remove it afterwards:
+tools — remember to remove it afterwards (IPv4 only):
 
 ```sh
-gcloud sql instances patch ochakai --authorized-networks=$(curl -s ifconfig.me)/32
+gcloud sql instances patch ochakai --authorized-networks=$(curl -4 -s ifconfig.me)/32
 export DB_IP=$(gcloud sql instances describe ochakai \
   --format='value(ipAddresses[0].ipAddress)')
 OCHAKAI_DATABASE_URL="postgres://ochakai:$DB_PASSWORD@$DB_IP:5432/ochakai?sslmode=require" \
@@ -224,18 +203,20 @@ OCHAKAI_DATABASE_URL="postgres://ochakai:$DB_PASSWORD@$DB_IP:5432/ochakai?sslmod
 gcloud sql instances patch ochakai --clear-authorized-networks
 ```
 
-Connect Claude Code:
+Connect Claude Code — with the Cloud Run proxy running, no headers, no
+tokens (this repository's committed `.mcp.json` does the same
+automatically when you open the repo in Claude Code):
 
 ```sh
-claude mcp add --transport http ochakai $OCHAKAI_URL/mcp \
-  --header "Authorization: Bearer $AGENT_TOKEN"
+gcloud run services proxy ochakai --region=$REGION --port=8787 &
+claude mcp add --transport http ochakai http://localhost:8787/mcp
 ```
 
-Smoke test over REST:
+Smoke test over REST (through the proxy, also tokenless):
 
 ```sh
-curl -H "Authorization: Bearer $AGENT_TOKEN" "$OCHAKAI_URL/api/v1/knowledge?q=revenue"
-curl -H "Authorization: Bearer $AGENT_TOKEN" -X POST "$OCHAKAI_URL/api/v1/compile" \
+curl "http://localhost:8787/api/v1/knowledge?q=revenue"
+curl -X POST "http://localhost:8787/api/v1/compile" \
   -d '{"metrics":["revenue"],"dimensions":["customers.region"],"dialect":"bigquery"}'
 ```
 
@@ -244,13 +225,15 @@ curl -H "Authorization: Bearer $AGENT_TOKEN" -X POST "$OCHAKAI_URL/api/v1/compil
 The sample UI ([examples/webui](../../examples/webui)) is **not** part of
 the ochakai image — the core keeps its serving surface minimal. It ships
 as its own tiny service: a static page plus a reverse proxy that attaches
-this service's identity token (`X-Serverless-Authorization`) to API
-calls, so **ochakai stays organization-restricted (§3b)** while the UI is
-reachable from any machine. The client's `Authorization` header (the
-ochakai token choosing the actor) passes through untouched.
+its service identity (`X-Serverless-Authorization`) to API calls, so
+ochakai stays organization-restricted while the UI is reachable from any
+machine. Browser users are recorded as the webui's service account
+(`agent:ochakai-webui@…`); per-user browser identity needs IAP or MCP
+OAuth (issue #5).
 
 ```sh
 # build & push (from the repository root)
+gcloud artifacts repositories create images --repository-format=docker --location=$REGION
 docker build --platform linux/amd64 -f examples/webui/Dockerfile \
   -t $REGION-docker.pkg.dev/$PROJECT_ID/images/ochakai-webui:0.1 .
 docker push $REGION-docker.pkg.dev/$PROJECT_ID/images/ochakai-webui:0.1
@@ -269,13 +252,12 @@ gcloud run deploy ochakai-webui \
   --set-env-vars=OCHAKAI_URL=$OCHAKAI_URL
 ```
 
-Open the webui service URL from any machine, paste a client token, and
-search. The UI and API are same-origin through the proxy, so no CORS
-setup is needed. Note the trade-off: the webui itself is public here
-(token-gated only) — anyone reaching it can attempt API calls, so treat
-it like the public-endpoint variant of §3. To require Google login in
-the browser too, put IAP in front of the webui service, or wait for
-first-class MCP OAuth (issue #5).
+Open the webui service URL from any machine and search — no token needed
+on `cloudrun-iam` deployments (leave the token field empty). The UI and
+API are same-origin through the proxy, so no CORS setup is needed. Note
+the trade-off: the webui itself is public, so anyone who finds its URL
+can read and write through it as the webui's identity. Put IAP in front
+of it if that is not acceptable.
 
 Alternatively, host `index.html` on any static host (no container) and
 allow its origin to call the REST API directly from the browser:
@@ -287,22 +269,21 @@ gcloud run services update ochakai --region=$REGION \
 
 CORS is off unless `OCHAKAI_CORS_ORIGINS` is set, origins match exactly
 (no wildcards), and this path requires the browser to reach ochakai
-itself — combine with §3b's proxy on restricted deployments.
+itself — on restricted deployments that means going through the Cloud Run
+proxy.
 
 ## 6. Troubleshooting in security-hardened organizations
 
 - **`allUsers` binding fails with "do not belong to a permitted customer"**:
   the org enforces Domain Restricted Sharing
-  (`iam.allowedPolicyMemberDomains`). Either request a project-level
-  exception, or skip `--allow-unauthenticated` and call the service with
-  Google ID tokens (Cloud Run accepts the app's bearer token in
-  `Authorization` and the Google ID token in `X-Serverless-Authorization`
-  simultaneously).
+  (`iam.allowedPolicyMemberDomains`). The recommended §3 setup never needs
+  `allUsers`, so keep the policy on; only §3-alt and the sample webui
+  require an exception.
 - **`run.app` returns Google's HTML 404 ("That's an error") even though
   the service is Ready**: before suspecting infrastructure, test a real
-  application endpoint (e.g. `/api/v1/knowledge?q=x` with a token) and
-  check request logs. Two Google Frontend behaviors conspire to make a
-  healthy service look dead:
+  application endpoint (e.g. `/api/v1/knowledge?q=x`) and check request
+  logs. Two Google Frontend behaviors conspire to make a healthy service
+  look dead:
   1. `/healthz` is intercepted by Google Frontends on `run.app` and 404s
      without ever reaching the container (and without request logs). Use
      `/health`.
@@ -310,10 +291,13 @@ itself — combine with §3b's proxy on restricted deployments.
      404 page, so an unhandled path looks like a routing failure.
   A genuinely unknown service URL returns a much shorter 404 page
   (~272 bytes vs ~1.5 KB) — comparing `content-length` tells them apart.
+- **Container exits with `cloudsql.instances.get ... NOT_AUTHORIZED`**:
+  the service account is missing `roles/cloudsql.client` (§3, first step).
 
 ## 7. Teardown
 
 ```sh
 gcloud run services delete ochakai --region=$REGION --quiet
+gcloud run services delete ochakai-webui --region=$REGION --quiet
 gcloud sql instances delete ochakai --quiet
 ```


### PR DESCRIPTION
The guide grew historically (public+tokens first, restrict+tokenless bolted on). For fresh projects it now reads in deployment order with the v0.2 recommended path as §3 — private service + `OCHAKAI_AUTH=cloudrun-iam`, domain invoker grant, verification through the proxy — and the public bearer-token variant as §3-alt. Image tag → 0.2.0, headerless Claude Code connection, webui tokenless note, extra troubleshooting entry, webui teardown.

Every command reflects what was actually run against ochakai-example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)