### PR TITLE
Draft review queue: sort=usage feed + web UI Review tab (#40)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -28,6 +28,9 @@ paths:
         With sort=verified_at the endpoint lists entries by verification age
         (oldest first, never-verified last) instead of searching — the feed
         for golden query canary runs (docs/guides/golden-query-canary.md).
+        With sort=usage it lists by demand (most search_hits first, never-used
+        oldest-first at the bottom) and each hit carries its usage totals —
+        the draft review/promotion feed.
         q and sort are mutually exclusive; combining them is a 400.
       parameters:
         - name: q
@@ -36,7 +39,7 @@ paths:
         - name: sort
           in: query
           description: Mutually exclusive with q.
-          schema: { type: string, enum: [verified_at] }
+          schema: { type: string, enum: [verified_at, usage] }
         - name: type
           in: query
           schema: { type: array, items: { $ref: "#/components/schemas/Type" } }
@@ -52,15 +55,18 @@ paths:
         - name: limit
           in: query
           description: >
-            Searching: default 10, max 50. With sort=verified_at the feed
-            reads more per page: default 100, max 1000. Out-of-range values
-            fall back to the default; non-integer values are a 400.
+            Searching: default 10, max 50. With sort=verified_at or
+            sort=usage the feed reads more per page: default 100, max 1000.
+            Out-of-range values fall back to the default; non-integer values
+            are a 400.
           schema: { type: integer }
       responses:
         "200":
           description: >
             Scored hits, verified entries boosted. With sort=verified_at,
-            hits are in verification-age order and carry score 0.
+            hits are in verification-age order and carry score 0. With
+            sort=usage, hits are in demand order, carry score 0, and each
+            populates the usage object.
           content:
             application/json:
               schema:
@@ -469,6 +475,13 @@ components:
         - type: object
           properties:
             score: { type: number }
+            usage:
+              allOf: [ { $ref: "#/components/schemas/Usage" } ]
+              readOnly: true
+              description: >
+                Usage totals, present only in the sort=usage listing (the
+                draft review feed); absent for search results and the
+                verified_at feed.
     CompileRequest:
       type: object
       required: [metrics]

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -154,13 +154,13 @@ func splitRef(s string) (string, string, error) {
 
 func cmdSearch(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
-		"Usage: ochakai search [flags] [query]\n\nSearch the knowledge base; verified entries rank higher.\nOutput: score, uri, status, title — description (one hit per line).\nWith --sort verified_at the command lists by verification age instead\nof searching (oldest first, never-verified last — the golden-query\ncanary feed); output is then verified_at, uri, status, title — description.",
-		"  ochakai search \"gross margin\" --type metric --type term --status verified\n  ochakai search churn --json | jq '.hits[0].attrs'\n  ochakai search --sort verified_at --type query --status verified --limit 100\n")
+		"Usage: ochakai search [flags] [query]\n\nSearch the knowledge base; verified entries rank higher.\nOutput: score, uri, status, title — description (one hit per line).\nWith --sort verified_at the command lists by verification age instead\nof searching (oldest first, never-verified last — the golden-query\ncanary feed); output leads with verified_at. With --sort usage it lists\nby demand (most search_hits first, never-used oldest-first at the bottom\n— the draft review feed); output leads with the search_hits count.",
+		"  ochakai search \"gross margin\" --type metric --type term --status verified\n  ochakai search churn --json | jq '.hits[0].attrs'\n  ochakai search --sort verified_at --type query --status verified --limit 100\n  ochakai search --sort usage --status draft --limit 50   # review queue\n")
 	var types, statuses, tags repeated
 	fs.Var(&types, "type", "filter by type: "+typeList()+", or any custom type (repeatable)")
 	fs.Var(&statuses, "status", "filter by status: "+statusList()+" (repeatable)")
 	fs.Var(&tags, "tag", "filter by tag (repeatable)")
-	sortBy := fs.String("sort", "", `list instead of search: "verified_at" = by verification age, oldest first`)
+	sortBy := fs.String("sort", "", `list instead of search: "verified_at" = by verification age (oldest first), "usage" = by demand (most search_hits first)`)
 	limit := fs.Int("limit", 0, "max results (server default 10, max 50; with --sort: 100, max 1000)")
 	asJSON := fs.Bool("json", false, "print the raw JSON response")
 	pos, err := parseArgs(fs, args)
@@ -168,7 +168,7 @@ func cmdSearch(ctx context.Context, args []string) error {
 		return err
 	}
 	if *sortBy != "" && len(pos) > 0 {
-		return fmt.Errorf("--sort lists entries by verification age; it cannot be combined with a search query")
+		return fmt.Errorf("--sort lists entries; it cannot be combined with a search query")
 	}
 	c, err := newClient(ctx, *url)
 	if err != nil {
@@ -186,10 +186,16 @@ func cmdSearch(ctx context.Context, args []string) error {
 	}
 	for _, h := range hits {
 		lead := fmt.Sprintf("%.3f", h.Score)
-		if *sortBy != "" {
+		switch *sortBy {
+		case "verified_at":
 			lead = "-" // never verified sorts last
 			if h.VerifiedAt != nil {
 				lead = h.VerifiedAt.Format(time.RFC3339)
+			}
+		case "usage":
+			lead = "0" // never-used drafts sort last
+			if h.Usage != nil {
+				lead = strconv.FormatInt(h.Usage.SearchHits, 10)
 			}
 		}
 		line := fmt.Sprintf("%s\t%s\t%s\t%s", lead, h.URI(), h.Status, h.Title)

--- a/cmd/ochakai/completion.go
+++ b/cmd/ochakai/completion.go
@@ -67,7 +67,7 @@ _ochakai() {
         '*--type[filter by type]:type:(metric query insight term table)' \
         '*--status[filter by status]:status:(draft verified deprecated rejected)' \
         '*--tag[filter by tag]:tag:' \
-        '--sort[list by verification age instead of searching]:sort:(verified_at)' \
+        '--sort[list instead of searching: by verification age or by demand]:sort:(verified_at usage)' \
         '--limit[max results]:limit:' \
         '--json[print the raw JSON response]' \
         '--url[server URL]:url:'
@@ -159,7 +159,7 @@ _ochakai() {
   case $prev in
     --type|-type) COMPREPLY=($(compgen -W "metric query insight term table" -- "$cur")); return ;;
     --status|-status) COMPREPLY=($(compgen -W "draft verified deprecated rejected" -- "$cur")); return ;;
-    --sort|-sort) COMPREPLY=($(compgen -W "verified_at" -- "$cur")); return ;;
+    --sort|-sort) COMPREPLY=($(compgen -W "verified_at usage" -- "$cur")); return ;;
     --dialect|-dialect) COMPREPLY=($(compgen -W "bigquery ansi" -- "$cur")); return ;;
     -f) compopt -o default 2>/dev/null; COMPREPLY=(); return ;;
   esac
