### PR TITLE
Compile notes for undeclared pass-through fields; deploy-guide version alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ ochakai context "why is revenue down?"  # the one-call read before a data questi
 ochakai search "revenue" --type metric --status verified
 ochakai get metric/revenue
 ochakai attach insight/revenue-reading weekly.png   # images travel with the entry
-ochakai compile --metric revenue --grain orders.created_at:month
+ochakai compile --metric revenue --grain orders.ordered_at:month
 ochakai export ./knowledge   # or: ochakai export - > okf.tar.gz
 ochakai import ./knowledge   # the inverse; works with any OKF bundle
 ochakai ui                   # web UI at http://127.0.0.1:8098, acting as you (no deploy)

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -613,7 +613,7 @@ func cmdDelete(ctx context.Context, args []string) error {
 func cmdCompile(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
 		"Usage: ochakai compile [flags] --metric <name>\n\nDeterministically compile metrics into SQL (never executed, never\nguessed). SQL goes to stdout; notes and related verified golden\nqueries go to stderr — prefer a verified query when it answers the\nquestion. Exit 2 means the request is outside the supported subset;\nthe reason is on stderr.",
-		"  ochakai compile --metric revenue --dimension orders.region --grain orders.created_at:month\n  ochakai compile --metric revenue --filter \"orders.status = shipped\" > revenue.sql\n")
+		"  ochakai compile --metric revenue --dimension customers.region --grain orders.ordered_at:month\n  ochakai compile --metric revenue --filter \"orders.status = shipped\" > revenue.sql\n")
 	var metrics, dims, filters repeated
 	fs.Var(&metrics, "metric", "metric name (repeatable, required)")
 	fs.Var(&dims, "dimension", "group-by column as dataset.field (repeatable)")

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -40,11 +40,11 @@ gcloud artifacts repositories create ghcr \
   --remote-docker-repo=https://ghcr.io \
   --location=$REGION
 
