### PR TITLE
API-only CLI: drop DB-direct commands, move import-ossie to the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,11 @@ git clone https://github.com/na0fu3y/ochakai && cd ochakai
 docker compose -f deploy/compose.yaml up
 ```
 
-Import a semantic model and try a search. `import-ossie` is a server
-admin command that talks to the database directly, so it runs inside the
-container (the compose file mounts `examples/` for this):
+Import a semantic model and try a search — everything goes through the
+API, so plain curl works:
 
 ```sh
-docker compose -f deploy/compose.yaml exec ochakai /ochakai import-ossie /examples/semantic-model.yaml
+curl -X POST --data-binary @examples/semantic-model.yaml http://localhost:8080/api/v1/import/ossie
 curl 'http://localhost:8080/api/v1/knowledge?q=revenue'
 ```
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -167,6 +167,41 @@ paths:
           content:
             application/gzip:
               schema: { type: string, format: binary }
+  /api/v1/import/ossie:
+    post:
+      operationId: importOssie
+      summary: Import an Apache Ossie semantic model
+      description: >
+        Accepts Ossie semantic model YAML verbatim. Each model is stored
+        for compile, and metric/table knowledge entries are derived so
+        the definitions are searchable. Re-import refreshes definitions
+        without clobbering human-curated status, tags, and bodies.
+      requestBody:
+        required: true
+        content:
+          application/yaml:
+            schema: { type: string }
+      responses:
+        "200":
+          description: Import report.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  models:
+                    type: array
+                    items: { type: string }
+                    description: Semantic model names stored.
+                  created:
+                    type: array
+                    items: { type: string }
+                    description: URIs of knowledge entries created.
+                  updated:
+                    type: array
+                    items: { type: string }
+                    description: URIs of knowledge entries refreshed.
+        "400": { $ref: "#/components/responses/Error" }
   /api/v1/compile:
     post:
       operationId: compileSQL

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -38,6 +38,8 @@ var clientCommands = map[string]func(context.Context, []string) error{
 	"whoami":  cmdWhoami,
 	"ui":      cmdUI,
 
+	"import-ossie": cmdImportOssie,
+
 	"completion": cmdCompletion,
 }
 
@@ -454,6 +456,46 @@ func cmdImport(ctx context.Context, args []string) error {
 	}
 	fmt.Printf("imported %d entries (%d created, %d updated, %d skipped)\n",
 		created+updated, created, updated, len(skipped))
+	return nil
+}
+
+func cmdImportOssie(ctx context.Context, args []string) error {
+	fs, url := newFlagSet(
+		"Usage: ochakai import-ossie [flags] <semantic-model.yaml | ->\n\nImport an Apache Ossie semantic model. Each model is stored for\n`compile`, and metric/table knowledge entries are derived so the\ndefinitions are searchable. Re-import refreshes definitions without\nclobbering human-curated status, tags, and bodies.",
+		"  ochakai import-ossie examples/semantic-model.yaml\n")
+	pos, err := parseArgs(fs, args)
+	if err != nil {
+		return err
+	}
+	if len(pos) != 1 {
+		fs.Usage()
+		return errReported
+	}
+	var src []byte
+	if pos[0] == "-" {
+		src, err = io.ReadAll(os.Stdin)
+	} else {
+		src, err = os.ReadFile(pos[0])
+	}
+	if err != nil {
+		return err
+	}
+	c, err := newClient(ctx, *url)
+	if err != nil {
+		return err
+	}
+	report, err := c.ImportOssie(ctx, src)
+	if err != nil {
+		return err
+	}
+	for _, uri := range report.Created {
+		fmt.Println("created", uri)
+	}
+	for _, uri := range report.Updated {
+		fmt.Println("updated", uri)
+	}
+	fmt.Printf("imported %d models (%d entries created, %d updated)\n",
+		len(report.Models), len(report.Created), len(report.Updated))
 	return nil
 }
 

--- a/cmd/ochakai/client_test.go
+++ b/cmd/ochakai/client_test.go
@@ -156,12 +156,12 @@ func TestScalar(t *testing.T) {
 // Guard: the client dispatch table and domain types stay in sync with the
 // commands documented in usage().
 func TestClientCommandsCoverDesignDoc(t *testing.T) {
-	for _, name := range []string{"search", "get", "create", "update", "delete", "compile", "export", "import", "use", "whoami", "ui", "completion"} {
+	for _, name := range []string{"search", "get", "create", "update", "delete", "compile", "export", "import", "import-ossie", "use", "whoami", "ui", "completion"} {
 		if _, ok := clientCommands[name]; !ok {
 			t.Errorf("missing client command %q", name)
 		}
 	}
-	if len(clientCommands) != 12 {
+	if len(clientCommands) != 13 {
 		t.Errorf("unexpected extra client commands: %d", len(clientCommands))
 	}
 	_ = domain.Types // keep the import honest

--- a/cmd/ochakai/completion.go
+++ b/cmd/ochakai/completion.go
@@ -44,14 +44,12 @@ _ochakai() {
     'compile:compile metrics into SQL'
     'export:download the knowledge base as an OKF bundle'
     'import:upload an OKF bundle'
+    'import-ossie:import an Apache Ossie semantic model'
     'use:pick the server for later commands'
     'whoami:print target server, identity, and reachability'
     'ui:serve the web UI locally, acting as you'
     'completion:print a shell completion script'
     'serve:start the MCP + REST server'
-    'import-ossie:import an Apache Ossie semantic model'
-    'export-okf:write the OKF bundle straight from the database'
-    'import-okf:load an OKF bundle straight into the database'
     'version:print the version'
     'help:show help'
   )
@@ -111,13 +109,7 @@ _ochakai() {
       _arguments '1:shell:(zsh bash fish)'
       ;;
     import-ossie)
-      _arguments '1:file:_files'
-      ;;
-    export-okf)
-      _arguments '1:directory:_files -/'
-      ;;
-    import-okf)
-      _arguments '1:bundle:_files'
+      _arguments '--url[server URL]:url:' '1:file:_files'
       ;;
   esac
 }
@@ -138,7 +130,7 @@ _ochakai() {
   cmd=${COMP_WORDS[1]}
 
   if [ "$COMP_CWORD" -eq 1 ]; then
-    COMPREPLY=($(compgen -W "search get create update delete compile export import use whoami ui completion serve import-ossie export-okf import-okf version help" -- "$cur"))
+    COMPREPLY=($(compgen -W "search get create update delete compile export import import-ossie use whoami ui completion serve version help" -- "$cur"))
     return
   fi
 
@@ -157,6 +149,7 @@ _ochakai() {
     compile)       opts="--metric --dimension --filter --grain --model --dialect --limit --json --url" ;;
     export)        opts="--url" ;;
     import)        opts="--dry-run --keep-root --url" ;;
+    import-ossie)  opts="--url" ;;
     whoami)        opts="--json --url" ;;
     ui)            opts="--port --url" ;;
     use)
@@ -166,7 +159,6 @@ _ochakai() {
       fi
       opts="--name" ;;
     completion)    COMPREPLY=($(compgen -W "zsh bash fish" -- "$cur")); return ;;
-    import-ossie|export-okf|import-okf) compopt -o default 2>/dev/null; COMPREPLY=(); return ;;
     *)             opts="" ;;
   esac
 
@@ -191,21 +183,19 @@ complete -c ochakai -n __fish_use_subcommand -a delete -d 'soft-delete an entry'
 complete -c ochakai -n __fish_use_subcommand -a compile -d 'compile metrics into SQL'
 complete -c ochakai -n __fish_use_subcommand -a export -d 'download the knowledge base as an OKF bundle'
 complete -c ochakai -n __fish_use_subcommand -a import -d 'upload an OKF bundle'
+complete -c ochakai -n __fish_use_subcommand -a import-ossie -d 'import an Apache Ossie semantic model'
 complete -c ochakai -n __fish_use_subcommand -a use -d 'pick the server for later commands'
 complete -c ochakai -n __fish_use_subcommand -a whoami -d 'print target server, identity, and reachability'
 complete -c ochakai -n __fish_use_subcommand -a ui -d 'serve the web UI locally, acting as you'
 complete -c ochakai -n __fish_use_subcommand -a completion -d 'print a shell completion script'
 complete -c ochakai -n __fish_use_subcommand -a serve -d 'start the MCP + REST server'
-complete -c ochakai -n __fish_use_subcommand -a import-ossie -d 'import an Apache Ossie semantic model'
-complete -c ochakai -n __fish_use_subcommand -a export-okf -d 'write the OKF bundle straight from the database'
-complete -c ochakai -n __fish_use_subcommand -a import-okf -d 'load an OKF bundle straight into the database'
 complete -c ochakai -n __fish_use_subcommand -a version -d 'print the version'
 
-complete -c ochakai -n '__fish_seen_subcommand_from search get create update delete compile export import whoami ui' -l url -x -d 'server URL'
+complete -c ochakai -n '__fish_seen_subcommand_from search get create update delete compile export import import-ossie whoami ui' -l url -x -d 'server URL'
 complete -c ochakai -n '__fish_seen_subcommand_from ui' -l port -x -d 'port on 127.0.0.1'
 complete -c ochakai -n '__fish_seen_subcommand_from import' -l dry-run -d 'parse and list, write nothing'
 complete -c ochakai -n '__fish_seen_subcommand_from import' -l keep-root -d 'keep a single top-level directory as the type'
-complete -c ochakai -n '__fish_seen_subcommand_from import import-okf' -F
+complete -c ochakai -n '__fish_seen_subcommand_from import import-ossie' -F
 complete -c ochakai -n '__fish_seen_subcommand_from search get create update compile whoami' -l json -d 'print raw JSON'
 complete -c ochakai -n '__fish_seen_subcommand_from search' -l type -x -a 'metric query insight term table' -d 'filter by type'
 complete -c ochakai -n '__fish_seen_subcommand_from search' -l status -x -a 'draft verified deprecated' -d 'filter by status'
@@ -221,6 +211,5 @@ complete -c ochakai -n '__fish_seen_subcommand_from compile' -l dialect -x -a 'b
 complete -c ochakai -n '__fish_seen_subcommand_from use' -l name -x -d 'name to save the URL under'
 complete -c ochakai -n '__fish_seen_subcommand_from use' -a '(ochakai use 2>/dev/null | cut -c3- | cut -f1)'
 complete -c ochakai -n '__fish_seen_subcommand_from completion' -a 'zsh bash fish'
-complete -c ochakai -n '__fish_seen_subcommand_from export export-okf' -a '(__fish_complete_directories)'
-complete -c ochakai -n '__fish_seen_subcommand_from import-ossie' -F
+complete -c ochakai -n '__fish_seen_subcommand_from export' -a '(__fish_complete_directories)'
 `

