### PR TITLE
README: ドメイン符号化の労働は誰がやるか — ochakai の賭けを明文化する

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,11 +117,8 @@ for what they still don't do:
   tribal knowledge that never fits in a semantic-model YAML and today
   travels by Slack. Your agent gets it in the same search that returns
   the metric definition.
-- **A write-back loop with a memory.** The division of labor is the whole
-  design: agents draft the breadth (the cheap, always-on encoding of what
-  they learn), and a human verifies the judgment-heavy core — the same
-  "agents draft, humans verify" split that keeps a knowledge base from
-  rotting into a graveyard. Entries start as drafts and a human promotes
+- **A write-back loop with a memory.** Agents are encouraged to write
+  learnings back; entries start as drafts and a human promotes
   them to `verified`, with provenance (who wrote it, who verified it,
   when) on every entry and every change kept as a revision. Proposals that
   don't make it are kept as `rejected` with the reason, so agents stop
@@ -134,6 +131,20 @@ for what they still don't do:
   entry rises in a *re-verification* feed (`sort=failed`) for a human or
   agent to re-check, instead of the next agent trusting the same entry
   blind (design doc 0025).
+- **No forward-deployed engineers, by design.** Encoding what your data
+  means is labor, and it doesn't vanish — the only question is *who* does
+  it. Palantir's answer is forward-deployed engineers who hand-build an
+  ontology on-site; the dbt and warehouse-native answer is self-serve,
+  folding curation into the engineering workflow that already ships the
+  data. ochakai's bet is a third path: the agent *is* the forward-deployed
+  labor — it drafts the breadth every time it learns something — and a
+  human verifies the judgment-heavy core, which is what keeps a knowledge
+  base from rotting into a stale, confidently-wrong graveyard. No FDE army
+  and no dedicated data steward: the smallest team that sustains a living
+  knowledge base is one reviewer already in the loop, with the gate built
+  into the workflow they already run — the bundled
+  [hooks](examples/claude-code) and the CI
+  [canary](docs/guides/golden-query-canary.md).
 - **Not a memory layer — the other half of one.** Memory layers (mem0,
   Zep, Letta) auto-extract per-user memories with an LLM and inject them
   back, unaudited: nobody reviews what got remembered, and a wrong


### PR DESCRIPTION
## 背景

「オントロジーを ochakai に入れるべきか」→ Palantir の成功要因（FDE による人手のドメイン符号化）まで辿った議論の、**理念としての回収**。実装（#103, `sort=failed` 再検証フィード）はマージ済み。この PR はその議論の位置づけを README の「Why ochakai」に文章として残すだけで、コード変更はない。

## 何を書いたか

新しい bullet「**No forward-deployed engineers, by design**」を追加:

- ドメイン符号化は**労働**であり消えない。変わるのは*誰がやるか*だけ
- Palantir の答え = FDE が現場でオントロジーを手作り
- dbt / ウェアハウス内蔵の答え = セルフサーブ（curation を出荷ワークフローに畳み込む）
- **ochakai の賭け = 第三の道**: エージェントが前方展開の労働（下書きの量産）を担い、人間が判断の核を検証する。これが知識ベースの「confidently-wrong な墓場化」を防ぐ
- **FDE 軍団も専任 steward も要らない**: 生きた知識ベースを支える最小単位は「既にループにいるレビュアー1人 + 既存ワークフローに埋め込んだ門（bundled hooks / CI canary）」

あわせて「A write-back loop with a memory」の bullet を**仕組み**（draft→verified→rejected→再検証フィード）に絞り、労働の賭けを新 bullet に分離した（役割の重複を解消）。

## 変更点

- `README.md` のみ（+16 / −5）。既存の [hooks](examples/claude-code) と [canary ガイド](docs/guides/golden-query-canary.md) へのリンクは実在を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KMfWqWWLYMAUq2qaWAKYD3)_