### PR TITLE
Web UI catches up with attachments; typed 413s; MCP limit contracts in schema

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -340,6 +340,7 @@ paths:
                     items: { type: string }
                     description: URIs of knowledge entries refreshed.
         "400": { $ref: "#/components/responses/Error" }
+        "413": { $ref: "#/components/responses/Error" }
   /api/v1/compile:
     post:
       operationId: compileSQL

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -192,15 +192,18 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 	return s
 }
 
+// The jsonschema tags spell out the numeric contracts (defaults, maxima,
+// out-of-range fallback) that api/openapi.yaml and the CLI help already
+// document — MCP agents only see the tool schema.
 type searchIn struct {
 	// Query drives the search. Optional in the schema because sort mode
 	// rejects it — one of query / sort must be set.
-	Query    string   `json:"query,omitempty"`
-	Types    []string `json:"types,omitempty"`
-	Statuses []string `json:"statuses,omitempty"`
-	Tags     []string `json:"tags,omitempty"`
-	Sort     string   `json:"sort,omitempty"` // "" to search; "verified_at" to list by verification age
-	Limit    int      `json:"limit,omitempty"`
+	Query    string   `json:"query,omitempty" jsonschema:"search text; omit when sort is set"`
+	Types    []string `json:"types,omitempty" jsonschema:"filter by type (metric, query, insight, term, table, or any custom slug)"`
+	Statuses []string `json:"statuses,omitempty" jsonschema:"filter by status: draft, verified, deprecated, rejected"`
+	Tags     []string `json:"tags,omitempty" jsonschema:"filter by tag"`
+	Sort     string   `json:"sort,omitempty" jsonschema:"omit to search; \"verified_at\" lists by verification age instead (mutually exclusive with query)"`
+	Limit    int      `json:"limit,omitempty" jsonschema:"max results: searching default 10, max 50; with sort default 100, max 1000 (out-of-range falls back to the default)"`
 }
 
 type searchOut struct {
@@ -208,14 +211,14 @@ type searchOut struct {
 }
 
 type contextIn struct {
-	Query    string   `json:"query"`
-	Types    []string `json:"types,omitempty"`
-	Statuses []string `json:"statuses,omitempty"`
-	Tags     []string `json:"tags,omitempty"`
-	Limit    int      `json:"limit,omitempty"`
+	Query    string   `json:"query" jsonschema:"the data question to gather context for"`
+	Types    []string `json:"types,omitempty" jsonschema:"filter by type (metric, query, insight, term, table, or any custom slug)"`
+	Statuses []string `json:"statuses,omitempty" jsonschema:"filter by status: draft, verified, deprecated, rejected"`
+	Tags     []string `json:"tags,omitempty" jsonschema:"filter by tag"`
+	Limit    int      `json:"limit,omitempty" jsonschema:"max primary entries: default 5, max 20 (out-of-range falls back to the default); linked companions share a 2x limit total cap"`
 	// MinScore drops hits below it; scores are search-mode dependent
 	// (trigram vs hybrid RRF), so leave it 0 unless calibrated.
-	MinScore float64 `json:"min_score,omitempty"`
+	MinScore float64 `json:"min_score,omitempty" jsonschema:"drop hits scoring below this; scores are search-mode dependent and uncalibrated, so leave 0 (off) unless calibrated against your corpus"`
 }
 
 type contextOut struct {
@@ -252,16 +255,16 @@ type deleteOut struct {
 }
 
 type writeIn struct {
-	Type        string         `json:"type"`
-	ID          string         `json:"id"`
+	Type        string         `json:"type" jsonschema:"one slug segment; recommended: metric, query, insight, term, table — any custom slug works"`
+	ID          string         `json:"id" jsonschema:"slug segments separated by / (hierarchical, e.g. sales/orders); the last segment must not be \"index\""`
 	Title       string         `json:"title"`
 	Description string         `json:"description,omitempty"`
 	Tags        []string       `json:"tags,omitempty"`
-	Status      string         `json:"status,omitempty"`
-	StatusNote  string         `json:"status_note,omitempty"`
-	Links       []domain.Link  `json:"links,omitempty"`
-	Attrs       map[string]any `json:"attrs,omitempty"`
-	Body        string         `json:"body,omitempty"`
+	Status      string         `json:"status,omitempty" jsonschema:"draft, verified, deprecated, or rejected; defaults to draft"`
+	StatusNote  string         `json:"status_note,omitempty" jsonschema:"free-form reason for the current status (why rejected/deprecated)"`
+	Links       []domain.Link  `json:"links,omitempty" jsonschema:"typed edges to other entries, e.g. {rel: about, target: metric/revenue}"`
+	Attrs       map[string]any `json:"attrs,omitempty" jsonschema:"type-specific structured attributes, e.g. question/sql for a query"`
+	Body        string         `json:"body,omitempty" jsonschema:"markdown body"`
 }
 
 func (in writeIn) toKnowledge() *domain.Knowledge {

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -59,6 +59,49 @@ func TestSearchQueryNotRequired(t *testing.T) {
 	t.Fatal("search_knowledge tool not found")
 }
 
+// TestLimitContractsInSchema pins that the tool schemas document the
+// limit defaults and maxima — MCP agents see only the schema, so the
+// contract that openapi.yaml and the CLI help carry must live here too.
+func TestLimitContractsInSchema(t *testing.T) {
+	cs := connect(t)
+	res, err := cs.ListTools(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	want := map[string][]string{
+		"search_knowledge": {"default 10", "max 50", "default 100", "max 1000"},
+		"get_context":      {"default 5", "max 20"},
+	}
+	for _, tool := range res.Tools {
+		substrs, ok := want[tool.Name]
+		if !ok {
+			continue
+		}
+		delete(want, tool.Name)
+		raw, err := json.Marshal(tool.InputSchema)
+		if err != nil {
+			t.Fatalf("marshal %s schema: %v", tool.Name, err)
+		}
+		var schema struct {
+			Properties map[string]struct {
+				Description string `json:"description"`
+			} `json:"properties"`
+		}
+		if err := json.Unmarshal(raw, &schema); err != nil {
+			t.Fatalf("unmarshal %s schema: %v", tool.Name, err)
+		}
+		desc := schema.Properties["limit"].Description
+		for _, s := range substrs {
+			if !strings.Contains(desc, s) {
+				t.Errorf("%s limit description %q does not mention %q", tool.Name, desc, s)
+			}
+		}
+	}
+	for name := range want {
+		t.Errorf("tool %s not found", name)
+	}
+}
+
 // TestSearchRejectsQueryWithSort mirrors the CLI and REST rule: a search
 // query combined with sort=verified_at is an error, not silently ignored.
 func TestSearchRejectsQueryWithSort(t *testing.T) {

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -175,10 +175,9 @@ func Handler(svc *service.Service) http.Handler {
 		if !ok {
 			return
 		}
-		data, err := io.ReadAll(http.MaxBytesReader(w, r.Body, domain.MaxAttachmentSize+1))
-		if err != nil {
-			writeJSON(w, http.StatusRequestEntityTooLarge,
-				map[string]string{"error": fmt.Sprintf("attachment exceeds %d MiB", domain.MaxAttachmentSize>>20)})
+		data, ok := readBody(w, r, domain.MaxAttachmentSize,
+			fmt.Sprintf("attachment exceeds %d MiB", domain.MaxAttachmentSize>>20))
+		if !ok {
 			return
 		}
 		// okf_path preserves the bundle location a foreign import carried
@@ -280,9 +279,8 @@ func Handler(svc *service.Service) http.Handler {
 	// metric/table knowledge entries are derived (design doc 0007 moved
 	// this from a DB-direct admin command to the API).
 	mux.HandleFunc("POST /api/v1/import/ossie", func(w http.ResponseWriter, r *http.Request) {
-		src, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 4<<20))
-		if err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "read body: " + err.Error()})
+		src, ok := readBody(w, r, 4<<20, "semantic model exceeds 4 MiB")
+		if !ok {
 			return
 		}
 		report, err := importer.ImportOssie(r.Context(), svc, src, httpauth.Actor(r.Context()))
@@ -313,6 +311,23 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(v)
+}
+
+// readBody reads at most limit bytes of the request body. Exceeding the
+// limit is a 413 with tooLarge as the message; any other read failure is
+// a 400 — a client disconnect must not masquerade as a size complaint.
+func readBody(w http.ResponseWriter, r *http.Request, limit int64, tooLarge string) ([]byte, bool) {
+	data, err := io.ReadAll(http.MaxBytesReader(w, r.Body, limit))
+	if err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeJSON(w, http.StatusRequestEntityTooLarge, map[string]string{"error": tooLarge})
+		} else {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "read body: " + err.Error()})
+		}
+		return nil, false
+	}
+	return data, true
 }
 
 func readJSON(w http.ResponseWriter, r *http.Request, v any) bool {

--- a/internal/restapi/restapi_test.go
+++ b/internal/restapi/restapi_test.go
@@ -1,6 +1,7 @@
 package restapi
 
 import (
+	"bytes"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -8,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/na0fu3y/ochakai/internal/compiler"
+	"github.com/na0fu3y/ochakai/internal/domain"
 	"github.com/na0fu3y/ochakai/internal/service"
 	"github.com/na0fu3y/ochakai/internal/store"
 )
@@ -61,6 +63,36 @@ func TestBadRequestValidation(t *testing.T) {
 			}
 			if !strings.Contains(rec.Body.String(), c.wantSubstr) {
 				t.Errorf("GET %s body %q does not mention %q", c.url, rec.Body, c.wantSubstr)
+			}
+		})
+	}
+}
+
+// TestOversizedBodies pins the 413 classification: only a body that
+// exceeds the limit is 413 — one byte over is enough, and the check
+// fires before any service call.
+func TestOversizedBodies(t *testing.T) {
+	h := Handler(&service.Service{})
+	cases := []struct {
+		name, method, url string
+		size              int
+		wantSubstr        string
+	}{
+		{"attachment", http.MethodPut, "/api/v1/attachments/insight/revenue/weekly.png",
+			domain.MaxAttachmentSize + 1, "attachment exceeds"},
+		{"ossie model", http.MethodPost, "/api/v1/import/ossie",
+			4<<20 + 1, "semantic model exceeds"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(c.method, c.url, bytes.NewReader(make([]byte, c.size)))
+			h.ServeHTTP(rec, req)
+			if rec.Code != http.StatusRequestEntityTooLarge {
+				t.Fatalf("%s %s (%d bytes) = %d, want 413 (body: %s)", c.method, c.url, c.size, rec.Code, rec.Body)
+			}
+			if !strings.Contains(rec.Body.String(), c.wantSubstr) {
+				t.Errorf("body %q does not mention %q", rec.Body, c.wantSubstr)
 			}
 		})
 	}

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -2,9 +2,11 @@
 <!-- Sample web UI for the ochakai REST API (api/openapi.yaml).
      A single self-contained file: no build step, no framework, no CDN.
      Serve it from anywhere (main.go proxies /api/v1 to ochakai) and it
