### PR TITLE
Idempotent import: skip revision + updated_at when entry content is unchanged

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -185,7 +185,14 @@ paths:
             schema: { $ref: "#/components/schemas/Knowledge" }
       responses:
         "200":
-          description: Updated.
+          description: Updated, or unchanged (see the Ochakai-Unchanged header).
+          headers:
+            Ochakai-Unchanged:
+              description: >
+                Set to "true" when the payload matched the stored content
+                exactly, so nothing was written — no revision, no
+                updated_at bump. Absent on a real update.
+              schema: { type: string, enum: ["true"] }
           content:
             application/json:
               schema: { $ref: "#/components/schemas/Knowledge" }

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -572,12 +572,16 @@ func cmdUpdate(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	updated, err := c.Update(ctx, k)
+	updated, changed, err := c.Update(ctx, k)
 	if err != nil {
 		return err
 	}
 	if *asJSON {
 		return printJSON(updated)
+	}
+	if !changed {
+		fmt.Printf("unchanged %s (%s)\n", updated.URI(), updated.Status)
+		return nil
 	}
 	fmt.Printf("updated %s (%s)\n", updated.URI(), updated.Status)
 	return nil
@@ -712,7 +716,7 @@ func cmdExport(ctx context.Context, args []string) error {
 
 func cmdImport(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
-		"Usage: ochakai import [flags] <dir | file.tar.gz | ->\n\nImport an OKF bundle (a directory of markdown + YAML frontmatter, or\na tar.gz of one; \"-\" reads the tar.gz from stdin). The inverse of\n`ochakai export`: paths name the entries (first segment = type, rest =\nid), reserved index.md / log.md files are skipped, unknown frontmatter\nkeys are kept as attrs, existing entries are replaced (kept as\nrevisions). Images referenced by an entry's body markdown links become\nits attachments, wherever they sit in the bundle (their location is\npreserved for re-export). An archive wrapped in a single directory is\nunwrapped. Works with any OKF bundle, not just ochakai's own.",
+		"Usage: ochakai import [flags] <dir | file.tar.gz | ->\n\nImport an OKF bundle (a directory of markdown + YAML frontmatter, or\na tar.gz of one; \"-\" reads the tar.gz from stdin). The inverse of\n`ochakai export`: paths name the entries (first segment = type, rest =\nid), reserved index.md / log.md files are skipped, unknown frontmatter\nkeys are kept as attrs, existing entries are replaced (kept as\nrevisions; entries identical to what is stored are left untouched\nand reported as unchanged). Images referenced by an entry's body markdown links become\nits attachments, wherever they sit in the bundle (their location is\npreserved for re-export). An archive wrapped in a single directory is\nunwrapped. Works with any OKF bundle, not just ochakai's own.",
 		"  ochakai import ./knowledge\n  ochakai import ga4-bundle.tar.gz --dry-run\n  ochakai export - | OCHAKAI_URL=https://other ochakai import -\n")
 	dryRun := fs.Bool("dry-run", false, "parse and list what would be written, write nothing")
 	keepRoot := fs.Bool("keep-root", false, "keep a single top-level directory as the type instead of unwrapping it")
@@ -752,7 +756,7 @@ func cmdImport(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	var created, updated int
+	var created, updated, unchanged int
 	for i := range entries {
 		k := &entries[i]
 		if _, err := c.Create(ctx, k); err == nil {
@@ -762,8 +766,14 @@ func cmdImport(ctx context.Context, args []string) error {
 		} else if !isConflict(err) {
 			return fmt.Errorf("%s: %w", k.URI(), err)
 		}
-		if _, err := c.Update(ctx, k); err != nil {
+		_, changed, err := c.Update(ctx, k)
+		if err != nil {
 			return fmt.Errorf("%s: %w", k.URI(), err)
+		}
+		if !changed {
+			unchanged++
+			fmt.Printf("unchanged %s\n", k.URI())
+			continue
 		}
 		updated++
 		fmt.Printf("updated %s\n", k.URI())
@@ -780,8 +790,8 @@ func cmdImport(ctx context.Context, args []string) error {
 		}
 		fmt.Printf("attached %s/%s/%s\n", a.Type, a.ID, a.Name)
 	}
-	fmt.Printf("imported %d entries (%d created, %d updated, %d attachments, %d skipped)\n",
-		created+updated, created, updated, len(atts), len(skipped))
+	fmt.Printf("imported %d entries (%d created, %d updated, %d unchanged, %d attachments, %d skipped)\n",
+		created+updated+unchanged, created, updated, unchanged, len(atts), len(skipped))
 	return nil
 }
 
@@ -820,8 +830,11 @@ func cmdImportOssie(ctx context.Context, args []string) error {
 	for _, uri := range report.Updated {
 		fmt.Println("updated", uri)
 	}
-	fmt.Printf("imported %d models (%d entries created, %d updated)\n",
-		len(report.Models), len(report.Created), len(report.Updated))
+	for _, uri := range report.Unchanged {
+		fmt.Println("unchanged", uri)
+	}
+	fmt.Printf("imported %d models (%d entries created, %d updated, %d unchanged)\n",
+		len(report.Models), len(report.Created), len(report.Updated), len(report.Unchanged))
 	return nil
 }
 

--- a/cmd/ochakai/client_test.go
+++ b/cmd/ochakai/client_test.go
@@ -4,7 +4,12 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"context"
+	"encoding/json"
 	"flag"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -227,5 +232,68 @@ func TestRenderContext(t *testing.T) {
 	}
 	if !strings.Contains(s, "1 more entries beyond --budget") {
 		t.Errorf("omitted entries must be reported:\n%s", s)
+	}
+}
+
+// TestImportReportsUnchanged pins the import summary against a fake
+// server: an existing entry whose PUT answers with Ochakai-Unchanged
+// counts (and prints) as unchanged, everything else as before. Servers
+// without the header (absent on the second PUT) keep reporting updated.
+func TestImportReportsUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	for name, doc := range map[string]string{
+		"same.md": "---\ntype: metric\ntitle: Same\n---\n\nbody\n",
+		"diff.md": "---\ntype: metric\ntitle: Diff\n---\n\nbody\n",
+	} {
+		if err := os.MkdirAll(filepath.Join(dir, "metric"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "metric", name), []byte(doc), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v1/knowledge", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "already exists"})
+	})
+	mux.HandleFunc("PUT /api/v1/knowledge/{type}/{id...}", func(w http.ResponseWriter, r *http.Request) {
+		var k domain.Knowledge
+		if err := json.NewDecoder(r.Body).Decode(&k); err != nil {
+			t.Errorf("bad PUT payload: %v", err)
+		}
+		if r.PathValue("id") == "same" {
+			w.Header().Set("Ochakai-Unchanged", "true")
+		}
+		_ = json.NewEncoder(w).Encode(k)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	orig := os.Stdout
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = pw
+	importErr := cmdImport(context.Background(), []string{dir, "--url", srv.URL})
+	pw.Close()
+	os.Stdout = orig
+	out, err := io.ReadAll(pr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if importErr != nil {
+		t.Fatalf("cmdImport: %v\noutput:\n%s", importErr, out)
+	}
+	for _, want := range []string{
+		"unchanged ochakai://metric/same\n",
+		"updated ochakai://metric/diff\n",
+		"imported 2 entries (0 created, 1 updated, 1 unchanged, 0 attachments, 0 skipped)\n",
+	} {
+		if !strings.Contains(string(out), want) {
+			t.Errorf("output misses %q:\n%s", want, out)
+		}
 	}
 }

--- a/internal/apiclient/apiclient.go
+++ b/internal/apiclient/apiclient.go
@@ -190,13 +190,21 @@ func (c *Client) Create(ctx context.Context, k *domain.Knowledge) (*domain.Knowl
 }
 
 // Update replaces the entry at k.Type/k.ID (full replacement; the server
-// keeps every change as a revision).
-func (c *Client) Update(ctx context.Context, k *domain.Knowledge) (*domain.Knowledge, error) {
-	var updated domain.Knowledge
-	if err := c.doJSON(ctx, http.MethodPut, entryPath(string(k.Type), k.ID), nil, k, &updated); err != nil {
-		return nil, err
+// keeps every change as a revision). changed=false reports the server
+// wrote nothing because the payload matched the stored content (the
+// Ochakai-Unchanged response header); servers predating the header
+// always report changed=true.
+func (c *Client) Update(ctx context.Context, k *domain.Knowledge) (updated *domain.Knowledge, changed bool, err error) {
+	resp, err := c.do(ctx, http.MethodPut, entryPath(string(k.Type), k.ID), nil, k)
+	if err != nil {
+		return nil, false, err
 	}
-	return &updated, nil
+	defer resp.Body.Close()
+	var out domain.Knowledge
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, false, err
+	}
+	return &out, resp.Header.Get("Ochakai-Unchanged") != "true", nil
 }
 
 func (c *Client) Delete(ctx context.Context, typ, id string) error {

--- a/internal/apiclient/types.go
+++ b/internal/apiclient/types.go
@@ -32,9 +32,10 @@ type TimeGrain struct {
 // ImportReport is the response of POST /api/v1/import/ossie.
 // TestImportReportMatchesServerWire pins it to importer.Report.
 type ImportReport struct {
-	Models  []string `json:"models"`
-	Created []string `json:"created"`
-	Updated []string `json:"updated"`
+	Models    []string `json:"models"`
+	Created   []string `json:"created"`
+	Updated   []string `json:"updated"`
+	Unchanged []string `json:"unchanged,omitempty"`
 }
 
 type CompileResult struct {

--- a/internal/apiclient/wire_test.go
+++ b/internal/apiclient/wire_test.go
@@ -56,9 +56,10 @@ func TestCompileRequestMatchesServerWire(t *testing.T) {
 
 func TestImportReportMatchesServerWire(t *testing.T) {
 	server := importer.Report{
-		Models:  []string{"sales_analytics"},
-		Created: []string{"metric/revenue"},
-		Updated: []string{"table/orders"},
+		Models:    []string{"sales_analytics"},
+		Created:   []string{"metric/revenue"},
+		Updated:   []string{"table/orders"},
+		Unchanged: []string{"metric/margin"},
 	}
 	data, err := json.Marshal(server)
 	if err != nil {
@@ -69,9 +70,10 @@ func TestImportReportMatchesServerWire(t *testing.T) {
 		t.Fatalf("client cannot decode the server response: %v", err)
 	}
 	want := ImportReport{
-		Models:  []string{"sales_analytics"},
-		Created: []string{"metric/revenue"},
-		Updated: []string{"table/orders"},
+		Models:    []string{"sales_analytics"},
+		Created:   []string{"metric/revenue"},
+		Updated:   []string{"table/orders"},
+		Unchanged: []string{"metric/margin"},
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("client decoded:\n%+v\nwant:\n%+v", got, want)

--- a/internal/domain/knowledge.go
+++ b/internal/domain/knowledge.go
@@ -3,8 +3,11 @@
 package domain
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 )
@@ -146,6 +149,32 @@ type Knowledge struct {
 
 // URI returns the canonical reference, e.g. "ochakai://metric/revenue".
 func (k *Knowledge) URI() string { return fmt.Sprintf("ochakai://%s/%s", k.Type, k.ID) }
+
+// SameContent reports whether o carries the same authored content as k:
+// the fields a writer controls (title, description, tags, status,
+// status_note, links, attrs, body). Server-managed provenance and
+// timestamps (created_*, verified_*, rejected_*, updated_at) and the
+// attachment list are not content. Attrs are compared as canonical JSON,
+// so the same value decoded from YAML (int) and from JSONB (float64)
+// compares equal; values JSON cannot encode compare as different.
+func (k *Knowledge) SameContent(o *Knowledge) bool {
+	return k.Type == o.Type && k.ID == o.ID &&
+		k.Title == o.Title && k.Description == o.Description &&
+		k.Status == o.Status && k.StatusNote == o.StatusNote &&
+		k.Body == o.Body &&
+		slices.Equal(k.Tags, o.Tags) &&
+		slices.Equal(k.Links, o.Links) &&
+		attrsEqual(k.Attrs, o.Attrs)
+}
+
+func attrsEqual(a, b map[string]any) bool {
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+	ja, errA := json.Marshal(a)
+	jb, errB := json.Marshal(b)
+	return errA == nil && errB == nil && bytes.Equal(ja, jb)
+}
 
 // Revision is one entry in an entry's change history: who changed it,
 // how, when, and the full snapshot as of that change. The audit trail

--- a/internal/domain/knowledge_test.go
+++ b/internal/domain/knowledge_test.go
@@ -3,6 +3,7 @@ package domain
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestValidID(t *testing.T) {
@@ -24,6 +25,63 @@ func TestValidID(t *testing.T) {
 	for _, id := range invalid {
 		if ValidID(id) {
 			t.Errorf("ValidID(%q) = true, want false", id)
+		}
+	}
+}
+
+// TestSameContent pins the no-op-update predicate: authored content
+// decides, server-managed provenance and timestamps never do, and attrs
+// compare by value across decoders (YAML ints vs JSON float64s).
+func TestSameContent(t *testing.T) {
+	base := func() *Knowledge {
+		return &Knowledge{
+			Type: TypeMetric, ID: "revenue", Title: "Revenue",
+			Description: "monthly revenue", Tags: []string{"sales"},
+			Status: StatusVerified, StatusNote: "checked",
+			Links: []Link{{Rel: "defined_in", Target: "model/sales"}},
+			Attrs: map[string]any{"threshold": 5, "model": "sales"},
+			Body:  "Sum of order totals.",
+		}
+	}
+
+	same := base()
+	// Server-managed fields must not count as content: an import payload
+	// never carries them, the stored entry always does.
+	now := time.Now()
+	actor := Actor{Kind: ActorHuman, Name: "na0"}
+	same.CreatedBy = actor
+	same.CreatedAt, same.UpdatedAt = now, now
+	same.VerifiedBy, same.VerifiedAt = &actor, &now
+	same.Attachments = []Attachment{{Name: "chart.png"}}
+	// The same number decoded from JSONB arrives as float64, from YAML as
+	// int — both are the value 5.
+	same.Attrs = map[string]any{"threshold": float64(5), "model": "sales"}
+	if !base().SameContent(same) {
+		t.Error("entries differing only in server-managed fields and attr number types must compare equal")
+	}
+
+	nilVsEmpty := base()
+	nilVsEmpty.Tags, nilVsEmpty.Links, nilVsEmpty.Attrs = []string{}, []Link{}, map[string]any{}
+	empty := base()
+	empty.Tags, empty.Links, empty.Attrs = nil, nil, nil
+	if !nilVsEmpty.SameContent(empty) {
+		t.Error("nil and empty tags/links/attrs must compare equal")
+	}
+
+	for name, mutate := range map[string]func(*Knowledge){
+		"title":       func(k *Knowledge) { k.Title = "Net Revenue" },
+		"description": func(k *Knowledge) { k.Description = "net" },
+		"tags":        func(k *Knowledge) { k.Tags = []string{"sales", "finance"} },
+		"status":      func(k *Knowledge) { k.Status = StatusDraft },
+		"status_note": func(k *Knowledge) { k.StatusNote = "" },
+		"links":       func(k *Knowledge) { k.Links[0].Target = "model/billing" },
+		"attrs":       func(k *Knowledge) { k.Attrs["threshold"] = 6 },
+		"body":        func(k *Knowledge) { k.Body = "Sum of order totals, net of refunds." },
+	} {
+		changed := base()
+		mutate(changed)
+		if base().SameContent(changed) {
+			t.Errorf("a %s change must not compare equal", name)
 		}
 	}
 }

--- a/internal/importer/ossie.go
+++ b/internal/importer/ossie.go
@@ -25,6 +25,9 @@ type Report struct {
 	Models  []string `json:"models"`
 	Created []string `json:"created"`
 	Updated []string `json:"updated"`
+	// Unchanged lists entries whose refreshed definition matched what was
+	// already stored, so nothing was written (no revision).
+	Unchanged []string `json:"unchanged,omitempty"`
 }
 
 // ImportOssie parses Ossie YAML and stores each semantic model plus derived
@@ -103,10 +106,15 @@ func upsertKnowledge(ctx context.Context, svc *service.Service, report *Report, 
 	if k.Description != "" {
 		existing.Description = k.Description
 	}
-	if _, err := svc.Update(ctx, existing, actor); err != nil {
+	_, changed, err := svc.Update(ctx, existing, actor)
+	if err != nil {
 		return err
 	}
-	report.Updated = append(report.Updated, k.URI())
+	if changed {
+		report.Updated = append(report.Updated, k.URI())
+	} else {
+		report.Unchanged = append(report.Unchanged, k.URI())
+	}
 	return nil
 }
 

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -181,11 +181,12 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 		Name:        "update_knowledge",
 		Annotations: nonDestructive,
 		Description: "Update a knowledge entry (full replacement of title/description/tags/status/links/attrs/body). " +
-			"Every change is kept as a revision. Setting status=verified records you as verified_by — " +
+			"Every change is kept as a revision; an update identical to the stored content writes nothing. " +
+			"Setting status=verified records you as verified_by — " +
 			"do it only for knowledge you have actually validated. Setting status=rejected records you " +
 			"as rejected_by; put the reason in status_note (also useful when deprecating).",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in writeIn) (*mcp.CallToolResult, knowledgeOut, error) {
-		k, err := svc.Update(ctx, in.toKnowledge(), httpauth.Actor(ctx))
+		k, _, err := svc.Update(ctx, in.toKnowledge(), httpauth.Actor(ctx))
 		if err != nil {
 			return nil, knowledgeOut{}, err
 		}

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -132,10 +132,16 @@ func Handler(svc *service.Service) http.Handler {
 		}
 		k.Type = domain.Type(r.PathValue("type"))
 		k.ID = r.PathValue("id")
-		updated, err := svc.Update(r.Context(), &k, httpauth.Actor(r.Context()))
+		updated, changed, err := svc.Update(r.Context(), &k, httpauth.Actor(r.Context()))
 		if err != nil {
 			writeError(w, err)
 			return
+		}
+		// A payload identical to the stored content wrote nothing (no
+		// revision, no updated_at bump); the header lets clients report
+		// "unchanged" without an extra read.
+		if !changed {
+			w.Header().Set("Ochakai-Unchanged", "true")
 		}
 		writeJSON(w, http.StatusOK, updated)
 	})

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -70,13 +70,18 @@ func (s *Service) Create(ctx context.Context, k *domain.Knowledge, actor domain.
 	return k, nil
 }
 
-func (s *Service) Update(ctx context.Context, k *domain.Knowledge, actor domain.Actor) (*domain.Knowledge, error) {
+// Update replaces an entry's content. changed=false means the payload
+// matched the stored content exactly, so nothing was written: revisions
+// are the audit trail of changes and updated_at means "content last
+// changed" — recurring bundle imports and agents re-saving what they
+// just read must not bury real history under identical snapshots.
+func (s *Service) Update(ctx context.Context, k *domain.Knowledge, actor domain.Actor) (updated *domain.Knowledge, changed bool, err error) {
 	if err := validate(k); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	old, err := s.Store.Get(ctx, k.Type, k.ID)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	if k.Status == "" {
 		k.Status = old.Status
@@ -85,12 +90,15 @@ func (s *Service) Update(ctx context.Context, k *domain.Knowledge, actor domain.
 	k.CreatedAt = old.CreatedAt
 	k.VerifiedBy, k.VerifiedAt = old.VerifiedBy, old.VerifiedAt
 	k.RejectedBy, k.RejectedAt = old.RejectedBy, old.RejectedAt
+	if k.SameContent(old) {
+		return old, false, nil
+	}
 	s.applyVerification(k, old, actor)
 	if err := s.Store.Update(ctx, k, actor); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	s.updateEmbedding(ctx, k)
-	return k, nil
+	return k, true, nil
 }
 
 func (s *Service) Delete(ctx context.Context, typ domain.Type, id string, actor domain.Actor) error {

--- a/internal/service/service_integration_test.go
+++ b/internal/service/service_integration_test.go
@@ -1,0 +1,99 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/na0fu3y/ochakai/internal/domain"
+	"github.com/na0fu3y/ochakai/internal/store"
+)
+
+// TestUpdateNoOpIntegration exercises the no-op update path against a real
+// PostgreSQL: a content-identical update must write nothing — no revision,
+// no updated_at bump — so recurring imports stop flooding the audit trail.
+// Skipped unless OCHAKAI_TEST_DATABASE_URL is set (see store integration
+// test for the docker one-liner).
+func TestUpdateNoOpIntegration(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := store.New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	// embedDim 0: this test needs no embeddings, so plain PostgreSQL
+	// (pg_trgm only, no pgvector) is enough.
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	svc := &Service{Store: s, Log: slog.New(slog.DiscardHandler)}
+	actor := domain.Actor{Kind: domain.ActorHuman, Name: "test"}
+	// The ID is unique per run: entries stay live after the test, and the
+	// service layer has no hard delete to clean up with.
+	id := fmt.Sprintf("svcit-%d", time.Now().UnixNano())
+
+	entry := func() *domain.Knowledge {
+		return &domain.Knowledge{
+			Type: domain.TypeMetric, ID: id, Title: "売上",
+			Description: "統合テスト用", Tags: []string{"sales"},
+			Status: domain.StatusDraft,
+			Links:  []domain.Link{{Rel: "defined_in", Target: "model/sales"}},
+			Attrs:  map[string]any{"threshold": 5},
+			Body:   "受注合計。",
+		}
+	}
+	created, err := svc.Create(ctx, entry(), actor)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Same content, but shaped like a re-imported payload: no server
+	// fields, status omitted, the attr number decoded as float64 (JSON).
+	same := entry()
+	same.Status = ""
+	same.Attrs = map[string]any{"threshold": float64(5)}
+	got, changed, err := svc.Update(ctx, same, actor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Error("content-identical update reported changed=true")
+	}
+	if !got.UpdatedAt.Equal(created.UpdatedAt) {
+		t.Errorf("no-op update bumped updated_at: %v -> %v", created.UpdatedAt, got.UpdatedAt)
+	}
+	revs, err := svc.Revisions(ctx, domain.TypeMetric, id, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(revs) != 1 {
+		t.Errorf("no-op update wrote a revision: got %d revisions, want 1", len(revs))
+	}
+
+	// A real change still writes: revision recorded, updated_at bumped.
+	edited := entry()
+	edited.Body = "受注合計。返品は含まない。"
+	got, changed, err = svc.Update(ctx, edited, actor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Error("content change reported changed=false")
+	}
+	if !got.UpdatedAt.After(created.UpdatedAt) {
+		t.Errorf("real update did not bump updated_at: %v", got.UpdatedAt)
+	}
+	if revs, err = svc.Revisions(ctx, domain.TypeMetric, id, 10); err != nil {
+		t.Fatal(err)
+	}
+	if len(revs) != 2 || revs[0].Change != "update" {
+		t.Errorf("real update must add an update revision: %+v", revs)
+	}
+}

--- a/internal/service/service_integration_test.go
+++ b/internal/service/service_integration_test.go
@@ -49,7 +49,13 @@ func TestUpdateNoOpIntegration(t *testing.T) {
 			Body:   "受注合計。",
 		}
 	}
-	created, err := svc.Create(ctx, entry(), actor)
+	if _, err := svc.Create(ctx, entry(), actor); err != nil {
+		t.Fatal(err)
+	}
+	// Read the baseline back through the store: PostgreSQL timestamptz is
+	// microsecond precision, so the Create return value's nanosecond
+	// time.Now() would never equal a value round-tripped through the DB.
+	created, err := svc.Get(ctx, domain.TypeMetric, id)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Problem

`ochakai import` (`cmdImport`) issued an `Update` for every entry on each run, even when nothing changed. A scheduled CI import that re-uploaded the same OKF bundle therefore bumped **every** entry's revision and `updated_at` on every run — real change history and the staleness signal drowned under identical snapshots. Measured: re-importing an unchanged 7-entry bundle incremented all 7 revisions by +1 each time. (Attachments were already skipped via sha256 comparison; entries were not.)

## Approach

Chose the **server-side** fix (option b) over client-side GET-and-compare (option a):

- `service.Update` already fetches the old entry via `Store.Get`, so comparing content is **zero added cost**.
- One fix covers **all** write paths — REST `PUT`, MCP `update_knowledge`, the ossie importer, and okf import — not just `cmdImport`.
- Option (a)'s extra GET would record an `EventFetched` usage event on every no-op, inflating the very usage signal the draft-review queue ranks by (the code explicitly guards this: *"reading the queue must not inflate the very signal it ranks by"*).

The "unchanged" reporting that option (a) wanted is delivered instead via an `Ochakai-Unchanged: true` response header on `PUT`, so clients can tally it without a second round-trip.

## Changes

- **`domain.Knowledge.SameContent`** — compares only author-controlled fields (`title`/`description`/`tags`/`status`/`status_note`/`links`/`attrs`/`body`). Server-managed provenance & timestamps (`created_*`, `verified_*`, `rejected_*`, `updated_at`) and the attachment list are **not** content. Attrs compare as canonical JSON, so the same value decoded from YAML (`int`) and from JSONB (`float64`) compares equal.
- **`service.Update`** now returns `(entry, changed, error)`; on a content match it writes nothing (no revision, no `updated_at` bump, no re-embed) and returns the stored entry.
- **REST `PUT`** sets `Ochakai-Unchanged: true` on a no-op; **`apiclient.Update`** surfaces it as `changed=false`. Servers predating the header always report `changed=true` (backward compatible). Documented in `openapi.yaml`.
- **`ochakai import` / `ochakai update`** report and tally `unchanged`; the ossie importer `Report` gains an additive `unchanged` list (CLI prints it too).

## Tests & verification

- `TestSameContent` (domain unit), `TestImportReportsUnchanged` (cmd layer, httptest fake server), `TestUpdateNoOpIntegration` (service, `OCHAKAI_TEST_DATABASE_URL`-gated, needs no pgvector).
- Verified end-to-end against a real PostgreSQL: importing the same bundle twice leaves every entry at rev 1 with `updated_at` unchanged; editing one entry's body bumps only that one to rev 2 (`update`); re-importing again reports all `unchanged`. `ochakai update` on an unedited `get | update` round-trip prints `unchanged`.
- `go vet ./...` and `go test ./...` pass.

## Reviewer notes

- Wire compatibility for the ossie `Report` is pinned by `TestImportReportMatchesServerWire` (updated to cover the new `unchanged` field).
- **Follow-up (not in this PR):** `store.PutAttachment` still writes an `"attach"` revision + `updated_at` bump even when re-attaching byte-identical content (same name/sha256/okf_path). The current test bundle had 0 attachments so it didn't surface, but image-bearing bundles keep this churn. Filed as a separate task.