### PR TITLE
Make the zsh completion script work as an fpath file, not just sourced

### DIFF
--- a/cmd/ochakai/completion.go
+++ b/cmd/ochakai/completion.go
@@ -11,8 +11,8 @@ import (
 
 func cmdCompletion(_ context.Context, args []string) error {
 	fs := newBareFlagSet(
-		"Usage: ochakai completion <zsh|bash|fish>\n\nPrint a shell completion script. Load it with:\n\n  zsh:   source <(ochakai completion zsh)    # ~/.zshrc, after compinit\n  bash:  source <(ochakai completion bash)   # ~/.bashrc\n  fish:  ochakai completion fish | source    # ~/.config/fish/config.fish",
-		"  ochakai completion zsh > \"${fpath[1]}/_ochakai\"   # or install statically\n")
+		"Usage: ochakai completion <zsh|bash|fish>\n\nPrint a shell completion script. Load it with:\n\n  zsh:   source <(ochakai completion zsh)    # ~/.zshrc, after compinit\n  bash:  source <(ochakai completion bash)   # ~/.bashrc\n  fish:  ochakai completion fish | source    # ~/.config/fish/config.fish\n\nOr install it as a file the shell picks up by itself (what package\nmanagers do):",
+		"  ochakai completion zsh > \"${fpath[1]}/_ochakai\"\n  ochakai completion fish > ~/.config/fish/completions/ochakai.fish\n")
 	pos, err := parseArgs(fs, args)
 	if err != nil {
 		return err
@@ -29,7 +29,10 @@ func cmdCompletion(_ context.Context, args []string) error {
 // Server names for `ochakai use <Tab>` come from the bare list output
 // (name\turl per line, current marked in column 1-2): cut -c3- | cut -f1.
 
-const zshCompletion = `# zsh completion for ochakai — source <(ochakai completion zsh)
+const zshCompletion = `#compdef ochakai
+# zsh completion for ochakai. Either source <(ochakai completion zsh)
+# in ~/.zshrc, or install it as an fpath file (no sourcing needed):
+#   ochakai completion zsh > "${fpath[1]}/_ochakai"
 _ochakai() {
   local -a commands
   commands=(
@@ -106,7 +109,13 @@ _ochakai() {
       ;;
   esac
 }
-compdef _ochakai ochakai
+# Sourced: register with compdef. Autoloaded from fpath: this file runs
+# as the function body, so call the (re)defined function directly.
+if [ "$funcstack[1]" = "_ochakai" ]; then
+  _ochakai
+else
+  compdef _ochakai ochakai
+fi
 `
 
 const bashCompletion = `# bash completion for ochakai — source <(ochakai completion bash)

--- a/cmd/ochakai/completion_test.go
+++ b/cmd/ochakai/completion_test.go
@@ -16,6 +16,11 @@ func TestCompletionScriptsStayInSync(t *testing.T) {
 		"bigquery ansi",                   // --dialect
 		"zsh bash fish",                   // completion <shell>
 	}
+	// The #compdef header is what fpath-installed files are matched by;
+	// without it only the source <(...) route works.
+	if !strings.HasPrefix(zshCompletion, "#compdef ochakai\n") {
+		t.Error("zsh script must start with '#compdef ochakai' for fpath installs")
+	}
 	for shell, script := range map[string]string{"zsh": zshCompletion, "bash": bashCompletion, "fish": fishCompletion} {
 		for name := range clientCommands {
 			if !strings.Contains(script, name) {


### PR DESCRIPTION
## Summary

Follow-up to #25. Shells pick up completions for most commands not by sourcing anything at startup, but from static files that package managers drop into well-known directories (zsh `$fpath` / `site-functions`, bash-completion dir, fish `completions/`), lazily loaded by command name. zsh matches those files by their first line, `#compdef <cmd>` — which the script from #25 lacked, so only the `source <(ochakai completion zsh)` route worked.

- Add the `#compdef ochakai` header plus cobra's `funcstack` guard, so the same script works both **sourced** (registers via `compdef`) and **autoloaded from fpath** (runs as the function body on first Tab). This is also the route a future Homebrew formula would use — brew formulas typically run `cmd completion zsh` once at install and save the output into site-functions.
- Document the file-drop install in `completion -h` for zsh and fish (fish needs no config at all: `ochakai completion fish > ~/.config/fish/completions/ochakai.fish`).
- Pin the header with a test.

## Verification

Both routes verified against a live zsh: `source` → `$_comps[ochakai]` = `_ochakai`, and a copy placed in an `$fpath` dir picked up by `compinit` with no sourcing → same registration. `zsh -n` passes; `go test ./cmd/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)