### PR TITLE
Code quality pass: dedupe store scans, close a delete race, fill test gaps

### DIFF
--- a/internal/apiclient/apiclient_test.go
+++ b/internal/apiclient/apiclient_test.go
@@ -284,3 +284,132 @@ func TestNewRejectsBadURLs(t *testing.T) {
 		}
 	}
 }
+
+func TestContextBuildsQueryAndDecodesPack(t *testing.T) {
+	var got url.Values
+	c := newTestPair(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/context" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		got = r.URL.Query()
+		_ = json.NewEncoder(w).Encode(ContextResult{
+			Hits:    []domain.SearchHit{{Knowledge: domain.Knowledge{Type: "metric", ID: "revenue"}, Score: 0.8}},
+			Entries: []domain.Knowledge{{Type: "metric", ID: "revenue", Title: "売上"}},
+		})
+	})
+	res, err := c.Context(context.Background(), "why did revenue drop",
+		[]string{"metric"}, []string{"verified"}, []string{"core"}, 7, 0.5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Hits) != 1 || len(res.Entries) != 1 || res.Entries[0].Title != "売上" {
+		t.Errorf("result = %+v", res)
+	}
+	if got.Get("q") != "why did revenue drop" || got.Get("type") != "metric" ||
+		got.Get("status") != "verified" || got.Get("tag") != "core" ||
+		got.Get("limit") != "7" || got.Get("min_score") != "0.5" {
+		t.Errorf("query = %v", got)
+	}
+}
+
+func TestAttachSendsBytesAndOKFPath(t *testing.T) {
+	body := []byte("attachment bytes")
+	c := newTestPair(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/api/v1/attachments/insight/sales/reading/weekly.png" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if r.URL.Query().Get("okf_path") != "images/weekly.png" {
+			t.Errorf("okf_path = %q", r.URL.Query().Get("okf_path"))
+		}
+		got, _ := io.ReadAll(r.Body)
+		if string(got) != string(body) {
+			t.Errorf("body = %q", got)
+		}
+		_ = json.NewEncoder(w).Encode(domain.Attachment{Name: "weekly.png", MediaType: "image/png", Size: int64(len(body))})
+	})
+	att, err := c.Attach(context.Background(), "insight", "sales/reading", "weekly.png", "images/weekly.png", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if att.Name != "weekly.png" || att.MediaType != "image/png" {
+		t.Errorf("attachment = %+v", att)
+	}
+}
+
+func TestAttachmentFetchesBytesAndMediaType(t *testing.T) {
+	c := newTestPair(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/attachments/insight/reading/weekly.png" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte("png bytes"))
+	})
+	data, mediaType, err := c.Attachment(context.Background(), "insight", "reading", "weekly.png")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "png bytes" || mediaType != "image/png" {
+		t.Errorf("data = %q, mediaType = %q", data, mediaType)
+	}
+}
+
+func TestDetachHitsAttachmentPath(t *testing.T) {
+	called := false
+	c := newTestPair(t, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		if r.Method != http.MethodDelete || r.URL.Path != "/api/v1/attachments/insight/reading/weekly.png" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+	if err := c.Detach(context.Background(), "insight", "reading", "weekly.png"); err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Error("no request sent")
+	}
+}
+
+func TestReportOutcomePostsAndDecodesTotals(t *testing.T) {
+	c := newTestPair(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v1/usage/query/monthly-revenue" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		var in map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+			t.Errorf("bad body: %v", err)
+		}
+		if in["outcome"] != "failed" || in["note"] != "joins dropped rows" {
+			t.Errorf("payload = %v", in)
+		}
+		_ = json.NewEncoder(w).Encode(domain.Usage{Worked: 3, Failed: 1})
+	})
+	u, err := c.ReportOutcome(context.Background(), "query", "monthly-revenue", "failed", "joins dropped rows")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u.Worked != 3 || u.Failed != 1 {
+		t.Errorf("usage = %+v", u)
+	}
+}
+
+func TestImportOssieSendsYAMLVerbatim(t *testing.T) {
+	src := []byte("name: sales\nmetrics: []\n")
+	c := newTestPair(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v1/import/ossie" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		got, _ := io.ReadAll(r.Body)
+		if string(got) != string(src) {
+			t.Errorf("body = %q", got)
+		}
+		_ = json.NewEncoder(w).Encode(ImportReport{Models: []string{"sales"}, Created: []string{"ochakai://metric/revenue"}})
+	})
+	report, err := c.ImportOssie(context.Background(), src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(report.Models) != 1 || report.Models[0] != "sales" || len(report.Created) != 1 {
+		t.Errorf("report = %+v", report)
+	}
+}

