### PR TITLE
Grow the sample web UI into a small catalog UI

### DIFF
--- a/examples/webui/README.md
+++ b/examples/webui/README.md
@@ -1,0 +1,42 @@
+# Sample web UI
+
+A browser UI for the ochakai REST API ([api/openapi.yaml](../../api/openapi.yaml)),
+in the spirit of metadata catalogs like OpenMetadata but with ochakai's
+constraints kept on purpose: **one self-contained `index.html`** — no build
+step, no framework, no CDN — so it stays easy to read, fork, and rebrand.
+It currently covers the whole API surface:
+
+- **Explore** — search with type / status / tag filters, plus the
+  *verification age* feed (`sort=verified_at`, the canary feed for
+  re-checking golden queries).
+- **Entry pages** — overview (markdown body), attributes (SQL et al.),
+  links between entries, and usage counts; with the status workflow as
+  one-click actions (verify / deprecate / reject with a `status_note`,
+  soft-delete).
+- **Create & edit** — drafts by default, hierarchical IDs, attrs as JSON.
+- **Compile** — metrics + dimensions + filters + time grain → SQL, with
+  verified golden queries shown alongside.
+- **Export OKF** — one click, your knowledge is yours.
+
+This started as a minimal sample and is growing toward a standalone web UI.
+It will stay a thin client of the public REST API — anything the UI can do,
+an agent can do — and it will stay simple; features that need server-side
+state or an LLM belong elsewhere.
+
+## Run it
+
+Locally, against the compose stack from the repo root:
+
+```sh
+docker compose -f deploy/compose.yaml up      # ochakai on :8080
+PORT=8090 OCHAKAI_URL=http://localhost:8080 go run ./examples/webui
+```
+
+Then open http://localhost:8090. `main.go` serves the static page and
+reverse-proxies `/api/v1` (and `/mcp`) to ochakai — same-origin, so no CORS.
+On Cloud Run it attaches this service's identity token, so the ochakai
+deployment stays IAM-restricted and browser users are recorded as
+`agent:<sa-email>` (see the comment in [main.go](main.go)).
+
+Without `OCHAKAI_URL` it serves the static page only; the page then calls
+whatever base URL you set via the chip in the top-right corner.

--- a/examples/webui/index.html
+++ b/examples/webui/index.html
@@ -114,6 +114,10 @@
   }
   input:focus, select:focus, textarea:focus { outline: 2px solid var(--accent-weak); border-color: var(--accent); }
   textarea { resize: vertical; }
+  /* 16px inputs on touch-sized screens so iOS Safari doesn't zoom on focus. */
+  @media (max-width: 800px) {
+    input[type=text], input[type=number], select, textarea { font-size: 16px; }
+  }
   .btn {
     font: inherit; font-weight: 500; cursor: pointer; border-radius: 8px;
     border: 1px solid var(--border); background: var(--surface); color: var(--text);
@@ -171,16 +175,24 @@
     margin-top: .7rem; border-left: 3px solid var(--border); padding: .1rem .8rem;
     color: var(--muted); font-size: .9rem;
   }
-  .tabs { display: flex; gap: .2rem; border-bottom: 1px solid var(--border); margin: 1.1rem 0 1rem; }
+  .tabs { display: flex; gap: .2rem; border-bottom: 1px solid var(--border); margin: 1.1rem 0 1rem; overflow-x: auto; }
   .tabs button {
     font: inherit; font-weight: 500; background: none; border: none; cursor: pointer;
     color: var(--muted); padding: .45rem .8rem; border-bottom: 2px solid transparent; margin-bottom: -1px;
+    white-space: nowrap;
   }
   .tabs button:hover { color: var(--text); }
   .tabs button.active { color: var(--accent-strong); border-bottom-color: var(--accent); }
   table.kv { border-collapse: collapse; width: 100%; }
   table.kv td { border-bottom: 1px solid var(--border); padding: .45rem .6rem .45rem 0; vertical-align: top; }
   table.kv td.k { color: var(--muted); width: 11rem; white-space: nowrap; }
+  /* Narrow screens: stack key over value so wide values (SQL) get the full width. */
+  @media (max-width: 640px) {
+    table.kv, table.kv tbody, table.kv tr, table.kv td { display: block; width: auto; }
+    table.kv td { border-bottom: none; padding: .1rem 0; }
+    table.kv td.k { padding-top: .55rem; }
+    table.kv tr { border-bottom: 1px solid var(--border); padding-bottom: .45rem; }
+  }
   .stat-tiles { display: grid; grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr)); gap: .8rem; max-width: 42rem; }
   .stat-tiles .tile { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: .9rem 1rem; }
   .tile .num { font-size: 1.7rem; font-weight: 700; }

--- a/examples/webui/index.html
+++ b/examples/webui/index.html
@@ -1,73 +1,852 @@
 <!doctype html>
-<!-- Minimal sample UI for the ochakai REST API (api/openapi.yaml).
-     Serve from anywhere and point it at your ochakai instance; this is a
-     starting point for building your own UI, not a product. -->
+<!-- Sample web UI for the ochakai REST API (api/openapi.yaml).
+     A single self-contained file: no build step, no framework, no CDN.
+     Serve it from anywhere (main.go proxies /api/v1 to ochakai) and it
+     covers the whole API surface — search, entry details with usage,
+     create/edit with the draft → verified workflow, SQL compilation, and
+     OKF export. A starting point for building your own UI. -->
 <html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>ochakai</title>
 <style>
