### PR TITLE
OKF bundle interop: keep foreign frontmatter keys, conformant indexes, safer archives

### DIFF
--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -398,9 +398,10 @@ func cmdExport(ctx context.Context, args []string) error {
 
 func cmdImport(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
-		"Usage: ochakai import [flags] <dir | file.tar.gz | ->\n\nImport an OKF bundle (a directory of markdown + YAML frontmatter, or\na tar.gz of one; \"-\" reads the tar.gz from stdin). The inverse of\n`ochakai export`: paths name the entries (first segment = type, rest =\nid), index.md files are skipped, existing entries are replaced (kept\nas revisions). Works with any OKF bundle, not just ochakai's own.",
+		"Usage: ochakai import [flags] <dir | file.tar.gz | ->\n\nImport an OKF bundle (a directory of markdown + YAML frontmatter, or\na tar.gz of one; \"-\" reads the tar.gz from stdin). The inverse of\n`ochakai export`: paths name the entries (first segment = type, rest =\nid), reserved index.md / log.md files are skipped, unknown frontmatter\nkeys are kept as attrs, existing entries are replaced (kept as\nrevisions). An archive wrapped in a single directory is unwrapped.\nWorks with any OKF bundle, not just ochakai's own.",
 		"  ochakai import ./knowledge\n  ochakai import ga4-bundle.tar.gz --dry-run\n  ochakai export - | OCHAKAI_URL=https://other ochakai import -\n")
 	dryRun := fs.Bool("dry-run", false, "parse and list what would be written, write nothing")
+	keepRoot := fs.Bool("keep-root", false, "keep a single top-level directory as the type instead of unwrapping it")
 	pos, err := parseArgs(fs, args)
 	if err != nil {
 		return err
@@ -412,6 +413,12 @@ func cmdImport(ctx context.Context, args []string) error {
 	files, err := readBundle(pos[0])
 	if err != nil {
 		return err
+	}
+	if !*keepRoot {
+		if unwrapped, root := okf.StripWrapper(files); root != "" {
+			fmt.Fprintf(os.Stderr, "note: unwrapped bundle directory %q (pass --keep-root to treat it as the type)\n", root)
+			files = unwrapped
+		}
 	}
 	entries, skipped := okf.FromBundle(files)
 	for _, s := range skipped {

--- a/cmd/ochakai/completion.go
+++ b/cmd/ochakai/completion.go
@@ -93,7 +93,7 @@ _ochakai() {
       _arguments '--url[server URL]:url:' '1:directory:_files -/'
       ;;
     import)
-      _arguments '--dry-run[parse and list, write nothing]' '--url[server URL]:url:' '1:bundle:_files'
+      _arguments '--dry-run[parse and list, write nothing]' '--keep-root[keep a single top-level directory as the type]' '--url[server URL]:url:' '1:bundle:_files'
       ;;
     use)
       local -a servers
@@ -152,7 +152,7 @@ _ochakai() {
     delete)        opts="--url" ;;
     compile)       opts="--metric --dimension --filter --grain --model --dialect --limit --json --url" ;;
     export)        opts="--url" ;;
-    import)        opts="--dry-run --url" ;;
+    import)        opts="--dry-run --keep-root --url" ;;
     whoami)        opts="--json --url" ;;
     use)
       if [[ $cur != -* ]]; then
@@ -197,6 +197,7 @@ complete -c ochakai -n __fish_use_subcommand -a version -d 'print the version'
 
 complete -c ochakai -n '__fish_seen_subcommand_from search get create update delete compile export import whoami' -l url -x -d 'server URL'
 complete -c ochakai -n '__fish_seen_subcommand_from import' -l dry-run -d 'parse and list, write nothing'
+complete -c ochakai -n '__fish_seen_subcommand_from import' -l keep-root -d 'keep a single top-level directory as the type'
 complete -c ochakai -n '__fish_seen_subcommand_from import import-okf' -F
 complete -c ochakai -n '__fish_seen_subcommand_from search get create update compile whoami' -l json -d 'print raw JSON'
 complete -c ochakai -n '__fish_seen_subcommand_from search' -l type -x -a 'metric query insight term table' -d 'filter by type'