-     covers the whole API surface — search, entry details with usage,
-     create/edit with the draft → verified workflow, SQL compilation, and
-     OKF export. A starting point for building your own UI. -->
+     covers the human-facing API surface — search, entry details with
+     usage and image attachments, create/edit with the draft → verified
+     workflow, SQL compilation, and OKF export. (/api/v1/context and the
+     Ossie import are agent/ops surfaces — see api/openapi.yaml.)
+     A starting point for building your own UI. -->
 <html lang="en">
 <head>
 <meta charset="utf-8">
@@ -203,6 +205,18 @@
   .md h1 { font-size: 1.3rem; } .md h2 { font-size: 1.15rem; } .md h3 { font-size: 1rem; }
   .md p { margin: .5em 0; }
   .md ul, .md ol { margin: .4em 0; padding-left: 1.5em; }
+  .md img { max-width: 100%; border: 1px solid var(--border); border-radius: 8px; display: block; margin: .6rem 0; }
+
+  /* ---- attachments ---- */
+  .att-card { display: flex; gap: 1rem; align-items: flex-start; }
+  .att-card a.thumb { flex-shrink: 0; }
+  .att-card img {
+    max-width: 13rem; max-height: 9rem; object-fit: contain; display: block;
+    border: 1px solid var(--border); border-radius: 6px; background: var(--code-bg);
+  }
+  .att-card .att-meta { min-width: 0; display: flex; flex-direction: column; gap: .3rem; align-items: flex-start; }
+  .att-card .att-meta .mono { overflow-wrap: anywhere; }
+  @media (max-width: 620px) { .att-card { flex-direction: column; } }
 
   /* ---- forms ---- */
   .form { max-width: 46rem; }
