### PR TITLE
Passwordless DB auth (Cloud SQL IAM) + dedicated runtime service account

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ see [api/openapi.yaml](api/openapi.yaml) and the sample in
 | `OCHAKAI_DATABASE_URL` | PostgreSQL connection string (required; `DATABASE_URL` also works) |
 | `OCHAKAI_CLIENTS` | Bearer tokens: `token=agent:claude-code,token2=human:alice`. Empty disables auth (dev only) |
 | `OCHAKAI_AUTH` | `clients` (default: bearer tokens) or `cloudrun-iam` (tokenless: actor from the Cloud-Run-verified caller identity; requires a non-public service) |
+| `OCHAKAI_DB_IAM_AUTH` | `true` enables Cloud SQL IAM database authentication: the connection password is a short-lived IAM token, so the `DATABASE_URL` carries no secret (Cloud Run/GCE only) |
 | `OCHAKAI_CORS_ORIGINS` | Exact-match origin allowlist for browser access to the REST API (for separately hosted web UIs). Default: no CORS headers |
 | `OCHAKAI_EMBEDDING_PROVIDER` | `vertex` enables hybrid semantic search (default: off, trigram-only) |
 | `OCHAKAI_VERTEX_PROJECT` / `OCHAKAI_VERTEX_LOCATION` / `OCHAKAI_VERTEX_MODEL` | Vertex AI settings (defaults: `us-central1`, `gemini-embedding-001`). Auth is ADC — no API keys |