@@ -232,7 +232,7 @@ complete -c ochakai -n '__fish_seen_subcommand_from attach' -l name -x -d 'attac
 complete -c ochakai -n '__fish_seen_subcommand_from attach' -F
 complete -c ochakai -n '__fish_seen_subcommand_from search context' -l type -x -a 'metric query insight term table' -d 'filter by type'
 complete -c ochakai -n '__fish_seen_subcommand_from search context' -l status -x -a 'draft verified deprecated rejected' -d 'filter by status'
-complete -c ochakai -n '__fish_seen_subcommand_from search' -l sort -x -a 'verified_at' -d 'list by verification age instead of searching'
+complete -c ochakai -n '__fish_seen_subcommand_from search' -l sort -x -a 'verified_at usage' -d 'list instead of searching: by verification age or by demand'
 complete -c ochakai -n '__fish_seen_subcommand_from search context' -l tag -x -d 'filter by tag'
 complete -c ochakai -n '__fish_seen_subcommand_from search context compile' -l limit -x -d 'max results / LIMIT clause'
 complete -c ochakai -n '__fish_seen_subcommand_from context' -l budget -x -d 'stop rendering after ~bytes'

--- a/internal/apiclient/apiclient.go
+++ b/internal/apiclient/apiclient.go
@@ -107,8 +107,9 @@ type SearchParams struct {
 	Tags     []string
 	// Sort switches the endpoint from searching to listing:
 	// "verified_at" returns entries by verification age, oldest first
-	// (the golden-query canary feed). The server rejects a Query
-	// combined with Sort, and the returned hits carry score 0.
+	// (the golden-query canary feed); "usage" returns entries by demand,
+	// most-searched first (the draft review feed, hits carry usage). The
+	// server rejects a Query combined with Sort; listed hits carry score 0.
 	Sort  string
 	Limit int
 }

--- a/internal/apiclient/apiclient_test.go
+++ b/internal/apiclient/apiclient_test.go
@@ -73,6 +73,29 @@ func TestSearchSortSendsSortParam(t *testing.T) {
 	}
 }
 