-  body { font-family: system-ui, sans-serif; max-width: 60rem; margin: 2rem auto; padding: 0 1rem; }
-  input, select, button { font: inherit; padding: .4rem .6rem; }
-  #q { width: 24rem; max-width: 60vw; }
-  .hit { border: 1px solid #ccc; border-radius: 8px; padding: .8rem 1rem; margin: .8rem 0; }
-  .meta { color: #666; font-size: .85rem; }
-  .badge { border-radius: 999px; padding: .05rem .6rem; font-size: .75rem; border: 1px solid #999; }
-  .verified { background: #e6f4ea; border-color: #34a853; }
-  pre { background: #f6f6f6; padding: .6rem; overflow-x: auto; }
+  :root {
+    --bg: #f6f8f6;
+    --surface: #ffffff;
+    --border: #e2e7e2;
+    --text: #1d2721;
+    --muted: #66736b;
+    --accent: #2e7d5b;
+    --accent-strong: #226548;
+    --accent-weak: #e7f3ec;
+    --code-bg: #f3f5f3;
+    --shadow: 0 1px 2px rgba(29, 39, 33, .05);
+    --shadow-hover: 0 2px 8px rgba(29, 39, 33, .10);
+    --draft-fg: #8a6116; --draft-bg: #fdf4dd; --draft-bd: #e5c877;
+    --verified-fg: #1e6b43; --verified-bg: #e3f4e9; --verified-bd: #7cc39a;
+    --deprecated-fg: #9a4e12; --deprecated-bg: #fcebdd; --deprecated-bd: #e3a370;
+    --rejected-fg: #a03434; --rejected-bg: #fbe7e7; --rejected-bd: #dd9494;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #141815;
+      --surface: #1c211d;
+      --border: #313832;
+      --text: #e4e9e5;
+      --muted: #98a49c;
+      --accent: #5cb388;
+      --accent-strong: #7cc7a0;
+      --accent-weak: #24352b;
+      --code-bg: #242a25;
+      --shadow: none;
+      --shadow-hover: none;
+      --draft-fg: #e0bb64; --draft-bg: #37301c; --draft-bd: #6d5c2c;
+      --verified-fg: #82d2a5; --verified-bg: #1e3327; --verified-bd: #35624a;
+      --deprecated-fg: #e8a465; --deprecated-bg: #382a1d; --deprecated-bd: #6d4d2e;
+      --rejected-fg: #e08e8e; --rejected-bg: #382020; --rejected-bd: #6d3535;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--text);
+    font: 15px/1.55 system-ui, -apple-system, "Segoe UI", sans-serif;
+  }
+  a { color: var(--accent-strong); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  code, pre, .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  pre {
+    background: var(--code-bg); border: 1px solid var(--border); border-radius: 8px;
+    padding: .7rem .9rem; overflow-x: auto; font-size: .86em; line-height: 1.5; margin: .6rem 0;
+  }
+  code { background: var(--code-bg); border-radius: 4px; padding: .1em .35em; font-size: .88em; }
+  pre code { background: none; padding: 0; }
+
+  /* ---- top bar ---- */
+  .topbar {
+    display: flex; align-items: center; gap: 1.2rem;
+    background: var(--surface); border-bottom: 1px solid var(--border);
+    padding: 0 1.2rem; height: 3.3rem; position: sticky; top: 0; z-index: 10;
+  }
+  .brand { font-weight: 700; font-size: 1.08rem; color: var(--text); display: flex; align-items: center; gap: .45rem; }
+  .brand:hover { text-decoration: none; }
+  .topnav { display: flex; gap: .2rem; align-self: stretch; }
+  .topnav a {
+    display: flex; align-items: center; padding: 0 .8rem; color: var(--muted);
+    border-bottom: 2px solid transparent; margin-bottom: -1px; font-weight: 500;
+  }
+  .topnav a:hover { color: var(--text); text-decoration: none; }
+  .topnav a.active { color: var(--accent-strong); border-bottom-color: var(--accent); }
+  .topbar .spacer { flex: 1; }
+  .server-chip {
+    font-size: .8rem; color: var(--muted); border: 1px solid var(--border); border-radius: 999px;
+    padding: .2rem .7rem; background: none; cursor: pointer; font-family: inherit;
+    max-width: 16rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .server-chip:hover { border-color: var(--accent); color: var(--text); }
+
+  /* ---- layout ---- */
+  main { max-width: 68rem; margin: 0 auto; padding: 1.4rem 1.2rem 4rem; }
+  .explore { display: grid; grid-template-columns: 14rem 1fr; gap: 1.6rem; align-items: start; }
+  @media (max-width: 760px) { .explore { grid-template-columns: 1fr; } .rail { position: static; } }
+  .rail { position: sticky; top: 4.6rem; }
+  .rail h3 {
+    font-size: .72rem; text-transform: uppercase; letter-spacing: .07em;
+    color: var(--muted); margin: 1.2rem 0 .45rem;
+  }
+  .rail h3:first-child { margin-top: .2rem; }
+  .rail label.check { display: flex; align-items: center; gap: .45rem; padding: .17rem 0; cursor: pointer; font-size: .9rem; }
+  .rail input[type=checkbox] { accent-color: var(--accent); }
+  .count { color: var(--muted); font-size: .8rem; margin-left: auto; }
+
+  /* ---- inputs & buttons ---- */
+  input[type=text], input[type=number], select, textarea {
+    font: inherit; color: inherit; background: var(--surface);
+    border: 1px solid var(--border); border-radius: 8px; padding: .45rem .65rem; width: 100%;
+  }
+  input:focus, select:focus, textarea:focus { outline: 2px solid var(--accent-weak); border-color: var(--accent); }
+  textarea { resize: vertical; }
+  .btn {
+    font: inherit; font-weight: 500; cursor: pointer; border-radius: 8px;
+    border: 1px solid var(--border); background: var(--surface); color: var(--text);
+    padding: .42rem .85rem; display: inline-flex; align-items: center; gap: .4rem;
+  }
+  .btn:hover { border-color: var(--accent); color: var(--accent-strong); }
+  .btn.primary { background: var(--accent); border-color: var(--accent); color: #fff; }
+  .btn.primary:hover { background: var(--accent-strong); color: #fff; }
+  .btn.danger:hover { border-color: var(--rejected-bd); color: var(--rejected-fg); }
+  .btn.small { padding: .22rem .6rem; font-size: .84rem; }
+
+  .searchbox { display: flex; gap: .6rem; margin-bottom: 1rem; }
+  .searchbox input { font-size: 1rem; padding: .55rem .8rem; }
+
+  /* ---- cards ---- */
+  .card {
+    background: var(--surface); border: 1px solid var(--border); border-radius: 10px;
+    padding: .85rem 1.1rem; margin: 0 0 .7rem; box-shadow: var(--shadow);
+  }
+  .card:hover { box-shadow: var(--shadow-hover); border-color: color-mix(in srgb, var(--accent) 45%, var(--border)); }
+  .card .head { display: flex; align-items: center; gap: .55rem; flex-wrap: wrap; }
+  .card .head a.title { font-weight: 600; font-size: 1.02rem; color: var(--text); }
+  .card .head a.title:hover { color: var(--accent-strong); }
+  .type-ico { font-size: 1rem; }
+  .card .meta { color: var(--muted); font-size: .8rem; margin-top: .15rem; }
+  .card .desc { margin-top: .3rem; font-size: .92rem; }
+  .card pre { margin-bottom: 0; }
+
+  .badge {
+    border-radius: 999px; padding: .06rem .6rem; font-size: .74rem; font-weight: 600;
+    border: 1px solid var(--border); color: var(--muted); white-space: nowrap;
+  }
+  .badge.draft { color: var(--draft-fg); background: var(--draft-bg); border-color: var(--draft-bd); }
+  .badge.verified { color: var(--verified-fg); background: var(--verified-bg); border-color: var(--verified-bd); }
+  .badge.deprecated { color: var(--deprecated-fg); background: var(--deprecated-bg); border-color: var(--deprecated-bd); }
+  .badge.rejected { color: var(--rejected-fg); background: var(--rejected-bg); border-color: var(--rejected-bd); }
+  .tag {
+    border-radius: 999px; padding: .04rem .55rem; font-size: .76rem;
+    background: var(--accent-weak); color: var(--accent-strong);
+  }
+  .empty { color: var(--muted); text-align: center; padding: 2.5rem 0; }
+  .error-banner {
+    background: var(--rejected-bg); border: 1px solid var(--rejected-bd); color: var(--rejected-fg);
+    border-radius: 8px; padding: .6rem .9rem; margin: .8rem 0; white-space: pre-wrap; word-break: break-word;
+  }
+
+  /* ---- detail ---- */
+  .crumbs { color: var(--muted); font-size: .84rem; margin-bottom: .5rem; }
+  .crumbs a { color: var(--muted); }
+  .detail-head { display: flex; align-items: center; gap: .7rem; flex-wrap: wrap; }
+  .detail-head h1 { font-size: 1.45rem; margin: 0; }
+  .detail-head .actions { margin-left: auto; display: flex; gap: .45rem; flex-wrap: wrap; }
+  .provenance { color: var(--muted); font-size: .84rem; margin: .45rem 0 0; }
+  .status-note {
+    margin-top: .7rem; border-left: 3px solid var(--border); padding: .1rem .8rem;
+    color: var(--muted); font-size: .9rem;
+  }
+  .tabs { display: flex; gap: .2rem; border-bottom: 1px solid var(--border); margin: 1.1rem 0 1rem; }
+  .tabs button {
+    font: inherit; font-weight: 500; background: none; border: none; cursor: pointer;
+    color: var(--muted); padding: .45rem .8rem; border-bottom: 2px solid transparent; margin-bottom: -1px;
+  }
+  .tabs button:hover { color: var(--text); }
+  .tabs button.active { color: var(--accent-strong); border-bottom-color: var(--accent); }
+  table.kv { border-collapse: collapse; width: 100%; }
+  table.kv td { border-bottom: 1px solid var(--border); padding: .45rem .6rem .45rem 0; vertical-align: top; }
+  table.kv td.k { color: var(--muted); width: 11rem; white-space: nowrap; }
+  .stat-tiles { display: grid; grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr)); gap: .8rem; max-width: 42rem; }
+  .stat-tiles .tile { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: .9rem 1rem; }
+  .tile .num { font-size: 1.7rem; font-weight: 700; }
+  .tile .lbl { color: var(--muted); font-size: .82rem; }
+
+  /* ---- markdown body ---- */
+  .md h1, .md h2, .md h3 { line-height: 1.3; margin: 1.1em 0 .4em; }
+  .md h1 { font-size: 1.3rem; } .md h2 { font-size: 1.15rem; } .md h3 { font-size: 1rem; }
+  .md p { margin: .5em 0; }
+  .md ul, .md ol { margin: .4em 0; padding-left: 1.5em; }
+
+  /* ---- forms ---- */
+  .form { max-width: 46rem; }
+  .form .row { display: grid; grid-template-columns: 1fr 1fr; gap: .9rem; }
+  @media (max-width: 620px) { .form .row { grid-template-columns: 1fr; } }
+  .form .field { margin-bottom: .9rem; }
+  .form label.top { display: block; font-size: .84rem; font-weight: 600; margin-bottom: .25rem; }
+  .form .hint { color: var(--muted); font-size: .78rem; margin-top: .2rem; }
+  .filters-list .filter-row { display: grid; grid-template-columns: 1fr 6.5rem 1fr 2.2rem; gap: .5rem; margin-bottom: .5rem; }
+
+  .section-title { font-size: 1.25rem; font-weight: 700; margin: .2rem 0 1rem; }
+  .toolbar { display: flex; align-items: center; gap: .6rem; margin-bottom: 1rem; flex-wrap: wrap; }
+  .toolbar .grow { flex: 1; }
+
+  #toast {
+    position: fixed; bottom: 1.2rem; left: 50%; transform: translateX(-50%);
+    background: var(--text); color: var(--bg); border-radius: 8px; padding: .5rem 1rem;
+    font-size: .9rem; opacity: 0; transition: opacity .25s; pointer-events: none; z-index: 100;
+  }
+  #toast.show { opacity: .95; }
 </style>
 </head>
 <body>
-<h1>ochakai</h1>
-<p>
-  <input id="base" size="24" title="ochakai base URL">
-</p>
-<p>
-  <input id="q" placeholder="search knowledge…">
-  <select id="type">
-    <option value="">all types</option>
-    <option>metric</option><option>query</option><option>insight</option>
-    <option>term</option><option>table</option>
-  </select>
-  <button onclick="search()">Search</button>
-</p>
-<div id="results"></div>
+<header class="topbar">
+  <a class="brand" href="#/">🍵 ochakai</a>
+  <nav class="topnav" id="topnav">
+    <a href="#/" data-route="explore">Explore</a>
+    <a href="#/compile" data-route="compile">Compile</a>
+    <a href="#/new" data-route="new">New entry</a>
+  </nav>
+  <span class="spacer"></span>
+  <a class="btn small" id="export-link" title="Download the knowledge base as an OKF bundle (tar.gz)">Export OKF</a>
+  <button class="server-chip mono" id="server-chip" title="ochakai base URL (click to change)"></button>
+</header>
+<main id="view"></main>
+<div id="toast"></div>
+
 <script>
-async function api(path) {
-  const base = document.getElementById('base').value.replace(/\/$/, '');
-  const res = await fetch(base + path);
-  if (!res.ok) throw new Error(await res.text());
-  return res.json();
+'use strict';
+
+/* ============================== helpers ============================== */
+
+const $ = s => document.querySelector(s);
+const view = $('#view');
+
+function esc(s) {
+  return String(s ?? '').replace(/[&<>"']/g, c =>
+    ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
 }
-async function search() {
-  const q = encodeURIComponent(document.getElementById('q').value);
-  const type = document.getElementById('type').value;
-  const out = document.getElementById('results');
-  out.textContent = 'searching…';
-  try {
-    const { hits } = await api(`/api/v1/knowledge?q=${q}${type ? '&type=' + type : ''}`);
-    out.innerHTML = '';
-    if (!hits.length) { out.textContent = 'no results'; return; }
-    for (const h of hits) {
-      const div = document.createElement('div');
-      div.className = 'hit';
-      const badge = `<span class="badge ${h.status === 'verified' ? 'verified' : ''}">${h.status}</span>`;
-      div.innerHTML = `<strong>${esc(h.title)}</strong> ${badge}
-        <div class="meta">ochakai://${h.type}/${h.id} · by ${h.created_by.kind}:${esc(h.created_by.name)}</div>
-        <div>${esc(h.description || '')}</div>` +
-        (h.attrs && h.attrs.sql ? `<pre>${esc(h.attrs.sql)}</pre>` : '') +
-        (h.body ? `<pre>${esc(h.body)}</pre>` : '');
-      out.appendChild(div);
+
+const TYPE_ICONS = { metric: '📊', query: '🧾', insight: '💡', term: '📖', table: '🗃️' };
+const icon = t => TYPE_ICONS[t] || '📄';
+const KNOWN_TYPES = Object.keys(TYPE_ICONS);
+const STATUSES = ['draft', 'verified', 'deprecated', 'rejected'];
+
+function fmtDate(s) {
+  if (!s) return '';
+  const d = new Date(s);
+  return isNaN(d) ? s : d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}
+function actorStr(a) {
+  if (!a || !a.name) return '';
+  return (a.kind === 'agent' ? '🤖 ' : '👤 ') + a.name;
+}
+// URL path for an entry; hierarchical IDs keep their slashes.
+function idPath(type, id) {
+  return encodeURIComponent(type) + '/' + String(id).split('/').map(encodeURIComponent).join('/');
+}
+const entryHash = e => '#/k/' + idPath(e.type, e.id);
+
+/* ---- tiny markdown renderer (headings, lists, code, links, emphasis) ---- */
+function md(src) {
+  const lines = String(src ?? '').split('\n');
+  let out = '', inCode = false, inList = null, para = [];
+  const inline = s => esc(s)
+    .replace(/`([^`]+)`/g, '<code>$1</code>')
+    .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+    .replace(/(^|\W)\*([^*\n]+)\*(?=\W|$)/g, '$1<em>$2</em>')
+    .replace(/\[([^\]]+)\]\((https?:[^)\s]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>');
+  const flushPara = () => { if (para.length) { out += '<p>' + inline(para.join(' ')) + '</p>'; para = []; } };
+  const flushList = () => { if (inList) { out += `</${inList}>`; inList = null; } };
+  for (const line of lines) {
+    if (/^```/.test(line)) {
+      flushPara(); flushList();
+      out += inCode ? '</code></pre>' : '<pre><code>';
+      inCode = !inCode;
+      continue;
     }
-  } catch (e) { out.textContent = 'error: ' + e.message; }
+    if (inCode) { out += esc(line) + '\n'; continue; }
+    const h = line.match(/^(#{1,3})\s+(.*)/);
+    if (h) { flushPara(); flushList(); out += `<h${h[1].length}>${inline(h[2])}</h${h[1].length}>`; continue; }
+    const li = line.match(/^\s*([-*]|\d+\.)\s+(.*)/);
+    if (li) {
+      flushPara();
+      const want = /^\d/.test(li[1]) ? 'ol' : 'ul';
+      if (inList !== want) { flushList(); out += `<${want}>`; inList = want; }
+      out += '<li>' + inline(li[2]) + '</li>';
+      continue;
+    }
+    if (!line.trim()) { flushPara(); flushList(); continue; }
+    para.push(line.trim());
+  }
+  if (inCode) out += '</code></pre>';
+  flushPara(); flushList();
+  return out;
 }
-function esc(s) { return String(s).replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c])); }
-document.getElementById('q').addEventListener('keydown', e => { if (e.key === 'Enter') search(); });
-// Same origin by default (works when served by main.go, which proxies
-// /api/v1 to ochakai); localhost fallback for file:// use.
-document.getElementById('base').value =
-  location.protocol.startsWith('http') ? location.origin : 'http://localhost:8080';
+
+/* ============================== api ============================== */
+
+function baseURL() {
+  return (localStorage.getItem('ochakai.base') ||
+    (location.protocol.startsWith('http') ? location.origin : 'http://localhost:8080')).replace(/\/$/, '');
+}
+function refreshServerChip() {
+  $('#server-chip').textContent = baseURL();
+  $('#export-link').href = baseURL() + '/api/v1/export';
+}
+$('#server-chip').addEventListener('click', () => {
+  const v = prompt('ochakai base URL', baseURL());
+  if (v !== null) {
+    localStorage.setItem('ochakai.base', v.trim().replace(/\/$/, ''));
+    refreshServerChip();
+    route();
+  }
+});
+
+async function api(path, opts = {}) {
+  const init = { method: opts.method || 'GET' };
+  if (opts.body !== undefined) {
+    init.headers = { 'Content-Type': 'application/json' };
+    init.body = JSON.stringify(opts.body);
+  }
+  const res = await fetch(baseURL() + path, init);
+  if (!res.ok) {
+    let msg = res.status + ' ' + res.statusText;
+    try {
+      const text = await res.text();
+      try { msg = JSON.parse(text).error || text; } catch { msg = text || msg; }
+    } catch { /* keep status text */ }
+    throw new Error(msg);
+  }
+  return res.status === 204 ? null : res.json();
+}
+
+function toast(msg) {
+  const t = $('#toast');
+  t.textContent = msg;
+  t.classList.add('show');
+  clearTimeout(toast._t);
+  toast._t = setTimeout(() => t.classList.remove('show'), 2200);
+}
+
+/* ============================== router ============================== */
+
+function route() {
+  const hash = location.hash.replace(/^#\/?/, '');
+  const [head, ...rest] = hash.split('/');
+  document.querySelectorAll('#topnav a').forEach(a => a.classList.remove('active'));
+  const mark = r => { const a = document.querySelector(`#topnav a[data-route="${r}"]`); if (a) a.classList.add('active'); };
+  if (head === 'k' && rest.length >= 2) {
+    mark('explore');
+    viewDetail(decodeURIComponent(rest[0]), rest.slice(1).map(decodeURIComponent).join('/'));
+  } else if (head === 'edit' && rest.length >= 2) {
+    viewEditor(decodeURIComponent(rest[0]), rest.slice(1).map(decodeURIComponent).join('/'));
+  } else if (head === 'new') {
+    mark('new');
+    viewEditor(null, null);
+  } else if (head === 'compile') {
+    mark('compile');
+    viewCompile();
+  } else {
+    mark('explore');
+    viewExplore();
+  }
+}
+window.addEventListener('hashchange', route);
+
+/* ============================== explore ============================== */
+
+// Filter state survives navigation within the session.
+const explore = { q: '', types: new Set(), statuses: new Set(), tag: '', staleFeed: false };
+
+function viewExplore() {
+  const typeChecks = KNOWN_TYPES.map(t => `
+    <label class="check"><input type="checkbox" data-type="${t}" ${explore.types.has(t) ? 'checked' : ''}>
+      <span class="type-ico">${icon(t)}</span>${t}</label>`).join('');
+  const extraTypes = [...explore.types].filter(t => !KNOWN_TYPES.includes(t)).map(t => `
+    <label class="check"><input type="checkbox" data-type="${esc(t)}" checked>
+      <span class="type-ico">${icon(t)}</span>${esc(t)}</label>`).join('');
+  const statusChecks = STATUSES.map(s => `
+    <label class="check"><input type="checkbox" data-status="${s}" ${explore.statuses.has(s) ? 'checked' : ''}>
+      <span class="badge ${s}">${s}</span></label>`).join('');
+
+  view.innerHTML = `
+  <div class="explore">
+    <aside class="rail">
+      <h3>Type</h3>
+      ${typeChecks}${extraTypes}
+      <input type="text" id="f-type-extra" placeholder="other type…" style="margin-top:.3rem;font-size:.84rem;padding:.25rem .5rem">
+      <h3>Status</h3>
+      ${statusChecks}
+      <h3>Tag</h3>
+      <input type="text" id="f-tag" placeholder="tag" value="${esc(explore.tag)}" style="font-size:.84rem;padding:.3rem .5rem">
+      <h3>Feed</h3>
+      <label class="check"><input type="checkbox" id="f-stale" ${explore.staleFeed ? 'checked' : ''}> verification age</label>
+      <div class="hint" style="color:var(--muted);font-size:.76rem">Oldest-verified first — the canary feed for re-checking golden queries.</div>
+    </aside>
+    <section>
+      <div class="searchbox">
+        <input type="text" id="q" placeholder="Search metrics, golden queries, insights, terms, tables…"
+               value="${esc(explore.q)}" ${explore.staleFeed ? 'disabled' : ''} autocomplete="off">
+      </div>
+      <div id="results"><div class="empty">…</div></div>
+    </section>
+  </div>`;
+
+  const rerun = () => runSearch();
+  $('#q').addEventListener('input', () => { explore.q = $('#q').value; debounce(rerun, 250); });
+  $('#q').focus({ preventScroll: true });
+  document.querySelectorAll('.rail input[data-type]').forEach(cb =>
+    cb.addEventListener('change', () => { cb.checked ? explore.types.add(cb.dataset.type) : explore.types.delete(cb.dataset.type); rerun(); }));
+  document.querySelectorAll('.rail input[data-status]').forEach(cb =>
+    cb.addEventListener('change', () => { cb.checked ? explore.statuses.add(cb.dataset.status) : explore.statuses.delete(cb.dataset.status); rerun(); }));
+  $('#f-type-extra').addEventListener('keydown', e => {
+    if (e.key === 'Enter' && e.target.value.trim()) { explore.types.add(e.target.value.trim()); viewExplore(); }
+  });
+  $('#f-tag').addEventListener('input', () => { explore.tag = $('#f-tag').value.trim(); debounce(rerun, 250); });
+  $('#f-stale').addEventListener('change', () => { explore.staleFeed = $('#f-stale').checked; viewExplore(); });
+
+  runSearch();
+}
+
+function debounce(fn, ms) {
+  clearTimeout(debounce._t);
+  debounce._t = setTimeout(fn, ms);
+}
+
+async function runSearch() {
+  const out = $('#results');
+  if (!out) return;
+  const p = new URLSearchParams();
+  if (explore.staleFeed) p.set('sort', 'verified_at');
+  else if (explore.q) p.set('q', explore.q);
+  for (const t of explore.types) p.append('type', t);
+  for (const s of explore.statuses) p.append('status', s);
+  if (explore.tag) p.append('tag', explore.tag);
+  p.set('limit', '25');
+  const my = runSearch._seq = (runSearch._seq || 0) + 1;
+  try {
+    const { hits } = await api('/api/v1/knowledge?' + p);
+    if (my !== runSearch._seq || out !== $('#results')) return; // stale response
+    if (!hits || !hits.length) {
+      out.innerHTML = `<div class="empty">No knowledge found${explore.q ? ' for “' + esc(explore.q) + '”' : ''}.</div>`;
+      return;
+    }
+    out.innerHTML = hits.map(hitCard).join('');
+  } catch (e) {
+    if (my !== runSearch._seq || out !== $('#results')) return;
+    out.innerHTML = `<div class="error-banner">Search failed: ${esc(e.message)}</div>`;
+  }
+}
+
+function hitCard(h) {
+  const tags = (h.tags || []).map(t => `<span class="tag">${esc(t)}</span>`).join(' ');
+  const who = actorStr(h.status === 'verified' ? h.verified_by || h.created_by : h.created_by);
+  const meta = [
+    `<span class="mono">ochakai://${esc(h.type)}/${esc(h.id)}</span>`,
+    who ? esc(who) : '',
+    h.verified_at ? 'verified ' + esc(fmtDate(h.verified_at)) : (h.updated_at ? 'updated ' + esc(fmtDate(h.updated_at)) : ''),
+  ].filter(Boolean).join(' · ');
+  const sql = h.attrs && h.attrs.sql ? `<pre>${esc(h.attrs.sql)}</pre>` : '';
+  return `<article class="card">
+    <div class="head">
+      <span class="type-ico" title="${esc(h.type)}">${icon(h.type)}</span>
+      <a class="title" href="${entryHash(h)}">${esc(h.title)}</a>
+      <span class="badge ${esc(h.status)}">${esc(h.status)}</span>
+      ${tags}
+    </div>
+    <div class="meta">${meta}</div>
+    ${h.description ? `<div class="desc">${esc(h.description)}</div>` : ''}
+    ${sql}
+  </article>`;
+}
+
+/* ============================== detail ============================== */
+
+async function viewDetail(type, id) {
+  view.innerHTML = '<div class="empty">…</div>';
+  let entry;
+  try {
+    entry = await api('/api/v1/knowledge/' + idPath(type, id));
+  } catch (e) {
+    view.innerHTML = `<div class="error-banner">Could not load ${esc(type)}/${esc(id)}: ${esc(e.message)}</div>`;
+    return;
+  }
+
+  const prov = [
+    entry.created_by && entry.created_by.name ? `created by ${actorStr(entry.created_by)} ${fmtDate(entry.created_at)}` : `created ${fmtDate(entry.created_at)}`,
+    entry.verified_by && entry.verified_by.name ? `verified by ${actorStr(entry.verified_by)} ${fmtDate(entry.verified_at)}` : '',
+    entry.rejected_by && entry.rejected_by.name ? `rejected by ${actorStr(entry.rejected_by)} ${fmtDate(entry.rejected_at)}` : '',
+    entry.updated_at && entry.updated_at !== entry.created_at ? `updated ${fmtDate(entry.updated_at)}` : '',
+  ].filter(Boolean).join(' · ');
+
+  const tags = (entry.tags || []).map(t => `<span class="tag">${esc(t)}</span>`).join(' ');
+  const canVerify = entry.status !== 'verified';
+  const canDeprecate = entry.status === 'verified';
+  const canReject = entry.status === 'draft';
+
+  view.innerHTML = `
+    <nav class="crumbs mono"><a href="#/">knowledge</a> / ${esc(entry.type)} / ${esc(entry.id)}</nav>
+    <div class="detail-head">
+      <span class="type-ico" style="font-size:1.4rem">${icon(entry.type)}</span>
+      <h1>${esc(entry.title)}</h1>
+      <span class="badge ${esc(entry.status)}">${esc(entry.status)}</span>
+      ${tags}
+      <span class="actions">
+        ${canVerify ? '<button class="btn small primary" id="act-verify">✓ Verify</button>' : ''}
+        ${canDeprecate ? '<button class="btn small" id="act-deprecate">Deprecate</button>' : ''}
+        ${canReject ? '<button class="btn small danger" id="act-reject">Reject</button>' : ''}
+        <a class="btn small" href="#/edit/${idPath(entry.type, entry.id)}">Edit</a>
+        <button class="btn small danger" id="act-delete">Delete</button>
+      </span>
+    </div>
+    <div class="provenance">${esc(prov)}</div>
+    ${entry.status_note ? `<div class="status-note">${esc(entry.status_note)}</div>` : ''}
+    <div class="tabs" id="tabs">
+      <button data-tab="overview" class="active">Overview</button>
+      <button data-tab="attrs">Attributes</button>
+      <button data-tab="links">Links${entry.links && entry.links.length ? ' (' + entry.links.length + ')' : ''}</button>
+      <button data-tab="usage">Usage</button>
+    </div>
+    <div id="tab-body"></div>`;
+
+  const tabs = {
+    overview: () => `
+      ${entry.description ? `<p style="font-size:1.02rem">${esc(entry.description)}</p>` : ''}
+      ${entry.body ? `<div class="md">${md(entry.body)}</div>` : ''}
+      ${!entry.description && !entry.body ? '<div class="empty">No description or body.</div>' : ''}`,
+    attrs: () => {
+      const attrs = entry.attrs || {};
+      const keys = Object.keys(attrs);
+      if (!keys.length) return '<div class="empty">No structured attributes.</div>';
+      return '<table class="kv">' + keys.map(k => {
+        const v = attrs[k];
+        const rendered = typeof v === 'string' && (k === 'sql' || v.includes('\n'))
+          ? `<pre>${esc(v)}</pre>`
+          : typeof v === 'string' ? esc(v) : `<pre>${esc(JSON.stringify(v, null, 2))}</pre>`;
+        return `<tr><td class="k mono">${esc(k)}</td><td>${rendered}</td></tr>`;
+      }).join('') + '</table>';
+    },
+    links: () => {
+      const links = entry.links || [];
+      if (!links.length) return '<div class="empty">No links to other entries.</div>';
+      return '<table class="kv">' + links.map(l => {
+        const seg = String(l.target || '').split('/');
+        const href = seg.length >= 2 ? '#/k/' + idPath(seg[0], seg.slice(1).join('/')) : null;
+        return `<tr><td class="k">${esc(l.rel)}</td>
+          <td>${href ? `<a class="mono" href="${href}">${esc(l.target)}</a>` : `<span class="mono">${esc(l.target)}</span>`}</td></tr>`;
+      }).join('') + '</table>';
+    },
+    usage: () => '<div class="empty">…</div>',
+  };
+
+  const body = $('#tab-body');
+  let usageLoaded = false;
+  async function showTab(name) {
+    document.querySelectorAll('#tabs button').forEach(b => b.classList.toggle('active', b.dataset.tab === name));
+    body.innerHTML = tabs[name]();
+    if (name === 'usage' && !usageLoaded) {
+      try {
+        const u = await api('/api/v1/usage/' + idPath(entry.type, entry.id));
+        usageLoaded = true;
+        tabs.usage = () => `
+          <div class="stat-tiles">
+            <div class="tile"><div class="num">${u.search_hits ?? 0}</div><div class="lbl">search hits</div></div>
+            <div class="tile"><div class="num">${u.fetches ?? 0}</div><div class="lbl">fetches</div></div>
+            <div class="tile"><div class="num">${u.compiles ?? 0}</div><div class="lbl">compiles</div></div>
+          </div>
+          <p class="provenance">${u.last_used_at ? 'last used ' + esc(fmtDate(u.last_used_at)) : 'never used'}</p>`;
+        if (document.querySelector('#tabs button.active')?.dataset.tab === 'usage') body.innerHTML = tabs.usage();
+      } catch (e) {
+        body.innerHTML = `<div class="error-banner">Usage unavailable: ${esc(e.message)}</div>`;
+      }
+    }
+  }
+  document.querySelectorAll('#tabs button').forEach(b => b.addEventListener('click', () => showTab(b.dataset.tab)));
+  showTab('overview');
+
+  const setStatus = async (status, askNote) => {
+    let note;
+    if (askNote) {
+      note = prompt(`Why ${status}? (recorded as status_note so agents stop re-proposing it)`, entry.status_note || '');
+      if (note === null) return;
+    }
+    const payload = editablePayload(entry);
+    payload.status = status;
+    if (note !== undefined) payload.status_note = note;
+    try {
+      await api('/api/v1/knowledge/' + idPath(entry.type, entry.id), { method: 'PUT', body: payload });
+      toast(`Marked ${status}.`);
+      viewDetail(entry.type, entry.id);
+    } catch (e) { toast('Failed: ' + e.message); }
+  };
+  $('#act-verify')?.addEventListener('click', () => setStatus('verified', false));
+  $('#act-deprecate')?.addEventListener('click', () => setStatus('deprecated', true));
+  $('#act-reject')?.addEventListener('click', () => setStatus('rejected', true));
+  $('#act-delete').addEventListener('click', async () => {
+    if (!confirm(`Soft-delete ${entry.type}/${entry.id}? Revision history is retained.`)) return;
+    try {
+      await api('/api/v1/knowledge/' + idPath(entry.type, entry.id), { method: 'DELETE' });
+      toast('Deleted.');
+      location.hash = '#/';
+    } catch (e) { toast('Failed: ' + e.message); }
+  });
+}
+
+// The writable subset of a Knowledge entry (PUT is a full replacement).
+function editablePayload(e) {
+  const p = { type: e.type, id: e.id, title: e.title };
+  for (const k of ['description', 'tags', 'status', 'status_note', 'links', 'attrs', 'body']) {
+    if (e[k] !== undefined && e[k] !== null) p[k] = e[k];
+  }
+  return p;
+}
+
+/* ============================== editor ============================== */
+
+async function viewEditor(type, id) {
+  const editing = type !== null;
+  let entry = { type: 'insight', id: '', title: '', description: '', tags: [], status: 'draft', status_note: '', links: [], attrs: {}, body: '' };
+  if (editing) {
+    try {
+      entry = await api('/api/v1/knowledge/' + idPath(type, id));
+    } catch (e) {
+      view.innerHTML = `<div class="error-banner">Could not load ${esc(type)}/${esc(id)}: ${esc(e.message)}</div>`;
+      return;
+    }
+  }
+  const linksText = (entry.links || []).map(l => `${l.rel} ${l.target}`).join('\n');
+  const attrsText = entry.attrs && Object.keys(entry.attrs).length ? JSON.stringify(entry.attrs, null, 2) : '';
+
+  view.innerHTML = `
+    <div class="section-title">${editing ? `Edit ${esc(entry.type)}/${esc(entry.id)}` : 'New knowledge entry'}</div>
+    <form class="form" id="editor">
+      <div class="row">
+        <div class="field">
+          <label class="top" for="e-type">Type</label>
+          <input type="text" id="e-type" list="type-list" value="${esc(entry.type)}" ${editing ? 'disabled' : ''} required>
+          <datalist id="type-list">${KNOWN_TYPES.map(t => `<option value="${t}">`).join('')}</datalist>
+          <div class="hint">metric, query, insight, term, table — or any slug of your own.</div>
+        </div>
+        <div class="field">
+          <label class="top" for="e-id">ID</label>
+          <input type="text" id="e-id" class="mono" value="${esc(entry.id)}" ${editing ? 'disabled' : ''}
+                 placeholder="sales/monthly-revenue" required>
+          <div class="hint">Slug segments separated by “/” (hierarchical, like OKF concept IDs).</div>
+        </div>
+      </div>
+      <div class="field">
+        <label class="top" for="e-title">Title</label>
+        <input type="text" id="e-title" value="${esc(entry.title)}" required>
+      </div>
+      <div class="field">
+        <label class="top" for="e-desc">Description</label>
+        <input type="text" id="e-desc" value="${esc(entry.description || '')}">
+      </div>
+      <div class="row">
+        <div class="field">
+          <label class="top" for="e-tags">Tags</label>
+          <input type="text" id="e-tags" value="${esc((entry.tags || []).join(', '))}" placeholder="finance, monthly">
+          <div class="hint">Comma-separated.</div>
+        </div>
+        <div class="field">
+          <label class="top" for="e-status">Status</label>
+          <select id="e-status">${STATUSES.map(s => `<option ${s === entry.status ? 'selected' : ''}>${s}</option>`).join('')}</select>
+        </div>
+      </div>
+      <div class="field">
+        <label class="top" for="e-note">Status note</label>
+        <input type="text" id="e-note" value="${esc(entry.status_note || '')}" placeholder="why deprecated / rejected">
+      </div>
+      <div class="field">
+        <label class="top" for="e-body">Body (markdown)</label>
+        <textarea id="e-body" rows="10" class="mono">${esc(entry.body || '')}</textarea>
+      </div>
+      <div class="field">
+        <label class="top" for="e-attrs">Attributes (JSON)</label>
+        <textarea id="e-attrs" rows="6" class="mono" placeholder='{"question": "…", "sql": "SELECT …"}'>${esc(attrsText)}</textarea>
+        <div class="hint">Type-specific structured attributes, e.g. question/sql for a query.</div>
+      </div>
+      <div class="field">
+        <label class="top" for="e-links">Links</label>
+        <textarea id="e-links" rows="3" class="mono" placeholder="about metric/revenue">${esc(linksText)}</textarea>
+        <div class="hint">One per line: <code>rel type/id</code>.</div>
+      </div>
+      <div id="editor-error"></div>
+      <p>
+        <button class="btn primary" type="submit">${editing ? 'Save' : 'Create draft'}</button>
+        <a class="btn" href="${editing ? '#/k/' + idPath(entry.type, entry.id) : '#/'}">Cancel</a>
+      </p>
+    </form>`;
+
+  $('#editor').addEventListener('submit', async ev => {
+    ev.preventDefault();
+    const errBox = $('#editor-error');
+    errBox.innerHTML = '';
+    const payload = {
+      type: editing ? entry.type : $('#e-type').value.trim(),
+      id: editing ? entry.id : $('#e-id').value.trim(),
+      title: $('#e-title').value.trim(),
+      description: $('#e-desc').value.trim(),
+      tags: $('#e-tags').value.split(',').map(s => s.trim()).filter(Boolean),
+      status: $('#e-status').value,
+      status_note: $('#e-note').value.trim(),
+      body: $('#e-body').value,
+    };
+    const attrsRaw = $('#e-attrs').value.trim();
+    if (attrsRaw) {
+      try { payload.attrs = JSON.parse(attrsRaw); }
+      catch (e) { errBox.innerHTML = `<div class="error-banner">Attributes is not valid JSON: ${esc(e.message)}</div>`; return; }
+    }
+    const links = $('#e-links').value.split('\n').map(s => s.trim()).filter(Boolean).map(line => {
+      const sp = line.indexOf(' ');
+      return sp > 0 ? { rel: line.slice(0, sp), target: line.slice(sp + 1).trim() } : { rel: 'related', target: line };
+    });
+    if (links.length) payload.links = links;
+    try {
+      const saved = editing
+        ? await api('/api/v1/knowledge/' + idPath(entry.type, entry.id), { method: 'PUT', body: payload })
+        : await api('/api/v1/knowledge', { method: 'POST', body: payload });
+      toast(editing ? 'Saved.' : 'Created.');
+      location.hash = entryHash(saved || payload);
+      if (editing) route(); // hash may be unchanged; re-render
+    } catch (e) {
+      errBox.innerHTML = `<div class="error-banner">${editing ? 'Save' : 'Create'} failed: ${esc(e.message)}</div>`;
+    }
+  });
+}
+
+/* ============================== compile ============================== */
+
+const compileState = { model: '', metrics: '', dimensions: '', filters: [], tgField: '', tgGrain: '', dialect: 'bigquery', limit: '' };
+
+function viewCompile() {
+  const c = compileState;
+  view.innerHTML = `
+    <div class="section-title">Compile SQL</div>
+    <p style="color:var(--muted);max-width:46rem">Deterministically compiles metrics from the imported semantic model —
+    ochakai never executes SQL and never guesses. Verified golden queries about the metrics are returned alongside;
+    prefer them when they answer the question.</p>
+    <form class="form" id="compile-form">
+      <div class="row">
+        <div class="field">
+          <label class="top" for="c-metrics">Metrics</label>
+          <input type="text" id="c-metrics" class="mono" value="${esc(c.metrics)}" placeholder="revenue, order_count" required>
+          <div class="hint">Comma-separated metric names.</div>
+        </div>
+        <div class="field">
+          <label class="top" for="c-model">Model</label>
+          <input type="text" id="c-model" class="mono" value="${esc(c.model)}" placeholder="(optional — resolved via the metric’s links)">
+        </div>
+      </div>
+      <div class="field">
+        <label class="top" for="c-dims">Dimensions</label>
+        <input type="text" id="c-dims" class="mono" value="${esc(c.dimensions)}" placeholder="customers.region, orders.channel">
+        <div class="hint">Comma-separated <code>dataset.field</code>.</div>
+      </div>
+      <div class="field">
+        <label class="top">Filters</label>
+        <div class="filters-list" id="c-filters"></div>
+        <button class="btn small" type="button" id="c-add-filter">+ Add filter</button>
+      </div>
+      <div class="row">
+        <div class="field">
+          <label class="top" for="c-tg-field">Time grain</label>
+          <div style="display:flex;gap:.5rem">
+            <input type="text" id="c-tg-field" class="mono" value="${esc(c.tgField)}" placeholder="orders.created_at">
+            <select id="c-tg-grain" style="width:8rem">
+              <option value="">—</option>
+              ${['day', 'week', 'month', 'quarter', 'year'].map(g => `<option ${g === c.tgGrain ? 'selected' : ''}>${g}</option>`).join('')}
+            </select>
+          </div>
+        </div>
+        <div class="field">
+          <label class="top" for="c-dialect">Dialect / limit</label>
+          <div style="display:flex;gap:.5rem">
+            <select id="c-dialect">${['bigquery', 'ansi'].map(d => `<option ${d === c.dialect ? 'selected' : ''}>${d}</option>`).join('')}</select>
+            <input type="number" id="c-limit" value="${esc(c.limit)}" placeholder="limit" min="1" style="width:7rem">
+          </div>
+        </div>
+      </div>
+      <p><button class="btn primary" type="submit">Compile</button></p>
+    </form>
+    <div id="compile-result"></div>`;
+
+  const OPS = ['=', '!=', '>', '>=', '<', '<=', 'in', 'not_in'];
+  const filtersBox = $('#c-filters');
+  function renderFilters() {
+    filtersBox.innerHTML = c.filters.map((f, i) => `
+      <div class="filter-row">
+        <input type="text" class="mono" data-f="field" data-i="${i}" value="${esc(f.field)}" placeholder="orders.status">
+        <select data-f="op" data-i="${i}">${OPS.map(o => `<option ${o === f.op ? 'selected' : ''}>${o}</option>`).join('')}</select>
+        <input type="text" class="mono" data-f="value" data-i="${i}" value="${esc(f.value)}" placeholder='completed or ["a","b"]'>
+        <button class="btn small" type="button" data-del="${i}" title="remove">✕</button>
+      </div>`).join('');
+    filtersBox.querySelectorAll('input,select').forEach(el =>
+      el.addEventListener('input', () => { c.filters[+el.dataset.i][el.dataset.f] = el.value; }));
+    filtersBox.querySelectorAll('[data-del]').forEach(b =>
+      b.addEventListener('click', () => { c.filters.splice(+b.dataset.del, 1); renderFilters(); }));
+  }
+  renderFilters();
+  $('#c-add-filter').addEventListener('click', () => { c.filters.push({ field: '', op: '=', value: '' }); renderFilters(); });
+
+  $('#compile-form').addEventListener('submit', async ev => {
+    ev.preventDefault();
+    c.metrics = $('#c-metrics').value; c.model = $('#c-model').value; c.dimensions = $('#c-dims').value;
+    c.tgField = $('#c-tg-field').value; c.tgGrain = $('#c-tg-grain').value;
+    c.dialect = $('#c-dialect').value; c.limit = $('#c-limit').value;
+    const body = {
+      metrics: c.metrics.split(',').map(s => s.trim()).filter(Boolean),
+      dialect: c.dialect,
+    };
+    if (c.model.trim()) body.model = c.model.trim();
+    const dims = c.dimensions.split(',').map(s => s.trim()).filter(Boolean);
+    if (dims.length) body.dimensions = dims;
+    const filters = c.filters.filter(f => f.field.trim()).map(f => {
+      let value = f.value;
+      try { value = JSON.parse(f.value); } catch { /* keep as string */ }
+      return { field: f.field.trim(), op: f.op, value };
+    });
+    if (filters.length) body.filters = filters;
+    if (c.tgField.trim() && c.tgGrain) body.time_grain = { field: c.tgField.trim(), grain: c.tgGrain };
+    if (c.limit) body.limit = +c.limit;
+
+    const out = $('#compile-result');
+    out.innerHTML = '<div class="empty">compiling…</div>';
+    try {
+      const r = await api('/api/v1/compile', { method: 'POST', body });
+      const datasets = (r.datasets_used || []).map(d => `<span class="tag mono">${esc(d)}</span>`).join(' ');
+      const notes = (r.notes || []).map(n => `<li>${esc(n)}</li>`).join('');
+      const golden = (r.verified_queries || []).map(hitCard).join('');
+      out.innerHTML = `
+        <div class="toolbar" style="margin-top:1.4rem">
+          <strong>Compiled SQL</strong> <span class="badge">${esc(r.dialect || c.dialect)}</span> ${datasets}
+          <span class="grow"></span>
+          <button class="btn small" id="copy-sql">Copy</button>
+        </div>
+        <pre id="sql-out">${esc(r.sql || '')}</pre>
+        ${notes ? `<ul style="color:var(--muted);font-size:.9rem">${notes}</ul>` : ''}
+        ${golden ? `<h3 style="margin-top:1.6rem">Verified golden queries — prefer these when applicable</h3>${golden}` : ''}`;
+      $('#copy-sql').addEventListener('click', async () => {
+        await navigator.clipboard.writeText(r.sql || '');
+        toast('SQL copied.');
+      });
+    } catch (e) {
+      out.innerHTML = `<div class="error-banner">Compile failed: ${esc(e.message)}</div>`;
+    }
+  });
+}
+
+/* ============================== boot ============================== */
+
+refreshServerChip();
+route();
 </script>
 </body>
 </html>

--- a/examples/webui/index.html
+++ b/examples/webui/index.html
@@ -68,15 +68,22 @@
     background: var(--surface); border-bottom: 1px solid var(--border);
     padding: 0 1.2rem; height: 3.3rem; position: sticky; top: 0; z-index: 10;
   }
-  .brand { font-weight: 700; font-size: 1.08rem; color: var(--text); display: flex; align-items: center; gap: .45rem; }
+  .brand { font-weight: 700; font-size: 1.08rem; color: var(--text); display: flex; align-items: center; gap: .45rem; white-space: nowrap; }
   .brand:hover { text-decoration: none; }
   .topnav { display: flex; gap: .2rem; align-self: stretch; }
   .topnav a {
     display: flex; align-items: center; padding: 0 .8rem; color: var(--muted);
-    border-bottom: 2px solid transparent; margin-bottom: -1px; font-weight: 500;
+    border-bottom: 2px solid transparent; margin-bottom: -1px; font-weight: 500; white-space: nowrap;
   }
   .topnav a:hover { color: var(--text); text-decoration: none; }
   .topnav a.active { color: var(--accent-strong); border-bottom-color: var(--accent); }
+  /* Narrow screens: brand + actions on the first row, nav tabs on their own row. */
+  @media (max-width: 800px) {
+    .topbar { flex-wrap: wrap; height: auto; padding-top: .55rem; gap: .5rem .8rem; }
+    .topnav { order: 10; flex-basis: 100%; align-self: auto; overflow-x: auto; }
+    .topnav a { padding: .1rem .8rem .5rem; }
+    .server-chip { flex: 0 1 auto; min-width: 3rem; }
+  }
   .topbar .spacer { flex: 1; }
   .server-chip {
     font-size: .8rem; color: var(--muted); border: 1px solid var(--border); border-radius: 999px;
@@ -88,8 +95,9 @@
   /* ---- layout ---- */
   main { max-width: 68rem; margin: 0 auto; padding: 1.4rem 1.2rem 4rem; }
   .explore { display: grid; grid-template-columns: 14rem 1fr; gap: 1.6rem; align-items: start; }
-  @media (max-width: 760px) { .explore { grid-template-columns: 1fr; } .rail { position: static; } }
+  .explore > section { min-width: 0; }
   .rail { position: sticky; top: 4.6rem; }
+  @media (max-width: 760px) { .explore { grid-template-columns: 1fr; } .rail { position: static; } }
   .rail h3 {
     font-size: .72rem; text-transform: uppercase; letter-spacing: .07em;
     color: var(--muted); margin: 1.2rem 0 .45rem;
@@ -109,7 +117,7 @@
   .btn {
     font: inherit; font-weight: 500; cursor: pointer; border-radius: 8px;
     border: 1px solid var(--border); background: var(--surface); color: var(--text);
-    padding: .42rem .85rem; display: inline-flex; align-items: center; gap: .4rem;
+    padding: .42rem .85rem; display: inline-flex; align-items: center; gap: .4rem; white-space: nowrap;
   }
   .btn:hover { border-color: var(--accent); color: var(--accent-strong); }
   .btn.primary { background: var(--accent); border-color: var(--accent); color: #fff; }
@@ -130,7 +138,7 @@
   .card .head a.title { font-weight: 600; font-size: 1.02rem; color: var(--text); }
   .card .head a.title:hover { color: var(--accent-strong); }
   .type-ico { font-size: 1rem; }
-  .card .meta { color: var(--muted); font-size: .8rem; margin-top: .15rem; }
+  .card .meta { color: var(--muted); font-size: .8rem; margin-top: .15rem; overflow-wrap: anywhere; }
   .card .desc { margin-top: .3rem; font-size: .92rem; }
   .card pre { margin-bottom: 0; }
 


### PR DESCRIPTION
## What

Rebuilds `examples/webui/index.html` from a 73-line search box into a small catalog UI in the spirit of OpenMetadata, while keeping ochakai's constraints on purpose: **still one self-contained file** — no build step, no framework, no CDN — served by the unchanged `main.go` same-origin proxy.

- **Explore** — type / status / tag filter rail, result cards, and the *verification age* feed (`sort=verified_at`, the golden-query canary view)
- **Entry pages** — tabs for overview (markdown body), attributes (SQL et al.), links, and usage counts; the status workflow as one-click actions (verify / deprecate / reject with `status_note`, soft-delete); hierarchical IDs throughout
- **Create & edit** — drafts by default, attrs as JSON, links as `rel type/id` lines
- **Compile** — metrics + dimensions + filters + time grain → SQL, with verified golden queries shown alongside (prefer-golden-queries in the UI, matching the API's contract)
- **Export OKF** — one click
- Light + dark themes, matcha-green accent; `examples/webui/README.md` documents scope and the direction toward a standalone UI (stays a thin client of the public REST API)

## Responsive

Verified at 375 / 700 / 1280 px with an element-overflow probe on every view (explore, all detail tabs, editor, compile with filter rows): no horizontal overflow, no sticky-rail overlap. Below 800px the top bar wraps into brand+actions / nav rows, key-value tables stack, tab rows scroll, and inputs go to 16px so iOS Safari doesn't zoom on focus.

## Verification

Exercised end-to-end in a browser against the compose stack: search + filters, hierarchical-ID detail pages, verify/deprecate/reject transitions, create/edit round-trips, usage tiles, compile with golden queries alongside, OKF export link. Note for hacking on it: `main.go` embeds `index.html` at build time (`go:embed`), so restart `go run` after editing the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)