### PR TITLE
Remove v0.3 migration shims: legacy usage route, removed-command stubs, env guard

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -215,8 +215,6 @@ paths:
         fetched individually, or referenced by compile_sql. The measure of
         the write-back loop — evidence for promoting drafts, and a staleness
         signal for verified entries that stopped being used.
-        (GET /api/v1/knowledge/{type}/{id}/usage remains as a legacy alias
-        for single-segment IDs.)
       responses:
         "200":
           description: Usage totals.

--- a/cmd/ochakai/main.go
+++ b/cmd/ochakai/main.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"os/signal"
 	"runtime/debug"
-	"strings"
 	"syscall"
 	"time"
 
@@ -64,11 +63,6 @@ func main() {
 	switch cmd {
 	case "serve":
 		err = serve(log)
-	case "export-okf", "import-okf":
-		// DB-direct twins of `export`/`import`, removed in design doc 0007.
-		fmt.Fprintf(os.Stderr, "ochakai: %s was removed; run `ochakai serve` next to the database and use `ochakai %s` against it (see `ochakai help`)\n",
-			cmd, strings.TrimSuffix(cmd, "-okf"))
-		os.Exit(1)
 	case "version":
 		fmt.Println(version)
 	case "help", "-h", "--help":

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -499,10 +499,16 @@ working against a newer schema.
 
 Version notes:
 
+- **→ 0.8.0 (breaking)**: the v0.3 migration shims are gone. The legacy
+  `GET /api/v1/knowledge/{type}/{id}/usage` alias is removed — use
+  `GET /api/v1/usage/{type}/{id}`. The startup guard that refused to run
+  with removed v0.2 variables (`OCHAKAI_CLIENTS`, `OCHAKAI_AUTH`,
+  `OCHAKAI_CORS_ORIGINS`, `OCHAKAI_EMBEDDING_PROVIDER`) is also gone:
+  stale variables are now silently ignored, so double-check they are
+  unset before upgrading straight from ≤0.2 (see the 0.3.0 note).
 - **→ 0.3.0 (breaking)**: ochakai is Google Cloud only (design doc 0003).
   Bearer-token auth (`OCHAKAI_CLIENTS`), `OCHAKAI_AUTH`, and
-  `OCHAKAI_CORS_ORIGINS` are removed — the service refuses to start if
-  the removed variables are still set, so remove them from the deployment
+  `OCHAKAI_CORS_ORIGINS` are removed — remove them from the deployment
   and follow §3 (IAM-restricted + identity headers). Deployments that
   were public + tokens must switch to `--no-allow-unauthenticated` with
   IAM invoker grants. `OCHAKAI_EMBEDDING_PROVIDER=vertex` is tolerated

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,10 +60,6 @@ type EmbeddingConfig struct {
 }
 
 func FromEnv() (*Config, error) {
-	if err := rejectRemovedEnv(); err != nil {
-		return nil, err
-	}
-
 	cfg := &Config{
 		Addr:        ":" + envOr("PORT", "8080"),
 		DatabaseURL: firstEnv("OCHAKAI_DATABASE_URL", "DATABASE_URL"),
@@ -126,30 +122,6 @@ func connectorFromEnv(publicURL string) (*ConnectorConfig, error) {
 		return nil, fmt.Errorf("connector mode needs all of OCHAKAI_CONNECTOR_GOOGLE_CLIENT_ID, OCHAKAI_CONNECTOR_GOOGLE_CLIENT_SECRET, OCHAKAI_CONNECTOR_ALLOWED_DOMAIN (design doc 0010)")
 	}
 	return conn, nil
-}
-
-// rejectRemovedEnv fails fast when configuration removed in v0.3 (design
-// doc 0003: Google Cloud only) is still present. Variables whose meaning
-// is unchanged are tolerated silently; ones whose behavior would be lost
-// refuse to start rather than silently weakening the deployment.
-func rejectRemovedEnv() error {
-	if os.Getenv("OCHAKAI_CLIENTS") != "" {
-		return fmt.Errorf("OCHAKAI_CLIENTS was removed in v0.3: ochakai authenticates via Cloud Run IAM only (docs/design/0003-gcp-only.md); unset it and use IAM invoker grants")
-	}
-	if os.Getenv("OCHAKAI_CORS_ORIGINS") != "" {
-		return fmt.Errorf("OCHAKAI_CORS_ORIGINS was removed in v0.3: host browser UIs behind a same-origin proxy like examples/webui (docs/design/0003-gcp-only.md)")
-	}
-	switch v := os.Getenv("OCHAKAI_AUTH"); v {
-	case "", "cloudrun-iam": // unchanged meaning; tolerated
-	default:
-		return fmt.Errorf("OCHAKAI_AUTH=%q was removed in v0.3: Cloud Run IAM is the only auth mode (docs/design/0003-gcp-only.md)", v)
-	}
-	switch v := os.Getenv("OCHAKAI_EMBEDDING_PROVIDER"); v {
-	case "", "vertex": // unchanged meaning; tolerated
-	default:
-		return fmt.Errorf("OCHAKAI_EMBEDDING_PROVIDER=%q is not supported: only Vertex AI (set OCHAKAI_VERTEX_PROJECT to enable)", v)
-	}
-	return nil
 }
 
 func envOr(key, fallback string) string {

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -210,11 +210,6 @@ func Handler(svc *service.Service) http.Handler {
 		}
 		writeJSON(w, http.StatusOK, map[string]any{"entries": entries})
 	})
-	// Legacy pre-0005 usage path, kept for existing clients. It shadows
-	// GET on entries whose two-segment ID ends in "usage" — the canonical
-	// path above has no such ambiguity.
-	mux.HandleFunc("GET /api/v1/knowledge/{type}/{id}/usage", usage)
-
 	// Attachments (design doc 0008): images attached to an entry, bytes
 	// fetched on demand — entry reads carry metadata only. The path is
 	// /attachments/{type}/{id segments...}/{name}; the final segment is


### PR DESCRIPTION
## Summary

Removes three graceful-removal shims that have served their transition purpose (feature review follow-up):

- **Legacy usage route** `GET /api/v1/knowledge/{type}/{id}/usage` (pre-design-doc-0005 alias). It also shadowed `GET` on entries whose two-segment hierarchical ID ends in `usage`; the canonical `GET /api/v1/usage/{type}/{id...}` has no such ambiguity. The OpenAPI description no longer mentions the alias.
- **`export-okf` / `import-okf` error stubs** in `cmd/ochakai` — the DB-direct commands were removed in design doc 0007; the stubs only printed a redirect message.
- **`rejectRemovedEnv`** in `internal/config` — the startup guard that refused to run when v0.2-era variables (`OCHAKAI_CLIENTS`, `OCHAKAI_AUTH`, `OCHAKAI_CORS_ORIGINS`, `OCHAKAI_EMBEDDING_PROVIDER`) were still set.

`deploy/cloudrun/README.md` gains a **→ 0.8.0 (breaking)** version note covering all three, including the caveat that stale v0.2 variables are now silently ignored, so upgraders coming straight from ≤0.2 should double-check they are unset.

Design docs are left untouched as historical records.

## Test plan

- `go build ./... && go vet ./...`
- `go test ./...` — all packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)