### PR TITLE
SearchLexical: ILIKE のワイルドカードをエスケープする

### DIFF
--- a/internal/store/filter_test.go
+++ b/internal/store/filter_test.go
@@ -45,11 +45,11 @@ func TestBuildWhereFoldsFreeTypes(t *testing.T) {
 // covers the effect on real rows; this pins the escaping itself.
 func TestEscapeLike(t *testing.T) {
 	cases := map[string]string{
-		"売上":      "売上",
-		"a%b":     `a\%b`,
-		"a_b":     `a\_b`,
-		`a\b`:     `a\\b`,
-		`100%_\`:  `100\%\_\\`,
+		"売上":     "売上",
+		"a%b":    `a\%b`,
+		"a_b":    `a\_b`,
+		`a\b`:    `a\\b`,
+		`100%_\`: `100\%\_\\`,
 	}
 	for in, want := range cases {
 		if got := escapeLike(in); got != want {

--- a/internal/store/filter_test.go
+++ b/internal/store/filter_test.go
@@ -38,3 +38,22 @@ func TestBuildWhereFoldsFreeTypes(t *testing.T) {
 		t.Errorf("free type args = %#v, want %#v", args, want)
 	}
 }
+
+// SearchLexical's substring floor feeds the query into an ILIKE pattern.
+// '%' and '_' are ILIKE wildcards; unescaped, they would turn a literal
+// search into a match-anything and flatten the ranking. TestIntegration
+// covers the effect on real rows; this pins the escaping itself.
+func TestEscapeLike(t *testing.T) {
+	cases := map[string]string{
+		"売上":      "売上",
+		"a%b":     `a\%b`,
+		"a_b":     `a\_b`,
+		`a\b`:     `a\\b`,
+		`100%_\`:  `100\%\_\\`,
+	}
+	for in, want := range cases {
+		if got := escapeLike(in); got != want {
+			t.Errorf("escapeLike(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -535,11 +535,19 @@ func (s *Store) addRevision(ctx context.Context, tx pgx.Tx, k *domain.Knowledge,
 // name.
 func (s *Store) SearchLexical(ctx context.Context, query string, f Filter, limit int) ([]domain.SearchHit, error) {
 	where, args := f.buildWhere("k.")
+	// The trigram term takes the raw query; the substring floor takes a
+	// separate, escaped LIKE pattern. Without escaping, a query containing
+	// '%' or '_' is read as an ILIKE wildcard — '%' matches every entry and
+	// hands them all the +0.3 boost, flattening the ranking (and '_' matches
+	// any one character). similarity() is unaffected; only the ILIKE floor.
 	args = append(args, query)
+	simParam := len(args)
+	args = append(args, "%"+escapeLike(query)+"%")
+	likeParam := len(args)
 	q := fmt.Sprintf(`
 		SELECT `+knowledgeCols+`, score FROM (
 			SELECT k.*, similarity(k.id || ' ' || k.title || ' ' || k.description || ' ' || array_to_string(k.tags, ' ') || ' ' || k.body || ' ' || att.names, $%d)
-				+ CASE WHEN k.id || ' ' || k.title || ' ' || k.description || ' ' || k.body || ' ' || att.names ILIKE '%%' || $%d || '%%' THEN 0.3 ELSE 0 END
+				+ CASE WHEN k.id || ' ' || k.title || ' ' || k.description || ' ' || k.body || ' ' || att.names ILIKE $%d THEN 0.3 ELSE 0 END
 				+ CASE WHEN k.status = 'verified' THEN 0.05 ELSE 0 END AS score
 			FROM knowledge k
 			LEFT JOIN LATERAL (
@@ -549,7 +557,7 @@ func (s *Store) SearchLexical(ctx context.Context, query string, f Filter, limit
 			WHERE %s
 		) ranked
 		WHERE score > 0.05
-		ORDER BY score DESC LIMIT %d`, len(args), len(args), where, limit)
+		ORDER BY score DESC LIMIT %d`, simParam, likeParam, where, limit)
 	rows, err := s.pool.Query(ctx, q, args...)
 	if err != nil {
 		return nil, err
@@ -824,6 +832,13 @@ func qualifyCols(alias string) string {
 		cols[i] = alias + "." + strings.TrimSpace(c)
 	}
 	return strings.Join(cols, ", ")
+}
+
+// escapeLike neutralizes the LIKE/ILIKE pattern metacharacters '%' and '_'
+// in a user query so it matches literally. PostgreSQL's default LIKE escape
+// character is the backslash, so the backslash itself is escaped first.
+func escapeLike(s string) string {
+	return strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(s)
 }
 
 // encodeVector renders a pgvector literal like "[0.1,0.2]".

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -440,6 +440,64 @@ func TestIntegrationListLinkingTo(t *testing.T) {
 	}
 }
 
+// SearchLexical's substring floor must treat the query literally: a query
+// of "%" or "_" is not an ILIKE wildcard. Before the escaping fix, "%"
+// matched every entry and boosted them all; "_" matched any single
+// character. Here only the entry that literally contains "%" may surface.
+func TestIntegrationSearchLexicalWildcardEscape(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	for _, table := range []string{"knowledge", "knowledge_revision"} {
+		if _, err := s.pool.Exec(ctx, `DELETE FROM `+table+` WHERE id LIKE 'it-wild-%'`); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	actor := domain.Actor{Kind: "human", Name: "test"}
+	plain := &domain.Knowledge{Type: domain.TypeMetrics, ID: "it-wild-plain", Title: "純増収益",
+		Description: "特殊文字を含まない", Status: domain.StatusDraft, CreatedBy: actor}
+	pct := &domain.Knowledge{Type: domain.TypeMetrics, ID: "it-wild-pct", Title: "解約率は5%以内",
+		Description: "パーセント記号を含む", Status: domain.StatusDraft, CreatedBy: actor}
+	for _, k := range []*domain.Knowledge{plain, pct} {
+		if err := s.Create(ctx, k); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// "%" is a literal search now: it may match only the entry containing
+	// one, never the plain entry via a wildcard-driven +0.3 boost.
+	hits, err := s.SearchLexical(ctx, "%", Filter{}, 10)
+	if err != nil {
+		t.Fatalf("SearchLexical(%q): %v", "%", err)
+	}
+	for _, h := range hits {
+		if h.ID == "it-wild-plain" {
+			t.Errorf(`"%%" matched it-wild-plain — ILIKE wildcard not escaped: %+v`, hits)
+		}
+	}
+	// "_" likewise must not match an entry that contains no underscore.
+	hits, err = s.SearchLexical(ctx, "_", Filter{}, 10)
+	if err != nil {
+		t.Fatalf("SearchLexical(%q): %v", "_", err)
+	}
+	for _, h := range hits {
+		if h.ID == "it-wild-plain" || h.ID == "it-wild-pct" {
+			t.Errorf(`"_" matched %s — ILIKE wildcard not escaped: %+v`, h.ID, hits)
+		}
+	}
+}
+
 // RecordEvents buffers off the read path (design doc 0025 §11): totals are
 // invisible until a flush, and Close drains the buffer so a clean shutdown
 // loses nothing.


### PR DESCRIPTION
## 問題

`SearchLexical` の substring-match 下駄が、ユーザークエリを **エスケープせずに** ILIKE パターンに埋めていた。

```
... ILIKE '%' || $q || '%' THEN 0.3 ELSE 0 END
```

`%` / `_` は ILIKE のワイルドカードなので:
- `%` を含む検索 → **全エントリに一致**し、全部に +0.3 の boost が付いて順位が平坦化
- `_` を含む検索 → 任意の 1 文字に一致

束縛パラメータなので SQL インジェクションではなく、**パターン扱いの正しさ**の問題。trigram の `similarity()` 項は影響を受けず、ILIKE の下駄だけ。

## 修正

- 生クエリ($q、similarity 用)と、エスケープ済み LIKE パターン(`%<escaped>%`、ILIKE 用)を **別パラメータに分離**
- `escapeLike` で `\` → `\\`、`%` → `\%`、`_` → `\_`(PostgreSQL の LIKE 既定エスケープ文字はバックスラッシュ、なので先にバックスラッシュを退避)

## テスト

- `escapeLike` の単体テスト(DB 不要)
- 統合テスト: `%` / `_` が、その文字を含まないエントリを引かないことを確認(ローカル pgvector で確認済み)

設計ドキュメント [0025 §11](docs/design/0025-cloud-storage-only.md) で指摘した既存バグ 3 件のうちの 1 件。永続層の選択と独立した修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)