### PR TITLE
Web UI: whole-card click, New entry folded into Explore, attachment thumbnails

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -463,14 +463,19 @@ paths:
       summary: Fetch attachment bytes
       description: >
         Returns the file bytes with the stored (sniffed) media type; the
-        ETag is the content's SHA-256. Fetching records a usage event
-        against the owning entry.
+        ETag is the content's SHA-256, and a matching If-None-Match gets
+        a 304 answered from metadata alone (no blob read, so repeat
+        renders in a UI cost nothing). Cache-Control is private,
+        no-cache: names are mutable (replace-by-name), so clients
+        revalidate every time. Fetching the bytes records a usage event
+        against the owning entry; a 304 revalidation does not.
       responses:
         "200":
           description: The attachment bytes.
           content:
             "*/*":
               schema: { type: string, format: binary }
+        "304": { description: Not modified (If-None-Match matched the content hash). }
         "404": { $ref: "#/components/responses/Error" }
     delete:
       operationId: deleteAttachment
@@ -664,6 +669,11 @@ components:
         failed: { type: integer, description: Outcome reports saying the entry led to a wrong or unusable result. }
         last_used_at: { type: string, format: date-time }
     SearchHit:
+      description: >
+        One search or listing result. REST hits carry attachment
+        metadata (filled in batch) so UIs can render image previews
+        without a fetch per entry; MCP search results omit it to keep
+        agent context lean (design doc 0015).
       allOf:
         - $ref: "#/components/schemas/Knowledge"
         - type: object

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -66,7 +66,7 @@ func Handler(svc *service.Service) http.Handler {
 				writeError(w, err)
 				return
 			}
-			writeJSON(w, http.StatusOK, map[string]any{"hits": hits})
+			writeHits(w, r, svc, hits)
 			return
 		}
 		hits, err := svc.Search(r.Context(), q.Get("q"), f, limit)
@@ -74,7 +74,7 @@ func Handler(svc *service.Service) http.Handler {
 			writeError(w, err)
 			return
 		}
-		writeJSON(w, http.StatusOK, map[string]any{"hits": hits})
+		writeHits(w, r, svc, hits)
 	})
 
 	// GET /api/v1/browse?type=...&prefix=... — one level of the ID
@@ -231,6 +231,14 @@ func Handler(svc *service.Service) http.Handler {
 			writeError(w, err)
 			return
 		}
+		ptrs := make([]*domain.Knowledge, len(entries))
+		for i := range entries {
+			ptrs[i] = &entries[i]
+		}
+		if err := svc.FillAttachments(r.Context(), ptrs); err != nil {
+			writeError(w, err)
+			return
+		}
 		writeJSON(w, http.StatusOK, map[string]any{"entries": entries})
 	})
 	// Attachments (design docs 0008, 0013): files attached to an entry
@@ -281,11 +289,32 @@ func Handler(svc *service.Service) http.Handler {
 		if !ok {
 			return
 		}
+		// Conditional GET before touching the blob store: bytes are
+		// content-addressed, so the hash is a perfect ETag, and the web
+		// UI re-renders the same images on every search — a 304 answered
+		// from metadata alone keeps GCS reads and egress off the bill.
+		// no-cache means "revalidate every time", which is required
+		// because the name→content mapping is mutable (replace-by-name).
+		meta, err := svc.AttachmentMeta(r.Context(), typ, id, name)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		etag := `"` + meta.SHA256 + `"`
+		w.Header().Set("ETag", etag)
+		w.Header().Set("Cache-Control", "private, no-cache")
+		if r.Header.Get("If-None-Match") == etag {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
 		att, data, err := svc.Attachment(r.Context(), typ, id, name)
 		if err != nil {
 			writeError(w, err)
 			return
 		}
+		// Re-stamp from the row the bytes came from, in case the
+		// attachment was replaced between the two reads.
+		w.Header().Set("ETag", `"`+att.SHA256+`"`)
 		ct := att.MediaType
 		// Plain text without a charset invites browser guessing; the sniffer
 		// only passes UTF-8/UTF-16 text through, so declare it.
@@ -298,7 +327,6 @@ func Handler(svc *service.Service) http.Handler {
 		// text/html, no image/svg+xml), but nosniff keeps a browser from
 		// overriding that and interpreting them as anything else.
 		w.Header().Set("X-Content-Type-Options", "nosniff")
-		w.Header().Set("ETag", `"`+att.SHA256+`"`)
 		w.Header().Set("Content-Disposition", `inline; filename="`+att.Name+`"`)
 		_, _ = w.Write(data)
 	})
@@ -396,6 +424,21 @@ func Handler(svc *service.Service) http.Handler {
 	})
 
 	return mux
