### PR TITLE
Web UI: 本文のエントリ間リンクをリンクとして描画する

### DIFF
--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -506,19 +506,40 @@ function crumbTrail(dirs, leaf) {
 // resolveImg maps an image reference from the body to a URL (the detail
 // view resolves entry-relative references to attachment URLs); references
 // it cannot resolve stay literal text rather than rendering broken images.
-function md(src, resolveImg) {
+// resolveEntry does the same for links to other entries — the edges the
+// server derives from this very text (design doc 0024) — returning a
+// route or null.
+function md(src, resolveImg, resolveEntry) {
   const lines = String(src ?? '').split('\n');
   let out = '', inCode = false, inList = null, para = [];
   const img = (m, alt, ref) => {
     const url = /^https?:/.test(ref) ? ref : resolveImg && resolveImg(ref);
     return url ? `<img src="${url}" alt="${alt}" loading="lazy">` : m;
   };
-  const inline = s => esc(s)
-    .replace(/`([^`]+)`/g, '<code>$1</code>')
+  // An http(s) target leaves the app; anything else is a bundle reference,
+  // and becomes a link exactly when it names an entry.
+  const link = (m, text, ref) => {
+    if (/^https?:/.test(ref)) return `<a href="${ref}" target="_blank" rel="noopener">${text}</a>`;
+    const route = resolveEntry && resolveEntry(ref);
+    return route ? `<a href="${route}">${text}</a>` : m;
+  };
+  // Everything after the code-span pass is applied outside <code> only:
+  // markup shown as an example is text, not markup. That is also the rule
+  // the server's link extraction follows (design doc 0024), so what reads
+  // as a link here is exactly what became an edge there.
+  const outsideCode = (html, fn) =>
+    html.split(/(<code>[\s\S]*?<\/code>)/).map((part, i) => i % 2 ? part : fn(part)).join('');
+  const inline = s => outsideCode(esc(s).replace(/`([^`]+)`/g, '<code>$1</code>'), t => t
     .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
     .replace(/(^|\W)\*([^*\n]+)\*(?=\W|$)/g, '$1<em>$2</em>')
     .replace(/!\[([^\]]*)\]\(([^)\s]+)\)/g, img)
-    .replace(/\[([^\]]+)\]\((https?:[^)\s]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>');
+    .replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, link)
+    // Bare and autolinked ochakai:// references, which carry no anchor
+    // text and read as the target's last segment.
+    .replace(/(?:&lt;)?(ochakai:\/\/[^\s&<>()[\]"']+)(?:&gt;)?/g, (m, uri) => {
+      const route = resolveEntry && resolveEntry(uri);
+      return route ? `<a href="${route}">${uri.split('/').pop()}</a>` : m;
+    }));
   const flushPara = () => { if (para.length) { out += '<p>' + inline(para.join(' ')) + '</p>'; para = []; } };
   const flushList = () => { if (inList) { out += `</${inList}>`; inList = null; } };
   for (const line of lines) {
@@ -1239,11 +1260,29 @@ async function viewDetail(id) {
     hit = hit || atts.find(a => a.name === ref.split('/').pop());
     return hit ? attURL(hit.name) : null;
   };
+  // Links to other entries, resolved the way the server derives them from
+  // this same body (design doc 0024): bundle-absolute "/x/y.md", relative
+  // "./y.md" against the document's directory, or the canonical URI. A
+  // reference to anything else — an attachment, an external URL, an
+  // anchor — is not an entry link and stays literal text.
+  const resolveEntry = ref => {
+    const target = String(ref).split(/[#?]/)[0];
+    if (!target) return null;
+    let id;
+    if (target.startsWith('ochakai://')) id = normalize(target.slice('ochakai://'.length));
+    else if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(target)) return null; // some other scheme
+    else if (!target.endsWith('.md')) return null; // an attachment, not an entry
+    else {
+      const rel = target.slice(0, -'.md'.length);
+      id = normalize(rel.startsWith('/') ? rel : (docDir ? docDir + '/' : '') + rel);
+    }
+    return id ? '#/k/' + idPath(id) : null;
+  };
 
   const tabs = {
     overview: () => `
       ${entry.description ? `<p style="font-size:1.02rem">${esc(entry.description)}</p>` : ''}
-      ${entry.body ? `<div class="md">${md(entry.body, resolveImg)}</div>` : ''}
+      ${entry.body ? `<div class="md">${md(entry.body, resolveImg, resolveEntry)}</div>` : ''}
       ${!entry.description && !entry.body ? '<div class="empty">No description or body.</div>' : ''}`,
     attrs: () => {
       const attrs = entry.attrs || {};


### PR DESCRIPTION
## 背景

[#100](https://github.com/na0fu3y/ochakai/pull/100)(設計 0024)で本文の markdown リンクがエントリ間の関係になりましたが、**Web UI の markdown レンダラはリンク規則が `https?:` 限定のまま**でした。

```js
.replace(/\[([^\]]+)\]\((https?:[^)\s]+)\)/g, ...)
```

そのため `[about](/metrics/revenue.md)` も裸の `ochakai://metrics/avg_order_value` も、ただの文字列として表示されていました。Links タブには出るのに本文中では素通しという状態です。本文がリンクの唯一の出所になった以上、**本文中でそれがリンクに見えないのは筋が通りません**。

## 変更

- `md()` に `resolveEntry` を渡し、以下を `#/k/<id>` に解決する:

  | 記法 | 表示 |
  |---|---|
  | `[about](/metrics/revenue.md)` | `about` |
  | `[粗利](./gross.md)` | `粗利`(エントリ自身のディレクトリ基準) |
  | `[単価](ochakai://metrics/avg_order_value)` | `単価` |
  | `<ochakai://metrics/revenue>` | `revenue`(最終セグメント) |
  | 裸の `ochakai://metrics/revenue` | `revenue` |

  解決規則はサーバの `domain.LinksFromBody` と同じで、相対解決は既存の `resolveImg` が使っている `normalize` を流用しています。

- `http(s)` は従来どおり `target=_blank` の外部リンク。`.md` 以外のファイル参照(添付)と他スキームは解決せず、これまでどおり文字列のまま

- **インラインコード内の markdown を描画しないよう修正。** `` `[about](/x.md)` `` がリンクになるのは以前からあったバグですが、0024 でサーバがコード内をエッジとして拾わないと決めた以上、**表示と抽出が食い違う**ことになります。コードスパン外だけに強調・画像・リンクを適用するよう `inline()` を組み替えました。

## 検証

ローカルの UI(`ochakai ui`)に全記法を含む本文を投入し、ブラウザで確認:

- **サーバが導出した 6 本のリンクと、本文中でリンクとして描画される 6 本(外部リンクを除く)が一致**
- インラインコードとフェンス内は文字列のまま(`[about](/metrics/revenue.md)` が literal で残る)
- 未作成エントリへのリンク(dangling)もリンクとして描画 — クリックすると既存の "Could not load" が出る。サーバが dangling を許容する以上これで整合します
- 添付参照 `[csv](linkdemo/rows.csv)` は文字列のまま
- **裸の `ochakai://metrics/avg_order_value` をクリックして当該エントリに遷移することを確認**

## 注記

解決規則がサーバ(Go)とクライアント(JS)の二箇所に存在することになります。API は `links` を返しますが本文中の位置を持たないため、描画には構文的な再解決が要ります。規則自体は小さく 0024 に明文化されているので、当面はこの重複を受け入れる判断です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)