### PR TITLE
MCP: expose knowledge as ochakai:// resources; tool annotations & field descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,15 @@ it on Cloud Run as a team-shared service.
 | `get_knowledge_usage` | Usage totals per entry — draft-promotion evidence, staleness signal |
 | `compile_sql` | Metrics + dimensions + filters + time grain → SQL. Never executes, never guesses |
 
+Every entry is also an **MCP resource** addressable by its canonical URI —
+`ochakai://{type}/{id}`, e.g. `ochakai://metric/revenue` (IDs may be
+hierarchical, like `ochakai://query/sales/top-customers`). Clients that
+support resource references (`@`-mentions) can pull an entry in as an OKF
+document — frontmatter, body, and links — without a tool call; discovery
+stays with `get_context`/`search_knowledge`. Read tools carry `readOnly`
+annotations and `delete_knowledge` a `destructive` one, so client
+auto-approval policies work without parsing descriptions.
+
 The REST API (`/api/v1`) is a superset of these tools, adding bulk
 export/import — see
 [api/openapi.yaml](api/openapi.yaml). To keep golden queries trustworthy

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -6,18 +6,24 @@ package mcpserver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/na0fu3y/ochakai/internal/domain"
 	"github.com/na0fu3y/ochakai/internal/httpauth"
+	"github.com/na0fu3y/ochakai/internal/okf"
 	"github.com/na0fu3y/ochakai/internal/service"
 	"github.com/na0fu3y/ochakai/internal/store"
 )
 
-const serverName = "ochakai"
+const (
+	serverName = "ochakai"
+	uriScheme  = "ochakai://"
+)
 
 // Handler returns the streamable HTTP handler serving the MCP endpoint.
 func Handler(svc *service.Service, version string) http.Handler {
@@ -43,8 +49,50 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"re-proposing similar knowledge. Knowledge is co-owned by humans and agents.",
 	})
 
+	// Expose entries as MCP resources so clients can @-mention them by their
+	// canonical ochakai:// URI. Only the template is advertised — enumerating
+	// every entry in resources/list would flood the client, so discovery stays
+	// with search_knowledge/get_context and the URI is the addressing scheme.
+	// {+id} (RFC 6570 reserved expansion) lets hierarchical, slash-separated
+	// IDs match; a plain {id} would stop at the first slash.
+	s.AddResourceTemplate(&mcp.ResourceTemplate{
+		Name:     "knowledge",
+		Title:    "Knowledge entry",
+		MIMEType: "text/markdown",
+		Description: "A single knowledge entry as an OKF document: YAML frontmatter (title, " +
+			"status, provenance, type-specific attrs) followed by the markdown body and its " +
+			"links. Address by canonical URI, e.g. ochakai://metric/revenue; IDs may be " +
+			"hierarchical (ochakai://query/sales/top-customers). Discover URIs with " +
+			"search_knowledge or get_context; get_knowledge returns the same entry as JSON.",
+		URITemplate: "ochakai://{type}/{+id}",
+	}, func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		typ, id, ok := parseKnowledgeURI(req.Params.URI)
+		if !ok {
+			return nil, mcp.ResourceNotFoundError(req.Params.URI)
+		}
+		k, err := svc.Get(ctx, domain.Type(typ), id)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				return nil, mcp.ResourceNotFoundError(req.Params.URI)
+			}
+			return nil, err
+		}
+		doc, err := okf.Document(k)
+		if err != nil {
+			return nil, err
+		}
+		return &mcp.ReadResourceResult{
+			Contents: []*mcp.ResourceContents{{
+				URI:      req.Params.URI,
+				MIMEType: "text/markdown",
+				Text:     string(doc),
+			}},
+		}, nil
+	})
+
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "search_knowledge",
+		Name:        "search_knowledge",
+		Annotations: readOnly,
 		Description: "Search the knowledge base across all types (recommended: metric, query, insight, term, table; custom types welcome). " +
 			"Verified entries rank higher. Filter with types/statuses/tags. Returns scored hits. " +
 			"Rejected entries are excluded unless statuses includes \"rejected\" — filter for them " +
@@ -75,7 +123,8 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_context",
+		Name:        "get_context",
+		Annotations: readOnly,
 		Description: "The one call to make before answering a data question: searches the knowledge " +
 			"base (verified entries rank higher), returns the full entries behind the top hits, " +
 			"and expands one hop through links so the insight explaining a metric and the golden " +