+}
+
+// writeHits responds with a hit list, attachment metadata filled in one
+// batch — the REST list surface carries it so UIs can render image
+// previews; MCP search results stay lean (design doc 0015).
+func writeHits(w http.ResponseWriter, r *http.Request, svc *service.Service, hits []domain.SearchHit) {
+	ptrs := make([]*domain.Knowledge, len(hits))
+	for i := range hits {
+		ptrs[i] = &hits[i].Knowledge
+	}
+	if err := svc.FillAttachments(r.Context(), ptrs); err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"hits": hits})
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {

--- a/internal/restapi/restapi_integration_test.go
+++ b/internal/restapi/restapi_integration_test.go
@@ -248,6 +248,20 @@ func TestRESTIntegrationAttachments(t *testing.T) {
 	if resp.StatusCode != http.StatusOK || string(body) != string(png) {
 		t.Errorf("stale conditional GET = %d with %d bytes, want 200 with the file", resp.StatusCode, len(body))
 	}
+
+	// Soft-delete the entry so its attachment row does not stay live in
+	// the shared test database: other packages' tests scan all live
+	// attachments (ListAllAttachments) and resolve bytes from their own
+	// blob stores, while this test's bytes live only in this process.
+	req, _ = http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/knowledge/"+typ+"/reading", nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("cleanup delete status = %d", resp.StatusCode)
+	}
 }
 
 // memBlobStore is a minimal in-memory blob.Store for the attachment