@@ -267,20 +281,34 @@ function actorStr(a) {
   if (!a || !a.name) return '';
   return (a.kind === 'agent' ? '🤖 ' : '👤 ') + a.name;
 }
+function fmtSize(n) {
+  if (!n && n !== 0) return '';
+  if (n < 1024) return n + ' B';
+  if (n < 1024 * 1024) return (n / 1024).toFixed(0) + ' KB';
+  return (n / (1024 * 1024)).toFixed(1) + ' MB';
+}
 // URL path for an entry; hierarchical IDs keep their slashes.
 function idPath(type, id) {
   return encodeURIComponent(type) + '/' + String(id).split('/').map(encodeURIComponent).join('/');
 }
 const entryHash = e => '#/k/' + idPath(e.type, e.id);
 
-/* ---- tiny markdown renderer (headings, lists, code, links, emphasis) ---- */
-function md(src) {
+/* ---- tiny markdown renderer (headings, lists, code, links, emphasis, images) ---- */
+// resolveImg maps an image reference from the body to a URL (the detail
+// view resolves entry-relative references to attachment URLs); references
+// it cannot resolve stay literal text rather than rendering broken images.
+function md(src, resolveImg) {
   const lines = String(src ?? '').split('\n');
   let out = '', inCode = false, inList = null, para = [];
+  const img = (m, alt, ref) => {
+    const url = /^https?:/.test(ref) ? ref : resolveImg && resolveImg(ref);
+    return url ? `<img src="${url}" alt="${alt}" loading="lazy">` : m;
+  };
   const inline = s => esc(s)
     .replace(/`([^`]+)`/g, '<code>$1</code>')
     .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
     .replace(/(^|\W)\*([^*\n]+)\*(?=\W|$)/g, '$1<em>$2</em>')
+    .replace(/!\[([^\]]*)\]\(([^)\s]+)\)/g, img)
     .replace(/\[([^\]]+)\]\((https?:[^)\s]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>');
   const flushPara = () => { if (para.length) { out += '<p>' + inline(para.join(' ')) + '</p>'; para = []; } };
   const flushList = () => { if (inList) { out += `</${inList}>`; inList = null; } };
@@ -331,7 +359,9 @@ $('#server-chip').addEventListener('click', () => {
 
 async function api(path, opts = {}) {
   const init = { method: opts.method || 'GET' };
-  if (opts.body !== undefined) {
+  if (opts.raw !== undefined) {
+    init.body = opts.raw; // raw bytes (attachment upload), no JSON envelope
+  } else if (opts.body !== undefined) {
     init.headers = { 'Content-Type': 'application/json' };
     init.body = JSON.stringify(opts.body);
   }
@@ -449,7 +479,8 @@ async function runSearch() {
   for (const t of explore.types) p.append('type', t);
   for (const s of explore.statuses) p.append('status', s);
   if (explore.tag) p.append('tag', explore.tag);
-  p.set('limit', '25');
+  // The canary feed reads more per page than a search (server default 100).
+  p.set('limit', explore.staleFeed ? '100' : '25');
   const my = runSearch._seq = (runSearch._seq || 0) + 1;
   try {
     const { hits } = await api('/api/v1/knowledge?' + p);
@@ -507,9 +538,12 @@ async function viewDetail(type, id) {
   ].filter(Boolean).join(' · ');
 
   const tags = (entry.tags || []).map(t => `<span class="tag">${esc(t)}</span>`).join(' ');
+  // Any transition the API allows is offered here (provenance over
+  // authorization, design doc 0002) — only the current status is hidden.
   const canVerify = entry.status !== 'verified';
-  const canDeprecate = entry.status === 'verified';
-  const canReject = entry.status === 'draft';
+  const canDeprecate = entry.status !== 'deprecated';
+  const canReject = entry.status !== 'rejected';
+  const atts = entry.attachments || [];
 
   view.innerHTML = `
     <nav class="crumbs mono"><a href="#/">knowledge</a> / ${esc(entry.type)} / ${esc(entry.id)}</nav>
@@ -532,14 +566,41 @@ async function viewDetail(type, id) {
       <button data-tab="overview" class="active">Overview</button>
       <button data-tab="attrs">Attributes</button>
       <button data-tab="links">Links${entry.links && entry.links.length ? ' (' + entry.links.length + ')' : ''}</button>
+      <button data-tab="attachments">Attachments${atts.length ? ' (' + atts.length + ')' : ''}</button>
       <button data-tab="usage">Usage</button>
     </div>
     <div id="tab-body"></div>`;
 
+  // Attachment paths and image resolution (design doc 0008). Body links
+  // are OKF bundle references: relative to the entry document's directory
+  // ("<type>/<id parent>/"), or bundle-root when they start with "/".
+  const lastSeg = entry.id.split('/').pop();
+  const idParent = entry.id.includes('/') ? entry.id.slice(0, entry.id.lastIndexOf('/')) : '';
+  const docDir = entry.type + (idParent ? '/' + idParent : '');
+  const attPath = name => '/api/v1/attachments/' + idPath(entry.type, entry.id) + '/' + encodeURIComponent(name);
+  const attURL = name => baseURL() + attPath(name);
+  const normalize = p => {
+    const out = [];
+    for (const seg of p.split('/')) {
+      if (!seg || seg === '.') continue;
+      if (seg === '..') out.pop(); else out.push(seg);
+    }
+    return out.join('/');
+  };
+  const resolveImg = ref => {
+    const p = normalize(ref.startsWith('/') ? ref : docDir + '/' + ref);
+    const canonical = a => entry.type + '/' + entry.id + '/' + a.name;
+    let hit = atts.find(a => p === (a.okf_path || canonical(a)) || p === canonical(a));
+    // Forgiving fallback: names are unique within the entry, so a filename
+    // match resolves references written against a layout we don't know.
+    hit = hit || atts.find(a => a.name === ref.split('/').pop());
+    return hit ? attURL(hit.name) : null;
+  };
+
   const tabs = {
     overview: () => `
       ${entry.description ? `<p style="font-size:1.02rem">${esc(entry.description)}</p>` : ''}
-      ${entry.body ? `<div class="md">${md(entry.body)}</div>` : ''}
+      ${entry.body ? `<div class="md">${md(entry.body, resolveImg)}</div>` : ''}
       ${!entry.description && !entry.body ? '<div class="empty">No description or body.</div>' : ''}`,
     attrs: () => {
       const attrs = entry.attrs || {};
@@ -563,14 +624,65 @@ async function viewDetail(type, id) {
           <td>${href ? `<a class="mono" href="${href}">${esc(l.target)}</a>` : `<span class="mono">${esc(l.target)}</span>`}</td></tr>`;
       }).join('') + '</table>';
     },