@@ -92,7 +141,8 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_knowledge",
+		Name:        "get_knowledge",
+		Annotations: readOnly,
 		Description: "Get one knowledge entry by type and id, including its full markdown body, structured attrs, " +
 			"links, and attachment metadata (images the body references — fetch bytes with get_attachment).",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in getIn) (*mcp.CallToolResult, knowledgeOut, error) {
@@ -104,7 +154,8 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "create_knowledge",
+		Name:        "create_knowledge",
+		Annotations: nonDestructive,
 		Description: "Create a knowledge entry. Write back what you learned: metric caveats, verified answers, " +
 			"glossary terms. Entries default to draft; your identity is recorded as created_by. " +
 			"Before creating, search existing entries including statuses=[\"rejected\"] to avoid " +
@@ -118,7 +169,8 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "update_knowledge",
+		Name:        "update_knowledge",
+		Annotations: nonDestructive,
 		Description: "Update a knowledge entry (full replacement of title/description/tags/status/links/attrs/body). " +
 			"Every change is kept as a revision. Setting status=verified records you as verified_by — " +
 			"do it only for knowledge you have actually validated. Setting status=rejected records you " +
@@ -132,7 +184,8 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "delete_knowledge",
+		Name:        "delete_knowledge",
+		Annotations: destructive,
 		Description: "Soft-delete a knowledge entry. History is retained as revisions; " +
 			"create_knowledge on the same type/id revives it.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in getIn) (*mcp.CallToolResult, deleteOut, error) {
@@ -143,7 +196,8 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_attachment",
+		Name:        "get_attachment",
+		Annotations: readOnly,
 		Description: "Fetch one image attached to a knowledge entry (get_knowledge lists attachment " +
 			"metadata under \"attachments\"). Returns the image as content plus its metadata. " +
 			"Images are context-heavy — fetch them deliberately, when the entry's body references " +
@@ -162,7 +216,8 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "get_knowledge_usage",
+		Name:        "get_knowledge_usage",
+		Annotations: readOnly,
 		Description: "Usage totals for one knowledge entry: how often it appeared in search results, " +
 			"was fetched individually, or was referenced by compile_sql, with last_used_at. " +
 			"The measure of the write-back loop — evidence when deciding to promote a draft, " +
@@ -176,7 +231,8 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
-		Name: "compile_sql",
+		Name:        "compile_sql",
+		Annotations: readOnly,
 		Description: "Deterministically compile metrics + dimensions + filters + time_grain into SQL from the " +
 			"imported Ossie semantic model (no LLM involved). Dialects: bigquery (default), ansi. " +
 			"ochakai does not execute SQL — run the result with your own warehouse tool. " +
@@ -190,6 +246,36 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 	})
 
 	return s