-export IMAGE=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:0.3.0
+export IMAGE=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:0.8.0
 ```
 
-(Check [releases](https://github.com/na0fu3y/ochakai/releases) for the
-latest tag; §3 requires 0.3.0 or later.)
+(Check [tags](https://github.com/na0fu3y/ochakai/tags) for the latest;
+§3 requires 0.3.0 or later, §4b requires 0.8.0 or later.)
 
 ## 2. Create the database (cheapest viable instance)
 
@@ -240,7 +240,7 @@ updated knowledge with `gemini-embedding-001`. Search becomes hybrid
 (trigram + vector, reciprocal rank fusion). If Vertex AI is ever
 unavailable, writes and searches degrade gracefully to trigram-only.
 
-## 4b. Optional: attachment images on GCS
+## 4b. Optional: attachment images on GCS (0.8.0+)
 
 By default attachment images live in Postgres (design doc 0008), which
 keeps local development Docker-only. When they start crowding the
@@ -264,6 +264,11 @@ On the next start, ochakai copies existing inline images to the bucket
 deleted) and clears the database copies; the backfill is idempotent, so
 an interrupted start resumes on the next one. New attachments go
 straight to the bucket.
+
+On images older than 0.8.0 the variable is silently ignored — no error,
+no migration. Check the running tag
+(`gcloud run services describe ochakai --region=$REGION --format='value(spec.template.spec.containers[0].image)'`)
+before enabling.
 
 **Rollback caveat**: the backfill is not additive — once it has run,
 binaries older than the env var (or a deployment with the var removed)

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -104,7 +104,7 @@ func Compile(m *Model, req Request) (*Result, error) {
 		if !ok {
 			return nil, &Error{Reason: fmt.Sprintf("metric %q has no expression for dialect %s or ANSI_SQL", name, dialect.ossieKey())}
 		}
-		expr, err := m.rewriteExpr(raw, dialect, needed)
+		expr, err := m.rewriteExpr(raw, dialect, needed, &notes)
 		if err != nil {
 			return nil, err
 		}
@@ -115,7 +115,7 @@ func Compile(m *Model, req Request) (*Result, error) {
 	type selectCol struct{ expr, alias string }
 	var groupCols []selectCol
 	if req.TimeGrain != nil {
-		expr, err := m.resolveFieldRef(req.TimeGrain.Field, dialect, needed)
+		expr, err := m.resolveFieldRef(req.TimeGrain.Field, dialect, needed, &notes)
 		if err != nil {
 			return nil, err
 		}
@@ -126,7 +126,7 @@ func Compile(m *Model, req Request) (*Result, error) {
 		groupCols = append(groupCols, selectCol{expr: truncated, alias: strings.ReplaceAll(req.TimeGrain.Field, ".", "_") + "_" + req.TimeGrain.Grain})
 	}
 	for _, dim := range req.Dimensions {
-		expr, err := m.resolveFieldRef(dim, dialect, needed)
+		expr, err := m.resolveFieldRef(dim, dialect, needed, &notes)
 		if err != nil {
 			return nil, err
 		}
@@ -135,7 +135,7 @@ func Compile(m *Model, req Request) (*Result, error) {
 
 	var whereClauses []string
 	for _, f := range req.Filters {
-		expr, err := m.resolveFieldRef(f.Field, dialect, needed)
+		expr, err := m.resolveFieldRef(f.Field, dialect, needed, &notes)
 		if err != nil {
 			return nil, err
 		}
@@ -205,13 +205,13 @@ func Compile(m *Model, req Request) (*Result, error) {
 		datasets = append(datasets, ds)
 	}
 	sort.Strings(datasets)
-	return &Result{SQL: b.String(), Dialect: dialect, DatasetsUsed: datasets, Notes: notes}, nil
+	return &Result{SQL: b.String(), Dialect: dialect, DatasetsUsed: datasets, Notes: dedupe(notes)}, nil
 }
 
 // rewriteExpr replaces every dataset.field reference in an expression with
 // the field's physical expression qualified by the dataset alias, and
 // records referenced datasets.
-func (m *Model) rewriteExpr(expr string, dialect Dialect, needed map[string]bool) (string, error) {
+func (m *Model) rewriteExpr(expr string, dialect Dialect, needed map[string]bool, notes *[]string) (string, error) {
 	var rewriteErr error
 	out := identRe.ReplaceAllStringFunc(expr, func(ref string) string {
 		parts := strings.SplitN(ref, ".", 2)
@@ -221,7 +221,7 @@ func (m *Model) rewriteExpr(expr string, dialect Dialect, needed map[string]bool
 			return ref
 		}
 		needed[ds.Name] = true
-		resolved, err := m.resolveField(ds, parts[1], dialect)
+		resolved, err := m.resolveField(ds, parts[1], dialect, notes)
 		if err != nil {
 			rewriteErr = err
 			return ref
@@ -236,7 +236,7 @@ func (m *Model) rewriteExpr(expr string, dialect Dialect, needed map[string]bool
 
 // resolveFieldRef resolves a "dataset.field" reference used as a dimension,
 // filter, or time grain column.
-func (m *Model) resolveFieldRef(ref string, dialect Dialect, needed map[string]bool) (string, error) {
+func (m *Model) resolveFieldRef(ref string, dialect Dialect, needed map[string]bool, notes *[]string) (string, error) {
 	parts := strings.SplitN(ref, ".", 2)
 	if len(parts) != 2 {
 		return "", &Error{Reason: fmt.Sprintf("field reference %q must be dataset.field", ref)}
@@ -246,13 +246,14 @@ func (m *Model) resolveFieldRef(ref string, dialect Dialect, needed map[string]b
 		return "", &Error{Reason: fmt.Sprintf("dataset %q is not defined in semantic model %q", parts[0], m.Name)}
 	}
 	needed[ds.Name] = true
-	return m.resolveField(ds, parts[1], dialect)
+	return m.resolveField(ds, parts[1], dialect, notes)
 }
 
 // resolveField maps a logical field to "alias.physical_expr". Unknown names
 // pass through as physical columns (the Ossie draft does not require every
-// column to be declared as a field).
-func (m *Model) resolveField(ds *Dataset, name string, dialect Dialect) (string, error) {
+// column to be declared as a field), with a note so the caller knows the
+// column's existence was taken on trust, not checked against the model.
+func (m *Model) resolveField(ds *Dataset, name string, dialect Dialect, notes *[]string) (string, error) {
 	f := ds.field(name)
 	if f == nil {
 		// Undeclared columns pass through as physical columns (the Ossie
@@ -264,6 +265,7 @@ func (m *Model) resolveField(ds *Dataset, name string, dialect Dialect) (string,
 		if !bareColumn.MatchString(name) {
 			return "", &Error{Reason: fmt.Sprintf("field %q is not defined in dataset %q and is not a bare column name; declare it as a field to use an expression", name, ds.Name)}
 		}
+		*notes = append(*notes, fmt.Sprintf("%s.%s is not declared in semantic model %q; passed through as a physical column", ds.Name, name, m.Name))
 		return ds.Name + "." + name, nil
 	}
 	expr, ok := f.Expression.ForDialect(dialect.ossieKey())
@@ -330,6 +332,20 @@ func (m *Model) resolveJoins(root string, needed map[string]bool, dialect Dialec
 		}
 	}
 	return joins, nil
+}
+
+// dedupe drops repeated notes (the same undeclared field may be resolved
+// as a dimension, a filter, and a grain in one request), keeping order.
+func dedupe(notes []string) []string {
+	seen := map[string]bool{}
+	out := notes[:0]
+	for _, n := range notes {
+		if !seen[n] {
+			seen[n] = true
+			out = append(out, n)
+		}
+	}
+	return out
 }
 
 func referencedDatasets(m *Model, expr string) []string {

--- a/internal/compiler/compiler_test.go
+++ b/internal/compiler/compiler_test.go
@@ -109,6 +109,36 @@ func TestCompileStarJoinWithDimensionsFiltersGrain(t *testing.T) {
 	}
 }
 
+func TestCompileUndeclaredFieldPassesThroughWithNote(t *testing.T) {
+	res, err := Compile(testModel(t), Request{
+		Metrics:    []string{"revenue"},
+		Dimensions: []string{"orders.status"},
+		Filters:    []Filter{{Field: "orders.status", Op: "=", Value: "shipped"}},
+		Dialect:    "ansi",
+	})
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if !strings.Contains(res.SQL, "orders.status AS orders_status") {
+		t.Errorf("undeclared field must pass through as a physical column:\n%s", res.SQL)
+	}
+	if len(res.Notes) != 1 || !strings.Contains(res.Notes[0], "orders.status is not declared") {
+		t.Errorf("want one deduplicated pass-through note, got %v", res.Notes)
+	}
+
+	declared, err := Compile(testModel(t), Request{
+		Metrics:    []string{"revenue"},
+		Dimensions: []string{"customers.region"},
+		Dialect:    "ansi",
+	})
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if len(declared.Notes) != 0 {
+		t.Errorf("declared fields must not produce notes, got %v", declared.Notes)
+	}
+}
+
 func TestCompileUnknownMetricFails(t *testing.T) {
 	_, err := Compile(testModel(t), Request{Metrics: []string{"nonexistent"}})
 	if err == nil || !strings.Contains(err.Error(), "nonexistent") {


### PR DESCRIPTION
Verified the Cloud Run deploy guide end-to-end on a live GCP project (ochakai-example): §8 upgrade, §4b GCS attachment backfill (first real exercise of #58 — worked exactly as written), full CLI surface, MCP tools/resources, webui, Claude Code hooks, and the canary guide's CLI flags. This PR carries the fixes that fell out of that pass.

## Compiler: notes for undeclared pass-through fields

`compile --grain orders.nonexistent_col:month` silently produced SQL referencing a column that may not exist. The pass-through itself is intentional (the Ossie draft doesn't require declaring every column) and stays; but the CLI has always printed `Result.Notes` to stderr while the compiler never filled them. Undeclared references now emit a note:

```
note: orders.created_at is not declared in semantic model "sales_analytics"; passed through as a physical column
```

Deduplicated across dimension/filter/grain uses of the same field; declared fields emit nothing. Test added; verified live against Cloud Run.

## Examples: use declared model fields

README quick-start and `compile` help used `orders.created_at:month` — a raw physical column that only compiled via pass-through (the declared field is `orders.ordered_at`). Examples now use declared fields, so they compile note-free.

## Deploy guide: version alignment

The guide documents 0.8.0 behavior but the newest tag/GHCR image is 0.7.0, where `OCHAKAI_GCS_BUCKET` is **silently ignored** — following §4b does nothing with no error. Changes:

- §4b marked **0.8.0+**, with a note that older images ignore the variable and a command to check the running tag first
- §1 example image tag bumped 0.3.0 → 0.8.0, "check releases" link now points at [tags](https://github.com/na0fu3y/ochakai/tags) (the releases page is empty)

Follow-up after merge: cut the 0.8.0 tag so the GHCR image exists and §4b works as written.

## Verified on ochakai-example

- §8 upgrade path: one-command image swap, migrations ran, data intact
- §4b: bucket + `objectUser` + env var → startup backfill moved inline images to `blob/<sha256>`, fetch still 200, new attachments go straight to GCS, content-addressed dedup confirmed
- CLI resolves Google ID tokens itself against the direct run.app URL (no proxy) — `whoami` reports `human:<email>` as documented
- MCP: 10 tools match the README table; `resources/read` on `ochakai://metric/revenue` returns the OKF document
- `gh attestation verify` passes for the 0.7.0 GHCR image

🤖 Generated with [Claude Code](https://claude.com/claude-code)