### PR TITLE
Remove migration shims and duplicate config paths for 0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,13 +219,13 @@ round-trip through OKF bundles as plain files next to their entry
 
 | Env var | Description |
 |---|---|
-| `OCHAKAI_DATABASE_URL` | Cloud SQL connection string (required; `DATABASE_URL` also works) |
-| `OCHAKAI_DB_IAM_AUTH` | `true` enables Cloud SQL IAM database authentication: the connection password is a short-lived IAM token, so the `DATABASE_URL` carries no secret |
-| `OCHAKAI_GCS_BUCKET` | Bucket for attachment bytes (auth is ADC — no keys); legacy in-Postgres bytes are migrated out at startup. Default: unset — the instance stores markdown entries only and attach operations return an error ([design doc 0013](docs/design/0013-attachment-files-gcs-only.md)) |
+| `OCHAKAI_DATABASE_URL` | Cloud SQL connection string (required) |
+| `OCHAKAI_DB_IAM_AUTH` | `true` enables Cloud SQL IAM database authentication: the connection password is a short-lived IAM token, so the connection string carries no secret |
+| `OCHAKAI_GCS_BUCKET` | Bucket for attachment bytes (auth is ADC — no keys). Default: unset — the instance stores markdown entries only and attach operations return an error ([design doc 0013](docs/design/0013-attachment-files-gcs-only.md)) |
 | `OCHAKAI_VERTEX_PROJECT` | Set to enable hybrid semantic search via Vertex AI embeddings (default: off, trigram-only — ochakai calls no external API unless you opt in). Auth is ADC — no API keys |
 | `OCHAKAI_VERTEX_LOCATION` / `OCHAKAI_VERTEX_MODEL` / `OCHAKAI_EMBEDDING_DIM` | Embedding details (defaults: `us-central1`, `gemini-embedding-001`, 768) |
 | `OCHAKAI_INSECURE_DEV` | Local development only: disables auth, everything acts as human:anonymous |
