### PR TITLE
Create revives soft-deleted entries instead of leaving the ID dead

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -66,7 +66,9 @@ paths:
       description: >
         Entries default to draft. Anyone who can reach ochakai may set
         status=verified; verified_by records who did (provenance over
-        authorization).
+        authorization). A live entry with the same type/id is a 409 —
+        including rejected ones — but creating over a soft-deleted entry
+        revives it (its prior history stays in the revisions).
       requestBody:
         required: true
         content:

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -96,8 +96,9 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
-		Name:        "delete_knowledge",
-		Description: "Soft-delete a knowledge entry. History is retained as revisions.",
+		Name: "delete_knowledge",
+		Description: "Soft-delete a knowledge entry. History is retained as revisions; " +
+			"create_knowledge on the same type/id revives it.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in getIn) (*mcp.CallToolResult, deleteOut, error) {
 		if err := svc.Delete(ctx, domain.Type(in.Type), in.ID, httpauth.Actor(ctx)); err != nil {
 			return nil, deleteOut{}, err

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -122,6 +122,12 @@ func (s *Store) Get(ctx context.Context, typ domain.Type, id string) (*domain.Kn
 	return &k, nil
 }
 
+// Create inserts a new entry. A live entry with the same type/id is
+// ErrAlreadyExists — including rejected ones, so the memory of no
+// survives. A soft-deleted entry is revived instead: the ID would
+// otherwise be dead forever (the row still owns the primary key while
+// Update refuses deleted rows), and its history stays in the revisions
+// either way.
 func (s *Store) Create(ctx context.Context, k *domain.Knowledge) error {
 	now := time.Now().UTC()
 	k.CreatedAt, k.UpdatedAt = now, now
@@ -134,7 +140,18 @@ func (s *Store) Create(ctx context.Context, k *domain.Knowledge) error {
 		rejectedKind, rejectedName := actorPtrs(k.RejectedBy)
 		tag, err := tx.Exec(ctx, `INSERT INTO knowledge (`+knowledgeCols+`)
 			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20)
-			ON CONFLICT (type, id) DO NOTHING`,
+			ON CONFLICT (type, id) DO UPDATE SET
+				title=EXCLUDED.title, description=EXCLUDED.description, tags=EXCLUDED.tags,
+				status=EXCLUDED.status, status_note=EXCLUDED.status_note,
+				created_by_kind=EXCLUDED.created_by_kind, created_by_name=EXCLUDED.created_by_name,
+				verified_by_kind=EXCLUDED.verified_by_kind, verified_by_name=EXCLUDED.verified_by_name,
+				verified_at=EXCLUDED.verified_at,
+				rejected_by_kind=EXCLUDED.rejected_by_kind, rejected_by_name=EXCLUDED.rejected_by_name,
+				rejected_at=EXCLUDED.rejected_at,
+				links=EXCLUDED.links, attrs=EXCLUDED.attrs, body=EXCLUDED.body,
+				created_at=EXCLUDED.created_at, updated_at=EXCLUDED.updated_at,
+				deleted_at=NULL
+			WHERE knowledge.deleted_at IS NOT NULL`,
 			k.Type, k.ID, k.Title, k.Description, k.Tags, k.Status, k.StatusNote,
 			k.CreatedBy.Kind, k.CreatedBy.Name, verifiedKind, verifiedName, k.VerifiedAt,
 			rejectedKind, rejectedName, k.RejectedAt,
@@ -179,6 +196,7 @@ func (s *Store) Update(ctx context.Context, k *domain.Knowledge, actor domain.Ac
 }
 
 // SoftDelete hides an entry from reads while keeping full history.
+// Create on the same type/id revives it.
 func (s *Store) SoftDelete(ctx context.Context, typ domain.Type, id string, actor domain.Actor) error {
 	return s.withTx(ctx, func(tx pgx.Tx) error {
 		k, err := s.Get(ctx, typ, id)

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -188,3 +188,109 @@ func TestIntegrationSoftDeleteWithoutEmbeddingTable(t *testing.T) {
 		t.Error("entry still visible after SoftDelete")
 	}
 }
+
+// Create over a soft-deleted entry revives it — otherwise the ID is dead
+// forever (the deleted row still owns the primary key while Update
+// refuses deleted rows). Live entries, including rejected ones, still
+// conflict.
+func TestIntegrationCreateRevivesSoftDeleted(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	for _, table := range []string{"knowledge", "knowledge_revision"} {
+		if _, err := s.pool.Exec(ctx, `DELETE FROM `+table+` WHERE id LIKE 'it-revive-%'`); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	actor := domain.Actor{Kind: "human", Name: "test"}
+	first := &domain.Knowledge{
+		Type: domain.TypeTerm, ID: "it-revive-me", Title: "first life",
+		Status: domain.StatusDraft, CreatedBy: actor,
+	}
+	if err := s.Create(ctx, first); err != nil {
+		t.Fatal(err)
+	}
+
+	// Live entry: create must still conflict.
+	dup := &domain.Knowledge{
+		Type: domain.TypeTerm, ID: "it-revive-me", Title: "imposter",
+		Status: domain.StatusDraft, CreatedBy: actor,
+	}
+	if err := s.Create(ctx, dup); err != ErrAlreadyExists {
+		t.Fatalf("create over a live entry = %v, want ErrAlreadyExists", err)
+	}
+
+	if err := s.SoftDelete(ctx, first.Type, first.ID, actor); err != nil {
+		t.Fatal(err)
+	}
+
+	// Soft-deleted entry: create revives it with the new content.
+	second := &domain.Knowledge{
+		Type: domain.TypeTerm, ID: "it-revive-me", Title: "second life",
+		Status: domain.StatusDraft, CreatedBy: domain.Actor{Kind: "agent", Name: "claude-code"},
+	}
+	if err := s.Create(ctx, second); err != nil {
+		t.Fatalf("create over a soft-deleted entry: %v", err)
+	}
+	got, err := s.Get(ctx, second.Type, second.ID)
+	if err != nil {
+		t.Fatalf("revived entry not readable: %v", err)
+	}
+	if got.Title != "second life" || got.CreatedBy.Name != "claude-code" {
+		t.Errorf("revived entry = %+v, want the new content and creator", got)
+	}
+
+	// The full lineage stays: create, delete, create.
+	var changes []string
+	rows, err := s.pool.Query(ctx,
+		`SELECT change FROM knowledge_revision WHERE type=$1 AND id=$2 ORDER BY rev`,
+		second.Type, second.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var c string
+		if err := rows.Scan(&c); err != nil {
+			t.Fatal(err)
+		}
+		changes = append(changes, c)
+	}
+	want := []string{"create", "delete", "create"}
+	if len(changes) != len(want) {
+		t.Fatalf("revisions = %v, want %v", changes, want)
+	}
+	for i := range want {
+		if changes[i] != want[i] {
+			t.Fatalf("revisions = %v, want %v", changes, want)
+		}
+	}
+
+	// Rejected entries are live: the memory of no is not overwritable.
+	rejected := &domain.Knowledge{
+		Type: domain.TypeTerm, ID: "it-revive-no", Title: "rejected",
+		Status: domain.StatusRejected, StatusNote: "duplicate",
+		CreatedBy: actor, RejectedBy: &actor,
+	}
+	if err := s.Create(ctx, rejected); err != nil {
+		t.Fatal(err)
+	}
+	again := &domain.Knowledge{
+		Type: domain.TypeTerm, ID: "it-revive-no", Title: "try again",
+		Status: domain.StatusDraft, CreatedBy: actor,
+	}
+	if err := s.Create(ctx, again); err != ErrAlreadyExists {
+		t.Fatalf("create over a rejected entry = %v, want ErrAlreadyExists", err)
+	}
+}


### PR DESCRIPTION
## Problem

After `ochakai delete <type>/<id>` (soft delete), the ID entered a dead state:

- **create** → 409 `knowledge already exists` — the deleted row still owns the primary key
- **update** → 404 `knowledge not found` — reads filter `deleted_at IS NULL`

So a soft-deleted ID could never be reused or restored through the API (found while testing #36).

## Fix

`store.Create` now uses a conditional upsert: `ON CONFLICT (type, id) DO UPDATE ... WHERE knowledge.deleted_at IS NOT NULL`.

- **Live entries still conflict** — including `rejected` ones, so the memory of *no* cannot be overwritten by re-creating.
- **Soft-deleted entries are revived** with the new content and creator; `deleted_at` is cleared.
- **History is continuous**: the revision chain reads `create, delete, create` — nothing is lost.

This also makes `ochakai import` able to restore a bundle containing previously-deleted entries, matching export/import round-trip expectations.

Docs updated: OpenAPI `createKnowledge` description and the `delete_knowledge` MCP tool description now state the revive semantics.

## Testing

- New integration test `TestIntegrationCreateRevivesSoftDeleted`: live-conflict, rejected-conflict, revive-with-new-content/creator, and the `create → delete → create` revision lineage. Passes against a fresh pgvector Postgres.
- `gofmt` / `go vet` / `go test ./...` / `CGO_ENABLED=0 go build -trimpath ./...` all pass.

Note: `internal/store/store_integration_test.go` also grows in #36; if both merge, the conflict is two independent appended test functions — trivial to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)