### PR TITLE
usage: 記録を読み取りパスから外す(バッファ + 定期フラッシュ)

### DIFF
--- a/internal/service/context_integration_test.go
+++ b/internal/service/context_integration_test.go
@@ -125,6 +125,10 @@ func TestSearchRecordsUsageIntegration(t *testing.T) {
 	if len(hits) == 0 || hits[0].ID != id {
 		t.Fatalf("search missed the entry: %+v", hits)
 	}
+	// Usage recording buffers off the read path (design doc 0025 §11).
+	if err := svc.Store.FlushUsage(ctx); err != nil {
+		t.Fatalf("FlushUsage: %v", err)
+	}
 	u, err := svc.Usage(ctx, id)
 	if err != nil {
 		t.Fatalf("Usage: %v", err)
@@ -192,6 +196,9 @@ func TestCompileIntegration(t *testing.T) {
 
 	// Compile usage lands on the model entry and on the metric entry
 	// naming it via attrs.model — and only on entries that exist.
+	if err := svc.Store.FlushUsage(ctx); err != nil {
+		t.Fatalf("FlushUsage: %v", err)
+	}
 	for _, target := range []string{modelID, metricEntryID} {
 		u, err := svc.Usage(ctx, target)
 		if err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -29,6 +30,15 @@ type Store struct {
 	blobs blob.Store
 	// lastEventPrune throttles knowledge_event pruning (unix seconds).
 	lastEventPrune atomic.Int64
+
+	// Usage events buffer in memory and flush on a timer so recording
+	// never touches the read path (design doc 0025 §11). usageBuf is
+	// guarded by usageMu; the flush loop stops on flushStop and drains
+	// once more before flushWG releases (see New/Close, usage.go).
+	usageMu   sync.Mutex
+	usageBuf  []usageEvent
+	flushStop chan struct{}
+	flushWG   sync.WaitGroup
 }
 
 // UseBlobStore routes attachment bytes to b (design doc 0013). Call
@@ -65,10 +75,23 @@ func New(ctx context.Context, databaseURL string, iamAuth bool) (*Store, error) 
 		pool.Close()
 		return nil, fmt.Errorf("connect to PostgreSQL: %w", err)
 	}
-	return &Store{pool: pool}, nil
+	s := &Store{pool: pool, flushStop: make(chan struct{})}
+	s.flushWG.Add(1)
+	go s.usageFlushLoop()
+	return s, nil
 }
 
-func (s *Store) Close() { s.pool.Close() }
+// Close stops the usage flush loop (draining the buffer one last time) and
+// releases the connection pool. Buffered events that have not yet flushed
+// are lost only if the process dies before Close — usage is a best-effort
+// statistic (design doc 0025 §10).
+func (s *Store) Close() {
+	if s.flushStop != nil {
+		close(s.flushStop)
+		s.flushWG.Wait()
+	}
+	s.pool.Close()
+}
 
 // Filter narrows search and list operations.
 type Filter struct {

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -167,6 +167,10 @@ func TestIntegration(t *testing.T) {
 	if err := s.RecordEvents(ctx, domain.EventFetched, actor, target); err != nil {
 		t.Fatalf("RecordEvents: %v", err)
 	}
+	// RecordEvents buffers; force the write before reading totals back.
+	if err := s.FlushUsage(ctx); err != nil {
+		t.Fatalf("FlushUsage: %v", err)
+	}
 	usage, err := s.Usage(ctx, k.ID)
 	if err != nil {
 		t.Fatalf("Usage: %v", err)
@@ -250,6 +254,9 @@ func TestIntegration(t *testing.T) {
 	}
 	if err := s.RecordOutcome(ctx, domain.EventFailed, actor, hot.ID, ""); err != nil {
 		t.Fatalf("RecordOutcome: %v", err)
+	}
+	if err := s.FlushUsage(ctx); err != nil {
+		t.Fatalf("FlushUsage: %v", err)
 	}
 	feed, err := s.ListByUsage(ctx, Filter{
 		Types:    []domain.Type{domain.TypeInsights},
@@ -433,6 +440,62 @@ func TestIntegrationListLinkingTo(t *testing.T) {
 	}
 }
 
+// RecordEvents buffers off the read path (design doc 0025 §11): totals are
+// invisible until a flush, and Close drains the buffer so a clean shutdown
+// loses nothing.
+func TestIntegrationUsageBuffering(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	for _, table := range []string{"knowledge", "knowledge_revision"} {
+		if _, err := s.pool.Exec(ctx, `DELETE FROM `+table+` WHERE id LIKE 'it-buf-%'`); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := s.pool.Exec(ctx, `DELETE FROM knowledge_usage WHERE knowledge_id LIKE 'it-buf-%'`); err != nil {
+		t.Fatal(err)
+	}
+
+	actor := domain.Actor{Kind: "agent", Name: "claude-code"}
+	k := &domain.Knowledge{Type: domain.TypeMetrics, ID: "it-buf-metric", Title: "計測",
+		Status: domain.StatusDraft, CreatedBy: actor}
+	if err := s.Create(ctx, k); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.RecordEvents(ctx, domain.EventSearchHit, actor, []string{k.ID}); err != nil {
+		t.Fatalf("RecordEvents: %v", err)
+	}
+	// Before a flush the event is only in memory — no total yet.
+	if u, err := s.Usage(ctx, k.ID); err != nil {
+		t.Fatal(err)
+	} else if u.SearchHits != 0 {
+		t.Errorf("event should be buffered, not yet counted: %+v", u)
+	}
+	// Close must drain the buffer.
+	s.Close()
+
+	s2, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s2.Close()
+	if u, err := s2.Usage(ctx, k.ID); err != nil {
+		t.Fatal(err)
+	} else if u.SearchHits != 1 {
+		t.Errorf("Close did not flush the buffered event: %+v", u)
+	}
+}
+
 // Move rewrites the id everywhere it is recorded — the row, revisions,
 // attachments, usage, embeddings — and rewrites inbound references (link
 // targets in both forms, attrs.model) so nothing breaks. The destination
@@ -490,6 +553,11 @@ func TestIntegrationMove(t *testing.T) {
 	}
 	if err := s.RecordEvents(ctx, domain.EventFetched, actor, []string{"it-move-src/metric"}); err != nil {
 		t.Fatal(err)
+	}
+	// Flush before Move so the event is persisted under the old id and the
+	// move carries it (RecordEvents now buffers, design doc 0025 §11).
+	if err := s.FlushUsage(ctx); err != nil {
+		t.Fatalf("FlushUsage: %v", err)
 	}
 
 	// Occupied destinations refuse, live or soft-deleted.

--- a/internal/store/usage.go
+++ b/internal/store/usage.go
@@ -11,24 +11,109 @@ import (
 // totals in knowledge_usage survive pruning, so /usage stays accurate.
 const eventRetention = 180 * 24 * time.Hour
 
-// RecordEvents appends raw usage events and bumps the running totals in a
-// single statement. ids name the target entries. Callers treat failures
-// as non-fatal: usage recording must never fail a read.
+// usageFlushInterval is how often buffered usage events are written, and
+// usageBufferMax caps the buffer so a stalled database cannot grow it
+// without bound — past the cap, new events are dropped (usage is a
+// best-effort statistic, design doc 0025 §10).
+const (
+	usageFlushInterval = 5 * time.Second
+	usageBufferMax     = 20000
+)
+
+// usageEvent is one buffered occurrence: who used which entry, when.
+type usageEvent struct {
+	id        string
+	event     string
+	actorKind string
+	actorName string
+	at        time.Time
+}
+
+// RecordEvents buffers usage events in memory and returns immediately,
+// keeping recording off the read path (design doc 0025 §11): the events
+// are written by the background flush loop, not by the caller. ids name
+// the target entries. Callers treat the error as non-fatal — it signals
+// only that the buffer was full and events were dropped, never a failed
+// read.
 func (s *Store) RecordEvents(ctx context.Context, event string, actor domain.Actor, ids []string) error {
 	if len(ids) == 0 {
 		return nil
 	}
+	now := time.Now()
+	s.usageMu.Lock()
+	defer s.usageMu.Unlock()
+	if len(s.usageBuf)+len(ids) > usageBufferMax {
+		return errUsageBufferFull
+	}
+	for _, id := range ids {
+		s.usageBuf = append(s.usageBuf, usageEvent{id, event, actor.Kind, actor.Name, now})
+	}
+	return nil
+}
+
+// errUsageBufferFull is returned by RecordEvents when the buffer is at
+// capacity; the events are dropped. Surfaced so the caller's log records
+// that usage was undercounted (service.recordUsage), never fatal.
+var errUsageBufferFull = errUsageBuffer("usage buffer full; events dropped")
+
+type errUsageBuffer string
+
+func (e errUsageBuffer) Error() string { return string(e) }
+
+// usageFlushLoop drains the usage buffer on a timer until Close, then once
+// more so a clean shutdown loses nothing already buffered.
+func (s *Store) usageFlushLoop() {
+	defer s.flushWG.Done()
+	t := time.NewTicker(usageFlushInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-t.C:
+			s.FlushUsage(context.Background())
+		case <-s.flushStop:
+			s.FlushUsage(context.Background())
+			return
+		}
+	}
+}
+
+// FlushUsage writes all buffered usage events: one knowledge_event row per
+// occurrence, and the running totals in knowledge_usage bumped in the same
+// statement. Exported so shutdown and tests can force a flush. On a
+// database error the drained batch is lost (best-effort); the error is
+// returned for visibility.
+func (s *Store) FlushUsage(ctx context.Context) error {
+	s.usageMu.Lock()
+	if len(s.usageBuf) == 0 {
+		s.usageMu.Unlock()
+		return nil
+	}
+	batch := s.usageBuf
+	s.usageBuf = nil
+	s.usageMu.Unlock()
+
+	ids := make([]string, len(batch))
+	events := make([]string, len(batch))
+	kinds := make([]string, len(batch))
+	names := make([]string, len(batch))
+	ats := make([]time.Time, len(batch))
+	for i, e := range batch {
+		ids[i], events[i], kinds[i], names[i], ats[i] = e.id, e.event, e.actorKind, e.actorName, e.at
+	}
+	// last_at takes the greatest event time on either side so a flush whose
+	// batch happens to carry an older occurrence never rewinds the total.
 	_, err := s.pool.Exec(ctx, `
 		WITH ev AS (
-			INSERT INTO knowledge_event (knowledge_id, event, actor_kind, actor_name)
-			SELECT i, $2, $3, $4 FROM unnest($1::text[]) AS u(i)
-			RETURNING knowledge_id, event
+			INSERT INTO knowledge_event (knowledge_id, event, actor_kind, actor_name, at)
+			SELECT * FROM unnest($1::text[], $2::text[], $3::text[], $4::text[], $5::timestamptz[])
+			RETURNING knowledge_id, event, at
 		)
 		INSERT INTO knowledge_usage (knowledge_id, event, count, last_at)
-		SELECT knowledge_id, event, count(*), now() FROM ev GROUP BY 1, 2
+		SELECT knowledge_id, event, count(*), max(at) FROM ev GROUP BY 1, 2
 		ON CONFLICT (knowledge_id, event)
-		DO UPDATE SET count = knowledge_usage.count + EXCLUDED.count, last_at = EXCLUDED.last_at`,
-		ids, event, actor.Kind, actor.Name)
+		DO UPDATE SET count = knowledge_usage.count + EXCLUDED.count,
+			last_at = GREATEST(knowledge_usage.last_at, EXCLUDED.last_at)`,
+		ids, events, kinds, names, ats)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## 問題

`RecordEvents` は読み取りパス(search / get / compile)で**同期的に** `knowledge_event` へのイベント挿入と `knowledge_usage` の集計 UPSERT を実行していた。

- 1000 人規模 = 約 500 万イベント/日、ピークはその数倍 → db-f1-micro が溶ける
- usage 記録の遅延・失敗が読み取りのレイテンシとスループットに直結

## 修正

- **`RecordEvents` はメモリにバッファして即座に返す**。実書き込みはバックグラウンドのフラッシュループが 5 秒間隔(+ `Close` 時に一度)で実行
- 1 オカレンス = 1 `knowledge_event` 行、集計はまとめて UPSERT。`last_at` は `GREATEST` で後退しない
- バッファ上限(20,000)超過時はイベントを落として error を返し、呼び出し側 `service.recordUsage` が**既存のログ経路**で undercount を記録(サイレントに握り潰さない)
- `RecordOutcome`(worked/failed の意図的な書き込み)は**同期のまま** — 呼び出し側にエラーを返す契約を保つ
- `FlushUsage` を公開し、graceful shutdown(`main.go` の `defer svc.Store.Close()`)とテストが強制フラッシュできるように

usage はベストエフォート統計(設計ドキュメント [0025 §10](docs/design/0025-cloud-storage-only.md))で、`Close` を経ないプロセス即死時のみ未フラッシュ分を失う。これは従来からの「usage recording must never fail a read」方針の延長。

## テスト

- `Close` がバッファをドレインすることを確認する統合テスト(record → Close → 別接続で総計が見える)
- 既存の record→即読みテストにフラッシュを挿入
- ローカル pgvector で全統合テスト green

設計ドキュメント [0025 §11](docs/design/0025-cloud-storage-only.md) の既存バグ 3 件のうちの 1 件。永続層の選択と独立。

🤖 Generated with [Claude Code](https://claude.com/claude-code)