--- a/cmd/ochakai/main.go
+++ b/cmd/ochakai/main.go
@@ -265,6 +265,10 @@ func importOKF(log *slog.Logger, path string) error {
 	if err != nil {
 		return err
 	}
+	if unwrapped, root := okf.StripWrapper(files); root != "" {
+		log.Info("unwrapped bundle directory", "dir", root)
+		files = unwrapped
+	}
 	entries, skipped := okf.FromBundle(files)
 	for _, s := range skipped {
 		log.Warn("skipped bundle file", "reason", s)

--- a/docs/design/0005-okf-compatibility.md
+++ b/docs/design/0005-okf-compatibility.md
@@ -59,10 +59,15 @@ ochakai もこれに合わせ、ID をスラッシュ区切りのスラグ列に
 |---|---|
 | タイプの表記 | frontmatter の `type` が推奨タイプの表示名/スラグならそれに写像。それ以外はスラグ化し、**表記が変わる場合は元の表記を `attrs.okf_type` に保存**。エクスポート時に `type` キーへ畳み戻し、属性としては出力しない |
 | パスと frontmatter の不一致 | **パスが勝つ**(OKF の concept ID = パス)。`tables/users.md` に `type: Table` とあれば type=`tables`、`okf_type: Table` として保存し、再エクスポートで元の位置・元の表記に戻る |
-| `index.md` | ナビゲーションであり実体ではない。インポートでは黙ってスキップし、エクスポートで全ディレクトリ階層に再生成する |
+| 未知の frontmatter キー | プロデューサ拡張キー(OKF SPEC §4.1)として**値ごとそのまま `attrs` に保存**し、エクスポートで**トップレベルキーに書き戻す**(`resource` / `owner` 等が元の位置・表記で往復する)。`attrs:` のネストは出力しない(旧形式のネストは読み込みで畳み込む)。封筒キーと同名の attr はエクスポートせず封筒が勝つ |
+| `resource` | 拡張キーの一般規則で `attrs.resource` として往復。ochakai 自身の table エントリは従来どおり `attrs.source` から導出して出力する(`attrs.resource` があればそちらが優先) |
+| `index.md` / `log.md` | OKF の予約ファイル。ナビゲーション/履歴であり実体ではないため、インポートでは黙ってスキップ。index.md はエクスポートで全ディレクトリ階層に再生成する(SPEC §6 に従い **frontmatter なし**、ルートのみ `okf_version` を宣言) |
+| 隠しファイル | セグメントが `.` で始まるパス(`.git`、macOS tar の `._*`、`.DS_Store`)はナレッジにならないため黙ってスキップ(ディレクトリ走査と tar で同じ扱い) |
 | 非 Markdown ファイル | ナレッジにならないためスキップし、レポートに残す(例: GA4 バンドルの `viz.html`) |
 | ルート直下の concept | タイプディレクトリがないため frontmatter のタイプで受ける(再エクスポートでタイプディレクトリ配下に移動する) |
-| サーバー所有キー | `timestamp` / `created_by` / `verified_*` は従来どおりペイロードから受け取らない。provenance は認証から来る |
+| 単一ディレクトリに包まれたアーカイブ | `tar czf bundle.tgz ga4/` の形。放置すると包みディレクトリ名が全エントリのタイプになるため、**自動でアンラップして通知**する(`ochakai import --keep-root` で抑止) |
+| 改行コード | CRLF は LF に正規化して受ける(OKF は改行コードを規定しない) |
+| サーバー所有キー | `timestamp` / `created_by` / `verified_*` は従来どおりペイロードから受け取らない。provenance は認証から来る。`status` / `status_note` は封筒キーとして受ける |
 
 ### 3.4 インポートの入口
 

--- a/internal/okf/bundle.go
+++ b/internal/okf/bundle.go
@@ -15,10 +15,13 @@ import (
 // frontmatter: the first path segment becomes the type and the remaining
 // segments the hierarchical ID; a frontmatter type spelled differently is
 // preserved as attrs[AttrOKFType] so re-export reproduces the original.
-// index.md files are navigation that Bundle regenerates, so they are
-// skipped silently. Anything else that cannot become an entry — non-
-// markdown files, unparsable documents, invalid slugs — is reported in
-// skipped as "path: reason" lines rather than failing the whole bundle.
+// index.md files are navigation that Bundle regenerates, and log.md files
+// are the other OKF-reserved name (update history, SPEC §3) — both are
+// skipped silently, as are hidden paths (.git trees, macOS tar's
+// AppleDouble ._* siblings, .DS_Store). Anything else that cannot become
+// an entry — non-markdown files, unparsable documents, invalid slugs — is
+// reported in skipped as "path: reason" lines rather than failing the
+// whole bundle.
 func FromBundle(files map[string][]byte) (entries []domain.Knowledge, skipped []string) {
 	paths := make([]string, 0, len(files))
 	for p := range files {
@@ -28,7 +31,10 @@ func FromBundle(files map[string][]byte) (entries []domain.Knowledge, skipped []
 
 	for _, p := range paths {
 		clean := path.Clean(strings.TrimPrefix(p, "./"))
-		if path.Base(clean) == "index.md" {
+		if hiddenPath(clean) {
+			continue
+		}
+		if base := path.Base(clean); base == "index.md" || base == "log.md" {
 			continue
 		}
 		if !strings.HasSuffix(clean, ".md") {
@@ -50,6 +56,57 @@ func FromBundle(files map[string][]byte) (entries []domain.Knowledge, skipped []
 		return entries[i].ID < entries[j].ID
 	})
 	return entries, skipped
+}
+
+// StripWrapper unwraps a bundle packed inside a single top-level
+// directory, the shape `tar czf bundle.tar.gz ga4/` produces. Without
+// unwrapping, the wrapper name would silently become every entry's type
+// (first path segment = type). A bundle rooted at the archive top —
+// anything with a top-level file, such as the root index.md every real
+// bundle carries — is returned unchanged. The wrapper name is returned so
+// callers can tell the user what happened ("" when nothing was stripped).
+func StripWrapper(files map[string][]byte) (map[string][]byte, string) {
+	root := ""
+	for p := range files {
+		clean := path.Clean(strings.TrimPrefix(p, "./"))
+		if hiddenPath(clean) {
+			continue // tar noise (._*, .DS_Store) must not defeat detection
+		}
+		i := strings.Index(clean, "/")
+		if i < 0 {
+			return files, ""
+		}
+		if root == "" {
+			root = clean[:i]
+		} else if root != clean[:i] {
+			return files, ""
+		}
+	}
+	if root == "" {
+		return files, ""
+	}
+	out := make(map[string][]byte, len(files))
+	for p, content := range files {
+		clean := path.Clean(strings.TrimPrefix(p, "./"))
+		if hiddenPath(clean) {
+			continue
+		}
+		out[strings.TrimPrefix(clean, root+"/")] = content
+	}
+	return out, root
+}
+
+// hiddenPath reports whether any segment of the (cleaned) path starts
+// with a dot: .git trees, .DS_Store, and the AppleDouble ._* files macOS
+// tar interleaves. Never knowledge — skipped without a report, matching
+// how directory imports already treat dot entries.
+func hiddenPath(clean string) bool {
+	for _, seg := range strings.Split(clean, "/") {
+		if strings.HasPrefix(seg, ".") {
+			return true
+		}
+	}
+	return false
 }
 
 func fromBundleFile(clean string, content []byte) (*domain.Knowledge, error) {

--- a/internal/okf/bundle_test.go
+++ b/internal/okf/bundle_test.go
@@ -1,6 +1,9 @@
 package okf
 
 import (
+	"io/fs"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -33,8 +36,8 @@ func TestBundleNestedDirectories(t *testing.T) {
 			t.Errorf("bundle missing %s", path)
 		}
 	}
-	if idx := string(files["query/sales/index.md"]); !strings.Contains(idx, "[refunds/](/query/sales/refunds/index.md) — 1 concepts") ||
-		!strings.Contains(idx, "[月次売上](/query/sales/monthly-revenue.md)") {
+	if idx := string(files["query/sales/index.md"]); !strings.Contains(idx, "[refunds/](refunds/index.md) - 1 concept") ||
+		!strings.Contains(idx, "[月次売上](monthly-revenue.md)") {
 		t.Errorf("nested index wrong:\n%s", idx)
 	}
 	// Recommended types come first in the root index, free types after.
@@ -88,12 +91,14 @@ func TestBundleRoundTrip(t *testing.T) {
 
 // A foreign OKF bundle — free type directories, spelled frontmatter types,
 // non-markdown extras — imports with structure preserved: path wins, the
-// original type spelling survives in attrs, index.md and non-markdown
-// files are skipped.
+// original type spelling survives in attrs, the reserved index.md / log.md
+// files are skipped silently and non-markdown files with a report.
 func TestFromBundleForeign(t *testing.T) {
 	files := map[string][]byte{
-		"index.md":         []byte("---\ntype: Index\n---\n\n# my bundle\n"),
-		"tables/index.md":  []byte("---\ntype: Index\n---\n\n# tables\n"),
+		"index.md":         []byte("# my bundle\n"),
+		"log.md":           []byte("# Update Log\n\n## 2026-05-22\n* **Creation**: initial import.\n"),
+		"tables/index.md":  []byte("# tables\n"),
+		"tables/log.md":    []byte("# tables log\n"),
 		"tables/users.md":  []byte("---\ntype: Table\ntitle: users\n---\n\nUser table.\n"),
 		"datasets/ga4.md":  []byte("---\ntype: dataset\ntitle: GA4\n---\n"),
 		"notes/2026/q3.md": []byte("---\ntitle: Q3 notes\n---\n"), // no frontmatter type at all
@@ -128,5 +133,113 @@ func TestFromBundleForeign(t *testing.T) {
 	}
 	if doc := string(out["tables/users.md"]); !strings.Contains(doc, "type: Table") {
 		t.Errorf("re-export lost spelling:\n%s", doc)
+	}
+}
+
+// testdata/foreign-bundle mirrors the shape of the OKF sample bundles
+// (GoogleCloudPlatform/knowledge-catalog): nested type directories,
+// top-level resource/timestamp/custom keys, reserved index.md and log.md,
+// a non-markdown viz.html. Importing it must keep every frontmatter key a
+// bundle owns and re-export it at the same path with the same spelling.
+func TestFromBundleFixture(t *testing.T) {
+	files := map[string][]byte{}
+	root := filepath.Join("testdata", "foreign-bundle")
+	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return err
+		}
+		data, err := os.ReadFile(p)
+		files[filepath.ToSlash(rel)] = data
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	entries, skipped := FromBundle(files)
+	if len(skipped) != 1 || !strings.Contains(skipped[0], "viz.html") {
+		t.Errorf("skipped = %v, want only viz.html", skipped)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("entries = %d, want 3", len(entries))
+	}
+	byURI := map[string]domain.Knowledge{}
+	for _, e := range entries {
+		byURI[e.URI()] = e
+	}
+	aov := byURI["ochakai://references/metrics/avg_order_value"]
+	if aov.Attrs["resource"] != "https://example.com/metrics/aov" ||
+		aov.Attrs["owner"] != "analytics-team" ||
+		aov.Attrs[AttrOKFType] != "Reference" {
+		t.Errorf("references/metrics/avg_order_value attrs = %v", aov.Attrs)
+	}
+	if !strings.Contains(aov.Body, "SUM(order_total)") || !strings.Contains(aov.Body, "# Citations") {
+		t.Errorf("body mangled:\n%s", aov.Body)
+	}
+
+	out, err := Bundle(entries)
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc := string(out["references/metrics/avg_order_value.md"])
+	for _, want := range []string{
+		"type: Reference",
+		"resource: https://example.com/metrics/aov",
+		"owner: analytics-team",
+	} {
+		if !strings.Contains(doc, want) {
+			t.Errorf("re-export missing %q:\n%s", want, doc)
+		}
+	}
+	if doc := string(out["tables/orders_.md"]); !strings.Contains(doc, "type: BigQuery Table") ||
+		!strings.Contains(doc, "resource: https://bigquery.googleapis.com/v2/projects/demo/datasets/shop/tables/orders_*") {
+		t.Errorf("tables/orders_ re-export wrong:\n%s", doc)
+	}
+}
+
+// `tar czf bundle.tar.gz ga4/` wraps the bundle in one directory; without
+// unwrapping, "ga4" would silently become every entry's type.
+func TestStripWrapper(t *testing.T) {
+	wrapped := map[string][]byte{
+		"./ga4/index.md":       []byte("# ga4\n"),
+		"ga4/tables/events.md": []byte("---\ntype: BigQuery Table\n---\n"),
+		"._ga4":                []byte("apple double"), // macOS tar noise must not defeat detection
+		"ga4/.DS_Store":        []byte("finder noise"),
+	}
+	files, root := StripWrapper(wrapped)
+	if root != "ga4" {
+		t.Fatalf("root = %q, want ga4", root)
+	}
+	if _, ok := files["tables/events.md"]; !ok {
+		t.Errorf("paths not unwrapped: %v", files)
+	}
+	if len(files) != 2 {
+		t.Errorf("hidden files must be dropped on unwrap: %v", files)
+	}
+	if entries, skipped := FromBundle(wrapped); len(skipped) != 0 || len(entries) != 1 {
+		t.Errorf("hidden files must be skipped silently: skipped=%v entries=%d", skipped, len(entries))
+	}
+
+	// A bundle rooted at the top (root index.md is a top-level file) is
+	// left alone.
+	flat := map[string][]byte{
+		"index.md":         []byte("# bundle\n"),
+		"tables/events.md": []byte("---\ntype: BigQuery Table\n---\n"),
+	}
+	if _, root := StripWrapper(flat); root != "" {
+		t.Errorf("flat bundle wrongly unwrapped (root %q)", root)
+	}
+
+	// Two top-level directories: nothing to unwrap.
+	two := map[string][]byte{
+		"metric/a.md": []byte("x"),
+		"table/b.md":  []byte("x"),
+	}
+	if _, root := StripWrapper(two); root != "" {
+		t.Errorf("multi-dir bundle wrongly unwrapped (root %q)", root)
 	}
 }

--- a/internal/okf/okf.go
+++ b/internal/okf/okf.go
@@ -49,25 +49,41 @@ func displayType(k *domain.Knowledge) string {
 	return string(k.Type)
 }
 
-// frontmatter is the OKF frontmatter for one concept. Only "type" is
-// required by the spec; the rest are recommended keys plus ochakai
-// extension keys (consumers must tolerate unknown keys).
+// Version is the OKF spec version ochakai produces, declared in the
+// bundle-root index.md (SPEC §11).
+const Version = "0.1"
+
+// frontmatter is the OKF frontmatter for one concept: the required "type",
+// the recommended keys, and ochakai extension keys. Entry attrs are not
+// nested here — Document emits them as producer-defined top-level keys
+// (SPEC §4.1), so foreign extension keys round-trip in place.
 type frontmatter struct {
-	Type        string         `yaml:"type"`
-	ID          string         `yaml:"id,omitempty"`
-	Title       string         `yaml:"title"`
-	Description string         `yaml:"description,omitempty"`
-	Resource    string         `yaml:"resource,omitempty"`
-	Tags        []string       `yaml:"tags,omitempty"`
-	Timestamp   string         `yaml:"timestamp"`
-	Status      string         `yaml:"status"`
-	StatusNote  string         `yaml:"status_note,omitempty"`
-	CreatedBy   string         `yaml:"created_by"`
-	VerifiedBy  string         `yaml:"verified_by,omitempty"`
-	VerifiedAt  string         `yaml:"verified_at,omitempty"`
-	RejectedBy  string         `yaml:"rejected_by,omitempty"`
-	RejectedAt  string         `yaml:"rejected_at,omitempty"`
-	Attrs       map[string]any `yaml:"attrs,omitempty"`
+	Type        string   `yaml:"type"`
+	ID          string   `yaml:"id,omitempty"`
+	Title       string   `yaml:"title"`
+	Description string   `yaml:"description,omitempty"`
+	Resource    string   `yaml:"resource,omitempty"`
+	Tags        []string `yaml:"tags,omitempty"`
+	Timestamp   string   `yaml:"timestamp"`
+	Status      string   `yaml:"status"`
+	StatusNote  string   `yaml:"status_note,omitempty"`
+	CreatedBy   string   `yaml:"created_by"`
+	VerifiedBy  string   `yaml:"verified_by,omitempty"`
+	VerifiedAt  string   `yaml:"verified_at,omitempty"`
+	RejectedBy  string   `yaml:"rejected_by,omitempty"`
+	RejectedAt  string   `yaml:"rejected_at,omitempty"`
+}
+
+// reservedKeys are the frontmatter keys the envelope owns. An attr with a
+// reserved name is not exported as an extension key: the envelope value
+// wins ("attrs" is reserved so a literal attr of that name cannot
+// masquerade as the legacy nested form on re-import).
+var reservedKeys = map[string]bool{
+	"type": true, "id": true, "title": true, "description": true,
+	"resource": true, "tags": true, "timestamp": true, "status": true,
+	"status_note": true, "created_by": true, "verified_by": true,
+	"verified_at": true, "rejected_by": true, "rejected_at": true,
+	"attrs": true, AttrOKFType: true,
 }
 
 // Bundle renders every entry into a path→content map. Paths follow
@@ -152,22 +168,33 @@ func (d *dir) subdirNames(atRoot bool) []string {
 
 // writeIndexes emits index.md for this directory and recurses. prefix is
 // the bundle-relative directory path, "" for the root or "a/b/" below it.
+// Index files carry no frontmatter (SPEC §6) — except the bundle root,
+// where an okf_version declaration is the one permitted block (§11) — and
+// list their entries with relative links, as in the spec's examples.
 func (d *dir) writeIndexes(files map[string][]byte, prefix string) {
-	title := "ochakai knowledge bundle"
-	if prefix != "" {
-		title = strings.TrimSuffix(prefix, "/")
-	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "---\ntype: Index\ntitle: %s\n---\n\n# %s\n\n", title, title)
+	if prefix == "" {
+		fmt.Fprintf(&b, "---\nokf_version: %q\n---\n\n# ochakai knowledge bundle\n\n", Version)
+	} else {
+		fmt.Fprintf(&b, "# %s\n\n", strings.TrimSuffix(prefix, "/"))
+	}
 	for _, name := range d.subdirNames(prefix == "") {
-		fmt.Fprintf(&b, "- [%s/](/%s%s/index.md) — %d concepts\n", name, prefix, name, d.subdirs[name].count)
+		noun := "concepts"
+		if d.subdirs[name].count == 1 {
+			noun = "concept"
+		}
+		fmt.Fprintf(&b, "* [%s/](%s/index.md) - %d %s\n", name, name, d.subdirs[name].count, noun)
 	}
 	for _, e := range d.entries {
+		title := e.k.Title
+		if title == "" {
+			title = e.name
+		}
 		desc := e.k.Description
 		if desc != "" {
-			desc = " — " + desc
+			desc = " - " + desc
 		}
-		fmt.Fprintf(&b, "- [%s](/%s%s.md)%s\n", e.k.Title, prefix, e.name, desc)
+		fmt.Fprintf(&b, "* [%s](%s.md)%s\n", title, e.name, desc)
 	}
 	files[prefix+"index.md"] = []byte(b.String())
 	for name, sub := range d.subdirs {
@@ -187,11 +214,13 @@ func Document(k *domain.Knowledge) ([]byte, error) {
 		Status:      string(k.Status),
 		StatusNote:  k.StatusNote,
 		CreatedBy:   k.CreatedBy.Kind + ":" + k.CreatedBy.Name,
-		Attrs:       withoutOKFType(k.Attrs),
 	}
-	// "resource" is the canonical URI of the underlying asset; only table
-	// entries describe a physical resource.
-	if k.Type == domain.TypeTable {
+	// "resource" is the canonical URI of the underlying asset. An imported
+	// bundle carries it as attrs["resource"]; for ochakai's own table
+	// entries it is derived from the source attr.
+	if src, ok := k.Attrs["resource"].(string); ok && src != "" {
+		fm.Resource = src
+	} else if k.Type == domain.TypeTable {
 		if src, ok := k.Attrs["source"].(string); ok {
 			fm.Resource = src
 		}
@@ -213,10 +242,25 @@ func Document(k *domain.Knowledge) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Extension attrs go out as top-level keys, after the envelope keys.
+	// yaml.Marshal sorts map keys, so the output is deterministic.
+	extras := map[string]any{}
+	for key, v := range k.Attrs {
+		if !reservedKeys[key] {
+			extras[key] = v
+		}
+	}
+	var exYAML []byte
+	if len(extras) > 0 {
+		if exYAML, err = yaml.Marshal(extras); err != nil {
+			return nil, err
+		}
+	}
 
 	var b strings.Builder
 	b.WriteString("---\n")
 	b.Write(fmYAML)
+	b.Write(exYAML)
 	b.WriteString("---\n")
 	if body := strings.TrimSpace(k.Body); body != "" {
 		b.WriteString("\n" + body + "\n")
@@ -228,21 +272,6 @@ func Document(k *domain.Knowledge) ([]byte, error) {
 		}
 	}
 	return []byte(b.String()), nil
-}
-
-// withoutOKFType drops the AttrOKFType key (it is folded into the type
-// frontmatter by displayType) without mutating the entry's attrs.
-func withoutOKFType(attrs map[string]any) map[string]any {
-	if _, ok := attrs[AttrOKFType]; !ok {
-		return attrs
-	}
-	out := make(map[string]any, len(attrs)-1)
-	for key, v := range attrs {
-		if key != AttrOKFType {
-			out[key] = v
-		}
-	}
-	return out
 }
 
 // WriteTarGz streams the bundle as a gzipped tarball (the OKF-sanctioned

--- a/internal/okf/okf_test.go
+++ b/internal/okf/okf_test.go
@@ -124,11 +124,57 @@ func TestBundleLayoutAndIndexes(t *testing.T) {
 			t.Errorf("bundle missing %s (have %d files)", path, len(files))
 		}
 	}
-	if !strings.Contains(string(files["insight/index.md"]), "[売上の季節性](/insight/revenue-seasonality.md)") {
-		t.Errorf("type index missing concept link:\n%s", files["insight/index.md"])
+	// Index files list their contents with relative links and no
+	// frontmatter (SPEC §6); the root index alone declares okf_version
+	// (§11).
+	typeIdx := string(files["insight/index.md"])
+	if !strings.Contains(typeIdx, "[売上の季節性](revenue-seasonality.md)") {
+		t.Errorf("type index missing concept link:\n%s", typeIdx)
 	}
-	if !strings.Contains(string(files["index.md"]), "[insight/](/insight/index.md)") {
-		t.Errorf("root index missing type link:\n%s", files["index.md"])
+	if strings.HasPrefix(typeIdx, "---") {
+		t.Errorf("non-root index must not carry frontmatter:\n%s", typeIdx)
+	}
+	root := string(files["index.md"])
+	if !strings.Contains(root, "[insight/](insight/index.md)") {
+		t.Errorf("root index missing type link:\n%s", root)
+	}
+	if !strings.HasPrefix(root, "---\nokf_version: \"0.1\"\n---\n") {
+		t.Errorf("root index must declare okf_version:\n%s", root)
+	}
+}
+
+// Extension attrs export as producer-defined top-level frontmatter keys
+// (SPEC §4.1), not nested under an attrs map, so foreign consumers see
+// them and foreign bundles round-trip in place.
+func TestDocumentFlattensAttrs(t *testing.T) {
+	entries := sample()
+	doc, err := Document(&entries[0]) // attrs: {kind: seasonality}
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fm map[string]any
+	if err := yaml.Unmarshal([]byte(strings.SplitN(string(doc), "---\n", 3)[1]), &fm); err != nil {
+		t.Fatal(err)
+	}
+	if fm["kind"] != "seasonality" {
+		t.Errorf("extension key not at top level: %v", fm)
+	}
+	if _, ok := fm["attrs"]; ok {
+		t.Errorf("attrs must not nest:\n%s", doc)
+	}
+
+	// An attr whose name collides with an envelope key must not clobber it.
+	k := entries[0]
+	k.Attrs = map[string]any{"title": "偽タイトル", "kind": "seasonality"}
+	doc, err = Document(&k)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := yaml.Unmarshal([]byte(strings.SplitN(string(doc), "---\n", 3)[1]), &fm); err != nil {
+		t.Fatalf("colliding attr broke the frontmatter: %v\n%s", err, doc)
+	}
+	if fm["title"] != "売上の季節性" {
+		t.Errorf("envelope must win over a colliding attr: %v", fm["title"])
 	}
 }
 

--- a/internal/okf/parse.go
+++ b/internal/okf/parse.go
@@ -31,8 +31,20 @@ func Parse(doc []byte) (*domain.Knowledge, error) {
 // verbatim so bundle import can preserve the original spelling when the
 // bundle path names the type differently. k.Type is "" when no type slug
 // could be derived \u2014 the caller decides whether path context fills it in.
+//
+// Frontmatter keys fall into three groups. Envelope keys (type, id, title,
+// description, tags, status, status_note) map to Knowledge fields.
+// Server-owned keys (timestamp, created_by, verified_*, rejected_*) are
+// ignored \u2014 provenance comes from authentication. Everything else is a
+// producer-defined extension key (OKF SPEC \u00a74.1) and is kept as-is in
+// attrs, so foreign keys like "resource" or "owner" survive a round-trip
+// at their original top-level position. A nested "attrs" map (the shape
+// older ochakai exports wrote) is folded in for backward compatibility.
 func parseDoc(doc []byte) (*domain.Knowledge, string, error) {
 	s := strings.TrimPrefix(string(doc), "\ufeff")
+	// OKF specifies UTF-8 markdown but not line endings; normalize CRLF so
+	// the delimiter scan below works on bundles authored on Windows.
+	s = strings.ReplaceAll(s, "\r\n", "\n")
 	if !strings.HasPrefix(s, "---\n") {
 		return nil, "", fmt.Errorf("not an OKF document: missing --- frontmatter")
 	}
@@ -50,39 +62,92 @@ func parseDoc(doc []byte) (*domain.Knowledge, string, error) {
 		return nil, "", fmt.Errorf("not an OKF document: unterminated frontmatter")
 	}
 
-	var fm struct {
-		Type        string         `yaml:"type"`
-		ID          string         `yaml:"id"`
-		Title       string         `yaml:"title"`
-		Description string         `yaml:"description"`
-		Tags        []string       `yaml:"tags"`
-		Status      string         `yaml:"status"`
-		Attrs       map[string]any `yaml:"attrs"`
-	}
-	if err := yaml.Unmarshal([]byte(fmPart), &fm); err != nil {
+	var raw map[string]any
+	if err := yaml.Unmarshal([]byte(fmPart), &raw); err != nil {
 		return nil, "", fmt.Errorf("invalid frontmatter: %w", err)
 	}
-	typ, keepSpelling := typeFromOKF(fm.Type)
-	attrs := fm.Attrs
-	if keepSpelling != "" {
+	var str = func(key string) (string, error) {
+		v, ok := raw[key]
+		if !ok || v == nil {
+			return "", nil
+		}
+		s, ok := v.(string)
+		if !ok {
+			return "", fmt.Errorf("invalid frontmatter: %s is not a string", key)
+		}
+		return s, nil
+	}
+	var fm struct{ typ, id, title, description, status, statusNote string }
+	for _, f := range []struct {
+		key string
+		dst *string
+	}{
+		{"type", &fm.typ}, {"id", &fm.id}, {"title", &fm.title},
+		{"description", &fm.description}, {"status", &fm.status},
+		{"status_note", &fm.statusNote},
+	} {
+		var err error
+		if *f.dst, err = str(f.key); err != nil {
+			return nil, "", err
+		}
+	}
+	var tags []string
+	if v, ok := raw["tags"]; ok && v != nil {
+		list, ok := v.([]any)
+		if !ok {
+			return nil, "", fmt.Errorf("invalid frontmatter: tags is not a list")
+		}
+		for _, t := range list {
+			s, ok := t.(string)
+			if !ok {
+				return nil, "", fmt.Errorf("invalid frontmatter: tags is not a list of strings")
+			}
+			tags = append(tags, s)
+		}
+	}
+
+	var attrs map[string]any
+	setAttr := func(key string, v any) {
 		if attrs == nil {
 			attrs = map[string]any{}
 		}
-		attrs[AttrOKFType] = keepSpelling
+		attrs[key] = v
+	}
+	if legacy, ok := raw["attrs"].(map[string]any); ok {
+		for key, v := range legacy {
+			setAttr(key, v)
+		}
+	}
+	for key, v := range raw {
+		switch key {
+		case "type", "id", "title", "description", "tags", "status", "status_note":
+			// envelope, extracted above
+		case "timestamp", "created_by", "verified_by", "verified_at", "rejected_by", "rejected_at":
+			// server-owned, never from the payload
+		case "attrs":
+			// legacy nested extensions, folded in above
+		default:
+			setAttr(key, v)
+		}
+	}
+	typ, keepSpelling := typeFromOKF(fm.typ)
+	if keepSpelling != "" {
+		setAttr(AttrOKFType, keepSpelling)
 	}
 
 	trimmedBody, links := splitLinks(strings.TrimSpace(body))
 	return &domain.Knowledge{
 		Type:        typ,
-		ID:          fm.ID,
-		Title:       fm.Title,
-		Description: fm.Description,
-		Tags:        fm.Tags,
-		Status:      domain.Status(fm.Status),
+		ID:          fm.id,
+		Title:       fm.title,
+		Description: fm.description,
+		Tags:        tags,
+		Status:      domain.Status(fm.status),
+		StatusNote:  fm.statusNote,
 		Links:       links,
 		Attrs:       attrs,
 		Body:        trimmedBody,
-	}, fm.Type, nil
+	}, fm.typ, nil
 }
 
 // typeFromOKF maps an OKF frontmatter type to an ochakai type. Display

--- a/internal/okf/parse_test.go
+++ b/internal/okf/parse_test.go
@@ -30,8 +30,17 @@ func TestParseRoundTrip(t *testing.T) {
 		if !reflect.DeepEqual(got.Links, want.Links) {
 			t.Errorf("links = %v, want %v", got.Links, want.Links)
 		}
-		if len(got.Attrs) != len(want.Attrs) {
-			t.Errorf("attrs = %v, want %v", got.Attrs, want.Attrs)
+		wantAttrs := want.Attrs
+		if want.Type == domain.TypeTable {
+			// The exported document spells the source attr as a top-level
+			// resource: key too; importing keeps what the document says.
+			wantAttrs = map[string]any{"resource": want.Attrs["source"]}
+			for key, v := range want.Attrs {
+				wantAttrs[key] = v
+			}
+		}
+		if !reflect.DeepEqual(got.Attrs, wantAttrs) {
+			t.Errorf("attrs = %v, want %v", got.Attrs, wantAttrs)
 		}
 		if wantBody := "12月は+40%が通常。"; want.Body != "" && got.Body != wantBody {
 			t.Errorf("body = %q, want %q", got.Body, wantBody)
@@ -109,6 +118,77 @@ func TestParseFreeTypes(t *testing.T) {
 	}
 	if strings.Contains(string(doc), AttrOKFType) {
 		t.Errorf("okf_type must fold into the type key, not export as an attr:\n%s", doc)
+	}
+}
+
+// Unknown top-level frontmatter keys are producer-defined extensions
+// (SPEC §4.1): they land in attrs as-is and export back to the top level,
+// so a foreign bundle's resource/owner keys survive a round-trip in place.
+func TestParseKeepsUnknownKeys(t *testing.T) {
+	k, err := Parse([]byte(`---
+type: Reference
+title: Average Pageviews
+resource: https://developers.google.com/analytics/bigquery/basic-queries
+owner: analytics-team
+timestamp: '2026-05-28T22:51:43+00:00'
+created_by: 'agent:someone'
+---
+
+Body.
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if k.Attrs["resource"] != "https://developers.google.com/analytics/bigquery/basic-queries" ||
+		k.Attrs["owner"] != "analytics-team" {
+		t.Errorf("unknown keys not kept: %v", k.Attrs)
+	}
+	for _, serverOwned := range []string{"timestamp", "created_by"} {
+		if _, ok := k.Attrs[serverOwned]; ok {
+			t.Errorf("server-owned key %s leaked into attrs: %v", serverOwned, k.Attrs)
+		}
+	}
+	if k.CreatedBy.Name != "" {
+		t.Errorf("created_by must come from authentication, not the payload: %v", k.CreatedBy)
+	}
+
+	doc, err := Document(k)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"resource: https://developers.google.com/analytics/bigquery/basic-queries",
+		"owner: analytics-team",
+	} {
+		if !strings.Contains(string(doc), want) {
+			t.Errorf("re-export missing %q:\n%s", want, doc)
+		}
+	}
+	if strings.Contains(string(doc), "attrs:") {
+		t.Errorf("re-export must not nest attrs:\n%s", doc)
+	}
+}
+
+func TestParseStatusNoteRoundTrip(t *testing.T) {
+	k, err := Parse([]byte("---\ntype: insight\nid: dup\ntitle: 重複\nstatus: rejected\nstatus_note: 既存と重複\n---\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if k.StatusNote != "既存と重複" {
+		t.Errorf("status_note = %q", k.StatusNote)
+	}
+	if _, ok := k.Attrs["status_note"]; ok {
+		t.Errorf("status_note is an envelope key, not an attr: %v", k.Attrs)
+	}
+}
+
+func TestParseNormalizesCRLF(t *testing.T) {
+	k, err := Parse([]byte("---\r\ntype: term\r\nid: churn\r\ntitle: 解約\r\n---\r\n\r\n本文。\r\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if k.Type != domain.TypeTerm || k.Title != "解約" || k.Body != "本文。" {
+		t.Errorf("CRLF document mangled: %+v", k)
 	}
 }
 

--- a/internal/okf/testdata/foreign-bundle/datasets/shop.md
+++ b/internal/okf/testdata/foreign-bundle/datasets/shop.md
@@ -1,0 +1,11 @@
+---
+type: BigQuery Dataset
+resource: https://bigquery.googleapis.com/v2/projects/demo/datasets/shop
+title: Demo shop dataset
+description: Synthetic e-commerce data for the demo shop.
+tags:
+- ecommerce
+timestamp: '2026-05-28T22:51:43+00:00'
+---
+
+Synthetic e-commerce data for the demo shop.

--- a/internal/okf/testdata/foreign-bundle/index.md
+++ b/internal/okf/testdata/foreign-bundle/index.md
@@ -1,0 +1,5 @@
+# Subdirectories
+
+* [datasets](datasets/index.md) - The demo shop dataset.
+* [references](references/index.md) - Metric definitions.
+* [tables](tables/index.md) - Table documentation.

--- a/internal/okf/testdata/foreign-bundle/log.md
+++ b/internal/okf/testdata/foreign-bundle/log.md
@@ -1,0 +1,4 @@
+# Directory Update Log
+
+## 2026-05-22
+* **Creation**: Established the bundle.

--- a/internal/okf/testdata/foreign-bundle/references/index.md
+++ b/internal/okf/testdata/foreign-bundle/references/index.md
@@ -1,0 +1,3 @@
+# References
+
+* [metrics](metrics/index.md) - Metric definitions.

--- a/internal/okf/testdata/foreign-bundle/references/metrics/avg_order_value.md
+++ b/internal/okf/testdata/foreign-bundle/references/metrics/avg_order_value.md
@@ -1,0 +1,19 @@
+---
+type: Reference
+resource: https://example.com/metrics/aov
+title: Average Order Value
+description: The average revenue per order.
+tags:
+- metric
+timestamp: '2026-05-28T22:51:43+00:00'
+owner: analytics-team
+---
+
+The average revenue per order.
+
+```sql
+SUM(order_total) / COUNT(DISTINCT order_id)
+```
+
+# Citations
+- https://example.com/metrics/aov

--- a/internal/okf/testdata/foreign-bundle/references/metrics/index.md
+++ b/internal/okf/testdata/foreign-bundle/references/metrics/index.md
@@ -1,0 +1,3 @@
+# Metrics
+
+* [Average Order Value](avg_order_value.md) - The average revenue per order.

--- a/internal/okf/testdata/foreign-bundle/tables/index.md
+++ b/internal/okf/testdata/foreign-bundle/tables/index.md
@@ -1,0 +1,3 @@
+# Tables
+
+* [Orders table](orders_.md) - Sharded orders export.

--- a/internal/okf/testdata/foreign-bundle/tables/orders_.md
+++ b/internal/okf/testdata/foreign-bundle/tables/orders_.md
@@ -1,0 +1,20 @@
+---
+type: BigQuery Table
+resource: https://bigquery.googleapis.com/v2/projects/demo/datasets/shop/tables/orders_*
+title: Orders table
+description: Sharded orders export.
+tags:
+- orders
+- BigQuery
+timestamp: '2026-05-28T22:53:05+00:00'
+---
+
+# Overview
+The `orders_YYYYMMDD` sharded table.
+
+# Metrics
+- [Average Order Value](../references/metrics/avg_order_value.md) — The average revenue per order.
+
+# Schema
+- `order_id` (STRING): Unique order identifier.
+- `order_total` (NUMERIC): Order total in JPY.

--- a/internal/okf/testdata/foreign-bundle/viz.html
+++ b/internal/okf/testdata/foreign-bundle/viz.html
@@ -1,0 +1,1 @@
+<html><body>not knowledge</body></html>


### PR DESCRIPTION
## 背景

本家 [OKF SPEC](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)(v0.1)と実物の GA4 サンプルバンドルで入出力を突き合わせたところ、往復でデータが失われる・仕様違反の出力になる問題が見つかった(#28 のフォローアップ)。

## 変更点

### 未知の frontmatter キーを「そのまま」往復させる
- インポート: 未知のトップレベルキー(`resource`、`owner` など)はプロデューサ拡張キー(SPEC §4.1)として**値ごと attrs に保存**。従来は読み捨てており、GA4 バンドルの全 concept が持つ `resource:` が消えていた。
- エクスポート: attrs を**トップレベル frontmatter キーとして書き戻す**。`attrs:` のネストは廃止(旧形式は読み込みで畳み込むので後方互換)。封筒キーと同名の attr は封筒が勝つ。
- `status_note` を封筒キーとしてパース(`get` → 編集 → `update` で却下理由が消えるのを修正)。

### エクスポートの仕様準拠
- index.md から frontmatter を撤去(SPEC §6「Index files contain no frontmatter」)。ルートのみ `okf_version: "0.1"` を宣言(§11)。リンクは相対パス・仕様例の `* [Title](url) - desc` 形式に。

### インポートの堅牢化
- `log.md` は index.md と並ぶ予約ファイル(§3)として黙ってスキップ。
- 単一ディレクトリに包まれたアーカイブ(`tar czf out.tgz ga4/`)を自動アンラップ+通知。従来は包み名が全エントリのタイプになっていた。`ochakai import --keep-root` で抑止可。
- 隠しパス(`.git`、macOS tar の `._*`、`.DS_Store`)を黙ってスキップ(ディレクトリ走査と同じ扱いに統一)。
- CRLF を LF に正規化(Windows 産バンドルが全ファイル不正扱いになっていた)。

## 検証

- 実物の GA4 バンドルで import → export: `resource` / 独自キーが元の位置・表記のまま復元、11 エントリが同一パスで往復。
- macOS で `tar czf ga4-wrapped.tar.gz ga4/` した実アーカイブを `import --dry-run`: アンラップ通知の上で 11 エントリ、スキップは `viz.html` の 1 件のみ。
- knowledge-catalog のサンプルを模した `internal/okf/testdata/foreign-bundle` フィクスチャテストを追加し、上記すべてに回帰の網を張った。
- 設計ドキュメント 0005 §3.3 の往復規則表を更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)