+    attachments: () => {
+      const cards = atts.map(a => `
+        <div class="card att-card">
+          <a class="thumb" href="${attURL(a.name)}" target="_blank" rel="noopener"><img src="${attURL(a.name)}" alt="${esc(a.name)}" loading="lazy"></a>
+          <div class="att-meta">
+            <span class="mono">${esc(a.name)}</span>
+            <span class="meta">${esc(a.media_type || '')} · ${fmtSize(a.size)}${a.created_by && a.created_by.name ? ' · ' + esc(actorStr(a.created_by)) : ''}${a.created_at ? ' · ' + esc(fmtDate(a.created_at)) : ''}</span>
+            <span class="meta">body reference: <code>![${esc(a.name)}](${esc(lastSeg)}/${esc(a.name)})</code></span>
+            <button class="btn small danger" data-detach="${esc(a.name)}">Detach</button>
+          </div>
+        </div>`).join('');
+      return `
+        ${cards || '<div class="empty">No attachments.</div>'}
+        <div class="toolbar" style="margin-top:1rem">
+          <input type="file" id="att-file" accept="image/png,image/jpeg,image/gif,image/webp" multiple hidden>
+          <button class="btn small" id="att-choose">Choose images…</button>
+          <span class="provenance" id="att-chosen" style="margin:0"></span>
+          <button class="btn small primary" id="att-upload">Attach</button>
+        </div>
+        <p class="provenance">png / jpeg / gif / webp, max 5 MiB each, 20 per entry. Reference an image from the
+        body (<code>![alt](${esc(lastSeg)}/name.png)</code>) so its caption is searchable and it survives OKF export.</p>`;
+    },
     usage: () => '<div class="empty">…</div>',
   };