--- a/internal/compiler/model_test.go
+++ b/internal/compiler/model_test.go
@@ -1,0 +1,98 @@
+package compiler
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// specMap mimics the real path a spec takes into ModelFromSpec /
+// ModelsFromSpec: YAML → map[string]any (importer), stored as JSONB,
+// decoded back to map[string]any (store).
+func specMap(t *testing.T, src string) map[string]any {
+	t.Helper()
+	var spec map[string]any
+	if err := yaml.Unmarshal([]byte(src), &spec); err != nil {
+		t.Fatalf("parse spec: %v", err)
+	}
+	return spec
+}
+
+func TestModelFromSpecSingleObject(t *testing.T) {
+	m, err := ModelFromSpec(specMap(t, testModelYAML), "")
+	if err != nil {
+		t.Fatalf("ModelFromSpec: %v", err)
+	}
+	if m.Name != "sales_analytics" {
+		t.Errorf("name = %q, want sales_analytics", m.Name)
+	}
+	if len(m.Datasets) != 2 || len(m.Metrics) != 2 || len(m.Relationships) != 1 {
+		t.Errorf("model shape wrong: %d datasets, %d metrics, %d relationships",
+			len(m.Datasets), len(m.Metrics), len(m.Relationships))
+	}
+	expr, ok := m.Metrics[0].Expression.ForDialect("ANSI_SQL")
+	if !ok || expr != "SUM(orders.amount)" {
+		t.Errorf("metric expression = %q, %v", expr, ok)
+	}
+}
+
+// The top-level document shape wraps models in a semantic_model list;
+// name selects one, and an empty name means the first.
+func TestModelFromSpecDocumentShape(t *testing.T) {
+	doc := "semantic_model:\n" +
+		"  - name: alpha\n    metrics:\n      - name: m1\n        expression: SUM(x)\n" +
+		"  - name: beta\n    metrics:\n      - name: m2\n        expression: SUM(y)\n"
+	spec := specMap(t, doc)
+
+	m, err := ModelFromSpec(spec, "beta")
+	if err != nil {
+		t.Fatalf("ModelFromSpec(beta): %v", err)
+	}
+	if m.Name != "beta" {
+		t.Errorf("name = %q, want beta", m.Name)
+	}
+
+	first, err := ModelFromSpec(spec, "")
+	if err != nil {
+		t.Fatalf("ModelFromSpec(empty name): %v", err)
+	}
+	if first.Name != "alpha" {
+		t.Errorf("empty name should select the first model, got %q", first.Name)
+	}
+
+	if _, err := ModelFromSpec(spec, "missing"); err == nil ||
+		!strings.Contains(err.Error(), "not found") {
+		t.Errorf("unknown name should fail with not found, got %v", err)
+	}
+}
+
+func TestModelsFromSpecShapes(t *testing.T) {
+	single, err := ModelsFromSpec(specMap(t, testModelYAML))
+	if err != nil || len(single) != 1 || single[0].Name != "sales_analytics" {
+		t.Errorf("single object: models = %+v, err = %v", single, err)
+	}
+
+	doc := "semantic_model:\n  - name: alpha\n  - name: beta\n"
+	many, err := ModelsFromSpec(specMap(t, doc))
+	if err != nil || len(many) != 2 || many[0].Name != "alpha" || many[1].Name != "beta" {
+		t.Errorf("document shape: models = %+v, err = %v", many, err)
+	}
+
+	if _, err := ModelsFromSpec(specMap(t, "just: garbage\n")); err == nil {
+		t.Error("a nameless non-model document must be rejected")
+	}
+}
+
+// A plain-string expression (the shortest Ossie shape) must parse as an
+// ANSI_SQL expression through the YAML → JSON round-trip.
+func TestModelFromSpecPlainStringExpression(t *testing.T) {
+	m, err := ModelFromSpec(specMap(t, "name: mini\nmetrics:\n  - name: n\n    expression: COUNT(*)\n"), "")
+	if err != nil {
+		t.Fatalf("ModelFromSpec: %v", err)
+	}
+	expr, ok := m.Metrics[0].Expression.ForDialect("ANSI_SQL")
+	if !ok || expr != "COUNT(*)" {
+		t.Errorf("plain string expression = %q, %v", expr, ok)
+	}
+}

--- a/internal/domain/knowledge.go
+++ b/internal/domain/knowledge.go
@@ -229,6 +229,26 @@ func ValidIDPrefix(prefix string) bool {
 	return true
 }
 
+// ToTypes converts transport-layer type filters (query parameters, tool
+// inputs) into domain types — shared by the REST and MCP surfaces so the
+// conversion is written once.
+func ToTypes(ss []string) []Type {
+	out := make([]Type, 0, len(ss))
+	for _, s := range ss {
+		out = append(out, Type(s))
+	}
+	return out
+}
+
+// ToStatuses is ToTypes for status filters.
+func ToStatuses(ss []string) []Status {
+	out := make([]Status, 0, len(ss))
+	for _, s := range ss {
+		out = append(out, Status(s))
+	}
+	return out
+}
+
 // SearchHit is one search result with its ranking score. Usage is
 // populated only by the sort=usage listing (the draft review feed), where
 // the promotion signal is the point; it stays nil for search results and

--- a/internal/domain/knowledge_test.go
+++ b/internal/domain/knowledge_test.go
@@ -127,3 +127,17 @@ func TestValidType(t *testing.T) {
 		t.Error(`BuiltinType("runbook") = true, want false`)
 	}
 }
+
+func TestToTypesAndToStatuses(t *testing.T) {
+	types := ToTypes([]string{"metric", "custom-type"})
+	if len(types) != 2 || types[0] != TypeMetric || types[1] != Type("custom-type") {
+		t.Errorf("ToTypes = %v", types)
+	}
+	statuses := ToStatuses([]string{"verified", "draft"})
+	if len(statuses) != 2 || statuses[0] != StatusVerified || statuses[1] != StatusDraft {
+		t.Errorf("ToStatuses = %v", statuses)
+	}
+	if got := ToTypes(nil); len(got) != 0 {
+		t.Errorf("ToTypes(nil) = %v, want empty", got)
+	}
+}