-| `PORT` / `OCHAKAI_ADDR` | Listen address (default `:8080`) |
+| `PORT` | Listen port (default `8080`) |
 
 Authentication has no configuration: ochakai reads the caller identity
 that Cloud Run forwards after its IAM check (`human:<email>` for people,

--- a/cmd/ochakai/main.go
+++ b/cmd/ochakai/main.go
@@ -135,25 +135,13 @@ func setup(ctx context.Context, log *slog.Logger) (*service.Service, *config.Con
 	} else {
 		log.Info("semantic search disabled; using trigram search only")
 	}
-	// Attachment bytes live only on GCS (design doc 0013). The blob store
-	// is wired and the legacy bytea backfill runs BEFORE schema migrations:
-	// migration 0009 drops the bytea column and refuses to run while
-	// inline bytes remain, so this order lets one boot with the bucket set
-	// finish the move. Failing the start on a backfill error is deliberate
-	// — the backfill is idempotent and the next boot resumes it.
+	// Attachment bytes live only on GCS (design doc 0013).
 	if cfg.GCSBucket != "" {
 		bs, err := blob.NewGCS(ctx, cfg.GCSBucket)
 		if err != nil {
 			return nil, nil, err
 		}
 		st.UseBlobStore(bs)
-		moved, err := st.MigrateBlobsOut(ctx)
-		if err != nil {
-			return nil, nil, fmt.Errorf("migrating attachment blobs to gs://%s: %w", cfg.GCSBucket, err)
-		}
-		if moved > 0 {
-			log.Info("migrated inline attachment blobs to GCS", "count", moved, "bucket", cfg.GCSBucket)
-		}
 		log.Info("attachment bytes on GCS", "bucket", cfg.GCSBucket)
 	} else {
 		log.Info("attachments disabled (no OCHAKAI_GCS_BUCKET); markdown entries only")
@@ -175,15 +163,12 @@ func serve(log *slog.Logger) error {
 	defer svc.Store.Close()
 
 	mux := http.NewServeMux()
-	// /health is the canonical health endpoint. /healthz is kept for local
-	// use but is unreachable behind Google Frontends (Cloud Run's run.app
-	// intercepts the path and returns its own 404) — discovered the hard way.
-	health := func(w http.ResponseWriter, _ *http.Request) {
+	// /health, not /healthz: Google Frontends intercept /healthz on
+	// run.app URLs and return their own 404 — discovered the hard way.
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
-	}
-	mux.HandleFunc("GET /health", health)
-	mux.HandleFunc("GET /healthz", health)
+	})
 	// The server deliberately does not serve the web UI (design doc 0006
 	// §4) — but a bare 404 at / strands newcomers who just ran the compose
 	// file and opened the port. Point them at the real entry points.

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -259,17 +259,14 @@ gcloud run services update ochakai --region=$REGION \
   --update-env-vars=OCHAKAI_GCS_BUCKET=$PROJECT_ID-ochakai-blobs
 ```
 
-On the next start, ochakai copies any legacy in-Postgres attachment
-bytes to the bucket (objects are content-addressed `blob/<sha256>`,
-create-only, never deleted), clears the database copies, and drops the
-legacy bytea column (migration 0009); the backfill is idempotent, so an
-interrupted start resumes on the next one. New attachments go straight
-to the bucket.
+Attachment bytes go straight to the bucket (objects are
+content-addressed `blob/<sha256>`, create-only, never deleted).
 
-**Upgrading from ≤0.8.x with attachments and no bucket**: set
-`OCHAKAI_GCS_BUCKET` *before* (or together with) deploying this version.
-Migration 0009 refuses to run while attachment bytes are still inline
-and no bucket is configured — the service fails to start with the
+**Upgrading from ≤0.8.x with attachments and no bucket**: run a 0.8.x
+release with `OCHAKAI_GCS_BUCKET` set once — its startup backfill moves
+the in-Postgres attachment bytes to the bucket. From 0.9.0 on, the
+backfill is gone and migration 0009 refuses to run while attachment
+bytes are still inline — the service fails to start with the
 instruction, nothing is lost. Once migrated, the bytea column is gone,
 so binaries and configurations without the bucket cannot read
 attachments again; keep the var set from then on.
@@ -479,9 +476,9 @@ Version notes:
 
 - **→ 0.9.0 (breaking)**: the MCP OAuth connector service is retired
   ([design doc 0012](../../docs/design/0012-retire-mcp-oauth-connector.md)).
-  A deployment with `OCHAKAI_CONNECTOR_PUBLIC_URL` set **refuses to
-  start** — deliberately, because that service was publicly invokable
-  and this image would otherwise serve the trust-the-headers private
+  `OCHAKAI_CONNECTOR_PUBLIC_URL` is now silently ignored — **never point
+  a connector deployment at this image**: that service was publicly
+  invokable, and this image would serve the trust-the-headers private
   surface on it. Delete the connector service instead of upgrading it
   (`gcloud run services delete ochakai-connector --region=$REGION`), and
   clean up its Google OAuth client, the Secret Manager client secret,
@@ -489,6 +486,13 @@ Version notes:
   unaffected; its startup migration drops the now-unused `oauth_*`
   tables (which the private service never read, so rolling it back
   afterwards remains safe).
+  Also removed in 0.9.0: the `DATABASE_URL` alias (use
+  `OCHAKAI_DATABASE_URL`), `OCHAKAI_ADDR` (use `PORT`), the `/healthz`
+  alias (use `/health`), the startup bytea→GCS backfill (upgrade through
+  0.8.x with `OCHAKAI_GCS_BUCKET` set if attachment bytes are still in
+  Postgres, §4b), and OKF import of the pre-0.4 nested `attrs:`
+  frontmatter form (re-export old bundles, or lift the keys to the top
+  level — SPEC §4.1).
 - **→ 0.8.0 (breaking)**: the v0.3 migration shims are gone. The legacy
   `GET /api/v1/knowledge/{type}/{id}/usage` alias is removed — use
   `GET /api/v1/usage/{type}/{id}`. The startup guard that refused to run

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Config struct {
-	// Addr is the listen address. Cloud Run's PORT is honored when set.
+	// Addr is the listen address, ":" + PORT (Cloud Run's contract).
 	Addr string
 	// DatabaseURL is the Cloud SQL connection string (required).
 	DatabaseURL string
@@ -21,9 +21,9 @@ type Config struct {
 	// InsecureDev disables authentication for local development: every
 	// request acts as human:anonymous. Never enable on a deployment.
 	InsecureDev bool
-	// GCSBucket, when set, stores attachment bytes as GCS objects
-	// (blob/<sha256>) instead of Postgres bytea rows; existing inline
-	// blobs are migrated out at startup (design doc 0011). Auth is ADC.
+	// GCSBucket names the bucket holding attachment bytes as GCS objects
+	// (blob/<sha256>, design doc 0013). Auth is ADC. When empty,
+	// attachments are unsupported — markdown entries only.
 	GCSBucket string
 
 	// Embedding is nil when semantic search is disabled (the default).
@@ -43,25 +43,13 @@ type EmbeddingConfig struct {
 func FromEnv() (*Config, error) {
 	cfg := &Config{
 		Addr:        ":" + envOr("PORT", "8080"),
-		DatabaseURL: firstEnv("OCHAKAI_DATABASE_URL", "DATABASE_URL"),
+		DatabaseURL: os.Getenv("OCHAKAI_DATABASE_URL"),
 		DBIAMAuth:   os.Getenv("OCHAKAI_DB_IAM_AUTH") == "true",
 		InsecureDev: os.Getenv("OCHAKAI_INSECURE_DEV") == "true",
 		GCSBucket:   os.Getenv("OCHAKAI_GCS_BUCKET"),
 	}
-	if addr := os.Getenv("OCHAKAI_ADDR"); addr != "" {
-		cfg.Addr = addr
-	}
 	if cfg.DatabaseURL == "" {
-		return nil, fmt.Errorf("OCHAKAI_DATABASE_URL (or DATABASE_URL) is required")
-	}
-
-	// The MCP OAuth connector service was removed (design doc 0012). This
-	// is a refuse-to-start guard, not silent tolerance like other removed
-	// variables: connector deployments were publicly invokable (allUsers),
-	// and a binary that ignored the variable would serve the trust-the-
-	// headers private surface on that public service.
-	if os.Getenv("OCHAKAI_CONNECTOR_PUBLIC_URL") != "" {
-		return nil, fmt.Errorf("OCHAKAI_CONNECTOR_PUBLIC_URL is set, but the MCP OAuth connector was removed (design doc 0012); this deployment is publicly invokable and must not run this image — delete the connector service (and its allUsers grant) instead of upgrading it")
+		return nil, fmt.Errorf("OCHAKAI_DATABASE_URL is required")
 	}
 
 	if project := os.Getenv("OCHAKAI_VERTEX_PROJECT"); project != "" {
@@ -85,13 +73,4 @@ func envOr(key, fallback string) string {
 		return v
 	}
 	return fallback
-}
-
-func firstEnv(keys ...string) string {
-	for _, k := range keys {
-		if v := os.Getenv(k); v != "" {
-			return v
-		}
-	}
-	return ""
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,24 +5,11 @@ import (
 	"testing"
 )
 
-// The connector service is removed (design doc 0012); a deployment still
-// configured for it was publicly invokable and must not silently start
-// as the private trust-the-headers surface.
-func TestRemovedConnectorRefusesToStart(t *testing.T) {
-	t.Setenv("OCHAKAI_DATABASE_URL", "postgres://x")
-
-	t.Run("guard", func(t *testing.T) {
-		t.Setenv("OCHAKAI_CONNECTOR_PUBLIC_URL", "https://connector.example")
-		if _, err := FromEnv(); err == nil || !strings.Contains(err.Error(), "OCHAKAI_CONNECTOR_PUBLIC_URL") {
-			t.Errorf("err = %v, want refuse-to-start guard", err)
-		}
-	})
-
-	t.Run("absent is fine", func(t *testing.T) {
-		if _, err := FromEnv(); err != nil {
-			t.Fatal(err)
-		}
-	})
+func TestDatabaseURLRequired(t *testing.T) {
+	t.Setenv("OCHAKAI_DATABASE_URL", "")
+	if _, err := FromEnv(); err == nil || !strings.Contains(err.Error(), "OCHAKAI_DATABASE_URL") {
+		t.Errorf("err = %v, want OCHAKAI_DATABASE_URL requirement", err)
+	}
 }
 
 func TestGCSBucket(t *testing.T) {

--- a/internal/okf/okf.go
+++ b/internal/okf/okf.go
@@ -76,14 +76,13 @@ type frontmatter struct {
 
 // reservedKeys are the frontmatter keys the envelope owns. An attr with a
 // reserved name is not exported as an extension key: the envelope value
-// wins ("attrs" is reserved so a literal attr of that name cannot
-// masquerade as the legacy nested form on re-import).
+// wins.
 var reservedKeys = map[string]bool{
 	"type": true, "id": true, "title": true, "description": true,
 	"resource": true, "tags": true, "timestamp": true, "status": true,
 	"status_note": true, "created_by": true, "verified_by": true,
 	"verified_at": true, "rejected_by": true, "rejected_at": true,
-	"attrs": true, AttrOKFType: true,
+	AttrOKFType: true,
 }
 
 // Bundle renders every entry into a path→content map. Paths follow

--- a/internal/okf/parse.go
+++ b/internal/okf/parse.go
@@ -113,19 +113,12 @@ func parseDoc(doc []byte) (*domain.Knowledge, string, error) {
 		}
 		attrs[key] = v
 	}
-	if legacy, ok := raw["attrs"].(map[string]any); ok {
-		for key, v := range legacy {
-			setAttr(key, v)
-		}
-	}
 	for key, v := range raw {
 		switch key {
 		case "type", "id", "title", "description", "tags", "status", "status_note":
 			// envelope, extracted above
 		case "timestamp", "created_by", "verified_by", "verified_at", "rejected_by", "rejected_at":
 			// server-owned, never from the payload
-		case "attrs":
-			// legacy nested extensions, folded in above
 		default:
 			setAttr(key, v)
 		}

--- a/internal/okf/parse_test.go
+++ b/internal/okf/parse_test.go
@@ -54,9 +54,8 @@ type: query
 id: monthly-revenue
 title: 月次売上
 status: draft
-attrs:
-  question: 月ごとの売上は？
-  sql: SELECT 1
+question: 月ごとの売上は？
+sql: SELECT 1
 ---
 
 Body text here.

--- a/internal/store/attachment.go
+++ b/internal/store/attachment.go
@@ -128,59 +128,6 @@ func (s *Store) GetAttachment(ctx context.Context, typ domain.Type, id, name str
 	return &att, data, nil
 }
 
-// MigrateBlobsOut copies every blob still stored inline in the legacy
-// bytea column to the external blob store and clears the inline bytes,
-// returning how many rows moved. It runs before schema migrations so
-// migration 0009 (which drops the column, design doc 0013) finds nothing
-// left to lose; on databases where the table or column is already gone
-// there is nothing to do. Idempotent per sha256 (Put is create-only,
-// NULLing is the last step), so an interrupted run is finished by the
-// next start.
-func (s *Store) MigrateBlobsOut(ctx context.Context) (int, error) {
-	if s.blobs == nil {
-		return 0, errors.New("no blob store configured")
-	}
-	var hasInline bool
-	if err := s.pool.QueryRow(ctx, `SELECT EXISTS (
-		SELECT 1 FROM information_schema.columns
-		WHERE table_schema = current_schema() AND table_name = 'blob' AND column_name = 'bytes')`).Scan(&hasInline); err != nil {
-		return 0, err
-	}
-	if !hasInline {
-		return 0, nil
-	}
-	rows, err := s.pool.Query(ctx, `SELECT sha256 FROM blob WHERE bytes IS NOT NULL ORDER BY sha256`)
-	if err != nil {
-		return 0, err
-	}
-	sums, err := pgx.CollectRows(rows, pgx.RowTo[string])
-	if err != nil {
-		return 0, err
-	}
-	// One blob at a time: startup memory stays bounded by the largest
-	// attachment, not the table.
-	moved := 0
-	for _, sum := range sums {
-		var mediaType string
-		var data []byte
-		if err := s.pool.QueryRow(ctx,
-			`SELECT media_type, bytes FROM blob WHERE sha256=$1`, sum).Scan(&mediaType, &data); err != nil {
-			return moved, err
-		}
-		if data == nil {
-			continue // raced with another instance's backfill
-		}
-		if err := s.blobs.Put(ctx, sum, mediaType, data); err != nil {
-			return moved, fmt.Errorf("migrate blob %s: %w", sum, err)
-		}
-		if _, err := s.pool.Exec(ctx, `UPDATE blob SET bytes = NULL WHERE sha256=$1`, sum); err != nil {
-			return moved, err
-		}
-		moved++
-	}
-	return moved, nil
-}
-
 // ListAttachments returns the metadata (no bytes) of a live entry's
 // attachments, in name order.
 func (s *Store) ListAttachments(ctx context.Context, typ domain.Type, id string) ([]domain.Attachment, error) {

--- a/internal/store/blob_integration_test.go
+++ b/internal/store/blob_integration_test.go
@@ -10,9 +10,8 @@ import (
 )
 
 // GCS-only blob storage (design doc 0013): attachment bytes live only in
-// the blob store, an instance without one refuses attachment operations,
-// and the legacy bytea backfill (MigrateBlobsOut) still moves inline rows
-// out before migration 0009 drops the column.
+// the blob store, and an instance without one refuses attachment
+// operations.
 func TestIntegrationBlobStoreOnly(t *testing.T) {
 	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
 	if dbURL == "" {
@@ -100,49 +99,5 @@ func TestIntegrationBlobStoreOnly(t *testing.T) {
 	if _, _, err := bare.GetAttachment(ctx, k.Type, k.ID, "chart.png"); err == nil ||
 		!strings.Contains(err.Error(), "OCHAKAI_GCS_BUCKET") {
 		t.Errorf("read without a blob store = %v, want config hint", err)
-	}
-
-	// Legacy backfill: simulate a pre-0013 database by re-adding the bytea
-	// column with one inline row, and verify MigrateBlobsOut moves it out
-	// (idempotently) — the step a real upgrade runs before migration 0009.
-	if _, err := s.pool.Exec(ctx, `ALTER TABLE blob ADD COLUMN bytes bytea`); err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if _, err := s.pool.Exec(ctx, `ALTER TABLE blob DROP COLUMN IF EXISTS bytes`); err != nil {
-			t.Errorf("restore schema: %v", err)
-		}
-	}()
-	legacy := append([]byte("\x89PNG\r\n\x1a\n"), []byte("legacy inline bytes")...)
-	legacySum := "it-ext-legacy-sum" // content addressing is not enforced by the table
-	if _, err := s.pool.Exec(ctx, `INSERT INTO blob (sha256, media_type, size, bytes)
-		VALUES ($1, 'image/png', $2, $3) ON CONFLICT (sha256) DO UPDATE SET bytes = EXCLUDED.bytes`,
-		legacySum, len(legacy), legacy); err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if _, err := s.pool.Exec(ctx, `DELETE FROM blob WHERE sha256=$1`, legacySum); err != nil {
-			t.Errorf("cleanup legacy blob: %v", err)
-		}
-	}()
-	moved, err := s.MigrateBlobsOut(ctx)
-	if err != nil {
-		t.Fatalf("MigrateBlobsOut: %v", err)
-	}
-	if moved != 1 {
-		t.Errorf("moved = %d, want 1", moved)
-	}
-	if got, err := fake.Get(ctx, legacySum); err != nil || string(got) != string(legacy) {
-		t.Errorf("backfill should upload the legacy blob: %v", err)
-	}
-	var inline []byte
-	if err := s.pool.QueryRow(ctx, `SELECT bytes FROM blob WHERE sha256=$1`, legacySum).Scan(&inline); err != nil {
-		t.Fatal(err)
-	}
-	if inline != nil {
-		t.Error("backfill should NULL the inline bytes")
-	}
-	if moved, err = s.MigrateBlobsOut(ctx); err != nil || moved != 0 {
-		t.Errorf("second backfill = (%d, %v), want (0, nil)", moved, err)
 	}
 }

--- a/internal/store/migrations/0009_drop_blob_bytes.sql
+++ b/internal/store/migrations/0009_drop_blob_bytes.sql
@@ -1,9 +1,9 @@
 -- Attachment bytes live only in GCS now (design doc 0013): the bytea
--- column of design doc 0008 is retired. The startup order guarantees the
--- backfill (MigrateBlobsOut) ran before this migration when a bucket is
--- configured; if inline bytes remain anyway — a GCS-less instance with
--- legacy attachments — dropping the column would destroy them, so fail
--- the migration with instructions instead.
+-- column of design doc 0008 is retired. The 0.8.x startup backfill
+-- (removed since) moved inline bytes to GCS before this migration ran;
+-- if inline bytes remain — an upgrade that skipped 0.8.x — dropping the
+-- column would destroy them, so fail the migration with instructions
+-- instead.
 DO $$
 BEGIN
     IF EXISTS (SELECT 1 FROM information_schema.columns
@@ -11,8 +11,9 @@ BEGIN
                  AND table_name = 'blob' AND column_name = 'bytes') THEN
         IF EXISTS (SELECT 1 FROM blob WHERE bytes IS NOT NULL) THEN
             RAISE EXCEPTION 'attachment bytes are still inline in PostgreSQL; '
-                'set OCHAKAI_GCS_BUCKET and restart so they migrate to GCS '
-                'before the bytea column can be dropped (design doc 0013)';
+                'upgrade through a 0.8.x release with OCHAKAI_GCS_BUCKET set '
+                'so they migrate to GCS before the bytea column can be '
+                'dropped (design doc 0013)';
         END IF;
         ALTER TABLE blob DROP COLUMN bytes;
     END IF;

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -32,7 +32,7 @@ type Store struct {
 }
 
 // UseBlobStore routes attachment bytes to b (design doc 0013). Call
-// before serving; legacy inline rows are moved by MigrateBlobsOut.
+// before serving.
 func (s *Store) UseBlobStore(b blob.Store) { s.blobs = b }
 
 // HasBlobStore reports whether attachment bytes have somewhere to live —


### PR DESCRIPTION
## Summary

0.9.0 に向けた片付け: 期限付きの移行シム 3 件と、重複した設定経路 3 件を削除します(+53 / −204 行)。MCP / REST / CLI のサーフェスには一切触れていません(設計ドキュメント 0015 に照らして現状維持が正解と判断)。

### 移行シムの撤去

- **bytea→GCS 起動時バックフィル(`MigrateBlobsOut`)**: 0.8.x で役目を終えた一回性の移行コード。データ保護はマイグレーション 0009 の拒否ガードが引き続き担い、例外メッセージを「bucket を設定して再起動」から「**0.8.x を経由してアップグレード**」に書き換え(バックフィル亡き後は前者が成立しないため)
- **`OCHAKAI_CONNECTOR_PUBLIC_URL` の起動拒否ガード**(設計ドキュメント 0012): 他の廃止変数と同様に黙って無視する扱いに。コネクタサービスを削除せよという警告は deploy ガイドの 0.9.0 ノートに太字で残置
- **OKF レガシー nested `attrs:` フロントマター**(#30 以前の自社エクスポート形式): 特別扱いを全廃し、`attrs` は通常の拡張キーとして対称に往復(reservedKeys からも削除)

### 重複した設定経路の一本化

- `OCHAKAI_ADDR` 削除 — `PORT`(Cloud Run の契約)のみ。v0.1 から一度も deploy/guides で使われていなかった
- `DATABASE_URL` エイリアス削除 — `OCHAKAI_DATABASE_URL` のみ
- `/healthz` 削除 — `/health` のみ(healthz は Google Frontends に横取りされ run.app では元々到達不能)

### ドキュメント

- README の環境変数表から嘘になっていた記述(「起動時にレガシーバイトを移行」)と重複行を除去
- deploy ガイド §4b と 0.9.0 版ノートに破壊的変更を全て列挙(≤0.8.x に添付があり bucket 未設定の場合は 0.8.x で一度 bucket を設定して起動してから上げる、というアップグレード経路を明記)

## Breaking changes (→ 0.9.0)

| 削除 | 移行先 |
|---|---|
| 起動時 bytea→GCS バックフィル | 0.8.x を経由(0009 のガードが未移行バイトを検知して起動拒否・データ喪失なし) |
| `OCHAKAI_CONNECTOR_PUBLIC_URL` ガード | 変数は無視される。コネクタサービス自体の削除は引き続き必須 |
| nested `attrs:` の読み込み | トップレベルキー(SPEC §4.1)。旧バンドルは再エクスポート |
| `DATABASE_URL` | `OCHAKAI_DATABASE_URL` |
| `OCHAKAI_ADDR` | `PORT` |
| `/healthz` | `/health` |

## Test plan

- [x] `go build ./...` / `go vet ./...` / `go test ./...` 全パス
- [x] 統合テスト: 使い捨て pgvector:pg17 コンテナで `OCHAKAI_TEST_DATABASE_URL` を与えて store / service の Integration 全件パス(新規 DB でマイグレーション 0001→0009 連鎖の再生を含む)

🤖 Generated with [Claude Code](https://claude.com/claude-code)