### PR TITLE
Update: If-Match による楽観ロック(opt-in)

### DIFF
--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -212,7 +212,9 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"do it only for knowledge you have actually validated. Setting status=rejected records you " +
 			"as rejected_by; put the reason in status_note (also useful when deprecating).",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in writeIn) (*mcp.CallToolResult, knowledgeOut, error) {
-		k, _, err := svc.Update(ctx, in.toKnowledge(), httpauth.Actor(ctx))
+		// MCP has no conditional-update channel; it does not opt into the
+		// If-Match precondition (nil), keeping last-write-wins here.
+		k, _, err := svc.Update(ctx, in.toKnowledge(), httpauth.Actor(ctx), nil)
 		if err != nil {
 			return nil, knowledgeOut{}, err
 		}

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -140,6 +140,9 @@ func Handler(svc *service.Service) http.Handler {
 			writeError(w, err)
 			return
 		}
+		// The ETag is the entry's version: a client can echo it in If-Match
+		// on a later PUT to update only if nothing changed meanwhile.
+		w.Header().Set("ETag", etagOf(k))
 		writeJSON(w, http.StatusOK, k)
 	})
 
@@ -148,11 +151,19 @@ func Handler(svc *service.Service) http.Handler {
 		if !readJSON(w, r, &k) {
 			return
 		}
+		// If-Match is an optional optimistic-concurrency precondition: its
+		// value is the ETag from a prior read. Absent means last-write-wins
+		// (design doc 0025 §11); malformed is a client error.
+		ifMatch, err := parseIfMatch(r)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "malformed If-Match: " + err.Error()})
+			return
+		}
 		// The path is the address; the body carries the metadata — type
 		// included, always (no fill-in from the stored entry, design doc
 		// 0016 §4.5).
 		k.ID = r.PathValue("id")
-		updated, changed, err := svc.Update(r.Context(), &k, httpauth.Actor(r.Context()))
+		updated, changed, err := svc.Update(r.Context(), &k, httpauth.Actor(r.Context()), ifMatch)
 		if err != nil {
 			writeError(w, err)
 			return
@@ -163,6 +174,7 @@ func Handler(svc *service.Service) http.Handler {
 		if !changed {
 			w.Header().Set("Ochakai-Unchanged", "true")
 		}
+		w.Header().Set("ETag", etagOf(updated))
 		writeJSON(w, http.StatusOK, updated)
 	})
 
@@ -489,6 +501,9 @@ func writeError(w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, store.ErrNotFound):
 		status = http.StatusNotFound
+	case errors.Is(err, store.ErrConflict):
+		// The If-Match precondition failed: the entry changed since read.
+		status = http.StatusPreconditionFailed
 	case errors.Is(err, store.ErrAlreadyExists):
 		status = http.StatusConflict
 	case errors.As(err, &compileErr):
@@ -499,6 +514,29 @@ func writeError(w http.ResponseWriter, err error) {
 		status = http.StatusNotImplemented
 	}
 	writeJSON(w, status, map[string]string{"error": err.Error()})
+}
+
+// etagOf renders an entry's version as an ETag: its updated_at in
+// RFC3339Nano, quoted. A client echoes it in If-Match to update
+// conditionally (design doc 0025 §11).
+func etagOf(k *domain.Knowledge) string {
+	return `"` + k.UpdatedAt.UTC().Format(time.RFC3339Nano) + `"`
+}
+
+// parseIfMatch reads an optional If-Match precondition. Absent or "*" means
+// no version precondition (the update still requires the entry to exist).
+// A quoted value is our entry ETag — the RFC3339Nano updated_at. A value
+// that is neither is a client error.
+func parseIfMatch(r *http.Request) (*time.Time, error) {
+	v := strings.TrimSpace(r.Header.Get("If-Match"))
+	if v == "" || v == "*" {
+		return nil, nil
+	}
+	t, err := time.Parse(time.RFC3339Nano, strings.Trim(v, `"`))
+	if err != nil {
+		return nil, err
+	}
+	return &t, nil
 }
 
 // queryInt and queryFloat parse optional numeric query parameters,

--- a/internal/restapi/restapi_test.go
+++ b/internal/restapi/restapi_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/na0fu3y/ochakai/internal/compiler"
 	"github.com/na0fu3y/ochakai/internal/domain"
