### PR TITLE
Make the quick start import work on a fresh machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,12 @@ git clone https://github.com/na0fu3y/ochakai && cd ochakai
 docker compose -f deploy/compose.yaml up
 ```
 
-Import a semantic model and try a search:
+Import a semantic model and try a search. `import-ossie` is a server
+admin command that talks to the database directly, so it runs inside the
+container (the compose file mounts `examples/` for this):
 
 ```sh
-go run ./cmd/ochakai import-ossie examples/semantic-model.yaml
+docker compose -f deploy/compose.yaml exec ochakai /ochakai import-ossie /examples/semantic-model.yaml
 curl 'http://localhost:8080/api/v1/knowledge?q=revenue'
 ```
 

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -11,6 +11,10 @@ services:
     environment:
       OCHAKAI_DATABASE_URL: postgres://ochakai:ochakai@db:5432/ochakai?sslmode=disable
       OCHAKAI_INSECURE_DEV: "true" # local only: all requests act as human:anonymous
+    volumes:
+      # Lets the quick start run `import-ossie` (a DB-direct admin command,
+      # design doc 0004 §2.3) inside the container, next to the database.
+      - ../examples:/examples:ro
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## What

The README quick start told users to run `go run ./cmd/ochakai import-ossie examples/semantic-model.yaml` right after `docker compose up`. This could never work on a fresh machine: `import-ossie` is a DB-direct server admin command requiring `OCHAKAI_DATABASE_URL`, and `deploy/compose.yaml` does not publish the db service's port 5432 to the host. It also silently assumed a Go toolchain.

- `deploy/compose.yaml`: bind-mount `../examples` read-only into the `ochakai` service.
- `README.md`: run the import inside the container, where `OCHAKAI_DATABASE_URL` already points at the db service:
  ```sh
  docker compose -f deploy/compose.yaml exec ochakai /ochakai import-ossie /examples/semantic-model.yaml
  ```

## Why container-exec instead of publishing 5432

Design doc 0004 §2.3 deliberately keeps `import-ossie` as a DB-direct admin command "run next to the database," and §7 rules out remote import. Publishing Postgres to the host would invite port conflicts and cut against the compose file's role as a self-contained dev harness. The bind mount keeps it to one command (no `docker compose cp` step) and removes the Go-toolchain dependency from the quick start.

## Notes for review

- The image is distroless (no shell), but `exec` invokes `/ochakai` directly, so no shell is needed.
- Verified on a clean compose stack (fresh project name and volume): the exact README command imported 4 entries (`metric/revenue`, `metric/avg_order_value`, `table/orders`, `table/customers`) and `curl 'http://localhost:8080/api/v1/knowledge?q=revenue'` returned the revenue metric.
- The Cloud Run guide's import instructions were already correct (SQL proxy + explicit `OCHAKAI_DATABASE_URL`) and are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)