### PR TITLE
ochakai ui: refuse cross-origin requests (CSRF guard)

### DIFF
--- a/cmd/ochakai/ui.go
+++ b/cmd/ochakai/ui.go
@@ -107,25 +107,59 @@ func uiHandler(target string, tokens oauth2.TokenSource) (http.Handler, error) {
 	})
 	mux.Handle("/api/v1/", proxy)
 	mux.Handle("/mcp", proxy)
-	return loopbackOnly(mux), nil
+	return localBrowserGuard(mux), nil
 }
 
-// loopbackOnly rejects requests whose Host header is not a loopback name.
-// The listener is already bound to 127.0.0.1; this additionally stops DNS
-// rebinding (a malicious page resolving its own hostname to 127.0.0.1 to
-// smuggle same-origin requests into a proxy that signs them as you —
-// kubectl proxy learned this the hard way).
-func loopbackOnly(next http.Handler) http.Handler {
+// localBrowserGuard fends off the two ways a web page in the user's
+// browser could abuse a loopback proxy that signs requests as them. The
+// listener is already bound to 127.0.0.1, so a network peer can't reach
+// it; these guards are about the browser the user drives.
+//
+//   - Host header: rejects non-loopback names, stopping DNS rebinding (a
+//     malicious page pointing its own hostname at 127.0.0.1 to get
+//     same-origin access).
+//   - Origin header: rejects cross-site writes (CSRF). A direct
+//     fetch('http://127.0.0.1:PORT/...') from evil.com carries the right
+//     Host but a foreign Origin; without this check a text/plain POST is
+//     a "simple request" (no CORS preflight) and would be proxied with
+//     the user's token. Same-origin UI requests send no Origin (GET) or a
+//     loopback Origin, so they pass.
+//
+// kubectl proxy learned the rebinding half the hard way; the CSRF half is
+// the same lesson one step further.
+func localBrowserGuard(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		host := r.Host
-		if h, _, err := net.SplitHostPort(host); err == nil {
-			host = h
-		}
-		switch host {
-		case "localhost", "127.0.0.1", "::1", "[::1]":
-			next.ServeHTTP(w, r)
-		default:
+		if !isLoopbackHost(r.Host) {
 			http.Error(w, "unexpected Host header (DNS rebinding guard): open the UI via http://127.0.0.1 or http://localhost", http.StatusForbidden)
+			return
 		}
+		if origin := r.Header.Get("Origin"); origin != "" && !isLoopbackOrigin(origin) {
+			http.Error(w, "cross-origin request refused (CSRF guard): this UI is only for the local browser", http.StatusForbidden)
+			return
+		}
+		next.ServeHTTP(w, r)
 	})
+}
+
+// isLoopbackHost reports whether a Host header (host or host:port) names
+// the loopback interface.
+func isLoopbackHost(host string) bool {
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	switch host {
+	case "localhost", "127.0.0.1", "::1", "[::1]":
+		return true
+	}
+	return false
+}
+
+// isLoopbackOrigin reports whether an Origin header ("scheme://host[:port]")
+// points at the local machine — the only origin the UI is served from.
+func isLoopbackOrigin(origin string) bool {
+	u, err := url.Parse(origin)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	return isLoopbackHost(u.Host)
 }

--- a/cmd/ochakai/ui_test.go
+++ b/cmd/ochakai/ui_test.go
@@ -114,3 +114,42 @@ func TestUIHandlerRejectsForeignHost(t *testing.T) {
 		}
 	}
 }
+
+// CSRF guard: a cross-site page reaching 127.0.0.1 directly carries the
+// loopback Host (passing the rebinding guard) but a foreign Origin. The
+// UI's own requests send no Origin or a loopback one and must reach the
+// backend. A foreign Origin must be refused before the proxy signs and
+// forwards the write.
+func TestUIHandlerRejectsForeignOrigin(t *testing.T) {
+	var reached bool
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached = true
+	}))
+	defer backend.Close()
+	h, err := uiHandler(backend.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for origin, want := range map[string]int{
+		"":                          http.StatusOK, // same-origin GET, or a non-browser client
+		"http://127.0.0.1:8098":     http.StatusOK,
+		"http://localhost:8098":     http.StatusOK,
+		"https://evil.example":      http.StatusForbidden,
+		"http://127.0.0.1.evil.com": http.StatusForbidden,
+		"null":                      http.StatusForbidden, // opaque origin (sandboxed iframe, data: page)
+	} {
+		reached = false
+		req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8098/api/v1/knowledge", nil)
+		if origin != "" {
+			req.Header.Set("Origin", origin)
+		}
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != want {
+			t.Errorf("Origin %q: POST = %d, want %d", origin, rec.Code, want)
+		}
+		if reachedBackend := reached; reachedBackend != (want == http.StatusOK) {
+			t.Errorf("Origin %q: reached backend = %v, want %v", origin, reachedBackend, want == http.StatusOK)
+		}
+	}
+}


### PR DESCRIPTION
## The gap

`ochakai ui`'s loopback proxy signs every proxied request with the user's Google identity. The existing DNS-rebinding guard checks the `Host` header, which stops a page from pointing *its own hostname* at 127.0.0.1 — but it does **not** stop a page from fetching `http://127.0.0.1:PORT/api/v1/...` directly. That request carries a genuine loopback `Host` (guard passes), and because the REST API accepts `Content-Type: text/plain`, a `text/plain` POST is a CORS "simple request" that skips preflight. So a malicious page the user visits while `ochakai ui` is running could create/update/delete knowledge as the user — classic confused-deputy CSRF. (Reads stay opaque, but writes don't need to read the response.)

## The fix

Reject any request whose `Origin` is present and not loopback, before it reaches the proxy (`cmd/ochakai/ui.go`, ~15 lines; server core untouched). The UI's own requests send **no** `Origin` (same-origin GET) or a **loopback** `Origin` (same-origin POST/PUT/DELETE), so they pass unchanged. Opaque origins (`null`, from sandboxed iframes / `data:` pages) are refused.

The Host and Origin checks are now one `localBrowserGuard` with a comment explaining both halves — rebinding (Host) and CSRF (Origin) — as the same lesson one step apart.

## Verification

- New `TestUIHandlerRejectsForeignOrigin`: asserts both the status code **and** that the backend is only reached for allowed origins (empty / loopback → 200 + reached; `evil.example` / `127.0.0.1.evil.com` / `null` → 403 + not reached). Full suite green, `go vet` + `gofmt` clean.
- Live against a running ochakai: UI page `200`, same-origin write `201`, **cross-site `text/plain` write `403` with the entry never created (`404`)**, same-origin read still works.

Follow-up to #32; found in a post-merge review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)