+}
+
+// Tool annotations let clients apply auto-approval policies without reading
+// prose. readOnlyHint here describes the knowledge domain: search/get/compile
+// never change an entry (they may bump usage counters — telemetry the hint
+// deliberately ignores). Writes are non-destructive because history is kept as
+// revisions; only delete is flagged destructive. The values are immutable and
+// shared across tools.
+var (
+	readOnly       = &mcp.ToolAnnotations{ReadOnlyHint: true}
+	nonDestructive = &mcp.ToolAnnotations{DestructiveHint: boolPtr(false)}
+	destructive    = &mcp.ToolAnnotations{DestructiveHint: boolPtr(true)}
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+// parseKnowledgeURI splits a canonical knowledge URI (ochakai://<type>/<id>)
+// into its type and id. Internal slashes stay with the id so hierarchical IDs
+// (ochakai://query/sales/orders) round-trip. ok is false when the URI lacks
+// the scheme or either segment is empty.
+func parseKnowledgeURI(uri string) (typ, id string, ok bool) {
+	rest, found := strings.CutPrefix(uri, uriScheme)
+	if !found {
+		return "", "", false
+	}
+	typ, id, ok = strings.Cut(rest, "/")
+	if !ok || typ == "" || id == "" {
+		return "", "", false
+	}
+	return typ, id, true
 }
 
 // The jsonschema tags spell out the numeric contracts (defaults, maxima,
@@ -227,8 +313,8 @@ type contextOut struct {
 }
 
 type getIn struct {
-	Type string `json:"type"`
-	ID   string `json:"id"`
+	Type string `json:"type" jsonschema:"the entry's type slug (metric, query, insight, term, table, or any custom slug)"`
+	ID   string `json:"id" jsonschema:"the entry's id; / separates segments for hierarchical ids (e.g. sales/orders)"`
 }
 
 type knowledgeOut struct {
@@ -236,9 +322,9 @@ type knowledgeOut struct {
 }
 
 type attachmentIn struct {
-	Type string `json:"type"`
-	ID   string `json:"id"`
-	Name string `json:"name"` // attachment filename, from the entry's attachments metadata
+	Type string `json:"type" jsonschema:"the entry's type slug (metric, query, insight, term, table, or any custom slug)"`
+	ID   string `json:"id" jsonschema:"the entry's id (/ separates segments for hierarchical ids)"`
+	Name string `json:"name" jsonschema:"attachment filename, from the entry's attachments metadata"`
 }
 
 type attachmentOut struct {

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -126,3 +126,132 @@ func TestSearchRejectsQueryWithSort(t *testing.T) {
 		t.Errorf("error %q does not mention the combination rule", text)
 	}
 }
+
+// TestParseKnowledgeURI pins the URI splitter feeding the resource template:
+// hierarchical IDs keep their slashes, and malformed URIs are rejected before
+// any store lookup.
+func TestParseKnowledgeURI(t *testing.T) {
+	cases := []struct {
+		uri     string
+		typ, id string
+		ok      bool
+	}{
+		{"ochakai://metric/revenue", "metric", "revenue", true},
+		{"ochakai://query/sales/top-customers", "query", "sales/top-customers", true},
+		{"ochakai://table/GA_sessions_2017", "table", "GA_sessions_2017", true},
+		{"ochakai://metric/", "", "", false},  // empty id
+		{"ochakai:///revenue", "", "", false}, // empty type
+		{"ochakai://metric", "", "", false},   // no id segment
+		{"file:///metric/revenue", "", "", false},
+		{"metric/revenue", "", "", false},
+	}
+	for _, c := range cases {
+		typ, id, ok := parseKnowledgeURI(c.uri)
+		if typ != c.typ || id != c.id || ok != c.ok {
+			t.Errorf("parseKnowledgeURI(%q) = (%q, %q, %v), want (%q, %q, %v)",
+				c.uri, typ, id, ok, c.typ, c.id, c.ok)
+		}
+	}
+}
+
+// TestResourceTemplateAdvertised pins that entries are addressable as MCP
+// resources via the ochakai:// template — and that we advertise only the
+// template, not an enumeration of every entry (resources/list stays empty).
+func TestResourceTemplateAdvertised(t *testing.T) {
+	cs := connect(t)
+	ctx := context.Background()
+
+	tmpls, err := cs.ListResourceTemplates(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListResourceTemplates: %v", err)
+	}
+	if len(tmpls.ResourceTemplates) != 1 {
+		t.Fatalf("got %d resource templates, want 1", len(tmpls.ResourceTemplates))
+	}
+	rt := tmpls.ResourceTemplates[0]
+	// {+id} (reserved expansion) is what lets hierarchical IDs match; a plain
+	// {id} would stop at the first slash.
+	if rt.URITemplate != "ochakai://{type}/{+id}" {
+		t.Errorf("URITemplate = %q, want ochakai://{type}/{+id}", rt.URITemplate)
+	}
+	if rt.MIMEType != "text/markdown" {
+		t.Errorf("MIMEType = %q, want text/markdown", rt.MIMEType)
+	}
+
+	res, err := cs.ListResources(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListResources: %v", err)
+	}
+	if len(res.Resources) != 0 {
+		t.Errorf("got %d static resources, want 0 (discovery is via tools, not enumeration)", len(res.Resources))
+	}
+}
+
+// TestReadResourceRejectsMalformedURI checks the resource handler refuses a
+// URI that matches the template shape but has an empty segment, returning
+// not-found before it ever reaches the store.
+func TestReadResourceRejectsMalformedURI(t *testing.T) {
+	cs := connect(t)
+	for _, uri := range []string{"ochakai://metric/", "ochakai:///revenue"} {
+		_, err := cs.ReadResource(context.Background(), &mcp.ReadResourceParams{URI: uri})
+		if err == nil {
+			t.Errorf("ReadResource(%q) succeeded, want not-found error", uri)
+		}
+	}
+}
+
+// TestToolAnnotations pins the auto-approval hints: readers are read-only,
+// writes are non-destructive (history kept as revisions), only delete is
+// destructive. MCP clients gate auto-approval on these, so they must be exact.
+func TestToolAnnotations(t *testing.T) {
+	cs := connect(t)
+	res, err := cs.ListTools(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	// want[name] = expected (readOnly, destructiveSet, destructiveValue)
+	type ann struct {
+		readOnly    bool
+		destructive *bool
+	}
+	yes, no := true, false
+	want := map[string]ann{
+		"search_knowledge":    {readOnly: true},
+		"get_context":         {readOnly: true},
+		"get_knowledge":       {readOnly: true},
+		"get_attachment":      {readOnly: true},
+		"get_knowledge_usage": {readOnly: true},
+		"compile_sql":         {readOnly: true},
+		"create_knowledge":    {destructive: &no},
+		"update_knowledge":    {destructive: &no},
+		"delete_knowledge":    {destructive: &yes},
+	}
+	seen := map[string]bool{}
+	for _, tool := range res.Tools {
+		w, ok := want[tool.Name]
+		if !ok {
+			continue
+		}
+		seen[tool.Name] = true
+		if tool.Annotations == nil {
+			t.Errorf("%s: no annotations", tool.Name)
+			continue
+		}
+		if tool.Annotations.ReadOnlyHint != w.readOnly {
+			t.Errorf("%s: ReadOnlyHint = %v, want %v", tool.Name, tool.Annotations.ReadOnlyHint, w.readOnly)
+		}
+		switch {
+		case w.destructive == nil && tool.Annotations.DestructiveHint != nil:
+			t.Errorf("%s: DestructiveHint set, want unset", tool.Name)
+		case w.destructive != nil && tool.Annotations.DestructiveHint == nil:
+			t.Errorf("%s: DestructiveHint unset, want %v", tool.Name, *w.destructive)
+		case w.destructive != nil && *tool.Annotations.DestructiveHint != *w.destructive:
+			t.Errorf("%s: DestructiveHint = %v, want %v", tool.Name, *tool.Annotations.DestructiveHint, *w.destructive)
+		}
+	}
+	for name := range want {
+		if !seen[name] {
+			t.Errorf("tool %s not found", name)
+		}
+	}
+}


### PR DESCRIPTION
Closes #39.

## やったこと

### 1. ナレッジを MCP resources として公開
- `ResourceTemplate` `ochakai://{type}/{+id}` を追加し、read handler を `svc.Get` にマップ。返す本文は `okf.Document`(YAML frontmatter = title/status/provenance/attrs + markdown body + links)なので `ochakai://` の正準表現そのもの。
- **`{+id}`(RFC 6570 reserved expansion)が必須**。素の `{id}` は最初の `/` で止まり、`ochakai://query/sales/orders` のような階層 ID にマッチしない(uritemplate で実証済み)。
- **template だけを advertise**。`resources/list` は空のまま(全件列挙はクライアントを溢れさせる)——探索は `search_knowledge`/`get_context` に委ね、URI はアドレッシング手段。issue の「追加で検討したいこと」の推奨どおり。subscriptions は今回スコープ外。
- not-found は `store.ErrNotFound` → `mcp.ResourceNotFoundError` にマップ。空セグメント URI は store に触れる前に弾く。

### 2. tool annotations
- readers(`search_knowledge` / `get_context` / `get_knowledge` / `get_attachment` / `get_knowledge_usage` / `compile_sql`)→ `readOnlyHint`
- `delete_knowledge` → `destructiveHint: true`
- writes(`create_knowledge` / `update_knowledge`)→ `destructiveHint: false`(履歴は revision として保持されるため非破壊)

`readOnlyHint` はナレッジ・ドメインについての宣言で、usage カウンタ更新(テレメトリ)は意図的に無視している旨をコメントに明記。

### 3. 入力フィールド説明
- `getIn` / `attachmentIn` の `type` / `id` / `name` に jsonschema 説明を追加。
- `searchIn` / `contextIn` / `writeIn` の statuses enum・types 推奨・limit 上限は issue 起票後に既に追加済みだったため差分なし。

### 追わなかったもの
- プログレッシブツール発見:ツール 9 本の ochakai では不要(issue にも記載)。
- go-sdk 更新:v1.6.1 が resource API / annotations を完全サポートしており更新不要。

## テスト
`internal/mcpserver/mcpserver_test.go` に DB 不要のスキーマ/ユニットテストを追加(既存テストの流儀に合わせて Postgres には依存しない):
- `TestParseKnowledgeURI` — 階層 ID の round-trip と不正 URI の拒否
- `TestResourceTemplateAdvertised` — template が 1 件、`resources/list` は空
- `TestReadResourceRejectsMalformedURI` — 空セグメントは store 到達前に not-found
- `TestToolAnnotations` — 各ツールの hint を厳密検証

read のハッピーパス(実 store 経由)は本パッケージの方針どおりユニットテストからは除外。`go build ./... && go test ./...` green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)