### PR TITLE
Drop image/gif from the attachment allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ organize knowledge into directories
 Entries can carry file attachments — the dashboard screenshot behind an
 insight, the ER diagram behind a table entry, the seeds.txt or spec PDF
 behind a dataset. Accepted formats are the intersection of what Claude
-reads and what Gemini embeds (png/jpeg/gif/webp, pdf, plain text —
+reads and what Gemini embeds (png/jpeg/webp, pdf, plain text —
 sniffed from the bytes). Search stays text-first (captions in the body),
 attachment bytes live in GCS and are fetched on demand, and attachments
 round-trip through OKF bundles as plain files next to their entry

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -423,7 +423,7 @@ paths:
       description: >
         Stores the raw request body as an attachment, replacing any
         attachment of the same name (kept as a revision). The media type
-        is sniffed from the bytes — png, jpeg, gif, webp, pdf, and plain
+        is sniffed from the bytes — png, jpeg, webp, pdf, and plain
         text are accepted (never text/html or image/svg+xml: they can
         carry scripts), at most 5 MiB and 20 attachments per entry.
         Reference the file from the entry's markdown body
@@ -634,7 +634,7 @@ components:
         agent context is never flooded with base64.
       properties:
         name: { type: string, description: Filename, unique within the entry. }
-        media_type: { type: string, enum: [image/png, image/jpeg, image/gif, image/webp] }
+        media_type: { type: string, enum: [image/png, image/jpeg, image/webp, application/pdf, text/plain] }
         size: { type: integer }
         sha256: { type: string, description: Content hash; attachments are content-addressed and immutable. }
         okf_path:

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -437,7 +437,7 @@ func cmdGet(ctx context.Context, args []string) error {
 
 func cmdAttach(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
-		"Usage: ochakai attach [flags] <type>/<id> <file...>\n\nAttach files to a knowledge entry (png, jpeg, gif, webp, pdf, plain\ntext — the type is sniffed from the bytes; max 5 MiB each, 20 per\nentry). An attachment of the same name is replaced (the change is kept\nas a revision). Reference the file from the entry's body so its\ncaption is searchable and it survives OKF export/import — the hint\nprinted after attaching shows the canonical relative link. Requires\nthe server to have GCS configured (OCHAKAI_GCS_BUCKET).",
+		"Usage: ochakai attach [flags] <type>/<id> <file...>\n\nAttach files to a knowledge entry (png, jpeg, webp, pdf, plain\ntext — the type is sniffed from the bytes; max 5 MiB each, 20 per\nentry). An attachment of the same name is replaced (the change is kept\nas a revision). Reference the file from the entry's body so its\ncaption is searchable and it survives OKF export/import — the hint\nprinted after attaching shows the canonical relative link. Requires\nthe server to have GCS configured (OCHAKAI_GCS_BUCKET).",
 		"  ochakai attach insight/revenue-reading weekly.png\n  ochakai attach table/orders seeds.txt\n  ochakai attach table/orders er-diagram.png --name schema.png\n")
 	name := fs.String("name", "", "attachment name (default: the file's basename; single file only)")
 	asJSON := fs.Bool("json", false, "print the attachment metadata as JSON")

--- a/cmd/ochakai/main.go
+++ b/cmd/ochakai/main.go
@@ -90,7 +90,7 @@ Client commands (talk to a server; --url > $OCHAKAI_URL > "use" selection):
   create [-f file]        create an entry from OKF markdown or JSON
   update <type>/<id>      replace an entry (every change kept as a revision)
   delete <type>/<id>      soft-delete an entry (history retained)
-  attach <type>/<id> <f>  attach images to an entry (png/jpeg/gif/webp)
+  attach <type>/<id> <f>  attach files to an entry (png/jpeg/webp/pdf/text)
   detach <type>/<id> <n>  remove an attachment
   usage <type>/<id>       show usage totals (search hits, fetches, compiles, outcomes)
   report <type>/<id> <o>  report an outcome: worked | failed (--note for why)

--- a/docs/design/0013-attachment-files-gcs-only.md
+++ b/docs/design/0013-attachment-files-gcs-only.md
@@ -36,13 +36,14 @@ Date: 2026-07-18
 | media_type | 由来 |
 |---|---|
 | `image/png` `image/jpeg` `image/webp` | 両リスト |
-| `image/gif` | 既存許可リストの祖父条項(下記) |
 | `application/pdf` | 両リスト |
 | `text/plain` | 両リスト |
 
-- **`image/gif` は残す。** gemini-embedding-2 のリストには無いが、
-  0008 以来の許可形式であり、既存データと OKF ラウンドトリップを壊して
-  まで落とす利得がない。将来の埋め込み対象からは外れるだけである。
+- **`image/gif` は落とす。** 0008 以来の許可形式で、当初は祖父条項として
+  残す判断だったが、同日の議論で互換性配慮は不要と決まり、リストを
+  交わり厳密に揃えた(gemini-embedding-2 は gif を埋め込めない)。
+  保存済みの gif 添付はメタデータもバイト列もそのまま読める — 弾かれる
+  のは新規 attach だけで、既存データの再インポートは skip 報告に載る。
 - **`text/plain` はスニッフィング判定**(従来どおりバイト列が決める。
   クライアント申告の media type は信用しない)。Go の
   `http.DetectContentType` は UTF-8/UTF-16 テキストを `text/plain` と

--- a/internal/domain/attachment.go
+++ b/internal/domain/attachment.go
@@ -34,17 +34,17 @@ const (
 )
 
 // attachmentMediaTypes is the allowlist of what an attachment may be
-// (design doc 0013): the intersection of what Claude accepts as an upload
-// and what gemini-embedding-2 takes as input, plus image/gif grandfathered
-// from the original image-only list (design doc 0008). Never text/html or
-// image/svg+xml: both can carry scripts, and serving them from the API
-// would hand every knowledge author an XSS vector into web UIs. Note that
-// sniffing decides — CSV/JSON/markup without an HTML signature all pass as
-// text/plain and are always served as such, never as something executable.
+// (design doc 0013): exactly the intersection of what Claude accepts as
+// an upload and what gemini-embedding-2 takes as input — gif, in the
+// original image-only list (design doc 0008), is not embeddable and was
+// dropped. Never text/html or image/svg+xml: both can carry scripts, and
+// serving them from the API would hand every knowledge author an XSS
+// vector into web UIs. Note that sniffing decides — CSV/JSON/markup
+// without an HTML signature all pass as text/plain and are always served
+// as such, never as something executable.
 var attachmentMediaTypes = map[string]bool{
 	"image/png":       true,
 	"image/jpeg":      true,
-	"image/gif":       true,
 	"image/webp":      true,
 	"application/pdf": true,
 	"text/plain":      true,
@@ -64,7 +64,7 @@ func DetectAttachmentMediaType(data []byte) (string, error) {
 	mt, _, _ := strings.Cut(http.DetectContentType(data), ";")
 	mt = strings.TrimSpace(mt)
 	if !attachmentMediaTypes[mt] {
-		return "", fmt.Errorf("unsupported attachment content %q (allowed: png, jpeg, gif, webp, pdf, plain text)", mt)
+		return "", fmt.Errorf("unsupported attachment content %q (allowed: png, jpeg, webp, pdf, plain text)", mt)
 	}
 	return mt, nil
 }

--- a/internal/domain/attachment_test.go
+++ b/internal/domain/attachment_test.go
@@ -29,9 +29,11 @@ func TestDetectAttachmentMediaType(t *testing.T) {
 	if mt, err := DetectAttachmentMediaType(png); err != nil || mt != "image/png" {
 		t.Errorf("png: got %q, %v", mt, err)
 	}
+	// gif fell out of the allowlist with the grandfather clause (Claude
+	// reads it, gemini-embedding-2 cannot embed it).
 	gif := append([]byte("GIF89a"), make([]byte, 16)...)
-	if mt, err := DetectAttachmentMediaType(gif); err != nil || mt != "image/gif" {
-		t.Errorf("gif: got %q, %v", mt, err)
+	if _, err := DetectAttachmentMediaType(gif); err == nil {
+		t.Error("gif accepted")
 	}
 	if mt, err := DetectAttachmentMediaType([]byte("%PDF-1.7 fake pdf body")); err != nil || mt != "application/pdf" {
 		t.Errorf("pdf: got %q, %v", mt, err)

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -864,12 +864,12 @@ async function viewDetail(type, id) {
       return `
         ${cards || '<div class="empty">No attachments.</div>'}
         <div class="toolbar" style="margin-top:1rem">
-          <input type="file" id="att-file" accept="image/png,image/jpeg,image/gif,image/webp,application/pdf,text/plain,.txt,.csv,.json" multiple hidden>
+          <input type="file" id="att-file" accept="image/png,image/jpeg,image/webp,application/pdf,text/plain,.txt,.csv,.json" multiple hidden>
           <button class="btn small" id="att-choose">Choose files…</button>
           <span class="provenance" id="att-chosen" style="margin:0"></span>
           <button class="btn small primary" id="att-upload">Attach</button>
         </div>
-        <p class="provenance">png / jpeg / gif / webp / pdf / plain text, max 5 MiB each, 20 per entry. Reference a file from the
+        <p class="provenance">png / jpeg / webp / pdf / plain text, max 5 MiB each, 20 per entry. Reference a file from the
         body (<code>![alt](${esc(lastSeg)}/name.png)</code> or <code>[name](${esc(lastSeg)}/name.txt)</code>) so it is findable and survives OKF export.</p>`;
     },
     linked: () => '<div class="empty">…</div>',


### PR DESCRIPTION
## 概要

PR #70 で祖父条項として残した `image/gif` を許可リストから外し、リストを **Claude アップロード ∩ gemini-embedding-2 の交わり厳密**(png / jpeg / webp / pdf / text-plain)に揃える。互換性配慮は不要との判断による(2026-07-18)。

- 影響は**新規 attach の拒否のみ**。保存済み gif 添付はメタデータもバイト列も従来どおり読める・配信される
- 既存バンドルの再インポートでは gif が skip 報告に載る(インポート自体は成功)
- design doc 0013 の該当節・README・OpenAPI(`Attachment.media_type` enum の更新漏れも修正)・CLI ヘルプ・Web UI の accept リストを同期

🤖 Generated with [Claude Code](https://claude.com/claude-code)