### PR TITLE
Move SQL compilation from a site-wide tab into the metric detail view

### DIFF
--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -6,7 +6,8 @@
      covers the human-facing API surface — search, folder browsing,
      entry details with usage, revision history, backlinks, attachments,
      create/edit with the draft → verified workflow, the draft review
-     queue (sort=usage), SQL compilation with Ossie model import, and
+     queue (sort=usage), SQL compilation (a Compile tab on metric
+     entries), Ossie model import (on the new-entry page), and
      OKF export. (/api/v1/context is an agent surface — see
      api/openapi.yaml.) A starting point for building your own UI. -->
 <html lang="en">
@@ -298,7 +299,6 @@
     <a href="#/" data-route="explore">Explore</a>
     <a href="#/browse" data-route="browse">Browse</a>
     <a href="#/review" data-route="review">Review</a>
-    <a href="#/compile" data-route="compile">Compile</a>
     <a href="#/new" data-route="new">New entry</a>
   </nav>
   <span class="spacer"></span>
@@ -484,9 +484,6 @@ function route() {
   } else if (head === 'review') {
     mark('review');
     viewReview();
-  } else if (head === 'compile') {
-    mark('compile');
-    viewCompile();
   } else {
     mark('explore');
     viewExplore();
@@ -761,6 +758,18 @@ async function viewDetail(type, id) {
   const canDeprecate = entry.status !== 'deprecated';
   const canReject = entry.status !== 'rejected';
   const atts = entry.attachments || [];
+  // Metrics are the compilable knowledge, so their detail view gets a
+  // Compile tab instead of a site-wide compile page. The compiler matches
+  // metrics by their semantic-model name — the entry title, verbatim, for
+  // imported metrics (the ID is a slug of it) — and the model is passed
+  // explicitly from attrs.model since name-based resolution assumes the
+  // name and the entry ID coincide.
+  const compilable = entry.type === 'metric';
+  const cstate = compilable ? {
+    metrics: entry.title,
+    model: typeof (entry.attrs || {}).model === 'string' ? entry.attrs.model : '',
+    dimensions: '', filters: [], tgField: '', tgGrain: '', dialect: 'bigquery', limit: '',
+  } : null;
 
   view.innerHTML = `
     <nav class="crumbs mono"><a href="#/">knowledge</a> / ${esc(entry.type)} / ${esc(entry.id)}</nav>
@@ -782,6 +791,7 @@ async function viewDetail(type, id) {
     ${entry.status_note ? `<div class="status-note">${esc(entry.status_note)}</div>` : ''}
     <div class="tabs" id="tabs">
       <button data-tab="overview" class="active">Overview</button>
+      ${compilable ? '<button data-tab="compile">Compile</button>' : ''}
       <button data-tab="attrs">Attributes</button>
       <button data-tab="links">Links${entry.links && entry.links.length ? ' (' + entry.links.length + ')' : ''}</button>
       <button data-tab="attachments">Attachments${atts.length ? ' (' + atts.length + ')' : ''}</button>
@@ -877,6 +887,13 @@ async function viewDetail(type, id) {
     usage: () => '<div class="empty">…</div>',
     history: () => '<div class="empty">…</div>',
   };
+  if (compilable) {
+    tabs.compile = () => `
+      <p class="provenance" style="margin:0 0 1rem">Deterministically compiles this metric from its imported
+      semantic model — ochakai never executes SQL and never guesses. Verified golden queries about the metrics
+      are returned alongside; prefer them when they answer the question.</p>
+      ${compileFormHTML(cstate)}`;
+  }
 
   function wireAttachments() {
     const fileInput = $('#att-file');
@@ -949,6 +966,7 @@ async function viewDetail(type, id) {
     document.querySelectorAll('#tabs button').forEach(b => b.classList.toggle('active', b.dataset.tab === name));
     body.innerHTML = tabs[name]();
     if (name === 'attachments') wireAttachments();
+    if (name === 'compile') wireCompileForm(cstate);
     if (lazy[name]) {
       try {
         tabs[name] = await lazy[name]();
@@ -1204,7 +1222,22 @@ async function viewEditor(type, id) {
         <button class="btn primary" type="submit">${editing ? 'Save' : 'Create draft'}</button>
         <a class="btn" href="${editing ? '#/k/' + idPath(entry.type, entry.id) : '#/'}">Cancel</a>
       </p>
-    </form>`;
+    </form>
+    ${editing ? '' : `
+    <div class="section-title" style="margin-top:2.4rem;font-size:1.05rem">Or import a semantic model</div>
+    <p style="color:var(--muted);max-width:46rem;font-size:.92rem">Importing an Apache Ossie semantic model (YAML)
+    creates its metric and table entries; each metric's detail view then offers a Compile tab. Re-import refreshes
+    definitions without clobbering human-curated status, tags, and bodies. OKF bundle import stays with the CLI
+    (<code>ochakai import</code>).</p>
+    <div class="toolbar">
+      <input type="file" id="ossie-file" accept=".yaml,.yml,application/yaml" hidden>
+      <button class="btn small" type="button" id="ossie-choose">Choose model YAML…</button>
+      <span class="provenance" id="ossie-chosen" style="margin:0"></span>
+      <button class="btn small primary" type="button" id="ossie-upload">Import</button>
+    </div>
+    <div id="ossie-result"></div>`}`;
+
+  if (!editing) wireOssieImport();
 
   let dirty = false;
   $('#editor').addEventListener('input', () => { dirty = true; });
@@ -1251,17 +1284,42 @@ async function viewEditor(type, id) {
   });
 }
 
+// Ossie semantic model import (design doc 0013) — offered on the new-entry
+// page, since importing is another way to create knowledge entries.
+function wireOssieImport() {
+  const ossieFile = $('#ossie-file');
+  $('#ossie-choose').addEventListener('click', () => ossieFile.click());
+  ossieFile.addEventListener('change', () => {
+    $('#ossie-chosen').textContent = ossieFile.files[0] ? ossieFile.files[0].name : '';
+  });
+  $('#ossie-upload').addEventListener('click', async () => {
+    const f = ossieFile.files[0];
+    if (!f) { toast('Choose a semantic model YAML first.'); return; }
+    const out = $('#ossie-result');
+    out.innerHTML = '<div class="empty">importing…</div>';
+    try {
+      const r = await api('/api/v1/import/ossie', { method: 'POST', raw: f });
+      const list = (label, uris) => (uris && uris.length)
+        ? `<li>${label}: ${uris.map(u => esc(u)).join(', ')}</li>` : '';
+      out.innerHTML = `
+        <div class="feed-banner" style="margin-top:.8rem">Imported model${(r.models || []).length > 1 ? 's' : ''}
+          <strong>${(r.models || []).map(esc).join(', ')}</strong>.</div>
+        <ul style="color:var(--muted);font-size:.9rem">${list('created', r.created)}${list('updated', r.updated)}${list('unchanged', r.unchanged)}</ul>`;
+      toast('Model imported.');
+    } catch (e) {
+      out.innerHTML = `<div class="error-banner">Import failed: ${esc(e.message)}</div>`;
+    }
+  });
+}
+
 /* ============================== compile ============================== */
 
-const compileState = { model: '', metrics: '', dimensions: '', filters: [], tgField: '', tgGrain: '', dialect: 'bigquery', limit: '' };
-
-function viewCompile() {
-  const c = compileState;
-  view.innerHTML = `
-    <div class="section-title">Compile SQL</div>
-    <p style="color:var(--muted);max-width:46rem">Deterministically compiles metrics from the imported semantic model —
-    ochakai never executes SQL and never guesses. Verified golden queries about the metrics are returned alongside;
-    prefer them when they answer the question.</p>
+// The compile form renders inside the Compile tab of a metric's detail
+// view (metrics are the compilable knowledge; the model resolves via the
+// metric's attrs.model). State is per-view, seeded from the metric, and
+// written back on every input so it survives tab switches.
+function compileFormHTML(c) {
+  return `
     <form class="form" id="compile-form">
       <div class="row">
         <div class="field">
@@ -1305,19 +1363,10 @@ function viewCompile() {
       </div>
       <p><button class="btn primary" type="submit">Compile</button></p>
     </form>
-    <div id="compile-result"></div>
-    <div class="section-title" style="margin-top:2.4rem;font-size:1.05rem">Semantic models</div>
-    <p style="color:var(--muted);max-width:46rem;font-size:.92rem">Compile works from imported Apache Ossie semantic
-    models. Import one here (YAML) — re-import refreshes definitions without clobbering human-curated status, tags,
-    and bodies. OKF bundle import stays with the CLI (<code>ochakai import</code>).</p>
-    <div class="toolbar">
-      <input type="file" id="ossie-file" accept=".yaml,.yml,application/yaml" hidden>
-      <button class="btn small" type="button" id="ossie-choose">Choose model YAML…</button>
-      <span class="provenance" id="ossie-chosen" style="margin:0"></span>
-      <button class="btn small primary" type="button" id="ossie-upload">Import</button>
-    </div>
-    <div id="ossie-result"></div>`;
+    <div id="compile-result"></div>`;
+}
 
+function wireCompileForm(c) {
   const OPS = ['=', '!=', '>', '>=', '<', '<=', 'in', 'not_in'];
   const filtersBox = $('#c-filters');
   function renderFilters() {
@@ -1336,35 +1385,18 @@ function viewCompile() {
   renderFilters();
   $('#c-add-filter').addEventListener('click', () => { c.filters.push({ field: '', op: '=', value: '' }); renderFilters(); });
 
-  const ossieFile = $('#ossie-file');
-  $('#ossie-choose').addEventListener('click', () => ossieFile.click());
-  ossieFile.addEventListener('change', () => {
-    $('#ossie-chosen').textContent = ossieFile.files[0] ? ossieFile.files[0].name : '';
-  });
-  $('#ossie-upload').addEventListener('click', async () => {
-    const f = ossieFile.files[0];
-    if (!f) { toast('Choose a semantic model YAML first.'); return; }
-    const out = $('#ossie-result');
-    out.innerHTML = '<div class="empty">importing…</div>';
-    try {
-      const r = await api('/api/v1/import/ossie', { method: 'POST', raw: f });
-      const list = (label, uris) => (uris && uris.length)
-        ? `<li>${label}: ${uris.map(u => esc(u)).join(', ')}</li>` : '';
-      out.innerHTML = `
-        <div class="feed-banner" style="margin-top:.8rem">Imported model${(r.models || []).length > 1 ? 's' : ''}
-          <strong>${(r.models || []).map(esc).join(', ')}</strong>.</div>
-        <ul style="color:var(--muted);font-size:.9rem">${list('created', r.created)}${list('updated', r.updated)}${list('unchanged', r.unchanged)}</ul>`;
-      toast('Model imported.');
-    } catch (e) {
-      out.innerHTML = `<div class="error-banner">Import failed: ${esc(e.message)}</div>`;
-    }
-  });
-
-  $('#compile-form').addEventListener('submit', async ev => {
-    ev.preventDefault();
+  // Write inputs back into the state object as they change, so edits
+  // survive a switch to another tab and back (the tab re-renders from c).
+  const persist = () => {
     c.metrics = $('#c-metrics').value; c.model = $('#c-model').value; c.dimensions = $('#c-dims').value;
     c.tgField = $('#c-tg-field').value; c.tgGrain = $('#c-tg-grain').value;
     c.dialect = $('#c-dialect').value; c.limit = $('#c-limit').value;
+  };
+  $('#compile-form').addEventListener('input', persist);
+
+  $('#compile-form').addEventListener('submit', async ev => {
+    ev.preventDefault();
+    persist();
     const body = {
       metrics: c.metrics.split(',').map(s => s.trim()).filter(Boolean),
       dialect: c.dialect,


### PR DESCRIPTION
## What changed

- Removed the **Compile** tab from the web UI's top nav (and its `#/compile` route; old URLs fall back to Explore).
- Metric entries — the compilable knowledge — now get a **Compile tab on their detail page**, with the metric and its semantic model prefilled. The form itself is unchanged (dimensions, filters, time grain, dialect/limit, compiled SQL + verified golden queries), and edits survive switching to another tab and back.
- The **Ossie semantic-model import** that shared the compile page moved to the bottom of the **New entry** page: importing is another way to create knowledge entries, and it explains that each imported metric gains a Compile tab.

## Why

A whole top-level page was too much surface for compile: it only applies to metrics, and the form started blank with no connection to the knowledge it compiles. Opening it from the compilable entry itself makes it both smaller and more discoverable.

## Notes for review

- The prefill uses the entry **title**, not the ID: the compiler matches metrics by their semantic-model name (`Model.metric` compares `Metric.Name`), and the importer stores that name verbatim as the title while the ID is a slug of it. The model is passed explicitly from `attrs.model` for the same reason — the server's name-based resolution (`Store.Get(TypeMetric, metrics[0])`) assumes the name and entry ID coincide.
- The Compile tab shows on every metric entry, including hand-authored ones without `attrs.model`; compile then fails with the server's clear "cannot resolve a semantic model" error, and the model field accepts an explicit name.
- Verified in a browser against a stub API: tab renders prefilled, compile POST carries `metrics`/`model` and renders SQL + notes, non-metric entries show no tab, `#/new` shows the import section, no console errors. `go build ./...` and the `ui`/`serve-ui` serving tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)