### PR TITLE
Prerequisites: enable sql-component.googleapis.com

### DIFF
--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -24,7 +24,8 @@ at the bottom.
 export PROJECT_ID=<your-project>
 export REGION=us-central1
 gcloud config set project $PROJECT_ID
-gcloud services enable run.googleapis.com sqladmin.googleapis.com artifactregistry.googleapis.com
+gcloud services enable run.googleapis.com sqladmin.googleapis.com \
+  sql-component.googleapis.com artifactregistry.googleapis.com
 ```
 
 Cloud Run cannot pull images from ghcr.io directly, so create an Artifact


### PR DESCRIPTION
`gcloud run deploy --add-cloudsql-instances` fails with `API [sql-component.googleapis.com] not enabled` on fresh projects — sqladmin alone isn't sufficient. Reported from a real deployment to a new project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)