### PR TITLE
Web UI: 0023 の型改名で取り残された比較を新語彙に合わせる

### DIFF
--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -433,8 +433,6 @@ function esc(s) {
     ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
 }
 
-// Keys mirror domain.Types (the plural built-in slugs, design doc 0016),
-// in the same display order.
 // Keys are the OKF type vocabulary, which is what the server stores
 // (design doc 0023). Lookup is case-insensitive to match the server's
 // filter matching — the stored spelling is whatever the writer used.
@@ -442,6 +440,10 @@ const TYPE_ICONS = { 'Semantic Model': '🧩', 'Metric': '📊', 'Golden Query':
 const ICON_BY_LOWER = new Map(Object.entries(TYPE_ICONS).map(([k, v]) => [k.toLowerCase(), v]));
 const icon = t => ICON_BY_LOWER.get(String(t ?? '').trim().toLowerCase()) || '📄';
 const KNOWN_TYPES = Object.keys(TYPE_ICONS);
+// Mirrors domain.EqualType: two types name the same kind regardless of
+// case or surrounding space, since the stored spelling is the writer's.
+const sameType = (a, b) =>
+  String(a ?? '').trim().toLowerCase() === String(b ?? '').trim().toLowerCase();
 const STATUSES = ['draft', 'verified', 'deprecated', 'rejected'];
 
 function fmtDate(s) {
@@ -1144,14 +1146,14 @@ async function viewDetail(id) {
 
   const tags = (entry.tags || []).map(t => `<span class="tag">${esc(t)}</span>`).join(' ');
   const atts = entry.attachments || [];
-  // Metrics are the compilable knowledge, so their detail view gets a
-  // Compile tab instead of a site-wide compile page. The compiler matches
+  // Metric entries are the compilable knowledge, so their detail view gets
+  // a Compile tab instead of a site-wide compile page. The compiler matches
   // metrics by their semantic-model name — conventionally the entry id's
-  // last segment (design doc 0018 §4.4) — and the model (a models entry
-  // id) is seeded from attrs.model when present; left blank, the server
-  // resolves it from the models entry defining the metric (design doc
-  // 0019).
-  const compilable = entry.type === 'metrics';
+  // last segment (design doc 0018 §4.4) — and the model (a Semantic Model
+  // entry id) is seeded from attrs.model when present; left blank, the
+  // server resolves it from the Semantic Model entry defining the metric
+  // (design doc 0019).
+  const compilable = sameType(entry.type, 'Metric');
   const cstate = compilable ? {
     metrics: entry.id.split('/').pop(),
     model: typeof (entry.attrs || {}).model === 'string' ? entry.attrs.model : '',
@@ -1580,7 +1582,7 @@ function wireReviewActions(container) {
 // in the tree routes here as #/new/<prefix>/.
 async function viewEditor(id, prefix = '') {
   const editing = id !== null;
-  let entry = { type: 'insights', id: prefix, title: '', description: '', tags: [], status: 'draft', status_note: '', links: [], attrs: {}, body: '' };
+  let entry = { type: 'Insight', id: prefix, title: '', description: '', tags: [], status: 'draft', status_note: '', links: [], attrs: {}, body: '' };
   if (editing) {
     try {
       entry = await api('/api/v1/knowledge/' + idPath(id));
@@ -1725,10 +1727,10 @@ async function viewEditor(id, prefix = '') {
 
 /* ============================== compile ============================== */
 
-// The compile form renders inside the Compile tab of a metric's detail
-// view (metrics are the compilable knowledge; the model resolves via the
-// metric's attrs.model). State is per-view, seeded from the metric, and
-// written back on every input so it survives tab switches.
+// The compile form renders inside the Compile tab of a Metric entry's
+// detail view (metrics are the compilable knowledge; the model resolves
+// via the metric's attrs.model). State is per-view, seeded from the
+// metric, and written back on every input so it survives tab switches.
 function compileFormHTML(c) {
   return `
     <form class="form" id="compile-form">
@@ -1740,7 +1742,7 @@ function compileFormHTML(c) {
         </div>
         <div class="field">
           <label class="top" for="c-model">Model</label>
-          <input type="text" id="c-model" class="mono" value="${esc(c.model)}" placeholder="models/… (optional — resolved from the models entry defining the metric)">
+          <input type="text" id="c-model" class="mono" value="${esc(c.model)}" placeholder="models/… (optional — resolved from the Semantic Model entry defining the metric)">
         </div>
       </div>
       <div class="field">


### PR DESCRIPTION
design doc 0023 の型語彙統一(#96)で内部スラグを OKF の綴りに改めた際、Web UI に旧スラグとの比較が2箇所残っていた。

## 直したもの

**Compile タブが出ない(報告されたバグ)** — `internal/webui/index.html`

```js
const compilable = entry.type === 'metrics';   // 0023 以降このスラグは存在しない
```

保存される型が `Metric` になったため常に false になり、Metric の詳細ページで Compile タブが描画されなくなっていた。同 commit で `icon()` に入れた大小文字非依存の照合に揃える。`domain.EqualType` と同じ意味を持つ比較がこれで2箇所目になったので、その場に `.toLowerCase()` を書かず `sameType` ヘルパーを `icon()` の隣に切り出した。

**新規作成フォームが自由型を作っていた(同じ走査で見つかったもの)**

作成フォームの初期値が `type: 'insights'` のままだった。0023 で `ValidType` が「1行・`/` を含まない・128バイト以内」に緩んだためエラーにはならず、**自由型 `insights`** のエントリが黙って作られていた — アイコンが付かず、ファセットのチップも `Insight` とは別建てになる。Compile の判定が見落とされたのと同じ理由で取り残されていた。

**コメント・表示文言** — TYPE_ICONS 上に残っていた 0016 時点のコメント(0023 が置き換えたときの消し忘れ)と、"a models entry" / "a metric's" のように型名を旧スラグで書いていた説明文・placeholder を新語彙に直した。

## あえて触らなかったもの

- 非 UI 側に残る小文字(`internal/apiclient/types.go` の `json:"metrics"`、`internal/compiler/model.go` の `datasets` / `metrics`)は compile リクエストと Ossie spec の**フィールド名**であって型の値ではない。語彙が違うので改名対象外。compile フォームの placeholder にある `models/…` も同様に**エントリ ID** で、0017 でパスは ID からのみ決まるようになっており型の綴りとは無関係。
- `index.html:668` の `KNOWN_TYPES.includes(t)`(ファセットで既知型と自由型を分ける判定)は大小文字を区別する同種の比較だが、書き込みは `CanonicalType` を通るため保存済みの推奨型の綴りは常に正規形で、現状チップが重複することはない。サービス層を迂回して投入する経路ができたら `sameType` に寄せるべき箇所。

## レビュアーへ

検証は `go build ./...` と `go test ./...` が通ることまで。**Compile タブ自体はブラウザで確認していない** — この HTML を覆うテストが無く、今回の判定も含めて Web UI のロジックは自動検証の外にある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)