+
+  function wireAttachments() {
+    const fileInput = $('#att-file');
+    $('#att-choose').addEventListener('click', () => fileInput.click());
+    fileInput.addEventListener('change', () => {
+      $('#att-chosen').textContent = [...fileInput.files].map(f => f.name).join(', ');
+    });
+    $('#att-upload').addEventListener('click', async () => {
+      const files = [...fileInput.files];
+      if (!files.length) { toast('Choose image files first.'); return; }
+      try {
+        for (const f of files) {
+          await api(attPath(f.name), { method: 'PUT', raw: f });
+        }
+        toast(files.length > 1 ? `Attached ${files.length} images.` : 'Attached.');
+        viewDetail(entry.type, entry.id);
+      } catch (e) { toast('Attach failed: ' + e.message); }
+    });
+    body.querySelectorAll('[data-detach]').forEach(b => b.addEventListener('click', async () => {
+      const name = b.dataset.detach;
+      if (!confirm(`Detach ${name}? The change is kept as a revision.`)) return;
+      try {
+        await api(attPath(name), { method: 'DELETE' });
+        toast('Detached.');
+        viewDetail(entry.type, entry.id);
+      } catch (e) { toast('Detach failed: ' + e.message); }
+    }));
+  }
 
   const body = $('#tab-body');
   let usageLoaded = false;
   async function showTab(name) {
     document.querySelectorAll('#tabs button').forEach(b => b.classList.toggle('active', b.dataset.tab === name));
     body.innerHTML = tabs[name]();
+    if (name === 'attachments') wireAttachments();
     if (name === 'usage' && !usageLoaded) {
       try {
         const u = await api('/api/v1/usage/' + idPath(entry.type, entry.id));


### PR DESCRIPTION
## Why

A REST/MCP/CLI/Web consistency review found the Web UI had fallen behind the recent feature work — most visibly image attachments (#46, design doc 0008) — plus two smaller cross-surface gaps.

## Web UI (internal/webui/index.html)

- **Attachments tab** on the detail view: image previews, metadata (media type, size, uploader, date), the canonical body-reference hint, detach, and upload. Upload PUTs raw bytes through the existing `api()` helper (new `raw` option), so `ochakai ui` records the change as `human:<you>` like every other edit.
- **Markdown images render.** Entry-relative references are resolved the OKF way — relative to the entry document's directory, bundle-root for `/`-prefixed paths — against the entry's attachments (`okf_path` respected, filename match as a forgiving fallback). The canonical `![alt](<id last segment>/<name>)` link now displays inline; unresolvable references stay literal text instead of broken images.
- **Status actions match the API.** Verify / Deprecate / Reject are offered for every transition the API allows (only the current status is hidden), instead of the previous draft-only-reject, verified-only-deprecate subset.
- **Verification-age feed requests `limit=100`** (the server default for `sort=verified_at`) instead of the 25-per-page search size.
- Header comment no longer claims "the whole API surface"; `/api/v1/context` and the Ossie import are called out as agent/ops surfaces.

## REST (internal/restapi)

- Oversized-body classification is exact: `http.MaxBytesError` → 413, any other read failure → 400, so a client disconnect can't masquerade as a size complaint. The boundary is also no longer ambiguous (previously a body of exactly limit+1 took the 400 path, larger took 413).
- `/api/v1/import/ossie` gets the same treatment; openapi.yaml documents its 413.
- `TestOversizedBodies` pins both endpoints.

## MCP (internal/mcpserver)

- Tool input schemas now carry the limit contracts (defaults, maxima, out-of-range fallback) and field semantics that openapi.yaml and the CLI help already documented — MCP agents only ever see the schema. `TestLimitContractsInSchema` pins the descriptions.

## Verification

- `gofmt` / `go vet` / `go test ./...` all green.
- Web UI exercised in a browser against a stub API: relative body image renders inline; Attachments tab lists, uploads (toast + count update), and detaches; the feed sends `limit=100` and search still sends 25; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)