### PR TITLE
Report the module version from build info when not stamped

### DIFF
--- a/cmd/ochakai/main.go
+++ b/cmd/ochakai/main.go
@@ -14,6 +14,7 @@ import (
 	"os/signal"
 	"os/user"
 	"path/filepath"
+	"runtime/debug"
 	"syscall"
 	"time"
 
@@ -29,12 +30,25 @@ import (
 	"github.com/na0fu3y/ochakai/internal/store"
 )
 
-// version is stamped by -ldflags at release; "dev" otherwise.
-var version = "dev"
+// version is stamped by -ldflags at release; otherwise it comes from the
+// module version Go records in the binary (`go install …@v0.4.0` →
+// "v0.4.0"), falling back to "dev" for in-tree builds.
+var version = ""
+
+func resolveVersion() string {
+	if version != "" {
+		return version
+	}
+	if bi, ok := debug.ReadBuildInfo(); ok && bi.Main.Version != "" && bi.Main.Version != "(devel)" {
+		return bi.Main.Version
+	}
+	return "dev"
+}
 
 func main() {
 	log := slog.New(slog.NewJSONHandler(os.Stderr, nil))
 	slog.SetDefault(log)
+	version = resolveVersion()
 
 	// No default command: a bare `ochakai` is almost always a CLI user
 	// exploring, not a server operator (the container image passes

--- a/cmd/ochakai/version_test.go
+++ b/cmd/ochakai/version_test.go
@@ -1,0 +1,20 @@
+package main
+
+import "testing"
+
+// resolveVersion order: ldflags stamp > module build info > "dev".
+func TestResolveVersion(t *testing.T) {
+	defer func(v string) { version = v }(version)
+
+	version = "v9.9.9"
+	if got := resolveVersion(); got != "v9.9.9" {
+		t.Errorf("stamped: got %q", got)
+	}
+
+	// In a test binary the main-module version is "" or "(devel)", so the
+	// unstamped path must fall through to "dev" — and never be empty.
+	version = ""
+	if got := resolveVersion(); got != "dev" {
+		t.Errorf("unstamped: got %q, want dev", got)
+	}
+}


### PR DESCRIPTION
## Summary

`go install github.com/na0fu3y/ochakai/cmd/ochakai@vX.Y.Z` builds without the release `-ldflags`, so `ochakai version` printed `dev` even for a tagged install (noticed right after the v0.3.0 CLI install attempt). Now the version resolves as: ldflags stamp → module version from `debug.ReadBuildInfo()` → `dev` for in-tree builds. The release/image path is unchanged.

## Verification

- Unit test for the resolution order.
- Real `go install …@0bb4674` run prints the pseudo-version (`v0.3.1-0.20260716112904-0bb4674cd5cb`) instead of `dev`; after tagging v0.4.0 the same path will print `v0.4.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)