--- a/internal/importer/ossie_integration_test.go
+++ b/internal/importer/ossie_integration_test.go
@@ -1,0 +1,128 @@
+package importer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/na0fu3y/ochakai/internal/domain"
+	"github.com/na0fu3y/ochakai/internal/service"
+	"github.com/na0fu3y/ochakai/internal/store"
+)
+
+// TestImportOssieIntegration exercises the whole ossie import against a
+// real PostgreSQL (skipped unless OCHAKAI_TEST_DATABASE_URL is set; see
+// the store integration test for the docker one-liner): the model is
+// stored for compile, metric/table entries are derived, re-import
+// refreshes definitions without clobbering human curation, and an
+// unchanged re-import reports unchanged instead of writing revisions.
+func TestImportOssieIntegration(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := store.New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	svc := &service.Service{Store: s, Log: slog.New(slog.NewTextHandler(os.Stderr, nil))}
+	actor := domain.Actor{Kind: "agent", Name: "importer-test"}
+
+	// Run-unique names keep reruns against a shared test DB conflict-free.
+	uid := fmt.Sprintf("ossit%d", time.Now().UnixNano())
+	modelName, metricName, dsName := uid+"_model", uid+"_revenue", uid+"_orders"
+	yamlSrc := []byte(fmt.Sprintf(`
+name: %s
+datasets:
+  - name: %s
+    source: shop.orders
+    description: One row per order.
+    fields:
+      - name: amount
+        expression: total_price
+metrics:
+  - name: %s
+    description: Total revenue.
+    expression: SUM(%s.amount)
+`, modelName, dsName, metricName, dsName))
+
+	report, err := ImportOssie(ctx, svc, yamlSrc, actor)
+	if err != nil {
+		t.Fatalf("ImportOssie: %v", err)
+	}
+	if len(report.Models) != 1 || report.Models[0] != modelName {
+		t.Errorf("models = %v, want [%s]", report.Models, modelName)
+	}
+	if len(report.Created) != 2 {
+		t.Errorf("created = %v, want the metric and table entries", report.Created)
+	}
+
+	metric, err := svc.Get(ctx, domain.TypeMetric, metricName)
+	if err != nil {
+		t.Fatalf("derived metric entry missing: %v", err)
+	}
+	if metric.Attrs["model"] != modelName {
+		t.Errorf("metric attrs.model = %v, want %s", metric.Attrs["model"], modelName)
+	}
+	table, err := svc.Get(ctx, domain.TypeTable, dsName)
+	if err != nil {
+		t.Fatalf("derived table entry missing: %v", err)
+	}
+	if table.Attrs["source"] != "shop.orders" {
+		t.Errorf("table attrs.source = %v", table.Attrs["source"])
+	}
+
+	// A byte-identical re-import writes nothing.
+	again, err := ImportOssie(ctx, svc, yamlSrc, actor)
+	if err != nil {
+		t.Fatalf("re-import: %v", err)
+	}
+	if len(again.Created) != 0 || len(again.Updated) != 0 || len(again.Unchanged) != 2 {
+		t.Errorf("identical re-import: created=%v updated=%v unchanged=%v",
+			again.Created, again.Updated, again.Unchanged)
+	}
+
+	// Human curation survives a definition refresh: verify the metric,
+	// tag it, give it a body — then re-import a changed description.
+	metric.Status = domain.StatusVerified
+	metric.Tags = []string{"curated"}
+	metric.Body = "human-written caveats"
+	if _, _, err := svc.Update(ctx, metric, domain.Actor{Kind: "human", Name: "curator"}); err != nil {
+		t.Fatal(err)
+	}
+	refreshed, err := ImportOssie(ctx, svc,
+		[]byte(strings.Replace(string(yamlSrc), "Total revenue.", "Total revenue, refreshed.", 1)), actor)
+	if err != nil {
+		t.Fatalf("refresh import: %v", err)
+	}
+	if len(refreshed.Updated) != 1 || !strings.Contains(refreshed.Updated[0], metricName) {
+		t.Errorf("refresh: updated = %v, want the metric entry", refreshed.Updated)
+	}
+	metric, err = svc.Get(ctx, domain.TypeMetric, metricName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if metric.Description != "Total revenue, refreshed." {
+		t.Errorf("description not refreshed: %q", metric.Description)
+	}
+	if metric.Status != domain.StatusVerified || len(metric.Tags) != 1 || metric.Body != "human-written caveats" {
+		t.Errorf("human curation clobbered: status=%s tags=%v body=%q",
+			metric.Status, metric.Tags, metric.Body)
+	}
+
+	// Garbage YAML is the client's mistake, not a crash.
+	var invalid *service.InvalidInputError
+	if _, err := ImportOssie(ctx, svc, []byte(": not yaml"), actor); !errors.As(err, &invalid) {
+		t.Errorf("garbage YAML: want InvalidInputError, got %T %v", err, err)
+	}
+}

--- a/internal/importer/ossie_test.go
+++ b/internal/importer/ossie_test.go
@@ -1,0 +1,17 @@
+package importer
+
+import "testing"
+
+func TestSlugify(t *testing.T) {
+	for in, want := range map[string]string{
+		"Revenue":          "revenue",
+		"Avg Order Value":  "avg-order-value",
+		"GA_sessions_2017": "ga_sessions_2017",
+		"  padded  ":       "padded",
+		"日本語 metric":       "metric", // non-ASCII collapses into "-", trimmed at the edges
+	} {
+		if got := slugify(in); got != want {
+			t.Errorf("slugify(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -109,7 +109,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"lists by demand (most search_hits first, never-used drafts oldest-first at the bottom) and " +
 			"each hit carries its usage totals — the draft review/promotion feed.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in searchIn) (*mcp.CallToolResult, searchOut, error) {
-		f := store.Filter{Types: toTypes(in.Types), Statuses: toStatuses(in.Statuses), Tags: in.Tags}
+		f := store.Filter{Types: domain.ToTypes(in.Types), Statuses: domain.ToStatuses(in.Statuses), Tags: in.Tags}
 		if in.Sort != "" {
 			if in.Sort != "verified_at" && in.Sort != "usage" {
 				return nil, searchOut{}, fmt.Errorf("invalid sort %q (valid: verified_at, usage)", in.Sort)
@@ -144,7 +144,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"fall back to search_knowledge/get_knowledge for precise lookups.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in contextIn) (*mcp.CallToolResult, contextOut, error) {
 		res, err := svc.Context(ctx, in.Query, store.Filter{
-			Types: toTypes(in.Types), Statuses: toStatuses(in.Statuses), Tags: in.Tags,
+			Types: domain.ToTypes(in.Types), Statuses: domain.ToStatuses(in.Statuses), Tags: in.Tags,
 		}, in.Limit, in.MinScore)
 		if err != nil {
 			return nil, contextOut{}, err
@@ -421,20 +421,4 @@ func (in writeIn) toKnowledge() *domain.Knowledge {
 		Attrs:       in.Attrs,
 		Body:        in.Body,
 	}
-}
-
-func toTypes(ss []string) []domain.Type {
-	out := make([]domain.Type, 0, len(ss))
-	for _, s := range ss {
-		out = append(out, domain.Type(s))
-	}
-	return out
-}
-
-func toStatuses(ss []string) []domain.Status {
-	out := make([]domain.Status, 0, len(ss))
-	for _, s := range ss {
-		out = append(out, domain.Status(s))
-	}
-	return out
 }

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -43,8 +43,8 @@ func Handler(svc *service.Service) http.Handler {
 			return
 		}
 		f := store.Filter{
-			Types:    toTypes(q["type"]),
-			Statuses: toStatuses(q["status"]),
+			Types:    domain.ToTypes(q["type"]),
+			Statuses: domain.ToStatuses(q["status"]),
 			Tags:     q["tag"],
 		}
 		if sort := q.Get("sort"); sort != "" {
@@ -107,8 +107,8 @@ func Handler(svc *service.Service) http.Handler {
 			return
 		}
 		res, err := svc.Context(r.Context(), q.Get("q"), store.Filter{
-			Types:    toTypes(q["type"]),
-			Statuses: toStatuses(q["status"]),
+			Types:    domain.ToTypes(q["type"]),
+			Statuses: domain.ToStatuses(q["status"]),
 			Tags:     q["tag"],
 		}, limit, minScore)
 		if err != nil {
@@ -485,20 +485,4 @@ func splitAttachmentPath(p string) (id, name string, ok bool) {
 		return "", "", false
 	}
 	return p[:i], p[i+1:], true
-}
-
-func toTypes(ss []string) []domain.Type {
-	out := make([]domain.Type, 0, len(ss))
-	for _, s := range ss {
-		out = append(out, domain.Type(s))
-	}
-	return out
-}
-
-func toStatuses(ss []string) []domain.Status {
-	out := make([]domain.Status, 0, len(ss))
-	for _, s := range ss {
-		out = append(out, domain.Status(s))
-	}
-	return out
 }

--- a/internal/restapi/restapi_integration_test.go
+++ b/internal/restapi/restapi_integration_test.go
@@ -1,0 +1,167 @@
+package restapi
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/na0fu3y/ochakai/internal/domain"
+	"github.com/na0fu3y/ochakai/internal/service"
+	"github.com/na0fu3y/ochakai/internal/store"
+)
+
+// TestRESTIntegration walks one entry through the REST surface against a
+// real PostgreSQL (skipped unless OCHAKAI_TEST_DATABASE_URL is set; see
+// the store integration test for the docker one-liner): create, read,
+// no-op update (Ochakai-Unchanged), browse, revisions, export, delete.
+// A run-unique custom type keeps reruns and other tests' rows out of the
+// browse assertions.
+func TestRESTIntegration(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := t.Context()
+	s, err := store.New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	svc := &service.Service{Store: s, Log: slog.New(slog.NewTextHandler(os.Stderr, nil))}
+	srv := httptest.NewServer(Handler(svc))
+	defer srv.Close()
+
+	typ := fmt.Sprintf("restit%d", time.Now().UnixNano())
+	entry := map[string]any{"type": typ, "id": "sales/orders", "title": "REST round trip"}
+	payload, _ := json.Marshal(entry)
+
+	// Create.
+	resp, err := http.Post(srv.URL+"/api/v1/knowledge", "application/json", bytes.NewReader(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create status = %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	// Read it back.
+	var got domain.Knowledge
+	getJSON(t, srv.URL+"/api/v1/knowledge/"+typ+"/sales/orders", &got)
+	if got.Title != "REST round trip" || got.Status != domain.StatusDraft {
+		t.Errorf("entry = %+v", got)
+	}
+
+	// A content-identical PUT writes nothing and says so in the header.
+	req, _ := http.NewRequest(http.MethodPut, srv.URL+"/api/v1/knowledge/"+typ+"/sales/orders", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK || resp.Header.Get("Ochakai-Unchanged") != "true" {
+		t.Errorf("no-op PUT: status = %d, Ochakai-Unchanged = %q",
+			resp.StatusCode, resp.Header.Get("Ochakai-Unchanged"))
+	}
+
+	// Browse: the type root shows the "sales" directory, the prefix level
+	// shows the entry.
+	var root service.BrowseResult
+	getJSON(t, srv.URL+"/api/v1/browse?type="+typ, &root)
+	if len(root.Dirs) != 1 || root.Dirs[0].Name != "sales" || root.Dirs[0].Count != 1 {
+		t.Errorf("browse root = %+v", root)
+	}
+	var level service.BrowseResult
+	getJSON(t, srv.URL+"/api/v1/browse?type="+typ+"&prefix=sales", &level)
+	if len(level.Entries) != 1 || level.Entries[0].ID != "sales/orders" {
+		t.Errorf("browse level = %+v", level)
+	}
+
+	// Revisions: exactly the create, with a snapshot.
+	var revs struct {
+		Revisions []domain.Revision `json:"revisions"`
+	}
+	getJSON(t, srv.URL+"/api/v1/revisions/"+typ+"/sales/orders", &revs)
+	if len(revs.Revisions) != 1 || revs.Revisions[0].Change != "create" ||
+		revs.Revisions[0].Snapshot.Title != "REST round trip" {
+		t.Errorf("revisions = %+v", revs.Revisions)
+	}
+
+	// Export: the bundle carries the entry at its canonical path.
+	resp, err = http.Get(srv.URL + "/api/v1/export")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK || resp.Header.Get("Content-Type") != "application/gzip" {
+		t.Fatalf("export: status = %d, content-type = %q", resp.StatusCode, resp.Header.Get("Content-Type"))
+	}
+	gz, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for tr := tar.NewReader(gz); ; {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if hdr.Name == typ+"/sales/orders.md" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("export bundle misses %s/sales/orders.md", typ)
+	}
+
+	// Delete, then the entry is gone.
+	req, _ = http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/knowledge/"+typ+"/sales/orders", nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("delete status = %d", resp.StatusCode)
+	}
+	resp, err = http.Get(srv.URL + "/api/v1/knowledge/" + typ + "/sales/orders")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("get after delete = %d, want 404", resp.StatusCode)
+	}
+}
+
+func getJSON(t *testing.T, url string, v any) {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("GET %s = %d: %s", url, resp.StatusCode, body)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(v); err != nil {
+		t.Fatalf("GET %s: decode: %v", url, err)
+	}
+}

--- a/internal/service/context_integration_test.go
+++ b/internal/service/context_integration_test.go
@@ -1,0 +1,218 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/na0fu3y/ochakai/internal/compiler"
+	"github.com/na0fu3y/ochakai/internal/domain"
+	"github.com/na0fu3y/ochakai/internal/httpauth"
+	"github.com/na0fu3y/ochakai/internal/store"
+)
+
+// newIntegrationService dials the test database, skipping without
+// OCHAKAI_TEST_DATABASE_URL (see the store integration test for the
+// docker one-liner). Tests use run-unique IDs (uid below) instead of
+// cleanup, the same pattern as TestUpdateNoOpIntegration.
+func newIntegrationService(t *testing.T, ctx context.Context) *Service {
+	t.Helper()
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	s, err := store.New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(s.Close)
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	return &Service{Store: s, Log: slog.New(slog.NewTextHandler(os.Stderr, nil))}
+}
+
+// uid returns a run-unique slug token, so reruns against a shared test
+// database never collide on primary keys.
+func uid(prefix string) string {
+	return fmt.Sprintf("%s%d", prefix, time.Now().UnixNano())
+}
+
+// TestContextIntegration exercises the one-call context pack end to end:
+// the entries behind the top hits arrive in full, links expand one hop in
+// both directions (the query a metric links to, and the insight linking
+// to the metric), and rejected companions stay out.
+func TestContextIntegration(t *testing.T) {
+	ctx := context.Background()
+	svc := newIntegrationService(t, ctx)
+	actor := domain.Actor{Kind: "human", Name: "test"}
+
+	id := uid("ctxit")
+	metricID, queryID, insightID, rejectedID := id+"-revenue", id+"-monthly", id+"-reading", id+"-rejected"
+	entries := []*domain.Knowledge{
+		{Type: domain.TypeMetric, ID: metricID, Title: metricID + " metric",
+			Status: domain.StatusVerified,
+			Links:  []domain.Link{{Rel: "answered_by", Target: "query/" + queryID}}},
+		{Type: domain.TypeQuery, ID: queryID, Title: "monthly numbers"},
+		{Type: domain.TypeInsight, ID: insightID, Title: "how to read it",
+			Links: []domain.Link{{Rel: "explains", Target: "ochakai://metric/" + metricID}}},
+		{Type: domain.TypeInsight, ID: rejectedID, Title: "bad take",
+			Status: domain.StatusRejected,
+			Links:  []domain.Link{{Rel: "explains", Target: "metric/" + metricID}}},
+	}
+	for _, k := range entries {
+		if _, err := svc.Create(ctx, k, actor); err != nil {
+			t.Fatalf("create %s: %v", k.ID, err)
+		}
+	}
+
+	res, err := svc.Context(ctx, metricID, store.Filter{}, 5, 0)
+	if err != nil {
+		t.Fatalf("Context: %v", err)
+	}
+	got := map[string]bool{}
+	for _, e := range res.Entries {
+		got[string(e.Type)+"/"+e.ID] = true
+	}
+	for _, want := range []string{"metric/" + metricID, "query/" + queryID, "insight/" + insightID} {
+		if !got[want] {
+			t.Errorf("context pack misses %s; got %v", want, got)
+		}
+	}
+	if got["insight/"+rejectedID] {
+		t.Error("rejected companions must stay out of the pack")
+	}
+
+	// A prohibitive min_score empties the pack instead of shipping junk.
+	filtered, err := svc.Context(ctx, metricID, store.Filter{}, 5, 1e9)
+	if err != nil {
+		t.Fatalf("Context with min_score: %v", err)
+	}
+	if len(filtered.Hits) != 0 || len(filtered.Entries) != 0 {
+		t.Errorf("min_score should drop everything, got %d hits / %d entries",
+			len(filtered.Hits), len(filtered.Entries))
+	}
+
+	// A blank question is the client's mistake.
+	var invalid *InvalidInputError
+	if _, err := svc.Context(ctx, "  ", store.Filter{}, 5, 0); !errors.As(err, &invalid) {
+		t.Errorf("empty query: want InvalidInputError, got %v", err)
+	}
+}
+
+// TestSearchRecordsUsageIntegration pins the passive half of the
+// write-back loop: appearing in search results bumps search_hits.
+func TestSearchRecordsUsageIntegration(t *testing.T) {
+	ctx := context.Background()
+	svc := newIntegrationService(t, ctx)
+	actor := domain.Actor{Kind: "human", Name: "test"}
+
+	id := uid("usgit")
+	if _, err := svc.Create(ctx, &domain.Knowledge{
+		Type: domain.TypeTerm, ID: id, Title: id + " term"}, actor); err != nil {
+		t.Fatal(err)
+	}
+
+	hits, err := svc.Search(httpauth.WithActor(ctx, actor), id, store.Filter{}, 5)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(hits) == 0 || hits[0].ID != id {
+		t.Fatalf("search missed the entry: %+v", hits)
+	}
+	u, err := svc.Usage(ctx, domain.TypeTerm, id)
+	if err != nil {
+		t.Fatalf("Usage: %v", err)
+	}
+	if u.SearchHits < 1 {
+		t.Errorf("search_hits = %d, want >= 1", u.SearchHits)
+	}
+}
+
+// TestCompileIntegration covers the compile path the unit tests cannot:
+// model resolution from the metric entry's attrs.model, and surfacing
+// verified golden queries next to the SQL.
+func TestCompileIntegration(t *testing.T) {
+	ctx := context.Background()
+	svc := newIntegrationService(t, ctx)
+	actor := domain.Actor{Kind: "human", Name: "test"}
+
+	id := uid("cplit")
+	modelName, metricName, goldenID := id+"_model", id+"_revenue", id+"-golden"
+	spec := map[string]any{
+		"name": modelName,
+		"datasets": []any{map[string]any{
+			"name": "orders", "source": "shop.orders",
+			"fields": []any{map[string]any{"name": "amount", "expression": "total_price"}},
+		}},
+		"metrics": []any{map[string]any{
+			"name": metricName, "expression": "SUM(orders.amount)",
+		}},
+	}
+	if err := svc.Store.UpsertSemanticModel(ctx, modelName, spec); err != nil {
+		t.Fatal(err)
+	}
+	for _, k := range []*domain.Knowledge{
+		{Type: domain.TypeMetric, ID: metricName, Title: "compile-test revenue",
+			Attrs: map[string]any{"model": modelName}},
+		{Type: domain.TypeQuery, ID: goldenID, Title: metricName + " by month",
+			Status: domain.StatusVerified},
+	} {
+		if _, err := svc.Create(ctx, k, actor); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Model omitted: resolved from the metric entry's attrs.model.
+	res, err := svc.Compile(ctx, CompileRequest{Request: compiler.Request{Metrics: []string{metricName}}})
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	if !strings.Contains(res.SQL, "SUM(orders.total_price)") {
+		t.Errorf("compiled SQL wrong:\n%s", res.SQL)
+	}
+	if len(res.VerifiedQueries) == 0 || res.VerifiedQueries[0].ID != goldenID {
+		t.Errorf("verified golden query not surfaced: %+v", res.VerifiedQueries)
+	}
+
+	// Unresolvable model and missing metrics are compile refusals, not crashes.
+	var cErr *compiler.Error
+	if _, err := svc.Compile(ctx, CompileRequest{Request: compiler.Request{Metrics: []string{id + "-none"}}}); !errors.As(err, &cErr) {
+		t.Errorf("unresolvable model: want compiler.Error, got %v", err)
+	}
+	if _, err := svc.Compile(ctx, CompileRequest{Model: id + "-missing", Request: compiler.Request{Metrics: []string{metricName}}}); !errors.As(err, &cErr) {
+		t.Errorf("unknown model: want compiler.Error, got %v", err)
+	}
+	if _, err := svc.Compile(ctx, CompileRequest{}); !errors.As(err, &cErr) {
+		t.Errorf("no metrics: want compiler.Error, got %v", err)
+	}
+}
+
+// TestDeleteIntegration pins soft delete through the service: the entry
+// vanishes from reads, and a second delete reports not-found instead of
+// stacking another delete revision.
+func TestDeleteIntegration(t *testing.T) {
+	ctx := context.Background()
+	svc := newIntegrationService(t, ctx)
+	actor := domain.Actor{Kind: "human", Name: "test"}
+
+	id := uid("delit")
+	if _, err := svc.Create(ctx, &domain.Knowledge{
+		Type: domain.TypeTerm, ID: id, Title: "to delete"}, actor); err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.Delete(ctx, domain.TypeTerm, id, actor); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := svc.Get(ctx, domain.TypeTerm, id); !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("deleted entry still readable: %v", err)
+	}
+	if err := svc.Delete(ctx, domain.TypeTerm, id, actor); !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("double delete: want ErrNotFound, got %v", err)
+	}
+}

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -105,3 +105,56 @@ func TestReportOutcomeValidation(t *testing.T) {
 		t.Errorf("oversized note: got %v, want a note-exceeds InvalidInputError", err)
 	}
 }
+
+func TestEmbeddingText(t *testing.T) {
+	k := &domain.Knowledge{
+		Title:       "Revenue",
+		Description: "total sales",
+		Tags:        []string{"finance", "kpi"},
+		Attrs:       map[string]any{"question": "monthly revenue?"},
+		Body:        "body text",
+	}
+	got := embeddingText(k)
+	for _, want := range []string{"Revenue", "total sales", "finance kpi", "monthly revenue?", "body text"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("embeddingText misses %q:\n%s", want, got)
+		}
+	}
+}
+
+// The body is truncated to stay within embedding-model input limits;
+// the envelope fields must survive untouched.
+func TestEmbeddingTextTruncatesBody(t *testing.T) {
+	k := &domain.Knowledge{Title: "T", Body: strings.Repeat("x", 5000)}
+	got := embeddingText(k)
+	if len(got) > 4100 {
+		t.Errorf("embeddingText length = %d, want body capped at 4000", len(got))
+	}
+	if !strings.HasPrefix(got, "T") {
+		t.Errorf("title must lead the text: %q", got[:20])
+	}
+}
+
+func TestValidateRejectsBadInput(t *testing.T) {
+	base := func() *domain.Knowledge {
+		return &domain.Knowledge{Type: "metric", ID: "revenue", Title: "Revenue"}
+	}
+	if err := validate(base()); err != nil {
+		t.Errorf("valid entry rejected: %v", err)
+	}
+	for name, mutate := range map[string]func(*domain.Knowledge){
+		"bad type":    func(k *domain.Knowledge) { k.Type = "no/slash" },
+		"bad id":      func(k *domain.Knowledge) { k.ID = "UPPER//bad" },
+		"index id":    func(k *domain.Knowledge) { k.ID = "sales/index" },
+		"empty title": func(k *domain.Knowledge) { k.Title = "   " },
+		"bad status":  func(k *domain.Knowledge) { k.Status = "published" },
+	} {
+		k := base()
+		mutate(k)
+		err := validate(k)
+		var invalid *InvalidInputError
+		if err == nil || !errors.As(err, &invalid) {
+			t.Errorf("%s: want InvalidInputError, got %v", name, err)
+		}
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -82,26 +82,35 @@ const knowledgeCols = `type, id, title, description, tags, status, status_note,
 	rejected_by_kind, rejected_by_name, rejected_at,
 	links, attrs, body, created_at, updated_at`
 
-func scanKnowledge(row pgx.CollectableRow) (domain.Knowledge, error) {
-	var k domain.Knowledge
+// knowledgeDest returns the scan destinations for knowledgeCols targeting
+// k, plus a finish func that decodes the JSON columns and nullable actors
+// after the scan. Row shapes with trailing columns (score, usage totals)
+// append their own destinations — the column list lives here once.
+func knowledgeDest(k *domain.Knowledge) (dests []any, finish func() error) {
 	var verifiedKind, verifiedName, rejectedKind, rejectedName *string
 	var links, attrs []byte
-	err := row.Scan(&k.Type, &k.ID, &k.Title, &k.Description, &k.Tags, &k.Status, &k.StatusNote,
+	dests = []any{&k.Type, &k.ID, &k.Title, &k.Description, &k.Tags, &k.Status, &k.StatusNote,
 		&k.CreatedBy.Kind, &k.CreatedBy.Name, &verifiedKind, &verifiedName, &k.VerifiedAt,
 		&rejectedKind, &rejectedName, &k.RejectedAt,
-		&links, &attrs, &k.Body, &k.CreatedAt, &k.UpdatedAt)
-	if err != nil {
+		&links, &attrs, &k.Body, &k.CreatedAt, &k.UpdatedAt}
+	finish = func() error {
+		k.VerifiedBy = actorFrom(verifiedKind, verifiedName)
+		k.RejectedBy = actorFrom(rejectedKind, rejectedName)
+		if err := json.Unmarshal(links, &k.Links); err != nil {
+			return err
+		}
+		return json.Unmarshal(attrs, &k.Attrs)
+	}
+	return dests, finish
+}
+
+func scanKnowledge(row pgx.CollectableRow) (domain.Knowledge, error) {
+	var k domain.Knowledge
+	dests, finish := knowledgeDest(&k)
+	if err := row.Scan(dests...); err != nil {
 		return k, err
 	}
-	k.VerifiedBy = actorFrom(verifiedKind, verifiedName)
-	k.RejectedBy = actorFrom(rejectedKind, rejectedName)
-	if err := json.Unmarshal(links, &k.Links); err != nil {
-		return k, err
-	}
-	if err := json.Unmarshal(attrs, &k.Attrs); err != nil {
-		return k, err
-	}
-	return k, nil
+	return k, finish()
 }
 
 func actorFrom(kind, name *string) *domain.Actor {
@@ -235,9 +244,17 @@ func (s *Store) SoftDelete(ctx context.Context, typ domain.Type, id string, acto
 		if err != nil {
 			return err
 		}
-		if _, err := tx.Exec(ctx,
-			`UPDATE knowledge SET deleted_at = now(), updated_at = now() WHERE type=$1 AND id=$2`, typ, id); err != nil {
+		// deleted_at IS NULL guards the race with a concurrent delete: the
+		// Get above ran outside this transaction, and a double delete must
+		// not record a second "delete" revision.
+		tag, err := tx.Exec(ctx,
+			`UPDATE knowledge SET deleted_at = now(), updated_at = now()
+			 WHERE type=$1 AND id=$2 AND deleted_at IS NULL`, typ, id)
+		if err != nil {
 			return err
+		}
+		if tag.RowsAffected() == 0 {
+			return ErrNotFound
 		}
 		// knowledge_embedding only exists once semantic search has been
 		// enabled; a failed statement aborts the whole Postgres transaction,
@@ -343,24 +360,11 @@ func (s *Store) SearchVector(ctx context.Context, vec []float32, f Filter, limit
 
 func scanHit(row pgx.CollectableRow) (domain.SearchHit, error) {
 	var h domain.SearchHit
-	var verifiedKind, verifiedName, rejectedKind, rejectedName *string
-	var links, attrs []byte
-	err := row.Scan(&h.Type, &h.ID, &h.Title, &h.Description, &h.Tags, &h.Status, &h.StatusNote,
-		&h.CreatedBy.Kind, &h.CreatedBy.Name, &verifiedKind, &verifiedName, &h.VerifiedAt,
-		&rejectedKind, &rejectedName, &h.RejectedAt,
-		&links, &attrs, &h.Body, &h.CreatedAt, &h.UpdatedAt, &h.Score)
-	if err != nil {
+	dests, finish := knowledgeDest(&h.Knowledge)
+	if err := row.Scan(append(dests, &h.Score)...); err != nil {
 		return h, err
 	}
-	h.VerifiedBy = actorFrom(verifiedKind, verifiedName)
-	h.RejectedBy = actorFrom(rejectedKind, rejectedName)
-	if err := json.Unmarshal(links, &h.Links); err != nil {
-		return h, err
-	}
-	if err := json.Unmarshal(attrs, &h.Attrs); err != nil {
-		return h, err
-	}
-	return h, nil
+	return h, finish()
 }
 
 // buildWhere renders filter conditions; prefix qualifies columns (e.g. "k.")
@@ -440,23 +444,13 @@ func (s *Store) ListByUsage(ctx context.Context, f Filter, limit int) ([]domain.
 // ListByUsage projection). Score stays 0 — this is a listing, not a search.
 func scanUsageHit(row pgx.CollectableRow) (domain.SearchHit, error) {
 	var h domain.SearchHit
-	var verifiedKind, verifiedName, rejectedKind, rejectedName *string
-	var links, attrs []byte
 	var u domain.Usage
-	err := row.Scan(&h.Type, &h.ID, &h.Title, &h.Description, &h.Tags, &h.Status, &h.StatusNote,
-		&h.CreatedBy.Kind, &h.CreatedBy.Name, &verifiedKind, &verifiedName, &h.VerifiedAt,
-		&rejectedKind, &rejectedName, &h.RejectedAt,
-		&links, &attrs, &h.Body, &h.CreatedAt, &h.UpdatedAt,
-		&u.SearchHits, &u.Fetches, &u.Compiles, &u.Worked, &u.Failed, &u.LastUsedAt)
-	if err != nil {
+	dests, finish := knowledgeDest(&h.Knowledge)
+	if err := row.Scan(append(dests,
+		&u.SearchHits, &u.Fetches, &u.Compiles, &u.Worked, &u.Failed, &u.LastUsedAt)...); err != nil {
 		return h, err
 	}
-	h.VerifiedBy = actorFrom(verifiedKind, verifiedName)
-	h.RejectedBy = actorFrom(rejectedKind, rejectedName)
-	if err := json.Unmarshal(links, &h.Links); err != nil {
-		return h, err
-	}
-	if err := json.Unmarshal(attrs, &h.Attrs); err != nil {
+	if err := finish(); err != nil {
 		return h, err
 	}
 	h.Usage = &u


### PR DESCRIPTION
## What changed

A full-tree review (every package read, `deadcode` + `go vet` clean) looking for legacy code, refactoring hazards, and test gaps. No dead code exists — the bytea backfill and the connector refuse-to-start guard are deliberate migration code — so this PR fixes the three real issues the review found and adds tests for the functionality that had none.

### Fixes

- **store: scan duplication.** `scanKnowledge` / `scanHit` / `scanUsageHit` each repeated the 20-column scan-and-decode sequence; a new knowledge column meant three synchronized edits. Consolidated into one `knowledgeDest` helper; the trailing score/usage columns append their own destinations.
- **store: SoftDelete race.** The pre-delete `Get` runs outside the transaction and the `UPDATE` had no `deleted_at IS NULL` guard, so a concurrent delete could record a second `delete` revision. The guard is added; a double delete now returns `ErrNotFound` (pinned by a new integration test).
- **domain: `ToTypes` / `ToStatuses`.** The identical string→enum helpers were copied in `restapi` and `mcpserver`; they now live once in `domain`.

### New tests

Integration tests gate on `OCHAKAI_TEST_DATABASE_URL` with run-unique IDs, matching the existing pattern — CI's pgvector service runs them.

- **service**: `Context` (two-way link expansion, rejected companions excluded, `min_score`), `Compile` (model resolution from `attrs.model`, verified-query surfacing, refusal cases), `Search` usage recording, `Delete` + double delete, `embeddingText`, `validate`.
- **importer**: `ImportOssie` end to end — derived metric/table entries, unchanged re-import writes nothing, human curation (status/tags/body) survives a definition refresh; `slugify`.
- **restapi**: one entry through the whole REST surface — create, `Ochakai-Unchanged` no-op PUT, browse tree, revisions, export bundle contents, delete → 404.
- **compiler**: `ModelFromSpec` / `ModelsFromSpec` across every accepted spec shape (single object, `semantic_model` document, name selection, plain-string expressions).
- **apiclient**: `Context`, `Attach` (okf_path), `Attachment`, `Detach`, `ReportOutcome`, `ImportOssie`.

### Coverage (with the test database, as in CI)

| package | before | after |
|---|---|---|
| service | 14% | 65% |
| importer | 0% | 80% |
| restapi | 48% | 61% |
| compiler | 74% | 84% |
| apiclient | 54% | 74% |

## Reviewer notes

- No behavior changes outside the SoftDelete guard; the scan consolidation is verified by the existing store integration suite.
- `blob` (GCS) and `embed` (Vertex AI) remain untested: both are thin wrappers over external services and would need emulators for little signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)