--- a/internal/restapi/restapi_integration_test.go
+++ b/internal/restapi/restapi_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -148,6 +149,124 @@ func TestRESTIntegration(t *testing.T) {
 	if resp.StatusCode != http.StatusNotFound {
 		t.Errorf("get after delete = %d, want 404", resp.StatusCode)
 	}
+}
+
+// TestRESTIntegrationAttachments covers the attachment surface the web
+// UI leans on: hit lists carry attachment metadata (filled in batch),
+// and attachment GETs answer conditional requests from metadata alone
+// (ETag = content hash, If-None-Match → 304).
+func TestRESTIntegrationAttachments(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := t.Context()
+	s, err := store.New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	s.UseBlobStore(memBlobStore{})
+	svc := &service.Service{Store: s, Log: slog.New(slog.NewTextHandler(os.Stderr, nil))}
+	srv := httptest.NewServer(Handler(svc))
+	defer srv.Close()
+
+	typ := fmt.Sprintf("restatt%d", time.Now().UnixNano())
+	payload, _ := json.Marshal(map[string]any{"type": typ, "id": "reading", "title": "attachment hits"})
+	resp, err := http.Post(srv.URL+"/api/v1/knowledge", "application/json", bytes.NewReader(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create status = %d", resp.StatusCode)
+	}
+
+	png := append([]byte("\x89PNG\r\n\x1a\n"), []byte("hit thumbnail bytes")...)
+	attURL := srv.URL + "/api/v1/attachments/" + typ + "/reading/weekly.png"
+	req, _ := http.NewRequest(http.MethodPut, attURL, bytes.NewReader(png))
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("attach status = %d", resp.StatusCode)
+	}
+
+	// The listing carries the attachment metadata.
+	var hits struct {
+		Hits []domain.SearchHit `json:"hits"`
+	}
+	getJSON(t, srv.URL+"/api/v1/knowledge?sort=verified_at&type="+typ, &hits)
+	if len(hits.Hits) != 1 || len(hits.Hits[0].Attachments) != 1 ||
+		hits.Hits[0].Attachments[0].Name != "weekly.png" ||
+		hits.Hits[0].Attachments[0].MediaType != "image/png" {
+		t.Fatalf("hits should carry attachment metadata: %+v", hits.Hits)
+	}
+	sum := hits.Hits[0].Attachments[0].SHA256
+
+	// Plain GET: bytes, content-hash ETag, revalidation policy.
+	resp, err = http.Get(attURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK || string(body) != string(png) {
+		t.Fatalf("attachment GET: status = %d, %d bytes", resp.StatusCode, len(body))
+	}
+	if resp.Header.Get("ETag") != `"`+sum+`"` || resp.Header.Get("Cache-Control") != "private, no-cache" {
+		t.Errorf("caching headers = %q / %q", resp.Header.Get("ETag"), resp.Header.Get("Cache-Control"))
+	}
+
+	// Conditional GET with the current hash: 304, no body.
+	req, _ = http.NewRequest(http.MethodGet, attURL, nil)
+	req.Header.Set("If-None-Match", `"`+sum+`"`)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotModified || len(body) != 0 {
+		t.Errorf("conditional GET = %d with %d bytes, want 304 empty", resp.StatusCode, len(body))
+	}
+
+	// A stale hash still gets the bytes.
+	req, _ = http.NewRequest(http.MethodGet, attURL, nil)
+	req.Header.Set("If-None-Match", `"deadbeef"`)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK || string(body) != string(png) {
+		t.Errorf("stale conditional GET = %d with %d bytes, want 200 with the file", resp.StatusCode, len(body))
+	}
+}
+
+// memBlobStore is a minimal in-memory blob.Store for the attachment
+// round-trip without GCS.
+type memBlobStore map[string][]byte
+
+func (m memBlobStore) Put(_ context.Context, sum, _ string, data []byte) error {
+	if _, ok := m[sum]; !ok {
+		m[sum] = append([]byte(nil), data...)
+	}
+	return nil
+}
+
+func (m memBlobStore) Get(_ context.Context, sum string) ([]byte, error) {
+	data, ok := m[sum]
+	if !ok {
+		return nil, fmt.Errorf("mem blob store: %s not found", sum)
+	}
+	return data, nil
 }
 
 func getJSON(t *testing.T, url string, v any) {

--- a/internal/service/attachment.go
+++ b/internal/service/attachment.go
@@ -44,6 +44,37 @@ func (s *Service) Attachment(ctx context.Context, typ domain.Type, id, name stri
 	return att, data, nil
 }
 
+// AttachmentMeta returns one attachment's metadata without its bytes —
+// enough for a conditional GET (ETag = content hash) to answer 304
+// without a blob-store read, and without recording a fetch: a cache
+// revalidation is not a use of the knowledge.
+func (s *Service) AttachmentMeta(ctx context.Context, typ domain.Type, id, name string) (*domain.Attachment, error) {
+	return s.Store.GetAttachmentMeta(ctx, typ, id, name)
+}
+
+// FillAttachments fills attachment metadata on entries in one batch
+// query. The REST list surfaces (search hits, backlinks) carry it so a
+// UI can render image previews without a fetch per entry; MCP search
+// results stay lean for agent context (design doc 0015).
+func (s *Service) FillAttachments(ctx context.Context, ks []*domain.Knowledge) error {
+	if len(ks) == 0 {
+		return nil
+	}
+	types := make([]domain.Type, len(ks))
+	ids := make([]string, len(ks))
+	for i, k := range ks {
+		types[i], ids[i] = k.Type, k.ID
+	}
+	atts, err := s.Store.ListAttachmentsBatch(ctx, types, ids)
+	if err != nil {
+		return err
+	}
+	for _, k := range ks {
+		k.Attachments = atts[string(k.Type)+"/"+k.ID]
+	}
+	return nil
+}
+
 // Detach removes an attachment (the change is kept as a revision).
 func (s *Service) Detach(ctx context.Context, typ domain.Type, id, name string, actor domain.Actor) error {
 	return s.Store.DeleteAttachment(ctx, typ, id, name, actor)

--- a/internal/store/attachment.go
+++ b/internal/store/attachment.go
@@ -142,6 +142,59 @@ func (s *Store) ListAttachments(ctx context.Context, typ domain.Type, id string)
 	return pgx.CollectRows(rows, scanAttachment)
 }
 
+// ListAttachmentsBatch returns attachment metadata for a set of entries
+// in one query, keyed by "<type>/<id>". Entries without attachments have
+// no key. The callers pass entries they already know are live (search
+// hits, backlinks), so no liveness join is needed.
+func (s *Store) ListAttachmentsBatch(ctx context.Context, types []domain.Type, ids []string) (map[string][]domain.Attachment, error) {
+	ts := make([]string, len(types))
+	for i, t := range types {
+		ts[i] = string(t)
+	}
+	rows, err := s.pool.Query(ctx, `SELECT a.knowledge_type, a.knowledge_id, `+attachmentCols+`
+		FROM attachment a
+		JOIN blob b ON b.sha256 = a.sha256
+		JOIN unnest($1::text[], $2::text[]) AS want(typ, id)
+		  ON a.knowledge_type = want.typ AND a.knowledge_id = want.id
+		ORDER BY a.knowledge_type, a.knowledge_id, a.name`, ts, ids)
+	if err != nil {
+		return nil, err
+	}
+	out := map[string][]domain.Attachment{}
+	for rows.Next() {
+		var typ, id string
+		var a domain.Attachment
+		if err := rows.Scan(&typ, &id, &a.Name, &a.MediaType, &a.Size, &a.SHA256, &a.OKFPath,
+			&a.CreatedBy.Kind, &a.CreatedBy.Name, &a.CreatedAt); err != nil {
+			return nil, err
+		}
+		out[typ+"/"+id] = append(out[typ+"/"+id], a)
+	}
+	return out, rows.Err()
+}
+
+// GetAttachmentMeta returns one attachment's metadata without touching
+// the blob store — enough to answer a conditional GET (the ETag is the
+// content hash) before deciding whether the bytes are needed.
+func (s *Store) GetAttachmentMeta(ctx context.Context, typ domain.Type, id, name string) (*domain.Attachment, error) {
+	rows, err := s.pool.Query(ctx, `SELECT `+attachmentCols+`
+		FROM attachment a
+		JOIN blob b ON b.sha256 = a.sha256
+		JOIN knowledge k ON k.type = a.knowledge_type AND k.id = a.knowledge_id AND k.deleted_at IS NULL
+		WHERE a.knowledge_type=$1 AND a.knowledge_id=$2 AND a.name=$3`, typ, id, name)
+	if err != nil {
+		return nil, err
+	}
+	att, err := pgx.CollectExactlyOneRow(rows, scanAttachment)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &att, nil
+}
+
 // DeleteAttachment removes the entry→blob mapping. The blob itself stays:
 // revisions still name its hash, and content-addressed rows are cheap.
 func (s *Store) DeleteAttachment(ctx context.Context, typ domain.Type, id, name string, actor domain.Actor) error {

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -5,11 +5,12 @@
      deployed — both proxy /api/v1 to ochakai; design doc 0006) and it
      covers the human-facing API surface — search, folder browsing,
      entry details with usage, revision history, backlinks, attachments,
-     create/edit with the draft → verified workflow, the draft review
-     queue (sort=usage), SQL compilation (a Compile tab on metric
-     entries), Ossie model import (on the new-entry page), and
-     OKF export. (/api/v1/context is an agent surface — see
-     api/openapi.yaml.) A starting point for building your own UI. -->
+     create/edit with the draft → verified workflow (behind Explore's
+     “＋ New entry” button), the draft review queue (sort=usage), SQL
+     compilation (a Compile tab on metric entries), Ossie model import
+     (on the new-entry page), and OKF export. (/api/v1/context is an
+     agent surface — see api/openapi.yaml.) A starting point for
+     building your own UI. -->
 <html lang="en">
 <head>
 <meta charset="utf-8">
@@ -159,6 +160,12 @@
     padding: .85rem 1.1rem; margin: 0 0 .7rem; box-shadow: var(--shadow);
   }
   .card:hover { box-shadow: var(--shadow-hover); border-color: color-mix(in srgb, var(--accent) 45%, var(--border)); }
+  .card[data-href] { cursor: pointer; }
+  .card .thumbs { display: flex; gap: .5rem; margin-top: .55rem; flex-wrap: wrap; }
+  .card .thumbs img {
+    height: 4.5rem; max-width: 11rem; object-fit: cover;
+    border: 1px solid var(--border); border-radius: 6px; background: var(--code-bg);
+  }
   .card .head { display: flex; align-items: center; gap: .55rem; flex-wrap: wrap; }
   .card .head a.title { font-weight: 600; font-size: 1.02rem; color: var(--text); }
   .card .head a.title:hover { color: var(--accent-strong); }
@@ -299,7 +306,6 @@
     <a href="#/" data-route="explore">Explore</a>
     <a href="#/browse" data-route="browse">Browse</a>
     <a href="#/review" data-route="review">Review</a>
-    <a href="#/new" data-route="new">New entry</a>
   </nav>
   <span class="spacer"></span>
   <a class="btn small" id="export-link" title="Download the knowledge base as an OKF bundle (tar.gz)">Export OKF</a>
@@ -474,9 +480,12 @@ function route() {
     mark('explore');
     viewDetail(decodeURIComponent(rest[0]), rest.slice(1).map(decodeURIComponent).join('/'));
   } else if (head === 'edit' && rest.length >= 2) {
+    mark('explore');
     viewEditor(decodeURIComponent(rest[0]), rest.slice(1).map(decodeURIComponent).join('/'));
   } else if (head === 'new') {
-    mark('new');
+    // New entry lives behind Explore's “＋ New entry” button, not a
+    // top-level tab — creating knowledge is part of exploring it.
+    mark('explore');
     viewEditor(null, null);
   } else if (head === 'browse') {
     mark('browse');
@@ -490,6 +499,18 @@ function route() {
   }
 }
 window.addEventListener('hashchange', route);
+
+// Result cards navigate on a click anywhere in them, not just the title.
+// A click on a control (link, button, form field) keeps its own behavior,
+// a click that selected text (copying the SQL or the ochakai:// URI) is
+// not a navigation, and the title stays a real link for keyboard tabbing
+// and open-in-new-tab.
+view.addEventListener('click', e => {
+  const card = e.target.closest('.card[data-href]');
+  if (!card || e.target.closest('a, button, input, textarea, select, label, summary')) return;
+  if (getSelection().toString()) return;
+  location.hash = card.dataset.href;
+});
 
 /* ============================== explore ============================== */
 
@@ -535,13 +556,14 @@ function viewExplore() {
       </details>
     </aside>
     <section>
-      ${explore.staleFeed
-        ? `<div class="feed-banner">Verification-age feed — oldest verified first, the canary list for
-           re-checking golden queries. Uncheck <strong>verification age</strong> to search.</div>`
-        : `<div class="searchbox">
-             <input type="text" id="q" placeholder="Search metrics, golden queries, insights, terms, tables…"
-                    value="${esc(explore.q)}" autocomplete="off">
-           </div>`}
+      <div class="searchbox">
+        ${explore.staleFeed
+          ? `<div class="feed-banner" style="flex:1;margin-bottom:0">Verification-age feed — oldest verified first,
+             the canary list for re-checking golden queries. Uncheck <strong>verification age</strong> to search.</div>`
+          : `<input type="text" id="q" placeholder="Search metrics, golden queries, insights, terms, tables…"
+                    value="${esc(explore.q)}" autocomplete="off">`}
+        <a class="btn" href="#/new" title="Create a knowledge entry, or import an Ossie semantic model">＋ New entry</a>
+      </div>
       <div id="results"><div class="empty">…</div></div>
     </section>
   </div>`;
@@ -627,6 +649,18 @@ async function runSearch() {
   }
 }
 
+// Image attachments as small previews on a result card. The metadata
+// rides along on REST hits; the bytes are separate GETs the browser
+// caches (ETag revalidation — repeat renders cost a 304, not a
+// re-download).
+function cardThumbs(h) {
+  const imgs = (h.attachments || []).filter(a => (a.media_type || '').startsWith('image/')).slice(0, 4);
+  if (!imgs.length) return '';
+  const src = a => baseURL() + '/api/v1/attachments/' + idPath(h.type, h.id) + '/' + encodeURIComponent(a.name);
+  return `<div class="thumbs">${imgs.map(a =>
+    `<img src="${src(a)}" alt="${esc(a.name)}" title="${esc(a.name)}" loading="lazy">`).join('')}</div>`;
+}
+
 function hitCard(h) {
   const tags = (h.tags || []).map(t => `<span class="tag">${esc(t)}</span>`).join(' ');
   const who = actorStr(h.status === 'verified' ? h.verified_by || h.created_by : h.created_by);
@@ -636,7 +670,7 @@ function hitCard(h) {
     h.verified_at ? 'verified ' + esc(fmtDate(h.verified_at)) : (h.updated_at ? 'updated ' + esc(fmtDate(h.updated_at)) : ''),
   ].filter(Boolean).join(' · ');
   const sql = h.attrs && h.attrs.sql ? `<pre>${esc(h.attrs.sql)}</pre>` : '';
-  return `<article class="card">
+  return `<article class="card" data-href="${entryHash(h)}">
     <div class="head">
       <span class="type-ico" title="${esc(h.type)}">${icon(h.type)}</span>
       <a class="title" href="${entryHash(h)}">${esc(h.title)}</a>
@@ -646,6 +680,7 @@ function hitCard(h) {
     <div class="meta">${meta}</div>
     ${h.description ? `<div class="desc">${esc(h.description)}</div>` : ''}
     ${sql}
+    ${cardThumbs(h)}
   </article>`;
 }
 
@@ -1110,7 +1145,7 @@ function reviewCard(h) {
     usageBits,
     outcomeBits,
   ].filter(Boolean).join(' · ');
-  return `<article class="card" data-type="${esc(h.type)}" data-id="${esc(h.id)}">
+  return `<article class="card" data-type="${esc(h.type)}" data-id="${esc(h.id)}" data-href="${entryHash(h)}">
     <div class="head">
       <span class="type-ico" title="${esc(h.type)}">${icon(h.type)}</span>
       <a class="title" href="${entryHash(h)}">${esc(h.title)}</a>
@@ -1124,6 +1159,7 @@ function reviewCard(h) {
     </div>
     <div class="meta">${meta}</div>
     ${h.description ? `<div class="desc">${esc(h.description)}</div>` : ''}
+    ${cardThumbs(h)}
   </article>`;
 }
 


### PR DESCRIPTION
Three Explore-tab experience fixes, from using the UI:

## What changed

**Whole-card click.** Result cards navigated only via their title link — there was no recorded intent behind that, just the simple default, but cards contain selectable text (SQL, `ochakai://` URIs) and, in the Review queue, Verify/Reject buttons, so wrapping the card in an anchor was never an option. Instead a delegated listener navigates on clicks anywhere in a card while clicks on controls and text selections keep their own behavior; the title stays a real link for keyboard tabbing and open-in-new-tab. Applies to Explore and Review cards.

**New entry folded into Explore.** The top-level New entry tab is gone; creating lives behind a "＋ New entry" button next to Explore's search box. `#/new` and `#/edit` keep working (Ossie import included) and highlight the Explore tab while open.

**Attachment thumbnails on cards.** REST hit lists (search, both feeds, backlinks) now carry attachment metadata, filled in one batch query (`Service.FillAttachments` / `Store.ListAttachmentsBatch`); cards render image attachments as small lazy-loaded thumbnails. MCP search results deliberately stay lean — agent context is not the place for attachment metadata (design doc 0015).

## Cost control for the thumbnails

Attachment GETs now answer conditional requests from metadata alone: the ETag is the content hash, a matching `If-None-Match` gets a 304 with **no blob-store read**, and `Cache-Control: private, no-cache` makes clients revalidate every time (names are mutable — replace-by-name). Repeat renders cost a headers-only round trip, so the GCS/egress impact of thumbnails is first-view-only. A 304 revalidation no longer records a usage fetch — a cache check is not a use of the knowledge.

## Reviewer notes

- `SearchHit` already embedded `Knowledge` (with `attachments`) in the OpenAPI schema; the server just never populated it on lists. This fills it on the REST surface only.
- First thumbnail loads do record usage fetches, same as the detail view's Attachments tab always has.
- Verified against real PostgreSQL: new `TestRESTIntegrationAttachments` covers metadata-carrying hits, the 304 path, and the stale-hash 200 path. Also exercised end-to-end in a browser (card click, Review buttons, thumbnails, browser-side revalidation: second fetch transfers ~300 bytes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)