### PR TITLE
Fix surface-consistency drift (REST/MCP/CLI/Web UI review, design doc 0015)

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,8 @@ annotations and `delete_knowledge` a `destructive` one, so client
 auto-approval policies work without parsing descriptions.
 
 The REST API (`/api/v1`) is a superset of these tools, adding bulk
-export/import — see
+export/import, the human-facing browse/revisions/backlinks reads, and
+attachment writes — see
 [api/openapi.yaml](api/openapi.yaml). To keep golden queries trustworthy
 over time, run them as canaries from your CI:
 [docs/guides/golden-query-canary.md](docs/guides/golden-query-canary.md).

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -5,9 +5,10 @@ info:
     ochakai is a context provider for data agents: metric definitions,
     verified golden queries, interpretation knowledge, glossary terms, and
     table catalog entries in one knowledge base. The REST API is a superset
-    of the MCP tools — the same operations plus bulk export/import — so
-    users can build their own web UIs. ochakai executes no SQL and uses no
-    LLM.
+    of the MCP tools — the same operations plus bulk export/import, the
+    human-facing browse/revisions/backlinks reads, and attachment writes —
+    so users can build their own web UIs. ochakai executes no SQL and uses
+    no LLM.
   version: 0.1.0
   license:
     name: MIT
@@ -528,6 +529,13 @@ paths:
                     type: array
                     items: { type: string }
                     description: URIs of knowledge entries refreshed.
+                  unchanged:
+                    type: array
+                    items: { type: string }
+                    description: >
+                      URIs of entries whose refreshed definition matched
+                      what was already stored, so nothing was written (no
+                      revision). Absent when empty.
         "400": { $ref: "#/components/responses/Error" }
         "413": { $ref: "#/components/responses/Error" }
   /api/v1/compile:
@@ -629,7 +637,8 @@ components:
     Attachment:
       type: object
       description: >
-        An image attached to a knowledge entry (design doc 0008). Metadata
+        A file attached to a knowledge entry — a dashboard screenshot, an
+        ER diagram, a seeds file (design docs 0008, 0013). Metadata
         travels with the entry; bytes are a separate, deliberate fetch so
         agent context is never flooded with base64.
       properties:

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -396,7 +396,7 @@ func cmdReport(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
 		"Usage: ochakai report [flags] <type>/<id> <worked|failed>\n\nReport whether acting on an entry gave a correct result — the last\nedge of the write-back loop. After running a golden query or compiled\nSQL, report worked or failed (say what went wrong with --note);\nfailed counts against verified entries flag them for re-verification.\nPrints the entry's updated usage totals.",
 		"  ochakai report query/monthly-revenue worked\n  ochakai report query/monthly-revenue failed --note \"joins dropped 2024 rows after schema change\"\n")
-	note := fs.String("note", "", "context recorded with the report: what was run, what went wrong")
+	note := fs.String("note", "", "context recorded with the report: what was run, what went wrong (max 2000 bytes)")
 	asJSON := fs.Bool("json", false, "print the updated usage totals as JSON")
 	pos, err := parseArgs(fs, args)
 	if err != nil {

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -156,7 +156,8 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 		Name:        "get_knowledge",
 		Annotations: readOnly,
 		Description: "Get one knowledge entry by type and id, including its full markdown body, structured attrs, " +
-			"links, and attachment metadata (images the body references — fetch bytes with get_attachment).",
+			"links, and attachment metadata (files the body references: images, PDFs, plain-text data — " +
+			"fetch bytes with get_attachment).",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in getIn) (*mcp.CallToolResult, knowledgeOut, error) {
 		k, err := svc.Get(ctx, domain.Type(in.Type), in.ID)
 		if err != nil {

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -233,8 +233,9 @@ func Handler(svc *service.Service) http.Handler {
 		}
 		writeJSON(w, http.StatusOK, map[string]any{"entries": entries})
 	})
-	// Attachments (design doc 0008): images attached to an entry, bytes
-	// fetched on demand — entry reads carry metadata only. The path is
+	// Attachments (design docs 0008, 0013): files attached to an entry
+	// (images, PDFs, plain text), bytes fetched on demand — entry reads
+	// carry metadata only. The path is
 	// /attachments/{type}/{id segments...}/{name}; the final segment is
 	// always the filename (attachment names are single segments), so the
 	// wildcard split is unambiguous. Lives outside /knowledge/ for the
@@ -324,8 +325,8 @@ func Handler(svc *service.Service) http.Handler {
 	})
 
 	// GET /api/v1/export — the whole knowledge base as an OKF bundle
-	// (tar.gz of markdown + YAML frontmatter, plus attached images as
-	// plain files). Your knowledge is yours.
+	// (tar.gz of markdown + YAML frontmatter, plus attachment files).
+	// Your knowledge is yours.
 	mux.HandleFunc("GET /api/v1/export", func(w http.ResponseWriter, r *http.Request) {
 		entries, err := svc.Store.ListAll(r.Context())
 		if err != nil {

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -1352,7 +1352,7 @@ function viewCompile() {
       out.innerHTML = `
         <div class="feed-banner" style="margin-top:.8rem">Imported model${(r.models || []).length > 1 ? 's' : ''}
           <strong>${(r.models || []).map(esc).join(', ')}</strong>.</div>
-        <ul style="color:var(--muted);font-size:.9rem">${list('created', r.created)}${list('updated', r.updated)}</ul>`;
+        <ul style="color:var(--muted);font-size:.9rem">${list('created', r.created)}${list('updated', r.updated)}${list('unchanged', r.unchanged)}</ul>`;
       toast('Model imported.');
     } catch (e) {
       out.innerHTML = `<div class="error-banner">Import failed: ${esc(e.message)}</div>`;


### PR DESCRIPTION
## Summary

Cross-surface consistency review of REST `/api/v1` / MCP `/mcp` / CLI / Web UI against [design doc 0015](docs/design/0015-surface-consistency.md). The surface split itself is faithful to the policy (MCP tool budget, CLI completeness, Web UI curation-only); the five findings below are all contract-doc and wording drift, fixed here.

Per-surface placement (0015 §4): no new endpoints — every change documents or surfaces behavior the API already has.

## Fixes

1. **`unchanged` missing from the OpenAPI import/ossie response** — `importer.Report` returns it and the CLI prints it, but the spec only listed `models`/`created`/`updated`. REST is the single contract (0015 §2), so the spec now carries it.
2. **OpenAPI `Attachment` schema still said "An image attached…"** — leftover from before design doc 0013 generalized attachments to files (PDF, plain text). The enum was already correct; the prose now matches.
3. **MCP `get_knowledge` description still said "(images the body references)"** — inconsistent even within the MCP surface, where `get_attachment` was already updated. Also fixed two stale "images" comments in `restapi.go`.
4. **Web UI dropped `unchanged` from the Ossie import report** — a no-op re-import rendered as an empty list. It now lists unchanged entries like the CLI does.
5. **README / OpenAPI info undersold the REST superset** — "adding bulk export/import" omitted browse/revisions/backlinks and attachment writes; now matches the accurate `restapi.go` package comment. Also added the 2000-byte note cap to `report --note` CLI help, matching the MCP schema and spec.

## Test plan

- `go build ./...` and full `go test ./...` pass (mcpserver / restapi / cmd suites cover the touched descriptions and help text).
- Web UI change is a one-line addition to the existing `list()` renderer; `unchanged` was already in the wire response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)