### PR TITLE
Fix SQL injection in compile_sql via undeclared field pass-through

### DIFF
--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -70,6 +70,14 @@ type Result struct {
 
 var identRe = regexp.MustCompile(`([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)`)
 
+// bareColumn matches a single unquoted SQL column identifier. It gates
+// caller-controlled field references (dimensions, filter fields, time
+// grain) that pass through as physical columns: those flow verbatim into
+// the compiled SQL, which is executed downstream with real warehouse
+// credentials, so anything that is not a plain identifier must be rejected
+// rather than concatenated (SQL injection).
+var bareColumn = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
 // Compile builds a SQL statement for the request against the model.
 func Compile(m *Model, req Request) (*Result, error) {
 	if len(req.Metrics) == 0 {
@@ -247,6 +255,15 @@ func (m *Model) resolveFieldRef(ref string, dialect Dialect, needed map[string]b
 func (m *Model) resolveField(ds *Dataset, name string, dialect Dialect) (string, error) {
 	f := ds.field(name)
 	if f == nil {
+		// Undeclared columns pass through as physical columns (the Ossie
+		// draft does not require every column to be declared), but only when
+		// the name is a bare SQL identifier. This branch is reachable with
+		// caller-controlled input (a dimension/filter/time-grain field that
+		// names no declared field), so an unchecked pass-through would splice
+		// arbitrary SQL into the compiled statement.
+		if !bareColumn.MatchString(name) {
+			return "", &Error{Reason: fmt.Sprintf("field %q is not defined in dataset %q and is not a bare column name; declare it as a field to use an expression", name, ds.Name)}
+		}
 		return ds.Name + "." + name, nil
 	}
 	expr, ok := f.Expression.ForDialect(dialect.ossieKey())
@@ -255,7 +272,7 @@ func (m *Model) resolveField(ds *Dataset, name string, dialect Dialect) (string,
 	}
 	// Field expressions are relative to their dataset: qualify bare
 	// identifiers with the dataset alias.
-	if regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`).MatchString(expr) {
+	if bareColumn.MatchString(expr) {
 		return ds.Name + "." + expr, nil
 	}
 	return "(" + expr + ")", nil

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -154,6 +154,58 @@ func TestCompileUnsupportedDialectFails(t *testing.T) {
 	}
 }
 
+// TestFieldRefInjectionRejected covers the caller-controlled field
+// references that pass through as physical columns. An undeclared field
+// that is not a bare identifier must be refused, never spliced into the
+// compiled SQL (which is executed downstream with real credentials).
+func TestFieldRefInjectionRejected(t *testing.T) {
+	const inject = "amount) AS x, (SELECT secret FROM other"
+	cases := []struct {
+		name string
+		req  Request
+	}{
+		{"dimension", Request{
+			Metrics:    []string{"revenue"},
+			Dimensions: []string{"orders." + inject},
+		}},
+		{"filter field", Request{
+			Metrics: []string{"revenue"},
+			Filters: []Filter{{Field: "orders." + inject, Op: "=", Value: "x"}},
+		}},
+		{"time grain field", Request{
+			Metrics:   []string{"revenue"},
+			TimeGrain: &TimeGrain{Field: "orders." + inject, Grain: "month"},
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := Compile(testModel(t), tc.req)
+			if err == nil {
+				t.Fatalf("injection not rejected; compiled SQL:\n%s", res.SQL)
+			}
+			if !strings.Contains(err.Error(), "bare column name") {
+				t.Fatalf("want bare-column rejection, got %v", err)
+			}
+		})
+	}
+}
+
+// TestUndeclaredBareColumnPassesThrough keeps the legitimate case working:
+// a plain, undeclared column is still usable without being declared.
+func TestUndeclaredBareColumnPassesThrough(t *testing.T) {
+	res, err := Compile(testModel(t), Request{
+		Metrics:    []string{"revenue"},
+		Dimensions: []string{"orders.channel"},
+		Dialect:    "ansi",
+	})
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if !strings.Contains(res.SQL, "orders.channel AS orders_channel") {
+		t.Errorf("bare column not passed through:\n%s", res.SQL)
+	}
+}
+
 func TestExpressionShapes(t *testing.T) {
 	cases := []string{
 		`expression: SUM(orders.amount)`,

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -263,6 +263,11 @@ func Handler(svc *service.Service) http.Handler {
 			return
 		}
 		w.Header().Set("Content-Type", att.MediaType)
+		// The bytes are user-uploaded and served inline; the media type is
+		// sniffed and allowlisted (images only, no SVG), but nosniff keeps a
+		// browser from overriding that and interpreting them as anything
+		// executable.
+		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.Header().Set("ETag", `"`+att.SHA256+`"`)
 		w.Header().Set("Content-Disposition", `inline; filename="`+att.Name+`"`)
 		_, _ = w.Write(data)


### PR DESCRIPTION
## Summary

Security audit of the codebase against ochakai's own threat model (`SECURITY.md`, design docs 0002 & 0010). Found and fixed one genuinely exploitable vulnerability, plus one defense-in-depth hardening.

## 1. SQL injection in `compile_sql` (high severity)

`compiler.resolveField` had a fallback that passed a field reference through as a physical column when it named no declared field. But the values flowing into that branch — `dimensions`, `filters[].field`, and `time_grain.field` — are **caller-controlled** and were concatenated into the compiled SQL **without identifier validation**.

`SECURITY.md` explicitly flags this surface as top priority: *"the compiled SQL is executed downstream with real warehouse credentials."* So this is a real injection, not just malformed output.

Proven with the new regression test — the pre-fix compiler emitted, for example:

```sql
WHERE orders.amount) AS x, (SELECT secret FROM other = 'x'
```

**Fix:** undeclared pass-through columns must match a bare SQL identifier (`^[A-Za-z_][A-Za-z0-9_]*$`); anything else is rejected with a clear error. Declared fields and trusted model-supplied expressions are unaffected, so no legitimate compile breaks. The new test covers all three injection vectors (dimension / filter field / time-grain field) and confirms a plain undeclared column still passes through.

## 2. `X-Content-Type-Options: nosniff` on attachment serving (hardening)

The REST attachment endpoint serves user-uploaded bytes inline (`Content-Disposition: inline`). The media type is sniffed and allowlisted (images only, SVG already excluded), but `nosniff` was missing. Added it so a browser can never override the declared type and interpret the bytes as something executable — consistent with the existing "no SVG to avoid XSS" intent.

## Surfaces reviewed and found sound

- **httpauth** JWT parse-without-verify: correct under the Cloud Run IAM model; `X-Serverless-Authorization` precedence prevents `Authorization`-header impersonation.
- **Connector OAuth**: PKCE S256 mandatory, CIMD SSRF guard (post-DNS public-IP check at dial time), authoritative `hd` domain check, refresh-token reuse revokes the grant, 256-bit tokens stored only as SHA-256.
- **Store**: all queries parameterized — no injection.
- **Web UI**: markdown renderer escapes before applying regexes — no XSS.
- **Bundle import**: tar extraction guarded by `filepath.IsLocal`, `okf_path` validated against traversal.

## Testing

- `go build ./...`, `go vet`, and the full `go test ./...` suite pass.
- New regression test fails on the pre-fix code and passes on the fix (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)