--- a/cmd/ochakai/main.go
+++ b/cmd/ochakai/main.go
@@ -72,7 +72,7 @@ func setup(ctx context.Context, log *slog.Logger) (*service.Service, *config.Con
 	if err != nil {
 		return nil, nil, err
 	}
-	st, err := store.New(ctx, cfg.DatabaseURL)
+	st, err := store.New(ctx, cfg.DatabaseURL, cfg.DBIAMAuth)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -53,10 +53,13 @@ gcloud sql instances create ochakai \
   --storage-size=10 \
   --storage-type=SSD \
   --no-storage-auto-increase \
-  --no-backup
+  --no-backup \
+  --database-flags=cloudsql.iam_authentication=on
 
 gcloud sql databases create ochakai --instance=ochakai
 
+# admin user for local import/maintenance only — its password never
+# reaches Cloud Run (the service itself connects passwordless, §3)
 export DB_PASSWORD=$(openssl rand -hex 24)
 gcloud sql users create ochakai --instance=ochakai --password=$DB_PASSWORD
 ```
@@ -70,33 +73,53 @@ Notes:
   run `CREATE EXTENSION` (pg_trgm, and vector if you enable embeddings)
   during its automatic migration.
 
-## 3. Deploy Cloud Run (organization-restricted, tokenless)
+## 3. Deploy Cloud Run (dedicated identity, passwordless, org-restricted)
 
-Grant the Cloud Run service account access to Cloud SQL. In projects
-created since 2024 the default compute service account has no roles, so
-this step is required (the container exits at startup with
-`cloudsql.instances.get ... NOT_AUTHORIZED` without it):
+Create a dedicated service account for ochakai and let it log in to the
+database with **IAM database authentication** — the connection password is
+a short-lived IAM token fetched at connect time, so **no database password
+exists anywhere in the deployment**:
 
 ```sh
-export SERVICE_ACCOUNT=$(gcloud projects describe $PROJECT_ID \
-  --format='value(projectNumber)')-compute@developer.gserviceaccount.com
+gcloud iam service-accounts create ochakai-run --display-name="ochakai service"
+export SERVICE_ACCOUNT=ochakai-run@$PROJECT_ID.iam.gserviceaccount.com
+
 gcloud projects add-iam-policy-binding $PROJECT_ID \
   --member=serviceAccount:$SERVICE_ACCOUNT --role=roles/cloudsql.client
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member=serviceAccount:$SERVICE_ACCOUNT --role=roles/cloudsql.instanceUser
+
+# database principal for the service account (note: no .gserviceaccount.com)
+export DB_SA_USER=ochakai-run@$PROJECT_ID.iam
+gcloud sql users create $DB_SA_USER --instance=ochakai --type=cloud_iam_service_account
 ```
 
-Deploy privately with `OCHAKAI_AUTH=cloudrun-iam`, then allow your
-organization to invoke it:
+Grant the service account database privileges (one-time, as the admin
+user — e.g. through §5's temporary authorized network):
+
+```sql
+GRANT cloudsqlsuperuser TO "ochakai-run@<PROJECT_ID>.iam";  -- CREATE EXTENSION in migrations
+GRANT ochakai TO "ochakai-run@<PROJECT_ID>.iam";            -- share admin-owned objects
+```
+
+Tip: run §5's import once **before the first deploy** — it creates the
+schema as the admin user, so both identities can work with it.
+
+Deploy privately with the dedicated identity, `OCHAKAI_AUTH=cloudrun-iam`
+(tokenless clients), and `OCHAKAI_DB_IAM_AUTH` (passwordless database),
+then allow your organization to invoke it:
 
 ```sh
 gcloud run deploy ochakai \
   --image=$IMAGE \
   --region=$REGION \
+  --service-account=$SERVICE_ACCOUNT \
   --no-allow-unauthenticated \
   --min-instances=0 --max-instances=1 \
   --cpu=1 --memory=512Mi \
   --add-cloudsql-instances=$PROJECT_ID:$REGION:ochakai \
-  --set-env-vars="OCHAKAI_AUTH=cloudrun-iam" \
-  --set-env-vars="OCHAKAI_DATABASE_URL=postgres:///ochakai?host=/cloudsql/$PROJECT_ID:$REGION:ochakai&user=ochakai&password=$DB_PASSWORD"
+  --set-env-vars="OCHAKAI_AUTH=cloudrun-iam,OCHAKAI_DB_IAM_AUTH=true" \
+  --set-env-vars="OCHAKAI_DATABASE_URL=postgres:///ochakai?host=/cloudsql/$PROJECT_ID:$REGION:ochakai&user=$DB_SA_USER"
 
 gcloud run services add-iam-policy-binding ochakai --region=$REGION \
   --member=domain:your-org.example --role=roles/run.invoker
@@ -119,9 +142,13 @@ How this works:
 - No `allUsers` grant is needed anywhere, so this is compatible with —
   and a good reason to keep — the Domain Restricted Sharing org policy
   (`iam.allowedPolicyMemberDomains`).
-- Environment variables are visible to project viewers in the console.
-  For production, put `OCHAKAI_DATABASE_URL` in Secret Manager and use
-  `--set-secrets`.
+- With `OCHAKAI_DB_IAM_AUTH` the `OCHAKAI_DATABASE_URL` contains no
+  password, so there is nothing secret in the environment variables.
+  (If you use password auth instead, put the URL in Secret Manager with
+  `--set-secrets`.)
+- The whole deployment is **secret-zero**: clients bring Google
+  identities, ochakai brings its service-account identity to the
+  database, and nothing needs to be issued, stored, or rotated.
 
 Verify through the
 [Cloud Run proxy](https://cloud.google.com/sdk/gcloud/reference/run/services/proxy)
@@ -162,7 +189,7 @@ Enabling them uses the Cloud Run service identity via ADC — no API keys.
 gcloud services enable aiplatform.googleapis.com
 
 gcloud projects add-iam-policy-binding $PROJECT_ID \
-  --member=serviceAccount:$SERVICE_ACCOUNT --role=roles/aiplatform.user
+  --member=serviceAccount:$SERVICE_ACCOUNT --role=roles/aiplatform.user   # ochakai-run SA from §3
 
 gcloud run services update ochakai --region=$REGION \
   --update-env-vars=OCHAKAI_EMBEDDING_PROVIDER=vertex,OCHAKAI_VERTEX_PROJECT=$PROJECT_ID

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,10 @@ type Config struct {
 	Addr string
 	// DatabaseURL is the PostgreSQL connection string (required).
 	DatabaseURL string
+	// DBIAMAuth enables Cloud SQL IAM database authentication: the
+	// connection password is a short-lived access token fetched from the
+	// GCE metadata server, so no database password exists anywhere.
+	DBIAMAuth bool
 	// AuthMode selects actor resolution (default: clients).
 	AuthMode AuthMode
 	// Clients maps bearer tokens to actors (clients mode only).
@@ -66,6 +70,7 @@ func FromEnv() (*Config, error) {
 		Addr:        ":" + envOr("PORT", "8080"),
 		DatabaseURL: firstEnv("OCHAKAI_DATABASE_URL", "DATABASE_URL"),
 		AuthMode:    AuthMode(envOr("OCHAKAI_AUTH", string(AuthClients))),
+		DBIAMAuth:   os.Getenv("OCHAKAI_DB_IAM_AUTH") == "true",
 		CORSOrigins: splitList(os.Getenv("OCHAKAI_CORS_ORIGINS")),
 	}
 	if addr := os.Getenv("OCHAKAI_ADDR"); addr != "" {

--- a/internal/store/iamauth.go
+++ b/internal/store/iamauth.go
@@ -1,0 +1,60 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// metadataTokenSource supplies OAuth access tokens from the GCE metadata
+// server for Cloud SQL IAM database authentication: the token is used as
+// the connection password, so no database password exists anywhere.
+// Tokens are cached and refreshed shortly before expiry; authentication
+// happens per new connection, so pooled connections are unaffected.
+type metadataTokenSource struct {
+	mu      sync.Mutex
+	token   string
+	expires time.Time
+}
+
+func (s *metadataTokenSource) password(ctx context.Context) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.token != "" && time.Now().Before(s.expires) {
+		return s.token, nil
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		"http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token", nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Metadata-Flavor", "Google")
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("Cloud SQL IAM auth needs the GCE metadata server (Cloud Run/GCE only): %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("metadata token: %s: %s", resp.Status, body)
+	}
+	var out struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil || out.AccessToken == "" {
+		return "", fmt.Errorf("metadata token: unexpected response")
+	}
+	s.token = out.AccessToken
+	// Refresh well before expiry so new connections never race it.
+	s.expires = time.Now().Add(time.Duration(out.ExpiresIn)*time.Second - 5*time.Minute)
+	return s.token, nil
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -23,8 +23,25 @@ type Store struct {
 	pool *pgxpool.Pool
 }
 
-func New(ctx context.Context, databaseURL string) (*Store, error) {
-	pool, err := pgxpool.New(ctx, databaseURL)
+func New(ctx context.Context, databaseURL string, iamAuth bool) (*Store, error) {
+	cfg, err := pgxpool.ParseConfig(databaseURL)
+	if err != nil {
+		return nil, err
+	}
+	if iamAuth {
+		// Cloud SQL IAM database authentication: the password of every
+		// new connection is a fresh short-lived access token.
+		tokens := &metadataTokenSource{}
+		cfg.BeforeConnect = func(ctx context.Context, cc *pgx.ConnConfig) error {
+			tok, err := tokens.password(ctx)
+			if err != nil {
+				return err
+			}
+			cc.Password = tok
+			return nil
+		}
+	}
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -19,7 +19,7 @@ func TestIntegration(t *testing.T) {
 		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
 	}
 	ctx := context.Background()
-	s, err := New(ctx, dbURL)
+	s, err := New(ctx, dbURL, false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
- `OCHAKAI_DB_IAM_AUTH=true`: pgx `BeforeConnect` sets the password to a cached short-lived metadata-server token — Cloud SQL IAM database authentication with zero new dependencies. `DATABASE_URL` carries no secret; console env vars leak nothing.
- Deploy guide §3 reworked: dedicated `ochakai-run` SA (`cloudsql.client` + `cloudsql.instanceUser`), IAM DB principal (name without `.gserviceaccount.com` — the API rejects the full email), one-time grants run as the API-created admin user (verified live: it can grant `cloudsqlsuperuser`).
- Together with tokenless client auth: secret-zero deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)