--- a/cmd/ochakai/completion_test.go
+++ b/cmd/ochakai/completion_test.go
@@ -9,7 +9,7 @@ import (
 // Guard: the hand-written completion scripts stay in sync with the real
 // command set and the enum flag values.
 func TestCompletionScriptsStayInSync(t *testing.T) {
-	admin := []string{"serve", "import-ossie", "export-okf", "import-okf", "version"}
+	admin := []string{"serve", "version"}
 	enums := []string{
 		"metric query insight term table", // --type
 		"draft verified deprecated",       // --status

--- a/cmd/ochakai/main.go
+++ b/cmd/ochakai/main.go
@@ -12,19 +12,15 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"os/user"
-	"path/filepath"
 	"runtime/debug"
+	"strings"
 	"syscall"
 	"time"
 
 	"github.com/na0fu3y/ochakai/internal/config"
-	"github.com/na0fu3y/ochakai/internal/domain"
 	"github.com/na0fu3y/ochakai/internal/embed"
 	"github.com/na0fu3y/ochakai/internal/httpauth"
-	"github.com/na0fu3y/ochakai/internal/importer"
 	"github.com/na0fu3y/ochakai/internal/mcpserver"
-	"github.com/na0fu3y/ochakai/internal/okf"
 	"github.com/na0fu3y/ochakai/internal/restapi"
 	"github.com/na0fu3y/ochakai/internal/service"
 	"github.com/na0fu3y/ochakai/internal/store"
@@ -67,24 +63,11 @@ func main() {
 	switch cmd {
 	case "serve":
 		err = serve(log)
-	case "import-ossie":
-		if len(os.Args) < 3 {
-			err = fmt.Errorf("usage: ochakai import-ossie <semantic-model.yaml>")
-		} else {
-			err = importOssie(log, os.Args[2])
-		}
-	case "export-okf":
-		if len(os.Args) < 3 {
-			err = fmt.Errorf("usage: ochakai export-okf <output-dir>")
-		} else {
-			err = exportOKF(log, os.Args[2])
-		}
-	case "import-okf":
-		if len(os.Args) < 3 {
-			err = fmt.Errorf("usage: ochakai import-okf <bundle-dir | bundle.tar.gz>")
-		} else {
-			err = importOKF(log, os.Args[2])
-		}
+	case "export-okf", "import-okf":
+		// DB-direct twins of `export`/`import`, removed in design doc 0007.
+		fmt.Fprintf(os.Stderr, "ochakai: %s was removed; run `ochakai serve` next to the database and use `ochakai %s` against it (see `ochakai help`)\n",
+			cmd, strings.TrimSuffix(cmd, "-okf"))
+		os.Exit(1)
 	case "version":
 		fmt.Println(version)
 	case "help", "-h", "--help":
@@ -114,13 +97,11 @@ Client commands (talk to a server; --url > $OCHAKAI_URL > "use" selection):
   compile --metric <m>    compile metrics into SQL (exit 2 = outside subset)
   export <dir | ->        download the knowledge base as an OKF bundle
   import <dir | tgz | ->  upload an OKF bundle (any producer's, not just ours)
+  import-ossie <file>     import an Apache Ossie semantic model
   ui                      serve the web UI locally, acting as you (no deploy)
 
-Server admin commands (run next to the database):
+Server command (runs next to the database):
   serve                   start the MCP + REST server
-  import-ossie <file>     import an Apache Ossie semantic model
-  export-okf <dir>        write the OKF bundle straight from the database
-  import-okf <dir | tgz>  load an OKF bundle straight into the database
 
   version                 print the version
   completion <shell>      print a completion script (zsh, bash, fish)
@@ -198,114 +179,4 @@ func serve(log *slog.Logger) error {
 		return err
 	}
 	return nil
-}
-
-func importOssie(log *slog.Logger, path string) error {
-	ctx := context.Background()
-	svc, _, err := setup(ctx, log)
-	if err != nil {
-		return err
-	}
-	defer svc.Store.Close()
-
-	src, err := os.ReadFile(path)
-	if err != nil {
-		return err
-	}
-	report, err := importer.ImportOssie(ctx, svc, src, cliActor())
-	if err != nil {
-		return err
-	}
-	log.Info("import complete", "models", report.Models,
-		"created", len(report.Created), "updated", len(report.Updated))
-	for _, uri := range report.Created {
-		fmt.Println("created", uri)
-	}
-	for _, uri := range report.Updated {
-		fmt.Println("updated", uri)
-	}
-	return nil
-}
-
-// exportOKF writes the knowledge base as an OKF bundle directory,
-// ready to commit to git or ship as an archive.
-func exportOKF(log *slog.Logger, dir string) error {
-	ctx := context.Background()
-	svc, _, err := setup(ctx, log)
-	if err != nil {
-		return err
-	}
-	defer svc.Store.Close()
-
-	entries, err := svc.Store.ListAll(ctx)
-	if err != nil {
-		return err
-	}
-	files, err := okf.Bundle(entries)
-	if err != nil {
-		return err
-	}
-	for path, content := range files {
-		full := filepath.Join(dir, filepath.FromSlash(path))
-		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
-			return err
-		}
-		if err := os.WriteFile(full, content, 0o644); err != nil {
-			return err
-		}
-	}
-	log.Info("export complete", "dir", dir, "concepts", len(entries), "files", len(files))
-	return nil
-}
-
-// importOKF loads an OKF bundle straight into the database, the inverse of
-// exportOKF. Existing entries are replaced (kept as revisions).
-func importOKF(log *slog.Logger, path string) error {
-	ctx := context.Background()
-	files, err := readBundle(path)
-	if err != nil {
-		return err
-	}
-	if unwrapped, root := okf.StripWrapper(files); root != "" {
-		log.Info("unwrapped bundle directory", "dir", root)
-		files = unwrapped
-	}
-	entries, skipped := okf.FromBundle(files)
-	for _, s := range skipped {
-		log.Warn("skipped bundle file", "reason", s)
-	}
-
-	svc, _, err := setup(ctx, log)
-	if err != nil {
-		return err
-	}
-	defer svc.Store.Close()
-
-	actor := cliActor()
-	var created, updated int
-	for i := range entries {
-		k := &entries[i]
-		if _, err := svc.Create(ctx, k, actor); err == nil {
-			created++
-			fmt.Println("created", k.URI())
-			continue
-		} else if !errors.Is(err, store.ErrAlreadyExists) {
-			return fmt.Errorf("%s: %w", k.URI(), err)
-		}
-		if _, err := svc.Update(ctx, k, actor); err != nil {
-			return fmt.Errorf("%s: %w", k.URI(), err)
-		}
-		updated++
-		fmt.Println("updated", k.URI())
-	}
-	log.Info("import complete", "created", created, "updated", updated, "skipped", len(skipped))
-	return nil
-}
-
-func cliActor() domain.Actor {
-	name := "cli"
-	if u, err := user.Current(); err == nil && u.Username != "" {
-		name = u.Username
-	}
-	return domain.Actor{Kind: domain.ActorHuman, Name: name}
 }

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -242,29 +242,13 @@ unavailable, writes and searches degrade gracefully to trigram-only.
 
 ## 5. Load a semantic model and connect Claude Code
 
-Import Apache Ossie semantic models through the
-[Cloud SQL Auth Proxy](https://cloud.google.com/sql/docs/postgres/sql-proxy)
-(uses your ADC; run `gcloud auth application-default login` once):
+Import Apache Ossie semantic models through the API. The CLI resolves
+Google ID tokens itself from your gcloud login, so no Cloud SQL proxy
+or authorized network is needed — `$OCHAKAI_URL` was exported when the
+service was deployed above:
 
 ```sh
-# terminal 1
-cloud-sql-proxy $PROJECT_ID:$REGION:ochakai --port 55432
-
-# terminal 2
-OCHAKAI_DATABASE_URL="postgres://ochakai:$DB_PASSWORD@localhost:55432/ochakai?sslmode=disable" \
-  go run github.com/na0fu3y/ochakai/cmd/ochakai@latest import-ossie examples/semantic-model.yaml
-```
-
-No proxy installed? A temporary authorized network works with no extra
-tools — remember to remove it afterwards (IPv4 only):
-
-```sh
-gcloud sql instances patch ochakai --authorized-networks=$(curl -4 -s ifconfig.me)/32
-export DB_IP=$(gcloud sql instances describe ochakai \
-  --format='value(ipAddresses[0].ipAddress)')
-OCHAKAI_DATABASE_URL="postgres://ochakai:$DB_PASSWORD@$DB_IP:5432/ochakai?sslmode=require" \
-  go run github.com/na0fu3y/ochakai/cmd/ochakai@latest import-ossie examples/semantic-model.yaml
-gcloud sql instances patch ochakai --clear-authorized-networks
+go run github.com/na0fu3y/ochakai/cmd/ochakai@latest import-ossie examples/semantic-model.yaml
 ```
 
 Connect Claude Code — with the Cloud Run proxy running, no headers, no

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -11,10 +11,6 @@ services:
     environment:
       OCHAKAI_DATABASE_URL: postgres://ochakai:ochakai@db:5432/ochakai?sslmode=disable
       OCHAKAI_INSECURE_DEV: "true" # local only: all requests act as human:anonymous
-    volumes:
-      # Lets the quick start run `import-ossie` (a DB-direct admin command,
-      # design doc 0004 §2.3) inside the container, next to the database.
-      - ../examples:/examples:ro
     depends_on:
       db:
         condition: service_healthy

--- a/docs/design/0007-api-only-cli.md
+++ b/docs/design/0007-api-only-cli.md
@@ -1,0 +1,67 @@
+# ochakai 設計ドキュメント 0007: DB 直結コマンドの廃止(API 一本化)
+
+Status: Accepted(2026-07-17 の議論で決定)
+Date: 2026-07-17
+
+## 1. 目的
+
+CLI から **DB 直結の server admin コマンドを廃止し、データの出し入れをすべて
+API 経由に一本化する**。0004 決定 3 は `serve` / `import-ossie` / `export-okf`
+(のちに `import-okf` も追加)を DB 直結のまま残したが、本ドキュメントは
+これを覆す。残る DB 直結コマンドは `serve` のみとなる。
+
+## 2. 動機
+
+### 2.1 二重実装と機能乖離
+
+`export-okf` / `import-okf` は client の `export` / `import` とほぼ同じ処理の
+二重実装だった。しかも `--dry-run` / `--keep-root` は client 側にしかなく、
+既に機能が乖離し始めていた。同じ成果物に 2 つの経路があると、以後の仕様追加の
+たびに片方だけ直る事故が起きる。
+
+### 2.2 利用者の混乱(先行事例)
+
+類似のシングルバイナリツールを調査した結果:
+
+- **etcd** は API 経由(etcdctl)とディスク直接操作(etcdutl)の同居が混乱を
+  招いたとして v3.5 でバイナリを分割し、v3.6 で重複機能を削除した。
+- **Gitea** の `gitea dump`、**Grafana** の `grafana cli` は DB 直結のまま
+  同居する設計で、設定ファイルの解決・実行ユーザー・コンテナ内実行をめぐる
+  混乱が慢性的に報告されている。
+- **Vault / Consul** はスナップショット取得のような管理操作すら稼働中サーバー
+  への認証付き API 呼び出しで行い、ストレージ直結コマンドをほぼ持たない。
+
+ochakai の従来構成は Gitea 型(ヘルプの区分けだけで同居)であり、
+最も混乱報告が多いパターンだった。目指すべきは Vault 型である。
+
+### 2.3 provenance の一貫性
+
+DB 直結コマンドは actor を OS ユーザー名から合成していた(`human:<username>`)。
+API 経由なら Cloud Run が検証した呼び出し元識別(0002)がそのまま記録され、
+provenance の信頼性が上がる。
+
+## 3. 決定
+
+1. **`export-okf` / `import-okf` を削除する。** 完全に client の
+   `export` / `import` の劣化版であり、代替はそのまま存在する。
+   旧コマンド名は「削除済み。`ochakai serve` を DB の隣で起動して
+   `ochakai export` / `import` を使う」と案内するスタブとして残す。
+2. **`import-ossie` は client コマンドに移行する。** 代替 API が無かったため
+   `POST /api/v1/import/ossie` を新設し(ボディは Ossie YAML そのまま、
+   応答は models / created / updated のレポート)、CLI は同名のまま
+   API 経由になる。利用者から見える変化は「DB の隣で実行」が
+   「サーバーに向けて実行」になることだけ。
+3. **DB の隣でしか動かないコマンドは `serve` だけになる。** ヘルプの
+   「Server admin commands」区分は「Server command」となる。
+4. サーバー無しで DB に流し込みたい場面(初期シード、リストア)は、
+   `OCHAKAI_INSECURE_DEV=true ochakai serve` をローカルに起動して client
+   コマンドを向けることで満たす。専用コマンドは作らない。
+
+## 4. 影響
+
+- Cloud Run 運用ガイドから Cloud SQL Auth Proxy / authorized network の
+  手順が消え、`import-ossie` は `$OCHAKAI_URL` に向けた 1 コマンドになる。
+- compose クイックスタートの `docker compose exec` と examples の
+  ボリュームマウントが不要になり、curl だけで完結する。
+- 0004 決定 3 のうち「`import-ossie` / `export-okf` を DB 直結で残す」は
+  本ドキュメントで廃止。`serve` の扱いと help の二区分表示は維持する。

--- a/docs/guides/golden-query-canary.md
+++ b/docs/guides/golden-query-canary.md
@@ -20,7 +20,7 @@ curl -s "$OCHAKAI/api/v1/knowledge?type=query&status=verified&sort=verified_at&l
 
 `sort=verified_at` は検証日時の古い順(未検証は最後)に返す。「90 日以上
 再検証されていない verified query」がカナリアの起点になる。OKF エクスポート
-(`ochakai export-okf` / `GET /api/v1/export`)を CI にチェックアウトする方式でもよい。
+(`ochakai export` / `GET /api/v1/export`)を CI にチェックアウトする方式でもよい。
 
 ### 2. 実行 — クライアントの資格情報で
 

--- a/internal/apiclient/apiclient.go
+++ b/internal/apiclient/apiclient.go
@@ -171,6 +171,23 @@ func (c *Client) Export(ctx context.Context) (io.ReadCloser, error) {
 	return resp.Body, nil
 }
 
+// ImportOssie uploads Apache Ossie semantic model YAML verbatim; the
+// server stores each model for compile and derives metric/table
+// knowledge entries.
+func (c *Client) ImportOssie(ctx context.Context, yamlSrc []byte) (*ImportReport, error) {
+	resp, err := c.doRaw(ctx, http.MethodPost, "/api/v1/import/ossie", nil,
+		"application/yaml", bytes.NewReader(yamlSrc))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var report ImportReport
+	if err := json.NewDecoder(resp.Body).Decode(&report); err != nil {
+		return nil, err
+	}
+	return &report, nil
+}
+
 // entryPath escapes each ID segment separately: IDs are hierarchical
 // ("sales/orders") and their slashes must stay real path separators.
 func entryPath(typ, id string) string {
@@ -186,13 +203,21 @@ func entryPath(typ, id string) string {
 
 func (c *Client) do(ctx context.Context, method, path string, query url.Values, body any) (*http.Response, error) {
 	var rd io.Reader
+	contentType := ""
 	if body != nil {
 		buf, err := json.Marshal(body)
 		if err != nil {
 			return nil, err
 		}
 		rd = bytes.NewReader(buf)
+		contentType = "application/json"
 	}
+	return c.doRaw(ctx, method, path, query, contentType, rd)
+}
+
+// doRaw is do without the JSON encoding: the body is sent verbatim
+// (nil rd and empty contentType for body-less requests).
+func (c *Client) doRaw(ctx context.Context, method, path string, query url.Values, contentType string, rd io.Reader) (*http.Response, error) {
 	u := c.base + path
 	if len(query) > 0 {
 		u += "?" + query.Encode()
@@ -201,8 +226,8 @@ func (c *Client) do(ctx context.Context, method, path string, query url.Values, 
 	if err != nil {
 		return nil, err
 	}
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
 	}
 	if c.tokens != nil {
 		tok, err := c.tokens.Token()

--- a/internal/apiclient/types.go
+++ b/internal/apiclient/types.go
@@ -29,6 +29,14 @@ type TimeGrain struct {
 	Grain string `json:"grain"` // day | week | month | quarter | year
 }
 
+// ImportReport is the response of POST /api/v1/import/ossie.
+// TestImportReportMatchesServerWire pins it to importer.Report.
+type ImportReport struct {
+	Models  []string `json:"models"`
+	Created []string `json:"created"`
+	Updated []string `json:"updated"`
+}
+
 type CompileResult struct {
 	SQL          string   `json:"sql"`
 	Dialect      string   `json:"dialect"`

--- a/internal/apiclient/wire_test.go
+++ b/internal/apiclient/wire_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/na0fu3y/ochakai/internal/compiler"
 	"github.com/na0fu3y/ochakai/internal/domain"
+	"github.com/na0fu3y/ochakai/internal/importer"
 	"github.com/na0fu3y/ochakai/internal/service"
 )
 
@@ -50,6 +51,30 @@ func TestCompileRequestMatchesServerWire(t *testing.T) {
 	}}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("server decoded:\n%+v\nwant:\n%+v", got, want)
+	}
+}
+
+func TestImportReportMatchesServerWire(t *testing.T) {
+	server := importer.Report{
+		Models:  []string{"sales_analytics"},
+		Created: []string{"metric/revenue"},
+		Updated: []string{"table/orders"},
+	}
+	data, err := json.Marshal(server)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got ImportReport
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("client cannot decode the server response: %v", err)
+	}
+	want := ImportReport{
+		Models:  []string{"sales_analytics"},
+		Created: []string{"metric/revenue"},
+		Updated: []string{"table/orders"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("client decoded:\n%+v\nwant:\n%+v", got, want)
 	}
 }
 

--- a/internal/importer/ossie.go
+++ b/internal/importer/ossie.go
@@ -20,11 +20,12 @@ import (
 	"github.com/na0fu3y/ochakai/internal/store"
 )
 
-// Report summarizes what an import did.
+// Report summarizes what an import did. The JSON tags are the wire
+// contract of POST /api/v1/import/ossie (mirrored in apiclient.ImportReport).
 type Report struct {
-	Models  []string
-	Created []string
-	Updated []string
+	Models  []string `json:"models"`
+	Created []string `json:"created"`
+	Updated []string `json:"updated"`
 }
 
 // ImportOssie parses Ossie YAML and stores each semantic model plus derived
@@ -33,7 +34,7 @@ type Report struct {
 func ImportOssie(ctx context.Context, svc *service.Service, yamlSrc []byte, actor domain.Actor) (*Report, error) {
 	var spec map[string]any
 	if err := yaml.Unmarshal(yamlSrc, &spec); err != nil {
-		return nil, fmt.Errorf("parse YAML: %w", err)
+		return nil, fmt.Errorf("invalid semantic model YAML: %w", err)
 	}
 	models, err := compiler.ModelsFromSpec(spec)
 	if err != nil {
@@ -43,7 +44,7 @@ func ImportOssie(ctx context.Context, svc *service.Service, yamlSrc []byte, acto
 	report := &Report{}
 	for _, m := range models {
 		if m.Name == "" {
-			return nil, fmt.Errorf("semantic model without a name")
+			return nil, fmt.Errorf("invalid semantic model: missing name")
 		}
 		modelSpec, err := toSpecMap(m)
 		if err != nil {

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -6,6 +6,7 @@ package restapi
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -14,6 +15,7 @@ import (
 	"github.com/na0fu3y/ochakai/internal/compiler"
 	"github.com/na0fu3y/ochakai/internal/domain"
 	"github.com/na0fu3y/ochakai/internal/httpauth"
+	"github.com/na0fu3y/ochakai/internal/importer"
 	"github.com/na0fu3y/ochakai/internal/okf"
 	"github.com/na0fu3y/ochakai/internal/service"
 	"github.com/na0fu3y/ochakai/internal/store"
@@ -140,6 +142,24 @@ func Handler(svc *service.Service) http.Handler {
 			// Headers already sent; nothing to do but log via server.
 			return
 		}
+	})
+
+	// POST /api/v1/import/ossie — import an Apache Ossie semantic model.
+	// The body is the YAML verbatim; models are stored for compile and
+	// metric/table knowledge entries are derived (design doc 0007 moved
+	// this from a DB-direct admin command to the API).
+	mux.HandleFunc("POST /api/v1/import/ossie", func(w http.ResponseWriter, r *http.Request) {
+		src, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 4<<20))
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "read body: " + err.Error()})
+			return
+		}
+		report, err := importer.ImportOssie(r.Context(), svc, src, httpauth.Actor(r.Context()))
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, report)
 	})
 
 	mux.HandleFunc("POST /api/v1/compile", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## What

Removes the DB-direct server admin commands and makes the API the single path for getting data in and out. The only command that still requires `OCHAKAI_DATABASE_URL` is `serve`.

- **`export-okf` / `import-okf`: removed.** They were DB-direct twins of the client `export`/`import` (which already had more features: `--dry-run`, `--keep-root`). The old names remain as stubs that explain the migration (`ochakai serve` next to the DB + `ochakai export`/`import` against it), exit 1.
- **`import-ossie`: same name, now a client command.** New endpoint `POST /api/v1/import/ossie` accepts Ossie semantic-model YAML verbatim and returns a `{models, created, updated}` report; the CLI reads a file (or `-` for stdin) and posts it. Added to `api/openapi.yaml`, with a wire test pinning `apiclient.ImportReport` to `importer.Report`.
- **Docs simplified by the change itself:**
  - Cloud Run guide §5 drops the entire Cloud SQL Auth Proxy / temporary authorized-network dance — importing is now one command against `$OCHAKAI_URL`.
  - README quick start no longer needs `docker compose exec`; plain curl works. The `examples/` volume mount in compose.yaml is gone.
- Completions (zsh/bash/fish) and their sync tests updated; `import-ossie` gains `--url` completion.

## Why

Design doc 0007 (included) records the decision. Short version: the two OKF commands were a duplicate implementation drifting from the client ones, and a survey of similar single-binary tools showed the mixed pattern (Gitea `dump`, Grafana `cli`) has the worst user-confusion track record, while etcd split etcdctl/etcdutl over exactly this and Vault does even admin ops through the API. Going API-only also fixes provenance: imports are now recorded under the caller's Cloud-Run-verified identity instead of a synthesized `human:<os-username>`.

## Notes for review

- YAML parse / validation failures return 400 (messages now say "invalid …", riding `writeError`'s existing heuristic); body capped at 4 MiB like the JSON endpoints.
- Empty report fields serialize as `null` rather than `[]` (Go nil slices, same as the existing `hits`) — flagged in case you'd prefer `[]` for a brand-new endpoint.
- Breaking change for scripts that ran `import-ossie` with `OCHAKAI_DATABASE_URL`: the command now needs a server URL. `export-okf`/`import-okf` get explicit removal stubs; `import-ossie` can't (name unchanged), so this deserves a release-note line.

Verified end-to-end against a live server + pgvector Postgres: CLI and curl import paths, re-import idempotency, compile using the imported model, bad-YAML 400, removed-command stubs, stdin input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)