+// The sort=usage feed (draft review) sends sort=usage and decodes the
+// per-hit usage object the plain search and verified_at feeds omit.
+func TestSearchUsageSortDecodesUsage(t *testing.T) {
+	var got url.Values
+	c := newTestPair(t, func(w http.ResponseWriter, r *http.Request) {
+		got = r.URL.Query()
+		_ = json.NewEncoder(w).Encode(map[string]any{"hits": []domain.SearchHit{
+			{Knowledge: domain.Knowledge{Type: domain.TypeInsight, ID: "draft-a", Title: "草案"},
+				Usage: &domain.Usage{SearchHits: 7, Fetches: 2}},
+		}})
+	})
+	hits, err := c.Search(context.Background(), SearchParams{Sort: "usage", Statuses: []string{"draft"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Get("sort") != "usage" || got.Get("status") != "draft" || got.Has("q") {
+		t.Errorf("query = %v", got)
+	}
+	if len(hits) != 1 || hits[0].Usage == nil || hits[0].Usage.SearchHits != 7 {
+		t.Errorf("usage did not decode: %+v", hits)
+	}
+}
+
 func TestUsageHitsCanonicalPathWithHierarchicalID(t *testing.T) {
 	c := newTestPair(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v1/usage/query/sales/monthly-revenue" {

--- a/internal/domain/knowledge.go
+++ b/internal/domain/knowledge.go
@@ -150,8 +150,12 @@ func ValidID(id string) bool {
 	return segs[len(segs)-1] != "index"
 }
 
-// SearchHit is one search result with its ranking score.
+// SearchHit is one search result with its ranking score. Usage is
+// populated only by the sort=usage listing (the draft review feed), where
+// the promotion signal is the point; it stays nil for search results and
+// the verified_at feed so their wire shape is unchanged.
 type SearchHit struct {
 	Knowledge
 	Score float64 `json:"score"`
+	Usage *Usage  `json:"usage,omitempty"`
 }

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -51,17 +51,23 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"to check whether a proposal was already rejected before creating similar knowledge. " +
 			"With sort=\"verified_at\" the tool lists entries by verification age instead of searching " +
 			"(oldest first, never-verified last; omit query, scores are 0) — the feed for " +
-			"golden-query canary runs and for finding stale verified knowledge.",
+			"golden-query canary runs and for finding stale verified knowledge. With sort=\"usage\" it " +
+			"lists by demand (most search_hits first, never-used drafts oldest-first at the bottom) and " +
+			"each hit carries its usage totals — the draft review/promotion feed.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in searchIn) (*mcp.CallToolResult, searchOut, error) {
 		f := store.Filter{Types: toTypes(in.Types), Statuses: toStatuses(in.Statuses), Tags: in.Tags}
 		if in.Sort != "" {
-			if in.Sort != "verified_at" {
-				return nil, searchOut{}, fmt.Errorf("invalid sort %q (valid: verified_at)", in.Sort)
+			if in.Sort != "verified_at" && in.Sort != "usage" {
+				return nil, searchOut{}, fmt.Errorf("invalid sort %q (valid: verified_at, usage)", in.Sort)
 			}
 			if in.Query != "" {
-				return nil, searchOut{}, fmt.Errorf("sort=verified_at lists entries by verification age; it cannot be combined with a search query")
+				return nil, searchOut{}, fmt.Errorf("sort=%s lists entries; it cannot be combined with a search query", in.Sort)
 			}
-			hits, err := svc.ListByVerifiedAt(ctx, f, in.Limit)
+			list := svc.ListByVerifiedAt
+			if in.Sort == "usage" {
+				list = svc.ListByUsage
+			}
+			hits, err := list(ctx, f, in.Limit)
 			if err != nil {
 				return nil, searchOut{}, err
 			}
@@ -202,7 +208,7 @@ type searchIn struct {
 	Types    []string `json:"types,omitempty" jsonschema:"filter by type (metric, query, insight, term, table, or any custom slug)"`
 	Statuses []string `json:"statuses,omitempty" jsonschema:"filter by status: draft, verified, deprecated, rejected"`
 	Tags     []string `json:"tags,omitempty" jsonschema:"filter by tag"`
-	Sort     string   `json:"sort,omitempty" jsonschema:"omit to search; \"verified_at\" lists by verification age instead (mutually exclusive with query)"`
+	Sort     string   `json:"sort,omitempty" jsonschema:"omit to search; \"verified_at\" lists by verification age, \"usage\" lists by demand (draft review feed) — both mutually exclusive with query"`
 	Limit    int      `json:"limit,omitempty" jsonschema:"max results: searching default 10, max 50; with sort default 100, max 1000 (out-of-range falls back to the default)"`
 }
 

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -102,27 +102,40 @@ func TestLimitContractsInSchema(t *testing.T) {
 	}
 }
 
-// TestSearchRejectsQueryWithSort mirrors the CLI and REST rule: a search
-// query combined with sort=verified_at is an error, not silently ignored.
-func TestSearchRejectsQueryWithSort(t *testing.T) {
+// TestSearchSortValidation mirrors the CLI and REST rules: a search query
+// combined with a sort mode is an error (not silently ignored), and an
+// unknown sort is rejected — for both verified_at and usage.
+func TestSearchSortValidation(t *testing.T) {
 	cs := connect(t)
-	res, err := cs.CallTool(context.Background(), &mcp.CallToolParams{
-		Name:      "search_knowledge",
-		Arguments: map[string]any{"sort": "verified_at", "query": "revenue"},
-	})
-	if err != nil {
-		t.Fatalf("CallTool: %v", err)
+	cases := []struct {
+		name       string
+		args       map[string]any
+		wantSubstr string
+	}{
+		{"verified_at with query", map[string]any{"sort": "verified_at", "query": "revenue"}, "cannot be combined"},
+		{"usage with query", map[string]any{"sort": "usage", "query": "revenue"}, "cannot be combined"},
+		{"invalid sort", map[string]any{"sort": "created_at"}, "invalid sort"},
 	}
-	if !res.IsError {
-		t.Fatal("expected a tool error for query combined with sort")
-	}
-	text := ""
-	for _, c := range res.Content {
-		if tc, ok := c.(*mcp.TextContent); ok {
-			text += tc.Text
-		}
-	}
-	if !strings.Contains(text, "cannot be combined") {
-		t.Errorf("error %q does not mention the combination rule", text)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			res, err := cs.CallTool(context.Background(), &mcp.CallToolParams{
+				Name: "search_knowledge", Arguments: c.args,
+			})
+			if err != nil {
+				t.Fatalf("CallTool: %v", err)
+			}
+			if !res.IsError {
+				t.Fatalf("expected a tool error for %s", c.name)
+			}
+			text := ""
+			for _, ct := range res.Content {
+				if tc, ok := ct.(*mcp.TextContent); ok {
+					text += tc.Text
+				}
+			}
+			if !strings.Contains(text, c.wantSubstr) {
+				t.Errorf("error %q does not mention %q", text, c.wantSubstr)
+			}
+		})
 	}
 }

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -45,15 +45,20 @@ func Handler(svc *service.Service) http.Handler {
 			Tags:     q["tag"],
 		}
 		if sort := q.Get("sort"); sort != "" {
-			if sort != "verified_at" {
-				writeError(w, service.Invalidf("invalid sort (valid: verified_at)"))
+			if sort != "verified_at" && sort != "usage" {
+				writeError(w, service.Invalidf("invalid sort (valid: verified_at, usage)"))
 				return
 			}
 			if q.Get("q") != "" {
-				writeError(w, service.Invalidf("sort=verified_at lists entries by verification age; it cannot be combined with a search query (q)"))
+				writeError(w, service.Invalidf("sort=%s lists entries; it cannot be combined with a search query (q)", sort))
 				return
 			}
-			hits, err := svc.ListByVerifiedAt(r.Context(), f, limit)
+			var hits []domain.SearchHit
+			if sort == "usage" {
+				hits, err = svc.ListByUsage(r.Context(), f, limit)
+			} else {
+				hits, err = svc.ListByVerifiedAt(r.Context(), f, limit)
+			}
 			if err != nil {
 				writeError(w, err)
 				return

--- a/internal/restapi/restapi_test.go
+++ b/internal/restapi/restapi_test.go
@@ -50,6 +50,7 @@ func TestBadRequestValidation(t *testing.T) {
 	}{
 		{"invalid sort", "/api/v1/knowledge?sort=created_at", "invalid sort"},
 		{"sort with query", "/api/v1/knowledge?sort=verified_at&q=revenue", "cannot be combined"},
+		{"usage sort with query", "/api/v1/knowledge?sort=usage&q=revenue", "cannot be combined"},
 		{"bad search limit", "/api/v1/knowledge?limit=abc", "invalid limit"},
 		{"bad context limit", "/api/v1/context?q=x&limit=1.5", "invalid limit"},
 		{"bad min_score", "/api/v1/context?q=x&min_score=high", "invalid min_score"},

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -300,6 +300,18 @@ func (s *Service) ListByVerifiedAt(ctx context.Context, f store.Filter, limit in
 	return hits, nil
 }
 
+// ListByUsage lists entries by demand — most-searched first, never-used
+// drafts oldest-first at the bottom — for the web UI draft review queue.
+// Not a search: no usage is recorded (reading the queue must not inflate
+// the very signal it ranks by). Each hit carries its usage totals; score
+// is 0, keeping the wire shape of a search across all list modes.
+func (s *Service) ListByUsage(ctx context.Context, f store.Filter, limit int) ([]domain.SearchHit, error) {
+	if limit <= 0 || limit > 1000 {
+		limit = 100
+	}
+	return s.Store.ListByUsage(ctx, f, limit)
+}
+
 // Usage returns usage totals for one entry (404 when the entry is gone).
 func (s *Service) Usage(ctx context.Context, typ domain.Type, id string) (*domain.Usage, error) {
 	if _, err := s.Store.Get(ctx, typ, id); err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -359,6 +359,65 @@ func (s *Store) ListByVerifiedAt(ctx context.Context, f Filter, limit int) ([]do
 	return pgx.CollectRows(rows, scanKnowledge)
 }
 
+// ListByUsage returns filtered entries ordered by demand, most-searched
+// first: search_hits descending, then oldest-created (created_at ascending)
+// as the tiebreak. This is the draft review feed — the promotion queue at
+// the top, and never-used drafts (search_hits 0) sinking oldest-first to
+// the bottom for inventory. Each hit carries its usage totals so the
+// caller renders the signal without a per-entry round trip. Score is 0.
+func (s *Store) ListByUsage(ctx context.Context, f Filter, limit int) ([]domain.SearchHit, error) {
+	where, args := f.buildWhere("k.")
+	// Conditional aggregation over knowledge_usage in one lateral pass:
+	// running totals per event live in that table (see usage.go).
+	q := fmt.Sprintf(`
+		SELECT `+qualifyCols("k")+`,
+			u.search_hits, u.fetches, u.compiles, u.last_used_at
+		FROM knowledge k
+		LEFT JOIN LATERAL (
+			SELECT
+				COALESCE(sum(count) FILTER (WHERE event = 'search_hit'), 0) AS search_hits,
+				COALESCE(sum(count) FILTER (WHERE event = 'fetched'), 0)   AS fetches,
+				COALESCE(sum(count) FILTER (WHERE event = 'compiled'), 0)  AS compiles,
+				max(last_at) AS last_used_at
+			FROM knowledge_usage
+			WHERE knowledge_type = k.type AND knowledge_id = k.id
+		) u ON true
+		WHERE %s
+		ORDER BY u.search_hits DESC, k.created_at ASC, k.type, k.id LIMIT %d`, where, limit)
+	rows, err := s.pool.Query(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	return pgx.CollectRows(rows, scanUsageHit)
+}
+
+// scanUsageHit reads a knowledge row followed by its usage totals (the
+// ListByUsage projection). Score stays 0 — this is a listing, not a search.
+func scanUsageHit(row pgx.CollectableRow) (domain.SearchHit, error) {
+	var h domain.SearchHit
+	var verifiedKind, verifiedName, rejectedKind, rejectedName *string
+	var links, attrs []byte
+	var u domain.Usage
+	err := row.Scan(&h.Type, &h.ID, &h.Title, &h.Description, &h.Tags, &h.Status, &h.StatusNote,
+		&h.CreatedBy.Kind, &h.CreatedBy.Name, &verifiedKind, &verifiedName, &h.VerifiedAt,
+		&rejectedKind, &rejectedName, &h.RejectedAt,
+		&links, &attrs, &h.Body, &h.CreatedAt, &h.UpdatedAt,
+		&u.SearchHits, &u.Fetches, &u.Compiles, &u.LastUsedAt)
+	if err != nil {
+		return h, err
+	}
+	h.VerifiedBy = actorFrom(verifiedKind, verifiedName)
+	h.RejectedBy = actorFrom(rejectedKind, rejectedName)
+	if err := json.Unmarshal(links, &h.Links); err != nil {
+		return h, err
+	}
+	if err := json.Unmarshal(attrs, &h.Attrs); err != nil {
+		return h, err
+	}
+	h.Usage = &u
+	return h, nil
+}
+
 // ListAll returns every non-deleted entry, ordered by type then id.
 // Used by the OKF exporter.
 func (s *Store) ListAll(ctx context.Context) ([]domain.Knowledge, error) {

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -150,6 +150,55 @@ func TestIntegration(t *testing.T) {
 	if len(list) < 2 || list[0].ID != older.ID {
 		t.Errorf("oldest verification must come first: %+v", list)
 	}
+
+	// ListByUsage: the draft review feed. Two drafts, unequal demand — the
+	// more-searched one ranks first, and each hit carries its usage totals.
+	hot := &domain.Knowledge{
+		Type: domain.TypeInsight, ID: "it-draft-hot", Title: "よく検索される草案",
+		Status: domain.StatusDraft, CreatedBy: domain.Actor{Kind: "agent", Name: "claude-code"},
+	}
+	cold := &domain.Knowledge{
+		Type: domain.TypeInsight, ID: "it-draft-cold", Title: "検索されない草案",
+		Status: domain.StatusDraft, CreatedBy: domain.Actor{Kind: "agent", Name: "claude-code"},
+	}
+	for _, d := range []*domain.Knowledge{hot, cold} {
+		if err := s.Create(ctx, d); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 0; i < 3; i++ {
+		if err := s.RecordEvents(ctx, domain.EventSearchHit, actor, []EventTarget{{Type: hot.Type, ID: hot.ID}}); err != nil {
+			t.Fatalf("RecordEvents: %v", err)
+		}
+	}
+	feed, err := s.ListByUsage(ctx, Filter{
+		Types:    []domain.Type{domain.TypeInsight},
+		Statuses: []domain.Status{domain.StatusDraft},
+	}, 100)
+	if err != nil {
+		t.Fatalf("ListByUsage: %v", err)
+	}
+	if len(feed) < 2 || feed[0].ID != hot.ID {
+		t.Errorf("most-searched draft must come first: %+v", feed)
+	}
+	if feed[0].Usage == nil || feed[0].Usage.SearchHits != 3 {
+		t.Errorf("hit must carry usage totals (search_hits=3): %+v", feed[0].Usage)
+	}
+	if feed[0].Score != 0 {
+		t.Errorf("listing hits carry score 0, got %v", feed[0].Score)
+	}
+	var sawCold bool
+	for _, h := range feed {
+		if h.ID == cold.ID {
+			sawCold = true
+			if h.Usage == nil || h.Usage.SearchHits != 0 {
+				t.Errorf("never-searched draft must report 0 search_hits: %+v", h.Usage)
+			}
+		}
+	}
+	if !sawCold {
+		t.Error("ListByUsage must include never-used drafts (the inventory tail)")
+	}
 }
 
 // SoftDelete must survive a database where semantic search was never

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -4,7 +4,8 @@
      Serve it from anywhere (main.go proxies /api/v1 to ochakai) and it
      covers the human-facing API surface — search, entry details with
      usage and image attachments, create/edit with the draft → verified
-     workflow, SQL compilation, and OKF export. (/api/v1/context and the
+     workflow, the draft review queue (sort=usage), SQL compilation, and
+     OKF export. (/api/v1/context and the
      Ossie import are agent/ops surfaces — see api/openapi.yaml.)
      A starting point for building your own UI. -->
 <html lang="en">
@@ -244,6 +245,7 @@
   <a class="brand" href="#/">🍵 ochakai</a>
   <nav class="topnav" id="topnav">
     <a href="#/" data-route="explore">Explore</a>
+    <a href="#/review" data-route="review">Review</a>
     <a href="#/compile" data-route="compile">Compile</a>
     <a href="#/new" data-route="new">New entry</a>
   </nav>
@@ -280,6 +282,18 @@ function fmtDate(s) {
 function actorStr(a) {
   if (!a || !a.name) return '';
   return (a.kind === 'agent' ? '🤖 ' : '👤 ') + a.name;
+}
+// Whole days since an ISO timestamp (null for unparseable input).
+function daysSince(s) {
+  if (!s) return null;
+  const d = new Date(s);
+  return isNaN(d) ? null : Math.floor((Date.now() - d.getTime()) / 86400000);
+}
+function fmtAge(days) {
+  if (days === null) return '';
+  if (days <= 0) return 'today';
+  if (days === 1) return 'yesterday';
+  return days + ' days ago';
 }
 function fmtSize(n) {
   if (!n && n !== 0) return '';
@@ -400,6 +414,9 @@ function route() {
   } else if (head === 'new') {
     mark('new');
     viewEditor(null, null);
+  } else if (head === 'review') {
+    mark('review');
+    viewReview();
   } else if (head === 'compile') {
     mark('compile');
     viewCompile();
@@ -704,18 +721,11 @@ async function viewDetail(type, id) {
   showTab('overview');
 
   const setStatus = async (status, askNote) => {
-    let note;
-    if (askNote) {
-      note = prompt(`Why ${status}? (recorded as status_note so agents stop re-proposing it)`, entry.status_note || '');
-      if (note === null) return;
-    }
-    const payload = editablePayload(entry);
-    payload.status = status;
-    if (note !== undefined) payload.status_note = note;
     try {
-      await api('/api/v1/knowledge/' + idPath(entry.type, entry.id), { method: 'PUT', body: payload });
-      toast(`Marked ${status}.`);
-      viewDetail(entry.type, entry.id);
+      if (await applyStatus(entry, status, askNote)) {
+        toast(`Marked ${status}.`);
+        viewDetail(entry.type, entry.id);
+      }
     } catch (e) { toast('Failed: ' + e.message); }
   };
   $('#act-verify')?.addEventListener('click', () => setStatus('verified', false));
@@ -738,6 +748,128 @@ function editablePayload(e) {
     if (e[k] !== undefined && e[k] !== null) p[k] = e[k];
   }
   return p;
+}
+
+// Apply a status transition (full-replacement PUT), prompting for a
+// status_note when the transition needs a recorded reason. Returns true on
+// success, false if the user cancelled the note prompt. Throws on API
+// failure so callers can toast it. Shared by the detail view and the
+// review queue; the entry may be a full Knowledge or a SearchHit (which
+// embeds one), since both carry the writable fields.
+async function applyStatus(entry, status, askNote) {
+  let note;
+  if (askNote) {
+    note = prompt(`Why ${status}? (recorded as status_note so agents stop re-proposing it)`, entry.status_note || '');
+    if (note === null) return false;
+  }
+  const payload = editablePayload(entry);
+  payload.status = status;
+  if (note !== undefined) payload.status_note = note;
+  await api('/api/v1/knowledge/' + idPath(entry.type, entry.id), { method: 'PUT', body: payload });
+  return true;
+}
+
+/* ============================== review queue ============================== */
+
+// A draft with zero search hits, older than this, is flagged stale — the
+// inventory case (nobody's finding it; a candidate to drop). Sort=usage
+// already sinks these to the bottom; the toggle isolates them.
+const STALE_DAYS = 14;
+const review = { staleOnly: false };
+
+function viewReview() {
+  view.innerHTML = `
+    <div class="section-title">Draft review queue</div>
+    <p style="color:var(--muted);max-width:48rem">Drafts agents wrote back, most-demanded first — ranked by search hits, how
+    often the draft already surfaces when people search. Verify what's true, reject what isn't (the reason is recorded as
+    status_note so agents stop re-proposing it). Never-used drafts sink to the bottom; toggle <em>stale</em> to triage them.</p>
+    <div class="toolbar">
+      <label class="check"><input type="checkbox" id="r-stale" ${review.staleOnly ? 'checked' : ''}>
+        stale only (0 hits, ≥ ${STALE_DAYS} days old)</label>
+      <span class="grow"></span>
+      <button class="btn small" id="r-refresh">Refresh</button>
+    </div>
+    <div id="review-results"><div class="empty">…</div></div>`;
+  $('#r-stale').addEventListener('change', () => { review.staleOnly = $('#r-stale').checked; runReview(); });
+  $('#r-refresh').addEventListener('click', runReview);
+  runReview();
+}
+
+function isStaleDraft(h) {
+  const age = daysSince(h.created_at);
+  return ((h.usage && h.usage.search_hits) || 0) === 0 && age !== null && age >= STALE_DAYS;
+}
+
+async function runReview() {
+  const out = $('#review-results');
+  if (!out) return;
+  const my = runReview._seq = (runReview._seq || 0) + 1;
+  try {
+    const { hits } = await api('/api/v1/knowledge?sort=usage&status=draft&limit=100');
+    if (my !== runReview._seq || out !== $('#review-results')) return; // stale response
+    let list = hits || [];
+    if (review.staleOnly) list = list.filter(isStaleDraft);
+    if (!list.length) {
+      out.innerHTML = `<div class="empty">${review.staleOnly ? 'No stale drafts — nothing gathering dust.' : 'No drafts awaiting review.'}</div>`;
+      return;
+    }
+    out.innerHTML = list.map(reviewCard).join('');
+    wireReviewActions(out);
+  } catch (e) {
+    if (my !== runReview._seq || out !== $('#review-results')) return;
+    out.innerHTML = `<div class="error-banner">Could not load the review queue: ${esc(e.message)}</div>`;
+  }
+}
+
+function reviewCard(h) {
+  const u = h.usage || {};
+  const tags = (h.tags || []).map(t => `<span class="tag">${esc(t)}</span>`).join(' ');
+  const who = actorStr(h.created_by);
+  const age = daysSince(h.created_at);
+  const usageBits = (u.search_hits || u.fetches || u.compiles)
+    ? `🔍 ${u.search_hits || 0} hits · fetched ${u.fetches || 0} · compiled ${u.compiles || 0}`
+    : 'no usage yet';
+  const meta = [
+    `<span class="mono">ochakai://${esc(h.type)}/${esc(h.id)}</span>`,
+    who ? esc(who) : '',
+    age !== null ? 'created ' + esc(fmtAge(age)) : '',
+    usageBits,
+  ].filter(Boolean).join(' · ');
+  return `<article class="card" data-type="${esc(h.type)}" data-id="${esc(h.id)}">
+    <div class="head">
+      <span class="type-ico" title="${esc(h.type)}">${icon(h.type)}</span>
+      <a class="title" href="${entryHash(h)}">${esc(h.title)}</a>
+      <span class="badge draft">draft</span>
+      ${isStaleDraft(h) ? '<span class="badge" title="0 search hits and idle — a candidate to drop">🕸️ stale</span>' : ''}
+      ${tags}
+      <span class="actions" style="margin-left:auto;display:flex;gap:.45rem">
+        <button class="btn small primary" data-act="verify">✓ Verify</button>
+        <button class="btn small danger" data-act="reject">Reject</button>
+      </span>
+    </div>
+    <div class="meta">${meta}</div>
+    ${h.description ? `<div class="desc">${esc(h.description)}</div>` : ''}
+  </article>`;
+}
+
+function wireReviewActions(container) {
+  container.querySelectorAll('[data-act]').forEach(btn => btn.addEventListener('click', async () => {
+    const card = btn.closest('[data-type]');
+    const status = btn.dataset.act === 'verify' ? 'verified' : 'rejected';
+    // Re-fetch the current entry before a full-replacement PUT: the list
+    // row may be stale, and status_note aside, we must not clobber a body
+    // edited since the queue loaded.
+    let entry;
+    try {
+      entry = await api('/api/v1/knowledge/' + idPath(card.dataset.type, card.dataset.id));
+    } catch (e) { toast('Load failed: ' + e.message); return; }
+    try {
+      if (await applyStatus(entry, status, status === 'rejected')) {
+        toast(`Marked ${status}.`);
+        runReview();
+      }
+    } catch (e) { toast('Failed: ' + e.message); }
+  }));
 }
 
 /* ============================== editor ============================== */


### PR DESCRIPTION
Closes #40.

## なぜ
README が製品の核と位置づける write-back ループの**人間側の動線**が欠けていた。agent は `create_knowledge` で draft を書き戻すが、人間がそれに気づき昇格/却下する surface が無かった。`knowledge_usage` に既にある需要シグナルでランク付けしたレビュー動線を追加する。

なお issue の3項目のうち #2（詳細画面から verify/reject ワンクリック）は実装済みだったため、本PRは残りの **レビューキュー** と **棚卸しビュー** を埋める。

## 何を
### バックエンド: 新リストモード `sort=usage`（`sort=verified_at` の鏡像）
- 検索ではなく需要順に列挙: `search_hits` 降順 → `created_at` 昇順（未使用 draft は古い順で末尾に沈む＝棚卸し）
- 各 hit に usage 合計を同梱し、UI が `/usage` の N+1 なしにシグナルを描画。`SearchHit` に `usage` を追加（`omitempty` — search / verified_at フィードのワイヤ形状は不変）
- store / service / REST / MCP / CLI + shell 補完 / apiclient / openapi に一貫して配線

### Web UI: Review タブ
- `sort=usage&status=draft` フィード。上部が昇格候補、行ごとに **Verify / Reject** ワンクリック（reject は status_note を prompt して記録）
- **stale only** トグルで棚卸しケース（0 hits・14日以上経過）を隔離し 🕸️ バッジ表示
- 詳細画面のステータス遷移を共有ヘルパ `applyStatus` に切り出して再利用

## issue の検討事項への回答
- **昇格シグナル**: `search_hits` のみ（まず単純に。fetched/compiled の重み付けは将来拡張余地）
- **provenance 依存**: IAP JWT（per-user provenance）は本PRのスコープ外。verify は既存の詳細画面ボタンと同じく web UI の identity に帰属する（本PRが悪化させるものではない）
- **通知**: スコープ外（まず UI のみ）

## テスト
- `store_integration_test`: `ListByUsage` の順序（search_hits 降順）・usage 同梱・score 0・未使用 draft の末尾包含。実 Postgres(pgvector) で LATERAL join / 条件集約 / 並び順を検証
- `restapi_test` / `mcpserver_test`: `sort=usage` + query の 400、未知 sort の 400
- `apiclient_test`: `sort=usage` 送出と `usage` オブジェクトのデコード
- **E2E**: `ochakai serve` + `ochakai ui` で実際にブラウザ操作し、順序表示・stale トグル・Verify のステータス遷移＋provenance 記録まで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)