### PR TITLE
型フィルタを大小文字非依存で照合する(設計ドキュメント 0023 §3.3)

### DIFF
--- a/internal/domain/knowledge.go
+++ b/internal/domain/knowledge.go
@@ -39,7 +39,8 @@ const (
 var Types = []Type{TypeModels, TypeMetrics, TypeQueries, TypeInsights, TypeTerms, TypeDatasets, TypeTables, TypeReferences}
 
 // BuiltinType reports whether t is one of the recommended types, matched
-// the same case-insensitive way filters are (EqualType).
+// case-insensitively (EqualType), the same way search filters match
+// (FoldType).
 func BuiltinType(t Type) bool {
 	for _, v := range Types {
 		if EqualType(t, v) {
@@ -83,7 +84,23 @@ func ValidType(t Type) bool {
 // "bigquery table" finds entries stored as "BigQuery Table"; the stored
 // spelling is always the one the writer used.
 func EqualType(a, b Type) bool {
-	return strings.EqualFold(strings.TrimSpace(string(a)), strings.TrimSpace(string(b)))
+	return FoldType(a) == FoldType(b)
+}
+
+// FoldType returns the comparison key for t: NFC-normalized, trimmed, and
+// lowercased. It is the matching half of design doc 0023 §3.3 ("照合は
+// 大小文字非依存、保存は原表記") in the form storage needs — a value to
+// compare against a folded column, rather than the pairwise EqualType.
+// Free types fold too: §3.3 widens the tolerance to every entry point and
+// every comparison, not just the recommended eight.
+//
+// The store folds the column with SQL lower(), which agrees with this for
+// ASCII and for the ordinary cased letters types are written in. The two
+// can disagree on exotic Unicode case pairs (final sigma, dotted I under a
+// Turkish collation); a type that hinges on those is beyond what either
+// side promises.
+func FoldType(t Type) string {
+	return strings.ToLower(strings.TrimSpace(Normalize(string(t))))
 }
 
 // Status is the verification status of a knowledge entry. deprecated means

--- a/internal/domain/knowledge_test.go
+++ b/internal/domain/knowledge_test.go
@@ -190,6 +190,26 @@ func TestTypeMatchingIsCaseInsensitive(t *testing.T) {
 	}
 }
 
+// FoldType is the same rule in the form the store needs: one comparison
+// key per kind, so a filter can be matched against a folded column.
+func TestFoldType(t *testing.T) {
+	if got := FoldType("  BigQuery Table "); got != "bigquery table" {
+		t.Errorf("FoldType = %q, want %q", got, "bigquery table")
+	}
+	// Free types fold too — the tolerance is not limited to the built-ins.
+	if FoldType("DATA CONTRACT") != FoldType("Data Contract") {
+		t.Error("FoldType must fold a free type")
+	}
+	if FoldType("BigQuery Tables") == FoldType(TypeTables) {
+		t.Error("FoldType must keep distinct types distinct")
+	}
+	// The key is NFC, matching how the write path stores the type, so a
+	// decomposed filter still lands on the stored row (design doc 0022).
+	if FoldType("\u30bf\u3099") != FoldType("\u30c0") { // decomposed vs composed
+		t.Error("FoldType must normalize to NFC")
+	}
+}
+
 func TestToTypesAndToStatuses(t *testing.T) {
 	types := ToTypes([]string{"Metric", "custom-type"})
 	if len(types) != 2 || types[0] != TypeMetrics || types[1] != Type("custom-type") {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -162,9 +162,11 @@ func (s *Service) applyVerification(k *domain.Knowledge, old *domain.Knowledge, 
 // normalizeKeys rewrites a write payload's byte-compared keys — the id
 // and the type — into NFC (design doc 0022); content fields are kept as
 // written. The type joined them in 0023: it is free text now, so a
-// foreign bundle can carry a non-ASCII type, and it is compared byte-wise
-// behind search filters. A recommended type also settles on its canonical
-// spelling, so storage holds one casing.
+// foreign bundle can carry a non-ASCII type, and search filters compare
+// against it. Filters fold case themselves (domain.FoldType), but not
+// width or accent composition — so the type is stored NFC and trimmed,
+// leaving lower() enough to fold the column. A recommended type also
+// settles on its canonical spelling, so storage holds one casing.
 //
 // Links are not normalized here because they are not read from the
 // payload at all — deriveLinks recomputes them from the body, normalizing

--- a/internal/store/filter_test.go
+++ b/internal/store/filter_test.go
@@ -1,0 +1,40 @@
+package store
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/na0fu3y/ochakai/internal/domain"
+)
+
+// Type filters match case-insensitively (design doc 0023 §3.3). This is the
+// DB-free half of that guarantee: the column is folded in SQL and the
+// arguments are folded in Go, so neither side can drift back to a byte
+// comparison. TestIntegration covers the same rule against real rows.
+func TestBuildWhereFoldsTypes(t *testing.T) {
+	where, args := Filter{Types: []domain.Type{"BigQuery Table", "  METRIC  "}}.buildWhere("k.")
+
+	if !strings.Contains(where, "lower(k.type) = ANY($1)") {
+		t.Errorf("type condition must fold the column, got %q", where)
+	}
+	if strings.Contains(where, "k.type = ANY") {
+		t.Errorf("type condition must not compare raw bytes, got %q", where)
+	}
+	want := []string{"bigquery table", "metric"}
+	if len(args) == 0 || !reflect.DeepEqual(args[0], want) {
+		t.Errorf("type args = %#v, want %#v", args, want)
+	}
+}
+
+// A free type folds too: §3.3 widens the tolerance to every comparison,
+// not just the recommended eight, so the fix cannot be a CanonicalType
+// lookup on the read path.
+func TestBuildWhereFoldsFreeTypes(t *testing.T) {
+	_, args := Filter{Types: []domain.Type{"DATA CONTRACT"}}.buildWhere("")
+
+	want := []string{"data contract"}
+	if len(args) == 0 || !reflect.DeepEqual(args[0], want) {
+		t.Errorf("free type args = %#v, want %#v", args, want)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -559,8 +559,15 @@ func (f Filter) buildWhere(prefix string) (string, []any) {
 	conds := []string{prefix + "deleted_at IS NULL"}
 	var args []any
 	if len(f.Types) > 0 {
-		args = append(args, f.Types)
-		conds = append(conds, fmt.Sprintf("%stype = ANY($%d)", prefix, len(args)))
+		// Types match case-insensitively (design doc 0023 §3.3): the stored
+		// spelling is whatever the writer used, so both sides fold. There is
+		// no index on type, so lower() costs nothing here.
+		folded := make([]string, len(f.Types))
+		for i, t := range f.Types {
+			folded[i] = domain.FoldType(t)
+		}
+		args = append(args, folded)
+		conds = append(conds, fmt.Sprintf("lower(%stype) = ANY($%d)", prefix, len(args)))
 	}
 	if len(f.Statuses) > 0 {
 		args = append(args, f.Statuses)

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -114,6 +114,46 @@ func TestIntegration(t *testing.T) {
 		t.Errorf("status=rejected filter should return the rejected entry: %+v", only)
 	}
 
+	// Type filters match case-insensitively while storage keeps the written
+	// spelling (design doc 0023 §3.3). Typing a type with spaces at a shell
+	// is the burden this is meant to relieve, so it has to hold for a free
+	// type too — not only for the recommended eight, which the write path
+	// canonicalizes anyway.
+	free := &domain.Knowledge{
+		Type: "Data Contract", ID: "it-contract", Title: "売上契約",
+		Description: "統合テスト用", Status: domain.StatusVerified,
+		CreatedBy: domain.Actor{Kind: "human", Name: "test"},
+	}
+	if err := s.Create(ctx, free); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		typ  domain.Type
+		want string
+	}{
+		{"Metric", k.ID}, {"metric", k.ID}, {"METRIC", k.ID},
+		{"Data Contract", free.ID}, {"data contract", free.ID}, {"DATA CONTRACT", free.ID},
+	} {
+		hits, err := s.SearchLexical(ctx, "売上", Filter{Types: []domain.Type{tc.typ}}, 10)
+		if err != nil {
+			t.Fatalf("SearchLexical(type=%q): %v", tc.typ, err)
+		}
+		found := false
+		for _, h := range hits {
+			found = found || h.ID == tc.want
+		}
+		if !found {
+			t.Errorf("type=%q must find %q, got %d hits", tc.typ, tc.want, len(hits))
+		}
+	}
+	// A type that only differs by case must not be stored as a second
+	// spelling by this test's own writes.
+	if got, err := s.Get(ctx, free.ID); err != nil {
+		t.Fatal(err)
+	} else if got.Type != "Data Contract" {
+		t.Errorf("stored spelling = %q, want the spelling as written", got.Type)
+	}
+
 	// Usage recording: raw events plus running totals.
 	actor := domain.Actor{Kind: "agent", Name: "claude-code"}
 	target := []string{k.ID}


### PR DESCRIPTION
## 何を直したか

型フィルタが保存済みの綴りと**バイト厳密比較**していたため、大小文字だけ違うフィルタが 0 件を返していた。v0.12.0 の ochakai-example で実地確認した症状:

    GET /api/v1/knowledge?type=Metric  -> 2 hits
    GET /api/v1/knowledge?type=metric  -> 0 hits   ← 保存は "Metric"
    GET /api/v1/knowledge?type=METRIC  -> 0 hits

## なぜ

設計ドキュメント 0023 §3.3「照合は大小文字非依存、保存は原表記」は照合の寛容さを**すべての入口と照合**に約束しているが、書き込み側(`CanonicalType` / NFC 正規化)だけが実装され、**読み取り側のフィルタ経路が素通し**だった。型に空白が入った 0023 では、この緩和は CLI で空白入りの型を打つ負担への実質的な救済でもあり、実用上そこそこ重要。

## どう直したか

修正は `store.buildWhere` 1 箇所。`Filter` を取る 6 つのクエリはすべてここを通る(`Browse` は `Filter` を取らないので対象外)。

- **`domain.FoldType` を追加**(NFC + トリム + 小文字化)= 照合の一意な鍵。`EqualType` もこれ経由に統一し「同じ型」の定義を 1 つにした。
- **`buildWhere` を `lower(type) = ANY(...)`** に変更、引数側も `FoldType` で畳む。型に索引は無いので `lower()` のコストは無い。
- 推奨 8 型だけでなく**自由型も畳む**。`ToTypes`→`CanonicalType` 案だと `Data Contract` 保存に対し `data contract` が依然ミスする — §3.3 が救済しようとした「補完の効かない自由型」こそ落ちてしまうため、読み取り経路で畳む方を採った。保存される綴りは書かれたまま不変。
- フィルタ経路が **NFC 正規化していなかった §3.2 の抜け**も同時に解消(保存側が既に NFC+トリムなので SQL の `lower()` で足りる)。

## レビューで見てほしい点

- **Go `ToLower` と Postgres `lower()` の不一致**: ASCII と型に使う通常の綴りでは一致するが、特殊な Unicode 大小文字対(語末シグマ、トルコ語ロケール下の I)ではズレうる。関数索引や畳み列は過剰と判断し、コメントで明記するに留めた。判断に異論があれば。
- **コメント修正**: `knowledge.go:42` に加え、`service.go` の `normalizeKeys` が「型はバイト厳密比較される」と主張していた記述(修正前は正しく、いまは誤り)も直した。
- 設計ドキュメント 0023 自体は変更していない。挙動が §3.3 の約束に追いついただけ。自由型を畳む読み方を doc に明記したい場合は言ってほしい。

## テスト

現状これを守るテストが無かったので追加した:

- `internal/store/filter_test.go` — DB 無しで SQL 形状を固定(バイト比較へ逆戻りさせない)
- `internal/store/store_integration_test.go` — 実 DB で `Metric`/`metric`/`METRIC` と `Data Contract`/`data contract`/`DATA CONTRACT` を検証、保存の綴りが不変であることも確認
- `internal/domain/knowledge_test.go` — `FoldType`(自由型・NFC 含む)

いずれも旧コードに対して報告どおりの 0 件を再現することを確認済み。CI は pgvector 付きで統合テストを走らせるので両方ゲートされる。`go test -race ./...` 全緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)