@@ -25,6 +26,7 @@ func TestWriteErrorStatuses(t *testing.T) {
 	}{
 		{"not found", store.ErrNotFound, http.StatusNotFound},
 		{"already exists", store.ErrAlreadyExists, http.StatusConflict},
+		{"if-match conflict", store.ErrConflict, http.StatusPreconditionFailed},
 		{"compile refusal", &compiler.Error{Reason: "outside the subset"}, http.StatusUnprocessableEntity},
 		{"invalid input", service.Invalidf("title is required"), http.StatusBadRequest},
 		{"unsupported", service.Unsupportedf("attachments need GCS"), http.StatusNotImplemented},
@@ -143,5 +145,45 @@ func TestReportOutcomeBadRequests(t *testing.T) {
 				t.Errorf("body %q does not mention %q", rec.Body, c.wantSubstr)
 			}
 		})
+	}
+}
+
+// TestETagRoundTrip pins the ETag/If-Match wire format: etagOf quotes the
+// updated_at, and parseIfMatch reads it (and "*", and absence) back — so a
+// value from a response header is accepted verbatim on the next request.
+func TestETagRoundTrip(t *testing.T) {
+	updated := time.Date(2026, 7, 24, 1, 2, 3, 456789000, time.UTC)
+	k := &domain.Knowledge{ID: "metrics/x", UpdatedAt: updated}
+	etag := etagOf(k)
+	if etag != `"2026-07-24T01:02:03.456789Z"` {
+		t.Fatalf("etagOf = %s", etag)
+	}
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/knowledge/metrics/x", nil)
+	req.Header.Set("If-Match", etag)
+	got, err := parseIfMatch(req)
+	if err != nil {
+		t.Fatalf("parseIfMatch: %v", err)
+	}
+	if got == nil || !got.Equal(updated) {
+		t.Errorf("parseIfMatch(%s) = %v, want %v", etag, got, updated)
+	}
+
+	// Absent and "*" carry no version precondition.
+	for _, v := range []string{"", "*"} {
+		r := httptest.NewRequest(http.MethodPut, "/x", nil)
+		if v != "" {
+			r.Header.Set("If-Match", v)
+		}
+		if p, err := parseIfMatch(r); err != nil || p != nil {
+			t.Errorf("parseIfMatch(If-Match:%q) = %v, %v; want nil, nil", v, p, err)
+		}
+	}
+
+	// A non-ETag value is a client error, not a silent no-precondition.
+	r := httptest.NewRequest(http.MethodPut, "/x", nil)
+	r.Header.Set("If-Match", `"not-a-timestamp"`)
+	if _, err := parseIfMatch(r); err == nil {
+		t.Error("malformed If-Match must be an error")
 	}
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -90,7 +90,14 @@ func (s *Service) Create(ctx context.Context, k *domain.Knowledge, actor domain.
 // are the audit trail of changes and updated_at means "content last
 // changed" — recurring bundle imports and agents re-saving what they
 // just read must not bury real history under identical snapshots.
-func (s *Service) Update(ctx context.Context, k *domain.Knowledge, actor domain.Actor) (updated *domain.Knowledge, changed bool, err error) {
+//
+// ifMatch is an optional optimistic-concurrency precondition (design doc
+// 0025 §11): when non-nil it is the updated_at the caller based the edit
+// on, and an entry that has changed since — whether before this call's
+// read, or in the read-modify-write window below — yields store.ErrConflict
+// rather than silently clobbering the other write. nil keeps the prior
+// last-write-wins behavior for callers that do not opt in.
+func (s *Service) Update(ctx context.Context, k *domain.Knowledge, actor domain.Actor, ifMatch *time.Time) (updated *domain.Knowledge, changed bool, err error) {
 	normalizeKeys(k)
 	if err := validate(k); err != nil {
 		return nil, false, err
@@ -99,6 +106,11 @@ func (s *Service) Update(ctx context.Context, k *domain.Knowledge, actor domain.
 	old, err := s.Store.Get(ctx, k.ID)
 	if err != nil {
 		return nil, false, err
+	}
+	// The caller's version is already stale if the stored entry moved on
+	// between their read and ours — reject before doing any work.
+	if ifMatch != nil && !old.UpdatedAt.Equal(ifMatch.UTC()) {
+		return nil, false, store.ErrConflict
 	}
 	if k.Status == "" {
 		k.Status = old.Status
@@ -111,7 +123,9 @@ func (s *Service) Update(ctx context.Context, k *domain.Knowledge, actor domain.
 		return old, false, nil
 	}
 	s.applyVerification(k, old, actor)
-	if err := s.Store.Update(ctx, k, actor); err != nil {
+	// Pass the precondition through so the write is also guarded against a
+	// concurrent update landing between the Get above and the write.
+	if err := s.Store.Update(ctx, k, actor, ifMatch); err != nil {
 		return nil, false, err
 	}
 	s.updateEmbedding(ctx, k)

--- a/internal/service/service_integration_test.go
+++ b/internal/service/service_integration_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -64,7 +65,7 @@ func TestUpdateNoOpIntegration(t *testing.T) {
 	same := entry()
 	same.Status = ""
 	same.Attrs = map[string]any{"threshold": float64(5)}
-	got, changed, err := svc.Update(ctx, same, actor)
+	got, changed, err := svc.Update(ctx, same, actor, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +86,7 @@ func TestUpdateNoOpIntegration(t *testing.T) {
 	// A real change still writes: revision recorded, updated_at bumped.
 	edited := entry()
 	edited.Body = "受注合計。返品は含まない。"
-	got, changed, err = svc.Update(ctx, edited, actor)
+	got, changed, err = svc.Update(ctx, edited, actor, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,5 +101,68 @@ func TestUpdateNoOpIntegration(t *testing.T) {
 	}
 	if len(revs) != 2 || revs[0].Change != "update" {
 		t.Errorf("real update must add an update revision: %+v", revs)
+	}
+}
+
+// TestUpdateIfMatchIntegration exercises the opt-in optimistic lock (design
+// doc 0025 §11): a matching If-Match updates, a stale one is rejected with
+// ErrConflict, and once the entry has moved on the old version stays
+// rejected until re-read.
+func TestUpdateIfMatchIntegration(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := store.New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	svc := &Service{Store: s, Log: slog.New(slog.DiscardHandler)}
+	actor := domain.Actor{Kind: domain.ActorHuman, Name: "test"}
+	id := fmt.Sprintf("svcit-ifmatch-%d", time.Now().UnixNano())
+
+	mk := func(body string) *domain.Knowledge {
+		return &domain.Knowledge{Type: domain.TypeMetrics, ID: id, Title: "売上",
+			Status: domain.StatusDraft, Body: body}
+	}
+	if _, err := svc.Create(ctx, mk("v1"), actor); err != nil {
+		t.Fatal(err)
+	}
+	base, err := svc.Get(ctx, id) // the version both writers below read
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Writer A updates against the current version — accepted.
+	v2, _, err := svc.Update(ctx, mk("v2"), actor, &base.UpdatedAt)
+	if err != nil {
+		t.Fatalf("If-Match update on the current version: %v", err)
+	}
+
+	// Writer B still holds the pre-A version: its update must be rejected,
+	// not silently clobber A's write (the lost-update this fix closes).
+	if _, _, err := svc.Update(ctx, mk("v3-from-stale"), actor, &base.UpdatedAt); !errors.Is(err, store.ErrConflict) {
+		t.Fatalf("stale If-Match: got %v, want ErrConflict", err)
+	}
+	// The stored content is still A's, untouched by B.
+	if cur, err := svc.Get(ctx, id); err != nil {
+		t.Fatal(err)
+	} else if cur.Body != "v2" {
+		t.Errorf("stale update clobbered the row: body = %q, want v2", cur.Body)
+	}
+
+	// After re-reading A's version, B can proceed.
+	if _, _, err := svc.Update(ctx, mk("v3"), actor, &v2.UpdatedAt); err != nil {
+		t.Fatalf("If-Match update after re-read: %v", err)
+	}
+
+	// Opting out (nil) keeps last-write-wins — no precondition, always writes.
+	if _, _, err := svc.Update(ctx, mk("v4-lww"), actor, nil); err != nil {
+		t.Fatalf("opt-out update: %v", err)
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -26,6 +26,15 @@ var ErrAlreadyExists = errors.New("knowledge already exists")
 // (design doc 0025 §11). The entry exists — a missing entry is ErrNotFound.
 var ErrConflict = errors.New("knowledge changed since it was read")
 
+// nowStored is the current UTC time truncated to the microsecond precision
+// PostgreSQL timestamptz stores. Setting entity timestamps from it means an
+// in-memory updated_at always equals the value that round-trips through the
+// database — the invariant the ETag/If-Match optimistic lock depends on
+// (design doc 0025 §11): time.Now()'s nanoseconds would otherwise make the
+// value returned by a write differ from the stored one on nanosecond-
+// resolution clocks (Linux), breaking a client's next conditional update.
+func nowStored() time.Time { return time.Now().UTC().Truncate(time.Microsecond) }
+
 type Store struct {
 	pool *pgxpool.Pool
 	// blobs holds attachment bytes (GCS, design doc 0013); metadata stays
@@ -205,7 +214,7 @@ func (s *Store) ListMetricEntryIDs(ctx context.Context, modelID string) ([]strin
 // Update refuses deleted rows), and its history stays in the revisions
 // either way.
 func (s *Store) Create(ctx context.Context, k *domain.Knowledge) error {
-	now := time.Now().UTC()
+	now := nowStored()
 	k.CreatedAt, k.UpdatedAt = now, now
 	return s.withTx(ctx, func(tx pgx.Tx) error {
 		links, attrs, err := marshalJSONFields(k)
@@ -250,7 +259,7 @@ func (s *Store) Create(ctx context.Context, k *domain.Knowledge) error {
 // read-modify-write race that silently lost updates. A nil ifMatch keeps
 // the prior last-write-wins behavior for callers that do not opt in.
 func (s *Store) Update(ctx context.Context, k *domain.Knowledge, actor domain.Actor, ifMatch *time.Time) error {
-	k.UpdatedAt = time.Now().UTC()
+	k.UpdatedAt = nowStored()
 	return s.withTx(ctx, func(tx pgx.Tx) error {
 		links, attrs, err := marshalJSONFields(k)
 		if err != nil {
@@ -336,7 +345,7 @@ func (s *Store) Move(ctx context.Context, oldID, newID string, actor domain.Acto
 	if err != nil {
 		return nil, err
 	}
-	k.UpdatedAt = time.Now().UTC()
+	k.UpdatedAt = nowStored()
 	err = s.withTx(ctx, func(tx pgx.Tx) error {
 		var taken bool
 		if err := tx.QueryRow(ctx,
@@ -417,7 +426,7 @@ func (s *Store) rewriteReferences(ctx context.Context, tx pgx.Tx, oldID, newID s
 	if err != nil {
 		return err
 	}
-	now := time.Now().UTC()
+	now := nowStored()
 	for i := range referrers {
 		r := &referrers[i]
 		// The moved entry resolves its own relative links against its old

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -21,6 +21,11 @@ import (
 var ErrNotFound = errors.New("knowledge not found")
 var ErrAlreadyExists = errors.New("knowledge already exists")
 
+// ErrConflict is returned by Update when an If-Match precondition does not
+// match the stored revision: the entry changed since the caller read it
+// (design doc 0025 §11). The entry exists — a missing entry is ErrNotFound.
+var ErrConflict = errors.New("knowledge changed since it was read")
+
 type Store struct {
 	pool *pgxpool.Pool
 	// blobs holds attachment bytes (GCS, design doc 0013); metadata stays
@@ -238,7 +243,13 @@ func (s *Store) Create(ctx context.Context, k *domain.Knowledge) error {
 	})
 }
 
-func (s *Store) Update(ctx context.Context, k *domain.Knowledge, actor domain.Actor) error {
+// Update writes k over the live entry with the same id. When ifMatch is
+// non-nil, the write is conditional on the stored updated_at equalling it
+// (optimistic concurrency, design doc 0025 §11): a mismatch means the entry
+// changed since the caller read it and returns ErrConflict, closing the
+// read-modify-write race that silently lost updates. A nil ifMatch keeps
+// the prior last-write-wins behavior for callers that do not opt in.
+func (s *Store) Update(ctx context.Context, k *domain.Knowledge, actor domain.Actor, ifMatch *time.Time) error {
 	k.UpdatedAt = time.Now().UTC()
 	return s.withTx(ctx, func(tx pgx.Tx) error {
 		links, attrs, err := marshalJSONFields(k)
@@ -247,20 +258,38 @@ func (s *Store) Update(ctx context.Context, k *domain.Knowledge, actor domain.Ac
 		}
 		verifiedKind, verifiedName := actorPtrs(k.VerifiedBy)
 		rejectedKind, rejectedName := actorPtrs(k.RejectedBy)
+		cond := ""
+		args := []any{k.ID, k.Type, k.Title, k.Description, k.Resource, k.Tags, k.Status, k.StatusNote,
+			verifiedKind, verifiedName, k.VerifiedAt,
+			rejectedKind, rejectedName, k.RejectedAt,
+			links, attrs, k.Body, k.UpdatedAt}
+		if ifMatch != nil {
+			args = append(args, ifMatch.UTC())
+			cond = fmt.Sprintf(" AND updated_at=$%d", len(args))
+		}
 		tag, err := tx.Exec(ctx, `UPDATE knowledge SET
 			type=$2, title=$3, description=$4, resource=$5, tags=$6, status=$7, status_note=$8,
 			verified_by_kind=$9, verified_by_name=$10, verified_at=$11,
 			rejected_by_kind=$12, rejected_by_name=$13, rejected_at=$14,
 			links=$15, attrs=$16, body=$17, updated_at=$18
-			WHERE id=$1 AND deleted_at IS NULL`,
-			k.ID, k.Type, k.Title, k.Description, k.Resource, k.Tags, k.Status, k.StatusNote,
-			verifiedKind, verifiedName, k.VerifiedAt,
-			rejectedKind, rejectedName, k.RejectedAt,
-			links, attrs, k.Body, k.UpdatedAt)
+			WHERE id=$1 AND deleted_at IS NULL`+cond, args...)
 		if err != nil {
 			return err
 		}
 		if tag.RowsAffected() == 0 {
+			// No row matched. With a precondition, tell a live-but-changed
+			// entry (ErrConflict) apart from a missing one (ErrNotFound).
+			if ifMatch != nil {
+				var live bool
+				if err := tx.QueryRow(ctx,
+					`SELECT EXISTS (SELECT 1 FROM knowledge WHERE id=$1 AND deleted_at IS NULL)`,
+					k.ID).Scan(&live); err != nil {
+					return err
+				}
+				if live {
+					return ErrConflict
+				}
+			}
 			return ErrNotFound
 		}
 		return s.addRevision(ctx, tx, k, "update", actor)

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -833,7 +833,7 @@ func TestIntegrationListRevisions(t *testing.T) {
 		t.Fatal(err)
 	}
 	k.Title = "v2"
-	if err := s.Update(ctx, k, actor); err != nil {
+	if err := s.Update(ctx, k, actor, nil); err != nil {
 		t.Fatal(err)
 	}
 	if err := s.SoftDelete(ctx, k.ID, actor); err != nil {


### PR DESCRIPTION
## 問題

`Store.Update` は `WHERE id=$1 AND deleted_at IS NULL` の**無条件 UPDATE**で、`service.Update` の `Get(old)` → `Store.Update` の間に別の書き込みが挟まると、その更新を**黙って last-write-wins で上書き**していた。人間とエージェントが同じエントリを共同編集する製品として、同時編集の消失は問題になる。

全項目上書きの PUT なので、競合を検出したら呼び出し側に知らせるしかない。標準 HTTP の If-Match で、**後方互換の opt-in** として実装した。

## 仕様

- **ETag = エントリの `updated_at`**(RFC3339Nano、引用符つき)。`GET` と `PUT` の応答で返す
- クライアントが読んだ ETag を `If-Match` で送ると、更新は**その版が現行のままの場合のみ成功**。不一致は **412 Precondition Failed**
- `If-Match` を送らないクライアントは**従来どおり**(last-write-wins)。`*`・不在は版の前提条件なし
- **MCP** は条件付き更新の経路がないので opt-in しない(`nil`)

## 実装

- `Store.Update` に `*time.Time` の前提条件を追加(`nil` で従来動作)。DB 側で `updated_at` を突き合わせ、**`Get`→`Update` の競合窓も閉じる**。0 行時は存在確認で `ErrConflict`(412)と `ErrNotFound`(404)を区別
- `service.Update` は、クライアントが読んだ版が既に古い場合を**書き込み前に**弾く

## テスト

- 統合(service): 一致で成功 → 古い版で `ErrConflict` → 再読込後に成功 → `nil` で LWW。古い版の更新が現行内容を破壊しないことも確認
- 単体(restapi): `etagOf`/`parseIfMatch` のワイヤ形式(ETag・`*`・不在・不正値)、`ErrConflict` → 412 マッピング
- ローカル pgvector で全統合テスト green

設計ドキュメント [0025 §11](docs/design/0025-cloud-storage-only.md) の既存バグ 3 件のうちの 1 件。永続層の選択と独立。GCS 移行時の `ifGenerationMatch` CAS と同じ意味論を、先に PostgreSQL 上で導入する形。

🤖 Generated with [Claude Code](https://claude.com/claude-code)