### PR TITLE
internal/projstore: 設計 0026 の核エンジン(GCS 正本 + in-RAM 投影)

### DIFF
--- a/internal/projstore/filter.go
+++ b/internal/projstore/filter.go
@@ -1,0 +1,59 @@
+package projstore
+
+import (
+	"strings"
+
+	"github.com/na0fu3y/ochakai/internal/domain"
+)
+
+// Filter mirrors store.Filter: an entry passes when its type is one of
+// Types (matched case-insensitively per design doc 0023 §3.3), its status
+// is one of Statuses, and it carries every tag in Tags. An empty slice is
+// "no constraint on this axis".
+type Filter struct {
+	Types    []domain.Type
+	Statuses []domain.Status
+	Tags     []string
+}
+
+func (f Filter) match(k *domain.Knowledge) bool {
+	if len(f.Types) > 0 {
+		ok := false
+		for _, t := range f.Types {
+			if strings.EqualFold(string(t), string(k.Type)) {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			return false
+		}
+	}
+	if len(f.Statuses) > 0 {
+		ok := false
+		for _, s := range f.Statuses {
+			if s == k.Status {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			return false
+		}
+	}
+	for _, want := range f.Tags {
+		if !hasTag(k.Tags, want) {
+			return false
+		}
+	}
+	return true
+}
+
+func hasTag(tags []string, want string) bool {
+	for _, t := range tags {
+		if t == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/projstore/gcs.go
+++ b/internal/projstore/gcs.go
@@ -1,0 +1,109 @@
+package projstore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/iterator"
+)
+
+// GCSObjectStore is the production ObjectStore: one GCS bucket, ADC auth
+// (same as internal/blob/gcs.go). Its CAS/create-only/list-generation
+// semantics were confirmed against real GCS by cmd/gcsverify.
+type GCSObjectStore struct {
+	bucket *storage.BucketHandle
+}
+
+// NewGCSObjectStore opens bucket via Application Default Credentials. It
+// does not probe the bucket — a Cloud Run start must not depend on a GCS
+// round trip (the 0003/0026 posture).
+func NewGCSObjectStore(ctx context.Context, bucket string) (*GCSObjectStore, error) {
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("gcs client: %w", err)
+	}
+	return &GCSObjectStore{bucket: client.Bucket(bucket)}, nil
+}
+
+func (g *GCSObjectStore) Get(ctx context.Context, name string) (Object, error) {
+	r, err := g.bucket.Object(name).NewReader(ctx)
+	if errors.Is(err, storage.ErrObjectNotExist) {
+		return Object{}, ErrNotFound
+	}
+	if err != nil {
+		return Object{}, fmt.Errorf("gcs get %s: %w", name, err)
+	}
+	defer r.Close()
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return Object{}, fmt.Errorf("gcs read %s: %w", name, err)
+	}
+	return Object{Data: data, Generation: r.Attrs.Generation}, nil
+}
+
+func (g *GCSObjectStore) PutCAS(ctx context.Context, name string, data []byte, ifGeneration int64) (int64, error) {
+	obj := g.bucket.Object(name)
+	switch {
+	case ifGeneration == CreateOnly:
+		obj = obj.If(storage.Conditions{DoesNotExist: true})
+	case ifGeneration == Unconditional:
+		// no precondition
+	default:
+		obj = obj.If(storage.Conditions{GenerationMatch: ifGeneration})
+	}
+	w := obj.NewWriter(ctx)
+	w.ContentType = "application/json"
+	if _, err := w.Write(data); err != nil {
+		_ = w.Close()
+		return 0, mapPrecondition(err, ifGeneration, name)
+	}
+	if err := w.Close(); err != nil {
+		return 0, mapPrecondition(err, ifGeneration, name)
+	}
+	return w.Attrs().Generation, nil
+}
+
+func (g *GCSObjectStore) Delete(ctx context.Context, name string) error {
+	err := g.bucket.Object(name).Delete(ctx)
+	if err == nil || errors.Is(err, storage.ErrObjectNotExist) {
+		return nil
+	}
+	return fmt.Errorf("gcs delete %s: %w", name, err)
+}
+
+func (g *GCSObjectStore) List(ctx context.Context, prefix string) ([]ObjectMeta, error) {
+	q := &storage.Query{Prefix: prefix}
+	// Diff detection needs only name+generation (0026 §5.2).
+	_ = q.SetAttrSelection([]string{"Name", "Generation"})
+	it := g.bucket.Objects(ctx, q)
+	var out []ObjectMeta
+	for {
+		a, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("gcs list %s: %w", prefix, err)
+		}
+		out = append(out, ObjectMeta{Name: a.Name, Generation: a.Generation})
+	}
+	return out, nil
+}
+
+// mapPrecondition turns a 412 into ErrExists for a create-only write or
+// ErrConflict for a generation-match write, matching the 0026 model.
+func mapPrecondition(err error, ifGeneration int64, name string) error {
+	var apiErr *googleapi.Error
+	if errors.As(err, &apiErr) && apiErr.Code == http.StatusPreconditionFailed {
+		if ifGeneration == CreateOnly {
+			return ErrExists
+		}
+		return ErrConflict
+	}
+	return fmt.Errorf("gcs put %s: %w", name, err)
+}

--- a/internal/projstore/gcs_integration_test.go
+++ b/internal/projstore/gcs_integration_test.go
@@ -1,0 +1,111 @@
+package projstore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/iterator"
+
+	"github.com/na0fu3y/ochakai/internal/domain"
+)
+
+// TestGCSIntegration exercises GCSObjectStore + the projection against real
+// GCS. It is skipped unless OCHAKAI_GCS_TEST_PROJECT names a project the
+// caller can create a bucket in (ADC auth). It creates a throwaway
+// versioned bucket and deletes it (and every object) at the end.
+//
+//	OCHAKAI_GCS_TEST_PROJECT=ochakai-example go test ./internal/projstore -run Integration -v
+func TestGCSIntegration(t *testing.T) {
+	project := os.Getenv("OCHAKAI_GCS_TEST_PROJECT")
+	if project == "" {
+		t.Skip("set OCHAKAI_GCS_TEST_PROJECT to run the real-GCS integration test")
+	}
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		t.Fatalf("storage client (ADC): %v", err)
+	}
+	defer client.Close()
+
+	name := fmt.Sprintf("%s-projstoretest-%d", project, time.Now().UnixNano())
+	bkt := client.Bucket(name)
+	if err := bkt.Create(ctx, project, &storage.BucketAttrs{
+		Location: "asia-northeast1", StorageClass: "STANDARD", VersioningEnabled: true,
+	}); err != nil {
+		t.Fatalf("bucket create: %v", err)
+	}
+	t.Logf("created throwaway bucket %s", name)
+	defer func() {
+		it := bkt.Objects(ctx, &storage.Query{Versions: true})
+		for {
+			a, err := it.Next()
+			if errors.Is(err, iterator.Done) {
+				break
+			}
+			if err != nil {
+				t.Logf("cleanup list: %v", err)
+				break
+			}
+			_ = bkt.Object(a.Name).Generation(a.Generation).Delete(ctx)
+		}
+		if err := bkt.Delete(ctx); err != nil {
+			t.Logf("bucket delete (remove %s manually): %v", name, err)
+		} else {
+			t.Logf("deleted bucket %s", name)
+		}
+	}()
+
+	os1 := &GCSObjectStore{bucket: bkt}
+	a := New(os1)
+	b := New(os1)
+
+	// Create + read-your-writes.
+	if err := a.Create(ctx, mkK("metrics/revenue", "売上", "四半期の売上を集計", domain.StatusVerified)); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := a.Create(ctx, mkK("metrics/revenue", "dup", "x", domain.StatusDraft)); err != ErrAlreadyExists {
+		t.Errorf("create-only against real GCS: err = %v, want ErrAlreadyExists", err)
+	}
+	got, err := a.Get(ctx, "metrics/revenue")
+	if err != nil || got.Title != "売上" {
+		t.Fatalf("get: %v %+v", err, got)
+	}
+
+	// CAS: a stale generation loses. Read the object generation directly.
+	obj, _ := os1.Get(ctx, "entries/metrics/revenue.json")
+	if _, err := os1.PutCAS(ctx, "entries/metrics/revenue.json", []byte(`{}`), obj.Generation); err != nil {
+		t.Fatalf("winning CAS: %v", err)
+	}
+	if _, err := os1.PutCAS(ctx, "entries/metrics/revenue.json", []byte(`{}`), obj.Generation); !errors.Is(err, ErrConflict) {
+		t.Errorf("stale CAS against real GCS: err = %v, want ErrConflict", err)
+	}
+
+	// Instance B projects A's write via LIST refresh.
+	if err := a.Create(ctx, mkK("models/churn", "churn", "ベクトル検索の対象", domain.StatusDraft)); err != nil {
+		t.Fatalf("create churn: %v", err)
+	}
+	hits, err := b.SearchLexical(ctx, "ベクトル検索", Filter{}, 10)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(hits) != 1 || hits[0].ID != "models/churn" {
+		t.Errorf("B did not project A's write from real GCS: %+v", hits)
+	}
+
+	// Vector round-trip through vectors/<id>.f32.
+	if err := a.SetVector(ctx, "models/churn", []float32{1, 0, 0}); err != nil {
+		t.Fatalf("setvector: %v", err)
+	}
+	vhits, err := b.SearchVector(ctx, []float32{1, 0, 0}, Filter{}, 10)
+	if err != nil {
+		t.Fatalf("searchvector: %v", err)
+	}
+	if len(vhits) != 1 || vhits[0].ID != "models/churn" {
+		t.Errorf("B did not project A's vector: %+v", vhits)
+	}
+}

--- a/internal/projstore/mem.go
+++ b/internal/projstore/mem.go
@@ -1,0 +1,78 @@
+package projstore
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// MemObjectStore is an in-memory ObjectStore that mirrors the GCS
+// semantics 0026 relies on: a monotonic per-write generation, CAS via
+// ifGeneration, strongly-consistent Get/List. It backs the package tests.
+type MemObjectStore struct {
+	mu      sync.Mutex
+	nextGen int64
+	objs    map[string]memObj
+}
+
+type memObj struct {
+	data []byte
+	gen  int64
+}
+
+func NewMemObjectStore() *MemObjectStore {
+	return &MemObjectStore{nextGen: 1, objs: map[string]memObj{}}
+}
+
+func (m *MemObjectStore) Get(_ context.Context, name string) (Object, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	o, ok := m.objs[name]
+	if !ok {
+		return Object{}, ErrNotFound
+	}
+	return Object{Data: append([]byte(nil), o.data...), Generation: o.gen}, nil
+}
+
+func (m *MemObjectStore) PutCAS(_ context.Context, name string, data []byte, ifGeneration int64) (int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cur, exists := m.objs[name]
+	switch {
+	case ifGeneration == CreateOnly:
+		if exists {
+			return 0, ErrExists
+		}
+	case ifGeneration == Unconditional:
+		// always allowed
+	default: // positive: must match current generation
+		if !exists || cur.gen != ifGeneration {
+			return 0, ErrConflict
+		}
+	}
+	gen := m.nextGen
+	m.nextGen++
+	m.objs[name] = memObj{data: append([]byte(nil), data...), gen: gen}
+	return gen, nil
+}
+
+func (m *MemObjectStore) Delete(_ context.Context, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.objs, name)
+	return nil
+}
+
+func (m *MemObjectStore) List(_ context.Context, prefix string) ([]ObjectMeta, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []ObjectMeta
+	for name, o := range m.objs {
+		if strings.HasPrefix(name, prefix) {
+			out = append(out, ObjectMeta{Name: name, Generation: o.gen})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}

--- a/internal/projstore/objectstore.go
+++ b/internal/projstore/objectstore.go
@@ -1,0 +1,67 @@
+// Package projstore implements the core of design doc 0026: Cloud Storage
+// 一本化 (builder を持たない要求駆動). GCS objects are the source of truth
+// (entries/<id>.json, versioned, written with compare-and-swap); each
+// instance projects them into an in-RAM index — a pg_trgm-faithful lexical
+// scorer, a flat float32 vector scan, and a backlink map — refreshed on
+// demand from a strongly-consistent LIST.
+//
+// This package is the 0026 engine, unit-tested against an in-memory object
+// store (mem.go) and runnable against real GCS (gcs.go, whose semantics
+// cmd/gcsverify confirmed). It does not yet replace internal/store; the
+// service-layer cutover is a follow-on change.
+package projstore
+
+import (
+	"context"
+	"errors"
+)
+
+var (
+	// ErrNotFound is returned by Get when no live object exists.
+	ErrNotFound = errors.New("projstore: entry not found")
+	// ErrConflict is a CAS miss: the object's generation moved under a
+	// positive ifGeneration precondition (0026 §6.2 rule 1). The caller
+	// re-reads and retries.
+	ErrConflict = errors.New("projstore: entry changed since it was read")
+	// ErrExists is a create-only miss: the object already existed under an
+	// ifGeneration==0 precondition (0026 §6.2 rule 2).
+	ErrExists = errors.New("projstore: entry already exists")
+)
+
+// Unconditional and CreateOnly are ifGeneration sentinels for PutCAS.
+const (
+	Unconditional int64 = -1 // overwrite regardless of current generation
+	CreateOnly    int64 = 0  // must not already exist (DoesNotExist)
+	// A positive value is a GenerationMatch precondition.
+)
+
+// Object is a stored object plus the generation identifying its version.
+type Object struct {
+	Data       []byte
+	Generation int64
+}
+
+// ObjectMeta is what a LIST returns without a GET: a name and its current
+// generation. Diff detection reads generations only (0026 §5.2).
+type ObjectMeta struct {
+	Name       string
+	Generation int64
+}
+
+// ObjectStore is the narrow GCS surface 0026 depends on. Both the GCS
+// implementation and the in-memory test double satisfy it.
+type ObjectStore interface {
+	// Get returns the current object and its generation, or ErrNotFound.
+	Get(ctx context.Context, name string) (Object, error)
+	// PutCAS writes data under an ifGeneration precondition: Unconditional
+	// overwrites; CreateOnly requires absence (miss → ErrExists); a positive
+	// value requires that generation (miss → ErrConflict). It returns the
+	// new generation.
+	PutCAS(ctx context.Context, name string, data []byte, ifGeneration int64) (int64, error)
+	// Delete removes the current version; bucket versioning retains history
+	// (0026 §6.2). Deleting an absent object is not an error.
+	Delete(ctx context.Context, name string) error
+	// List returns every object under prefix with its generation in one
+	// strongly-consistent pass (0026 §6.1).
+	List(ctx context.Context, prefix string) ([]ObjectMeta, error)
+}

--- a/internal/projstore/projection.go
+++ b/internal/projstore/projection.go
@@ -1,0 +1,79 @@
+package projstore
+
+import (
+	"encoding/binary"
+	"math"
+	"strings"
+
+	"github.com/na0fu3y/ochakai/internal/domain"
+)
+
+// indexed is one entry's in-RAM projection: the entry itself, the
+// generation of entries/<id>.json it was built from, the trigram set of
+// the similarity() field, the lowercased substring-boost field, and the
+// embedding (nil if none).
+type indexed struct {
+	k        domain.Knowledge
+	gen      int64
+	simTrig  map[string]struct{}
+	likeText string
+	vec      []float32
+}
+
+func buildIndexed(k domain.Knowledge, gen int64) *indexed {
+	return &indexed{
+		k:        k,
+		gen:      gen,
+		simTrig:  trigramSet(simText(&k)),
+		likeText: strings.ToLower(likeText(&k)),
+	}
+}
+
+// simText is the field pg_trgm.similarity() scores against, matching
+// store.SearchLexical: id, title, description, tags, body (attachment
+// names are appended by the store when available).
+func simText(k *domain.Knowledge) string {
+	return strings.Join([]string{k.ID, k.Title, k.Description, strings.Join(k.Tags, " "), k.Body}, " ")
+}
+
+// likeText is the substring-boost field: id, title, description, body —
+// note it excludes tags, exactly as the ILIKE arm of store.SearchLexical.
+func likeText(k *domain.Knowledge) string {
+	return strings.Join([]string{k.ID, k.Title, k.Description, k.Body}, " ")
+}
+
+// --- vector helpers (0026 §4.1: flat float32, full scan) -------------------
+
+func encodeF32(v []float32) []byte {
+	b := make([]byte, 4*len(v))
+	for i, f := range v {
+		binary.LittleEndian.PutUint32(b[i*4:], math.Float32bits(f))
+	}
+	return b
+}
+
+func decodeF32(b []byte) []float32 {
+	n := len(b) / 4
+	v := make([]float32, n)
+	for i := 0; i < n; i++ {
+		v[i] = math.Float32frombits(binary.LittleEndian.Uint32(b[i*4:]))
+	}
+	return v
+}
+
+// cosine is the cosine similarity pgvector reports as 1 - (a <=> b).
+func cosine(a, b []float32) float64 {
+	if len(a) != len(b) || len(a) == 0 {
+		return 0
+	}
+	var dot, na, nb float64
+	for i := range a {
+		dot += float64(a[i]) * float64(b[i])
+		na += float64(a[i]) * float64(a[i])
+		nb += float64(b[i]) * float64(b[i])
+	}
+	if na == 0 || nb == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(na) * math.Sqrt(nb))
+}

--- a/internal/projstore/projection_test.go
+++ b/internal/projstore/projection_test.go
@@ -1,0 +1,108 @@
+package projstore
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/na0fu3y/ochakai/internal/domain"
+)
+
+// TestSearchLexicalScoring checks the composed score matches the
+// store.SearchLexical formula: similarity + 0.3 substring + 0.05 verified,
+// kept when > 0.05, ranked desc.
+func TestSearchLexicalScoring(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore()
+	// exact holds the query as a substring (gets the 0.3 floor) and is
+	// verified (+0.05); partial only shares trigrams; unrelated scores ~0.
+	_ = s.Create(ctx, mkK("metrics/revenue", "revenue", "monthly revenue rollup", domain.StatusVerified))
+	_ = s.Create(ctx, mkK("metrics/revenues", "revenues", "yearly revenues", domain.StatusDraft))
+	_ = s.Create(ctx, mkK("other/weather", "weather", "unrelated text", domain.StatusDraft))
+
+	hits, err := s.SearchLexical(ctx, "revenue", Filter{}, 10)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(hits) < 2 {
+		t.Fatalf("want >=2 hits, got %d: %+v", len(hits), hits)
+	}
+	if hits[0].ID != "metrics/revenue" {
+		t.Errorf("top hit = %q, want metrics/revenue", hits[0].ID)
+	}
+	// The top hit carries the substring floor (0.3) plus verified (0.05)
+	// on top of its trigram similarity, so it clears 0.35 and outranks the
+	// draft "revenues" entry (which lacks the verified boost).
+	if hits[0].Score <= 0.35 {
+		t.Errorf("top score = %v, want > 0.35 (substring + verified + sim)", hits[0].Score)
+	}
+	if hits[0].Score <= hits[1].Score {
+		t.Errorf("verified entry should outrank draft: %v vs %v", hits[0].Score, hits[1].Score)
+	}
+	// Unrelated entry is below the 0.05 floor and excluded.
+	for _, h := range hits {
+		if h.ID == "other/weather" {
+			t.Errorf("unrelated entry should be filtered out: %v", h.Score)
+		}
+	}
+}
+
+func TestSearchLexicalFilters(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore()
+	_ = s.Create(ctx, mkK("a", "revenue metric", "x", domain.StatusVerified))
+	_ = s.Create(ctx, mkK("b", "revenue model", "x", domain.StatusDraft))
+
+	hits, _ := s.SearchLexical(ctx, "revenue", Filter{Statuses: []domain.Status{domain.StatusVerified}}, 10)
+	if len(hits) != 1 || hits[0].ID != "a" {
+		t.Errorf("status filter failed: %+v", hits)
+	}
+	// Type matches case-insensitively (design doc 0023 §3.3).
+	hits, _ = s.SearchLexical(ctx, "revenue", Filter{Types: []domain.Type{"CONCEPT"}}, 10)
+	if len(hits) != 2 {
+		t.Errorf("case-insensitive type filter failed: %+v", hits)
+	}
+}
+
+func TestSearchVectorFlatScan(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore()
+	_ = s.Create(ctx, mkK("near", "n", "n", domain.StatusDraft))
+	_ = s.Create(ctx, mkK("far", "f", "f", domain.StatusDraft))
+	if err := s.SetVector(ctx, "near", []float32{1, 0, 0}); err != nil {
+		t.Fatalf("setvector: %v", err)
+	}
+	if err := s.SetVector(ctx, "far", []float32{0, 1, 0}); err != nil {
+		t.Fatalf("setvector: %v", err)
+	}
+	hits, err := s.SearchVector(ctx, []float32{1, 0, 0}, Filter{}, 10)
+	if err != nil {
+		t.Fatalf("searchvector: %v", err)
+	}
+	if len(hits) != 2 || hits[0].ID != "near" {
+		t.Fatalf("vector ranking wrong: %+v", hits)
+	}
+	if math.Abs(hits[0].Score-1) > 1e-6 {
+		t.Errorf("near cosine = %v, want 1", hits[0].Score)
+	}
+}
+
+// TestBacklinks derives links from the body (design doc 0024) and inverts
+// them, the fold 0026 does in-RAM.
+func TestBacklinks(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore()
+	// Body references another entry via an ochakai:// link.
+	src := mkK("models/churn", "churn", "uses ochakai://metrics/revenue as input", domain.StatusDraft)
+	src.Links = domain.LinksFromBody(src.ID, src.Body)
+	_ = s.Create(ctx, src)
+	_ = s.Create(ctx, mkK("metrics/revenue", "revenue", "the metric", domain.StatusDraft))
+
+	back, err := s.ListLinkingTo(ctx, "metrics/revenue", 10)
+	if err != nil {
+		t.Fatalf("backlinks: %v", err)
+	}
+	if len(back) != 1 || back[0].ID != "models/churn" {
+		t.Errorf("backlinks = %+v, want [models/churn]", back)
+	}
+}

--- a/internal/projstore/store.go
+++ b/internal/projstore/store.go
@@ -1,0 +1,394 @@
+package projstore
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/na0fu3y/ochakai/internal/domain"
+)
+
+// ErrAlreadyExists is returned by Create when the id is already live.
+var ErrAlreadyExists = errors.New("projstore: knowledge already exists")
+
+// Store is the 0026 store: GCS objects are the source of truth, an in-RAM
+// projection is the index. Writes go straight to objects with CAS; reads
+// by id read objects (strong, read-your-writes); search reads the
+// projection, which each instance refreshes from a LIST on demand.
+type Store struct {
+	os       ObjectStore
+	prefix   string // entry object prefix, e.g. "entries/"
+	vprefix  string // vector object prefix, e.g. "vectors/"
+	interval time.Duration
+
+	mu      sync.RWMutex
+	entries map[string]*indexed // id -> projection
+	vgens   map[string]int64    // id -> generation of its loaded vector
+	last    time.Time
+}
+
+// New returns a Store over os. The projection starts empty; the first
+// search (or an explicit Refresh) loads it.
+func New(os ObjectStore) *Store {
+	return &Store{
+		os:      os,
+		prefix:  "entries/",
+		vprefix: "vectors/",
+		entries: map[string]*indexed{},
+		vgens:   map[string]int64{},
+	}
+}
+
+// SetRefreshInterval throttles projection refresh: a search refreshes at
+// most once per interval (0026 §5.2/§10). Zero (the default) refreshes on
+// every search — convenient for tests and low-traffic instances.
+func (s *Store) SetRefreshInterval(d time.Duration) { s.interval = d }
+
+func (s *Store) entryName(id string) string  { return s.prefix + id + ".json" }
+func (s *Store) vectorName(id string) string { return s.vprefix + id + ".f32" }
+
+func (s *Store) idFromEntry(name string) (string, bool) {
+	if !strings.HasPrefix(name, s.prefix) || !strings.HasSuffix(name, ".json") {
+		return "", false
+	}
+	return strings.TrimSuffix(strings.TrimPrefix(name, s.prefix), ".json"), true
+}
+
+// --- writes (objects are the truth) ----------------------------------------
+
+// Create writes a new entry create-only: a colliding id returns
+// ErrAlreadyExists (0026 §6.2 rule 2). A previously soft-deleted id is
+// free to reuse — its history survives as noncurrent object versions.
+func (s *Store) Create(ctx context.Context, k *domain.Knowledge) error {
+	now := time.Now().UTC()
+	k.CreatedAt, k.UpdatedAt = now, now
+	data, err := marshalEntry(k)
+	if err != nil {
+		return err
+	}
+	gen, err := s.os.PutCAS(ctx, s.entryName(k.ID), data, CreateOnly)
+	if errors.Is(err, ErrExists) {
+		return ErrAlreadyExists
+	}
+	if err != nil {
+		return err
+	}
+	s.project(k, gen)
+	return nil
+}
+
+// Update overwrites the live entry under compare-and-swap. When ifMatch
+// is non-nil it must equal the stored updated_at (the #108 optimistic
+// lock); independently the write is conditioned on the object's current
+// generation, so a concurrent writer loses with ErrConflict (0026 §6.2
+// rule 1). Missing entry → ErrNotFound.
+func (s *Store) Update(ctx context.Context, k *domain.Knowledge, actor domain.Actor, ifMatch *time.Time) error {
+	cur, err := s.os.Get(ctx, s.entryName(k.ID))
+	if errors.Is(err, ErrNotFound) {
+		return ErrNotFound
+	}
+	if err != nil {
+		return err
+	}
+	var curK domain.Knowledge
+	if err := json.Unmarshal(cur.Data, &curK); err != nil {
+		return err
+	}
+	if ifMatch != nil && !curK.UpdatedAt.Equal(*ifMatch) {
+		return ErrConflict
+	}
+	k.CreatedAt = curK.CreatedAt
+	k.UpdatedAt = time.Now().UTC()
+	data, err := marshalEntry(k)
+	if err != nil {
+		return err
+	}
+	gen, err := s.os.PutCAS(ctx, s.entryName(k.ID), data, cur.Generation)
+	if err != nil {
+		return err // ErrConflict on a lost CAS race
+	}
+	s.project(k, gen)
+	return nil
+}
+
+// SoftDelete removes the entry from reads; bucket versioning keeps its
+// history (0026 §6.2). Deleting an absent id is a no-op.
+func (s *Store) SoftDelete(ctx context.Context, id string, actor domain.Actor) error {
+	if err := s.os.Delete(ctx, s.entryName(id)); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	delete(s.entries, id)
+	s.mu.Unlock()
+	return nil
+}
+
+// SetVector writes an entry's embedding to vectors/<id>.f32 (0026 §6.2
+// rule 3 — embeddings are confirmed at write time, never rebuilt). The
+// caller supplies the vector (the service owns the Vertex call).
+func (s *Store) SetVector(ctx context.Context, id string, vec []float32) error {
+	gen, err := s.os.PutCAS(ctx, s.vectorName(id), encodeF32(vec), Unconditional)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	if e := s.entries[id]; e != nil {
+		e.vec = append([]float32(nil), vec...)
+	}
+	s.vgens[id] = gen
+	s.mu.Unlock()
+	return nil
+}
+
+// --- reads -----------------------------------------------------------------
+
+// Get reads the entry directly from its object: strongly consistent, so
+// "save then open" always sees the latest (0026 §7).
+func (s *Store) Get(ctx context.Context, id string) (*domain.Knowledge, error) {
+	o, err := s.os.Get(ctx, s.entryName(id))
+	if errors.Is(err, ErrNotFound) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	var k domain.Knowledge
+	if err := json.Unmarshal(o.Data, &k); err != nil {
+		return nil, err
+	}
+	return &k, nil
+}
+
+// ListAll returns every live entry from the projection (after a refresh).
+func (s *Store) ListAll(ctx context.Context) ([]domain.Knowledge, error) {
+	if err := s.Refresh(ctx); err != nil {
+		return nil, err
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]domain.Knowledge, 0, len(s.entries))
+	for _, e := range s.entries {
+		out = append(out, e.k)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out, nil
+}
+
+// ListLinkingTo returns entries whose body-derived links (design doc 0024)
+// point at id — the backlinks 0026 folds in-RAM from the full entry set.
+func (s *Store) ListLinkingTo(ctx context.Context, id string, limit int) ([]domain.Knowledge, error) {
+	if err := s.Refresh(ctx); err != nil {
+		return nil, err
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var out []domain.Knowledge
+	for _, e := range s.entries {
+		for _, l := range e.k.Links {
+			if l.Target == id {
+				out = append(out, e.k)
+				break
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+// SearchLexical reproduces store.SearchLexical in-process: similarity() +
+// a 0.3 substring floor + a 0.05 verified boost, kept when > 0.05, ranked
+// desc. The substring floor is a literal Contains, so the ILIKE wildcard
+// bug (design doc 0026 §13-3) cannot occur here.
+func (s *Store) SearchLexical(ctx context.Context, query string, f Filter, limit int) ([]domain.SearchHit, error) {
+	if err := s.Refresh(ctx); err != nil {
+		return nil, err
+	}
+	qtrig := trigramSet(query)
+	qlike := strings.ToLower(query)
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var hits []domain.SearchHit
+	for _, e := range s.entries {
+		if !f.match(&e.k) {
+			continue
+		}
+		score := similaritySets(e.simTrig, qtrig)
+		if strings.Contains(e.likeText, qlike) {
+			score += 0.3
+		}
+		if e.k.Status == domain.StatusVerified {
+			score += 0.05
+		}
+		if score > 0.05 {
+			hits = append(hits, domain.SearchHit{Knowledge: e.k, Score: score})
+		}
+	}
+	return topHits(hits, limit), nil
+}
+
+// SearchVector ranks entries by cosine similarity against a flat scan of
+// stored embeddings (0026 §4.1) — bit-for-bit the full scan migrate.go
+// already deems sufficient, moved in-process.
+func (s *Store) SearchVector(ctx context.Context, vec []float32, f Filter, limit int) ([]domain.SearchHit, error) {
+	if err := s.Refresh(ctx); err != nil {
+		return nil, err
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var hits []domain.SearchHit
+	for _, e := range s.entries {
+		if e.vec == nil || !f.match(&e.k) {
+			continue
+		}
+		hits = append(hits, domain.SearchHit{Knowledge: e.k, Score: cosine(vec, e.vec)})
+	}
+	return topHits(hits, limit), nil
+}
+
+// --- projection refresh (0026 §5.2) ----------------------------------------
+
+// Refresh brings the in-RAM projection up to the current object set: a
+// strongly-consistent LIST, diffed by generation, GETs only what changed,
+// and drops what vanished. Throttled by the refresh interval. This is the
+// whole "builder" — request-driven, in-process, no separate job.
+func (s *Store) Refresh(ctx context.Context) error {
+	s.mu.Lock()
+	if s.interval > 0 && !s.last.IsZero() && time.Since(s.last) < s.interval {
+		s.mu.Unlock()
+		return nil
+	}
+	s.mu.Unlock()
+
+	metas, err := s.os.List(ctx, s.prefix)
+	if err != nil {
+		return err
+	}
+	seen := make(map[string]bool, len(metas))
+	for _, m := range metas {
+		id, ok := s.idFromEntry(m.Name)
+		if !ok {
+			continue
+		}
+		seen[id] = true
+		s.mu.RLock()
+		cur, have := s.entries[id]
+		s.mu.RUnlock()
+		if have && cur.gen == m.Generation {
+			continue // unchanged
+		}
+		o, err := s.os.Get(ctx, m.Name)
+		if errors.Is(err, ErrNotFound) {
+			continue // raced with a delete; the next LIST reconciles
+		}
+		if err != nil {
+			return err
+		}
+		var k domain.Knowledge
+		if err := json.Unmarshal(o.Data, &k); err != nil {
+			return err
+		}
+		ind := buildIndexed(k, o.Generation)
+		s.mu.Lock()
+		if old := s.entries[id]; old != nil {
+			ind.vec = old.vec // keep the loaded embedding across an entry edit
+		}
+		s.entries[id] = ind
+		s.mu.Unlock()
+	}
+
+	// Drop entries whose objects are gone.
+	s.mu.Lock()
+	for id := range s.entries {
+		if !seen[id] {
+			delete(s.entries, id)
+			delete(s.vgens, id)
+		}
+	}
+	s.mu.Unlock()
+
+	if err := s.refreshVectors(ctx); err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	s.last = time.Now()
+	s.mu.Unlock()
+	return nil
+}
+
+// refreshVectors pulls changed embeddings (vectors/<id>.f32) into the
+// projection, so an instance sees vectors other instances wrote.
+func (s *Store) refreshVectors(ctx context.Context) error {
+	metas, err := s.os.List(ctx, s.vprefix)
+	if err != nil {
+		return err
+	}
+	for _, m := range metas {
+		id := strings.TrimSuffix(strings.TrimPrefix(m.Name, s.vprefix), ".f32")
+		s.mu.RLock()
+		_, live := s.entries[id]
+		known := s.vgens[id]
+		s.mu.RUnlock()
+		if !live || known == m.Generation {
+			continue
+		}
+		o, err := s.os.Get(ctx, m.Name)
+		if errors.Is(err, ErrNotFound) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		vec := decodeF32(o.Data)
+		s.mu.Lock()
+		if e := s.entries[id]; e != nil {
+			e.vec = vec
+		}
+		s.vgens[id] = o.Generation
+		s.mu.Unlock()
+	}
+	return nil
+}
+
+// project applies a just-written entry to the local projection so the
+// writing instance reflects its own write without waiting for a refresh.
+func (s *Store) project(k *domain.Knowledge, gen int64) {
+	ind := buildIndexed(*k, gen)
+	s.mu.Lock()
+	if old := s.entries[k.ID]; old != nil {
+		ind.vec = old.vec
+	}
+	s.entries[k.ID] = ind
+	s.mu.Unlock()
+}
+
+// --- helpers ---------------------------------------------------------------
+
+// marshalEntry serializes k as its object body. Attachments are managed
+// through their own objects, never stored in the entry (they are read-only
+// metadata on the domain type), so they are cleared first.
+func marshalEntry(k *domain.Knowledge) ([]byte, error) {
+	c := *k
+	c.Attachments = nil
+	return json.Marshal(&c)
+}
+
+func topHits(hits []domain.SearchHit, limit int) []domain.SearchHit {
+	sort.Slice(hits, func(i, j int) bool {
+		if hits[i].Score != hits[j].Score {
+			return hits[i].Score > hits[j].Score
+		}
+		return hits[i].ID < hits[j].ID
+	})
+	if limit > 0 && len(hits) > limit {
+		hits = hits[:limit]
+	}
+	return hits
+}

--- a/internal/projstore/store_test.go
+++ b/internal/projstore/store_test.go
@@ -1,0 +1,117 @@
+package projstore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/na0fu3y/ochakai/internal/domain"
+)
+
+func newTestStore() *Store { return New(NewMemObjectStore()) }
+
+func mkK(id, title, body string, status domain.Status) *domain.Knowledge {
+	return &domain.Knowledge{
+		Type: "concept", ID: id, Title: title, Body: body, Status: status,
+		CreatedBy: domain.Actor{Kind: "human", Name: "t"},
+	}
+}
+
+func TestCreateGetAndCreateOnly(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore()
+	k := mkK("metrics/revenue", "売上", "四半期の売上を集計する", domain.StatusDraft)
+	if err := s.Create(ctx, k); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	// Read-your-writes: Get sees it immediately.
+	got, err := s.Get(ctx, "metrics/revenue")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Title != "売上" || got.CreatedAt.IsZero() {
+		t.Errorf("unexpected entry: %+v", got)
+	}
+	// Create-only: a second create on the same id is rejected.
+	if err := s.Create(ctx, mkK("metrics/revenue", "dup", "x", domain.StatusDraft)); err != ErrAlreadyExists {
+		t.Errorf("duplicate create err = %v, want ErrAlreadyExists", err)
+	}
+}
+
+func TestUpdateOptimisticLockAndCAS(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore()
+	k := mkK("a", "A", "body", domain.StatusDraft)
+	if err := s.Create(ctx, k); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	cur, _ := s.Get(ctx, "a")
+
+	// Stale ifMatch is rejected (the #108 optimistic lock).
+	stale := cur.UpdatedAt.Add(-time.Hour)
+	if err := s.Update(ctx, mkK("a", "A2", "body2", domain.StatusDraft), cur.CreatedBy, &stale); err != ErrConflict {
+		t.Errorf("stale ifMatch err = %v, want ErrConflict", err)
+	}
+	// Correct ifMatch succeeds.
+	up := mkK("a", "A2", "body2", domain.StatusDraft)
+	if err := s.Update(ctx, up, cur.CreatedBy, &cur.UpdatedAt); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	got, _ := s.Get(ctx, "a")
+	if got.Title != "A2" || !got.CreatedAt.Equal(cur.CreatedAt) {
+		t.Errorf("update lost fields: %+v", got)
+	}
+	// Missing entry.
+	if err := s.Update(ctx, mkK("nope", "x", "y", domain.StatusDraft), cur.CreatedBy, nil); err != ErrNotFound {
+		t.Errorf("update missing err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestSoftDeleteRemovesFromReadsAndSearch(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore()
+	_ = s.Create(ctx, mkK("gone", "消える", "検索対象の本文", domain.StatusDraft))
+	if _, err := s.Get(ctx, "gone"); err != nil {
+		t.Fatalf("precondition get: %v", err)
+	}
+	if err := s.SoftDelete(ctx, "gone", domain.Actor{Kind: "human", Name: "t"}); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := s.Get(ctx, "gone"); err != ErrNotFound {
+		t.Errorf("get after delete = %v, want ErrNotFound", err)
+	}
+	hits, _ := s.SearchLexical(ctx, "検索対象", Filter{}, 10)
+	if len(hits) != 0 {
+		t.Errorf("deleted entry still in search: %+v", hits)
+	}
+}
+
+// TestRefreshPicksUpForeignWrites simulates a second instance: writes land
+// in the object store directly, and a Refresh must project them (0026 §5.2).
+func TestRefreshPicksUpForeignWrites(t *testing.T) {
+	ctx := context.Background()
+	os := NewMemObjectStore()
+	a := New(os) // instance A
+	b := New(os) // instance B, shares the same objects
+
+	// A creates an entry; B hasn't refreshed yet.
+	if err := a.Create(ctx, mkK("x", "タイトル", "ベクトル検索の本文", domain.StatusVerified)); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	// B's search refreshes from LIST and finds it.
+	hits, err := b.SearchLexical(ctx, "ベクトル検索", Filter{}, 10)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(hits) != 1 || hits[0].ID != "x" {
+		t.Fatalf("B did not project A's write: %+v", hits)
+	}
+	// A deletes it; B's next refresh drops it.
+	if err := a.SoftDelete(ctx, "x", domain.Actor{Kind: "human", Name: "t"}); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	hits, _ = b.SearchLexical(ctx, "ベクトル検索", Filter{}, 10)
+	if len(hits) != 0 {
+		t.Errorf("B still sees deleted entry: %+v", hits)
+	}
+}

--- a/internal/projstore/trigram.go
+++ b/internal/projstore/trigram.go
@@ -1,0 +1,67 @@
+package projstore
+
+import (
+	"strings"
+	"unicode"
+)
+
+// trigramSet reproduces PostgreSQL pg_trgm.show_trgm for s: lowercase,
+// split into words on non-alphanumeric runes, pad each word with two
+// leading and one trailing space, and take every length-3 rune window.
+//
+//	"word"  -> {"  w", " wo", "wor", "ord", "rd "}
+//	"添付"  -> {"  添", " 添付", "添付 "}   (padding makes 2-char CJK searchable)
+//
+// This is the basis of the 99.3% top-10 match to pg_trgm measured in
+// 0026 §3. Unlike PostgreSQL, multibyte trigrams are kept as true runes
+// rather than CRC32-compressed into 3 bytes, which is strictly more
+// faithful (the sole source of the 0.7% divergence, always in our favor).
+func trigramSet(s string) map[string]struct{} {
+	set := make(map[string]struct{})
+	for _, word := range words(strings.ToLower(s)) {
+		rs := make([]rune, 0, len([]rune(word))+3)
+		rs = append(rs, ' ', ' ')
+		rs = append(rs, []rune(word)...)
+		rs = append(rs, ' ')
+		for i := 0; i+3 <= len(rs); i++ {
+			set[string(rs[i:i+3])] = struct{}{}
+		}
+	}
+	return set
+}
+
+// words splits on runes pg_trgm does not treat as word characters
+// (anything that is neither a Unicode letter nor number).
+func words(s string) []string {
+	return strings.FieldsFunc(s, func(r rune) bool {
+		return !(unicode.IsLetter(r) || unicode.IsNumber(r))
+	})
+}
+
+// similaritySets is pg_trgm.similarity: |A∩B| / |A∪B| over trigram sets.
+func similaritySets(a, b map[string]struct{}) float64 {
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+	// Iterate the smaller set for the intersection.
+	small, large := a, b
+	if len(large) < len(small) {
+		small, large = large, small
+	}
+	inter := 0
+	for t := range small {
+		if _, ok := large[t]; ok {
+			inter++
+		}
+	}
+	union := len(a) + len(b) - inter
+	if union == 0 {
+		return 0
+	}
+	return float64(inter) / float64(union)
+}
+
+// similarity is pg_trgm.similarity(a, b) computed from scratch.
+func similarity(a, b string) float64 {
+	return similaritySets(trigramSet(a), trigramSet(b))
+}

--- a/internal/projstore/trigram_test.go
+++ b/internal/projstore/trigram_test.go
@@ -1,0 +1,65 @@
+package projstore
+
+import (
+	"math"
+	"testing"
+)
+
+// TestTrigramSet locks the pg_trgm.show_trgm output the 0026 §3 match
+// depends on, including the CJK padding that lets 2-char queries hit.
+func TestTrigramSet(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"word", []string{"  w", " wo", "wor", "ord", "rd "}},
+		{"添付", []string{"  添", " 添付", "添付 "}},
+		{"a", []string{"  a", " a "}},
+		{"a b", []string{"  a", " a ", "  b", " b "}}, // two words, separate padding
+	}
+	for _, c := range cases {
+		got := trigramSet(c.in)
+		if len(got) != len(c.want) {
+			t.Errorf("%q: got %d trigrams %v, want %d %v", c.in, len(got), keys(got), len(c.want), c.want)
+			continue
+		}
+		for _, w := range c.want {
+			if _, ok := got[w]; !ok {
+				t.Errorf("%q: missing trigram %q (got %v)", c.in, w, keys(got))
+			}
+		}
+	}
+}
+
+func TestSimilarity(t *testing.T) {
+	// Identical strings are perfectly similar.
+	if s := similarity("revenue", "revenue"); math.Abs(s-1) > 1e-9 {
+		t.Errorf("identical similarity = %v, want 1", s)
+	}
+	// Disjoint strings share nothing.
+	if s := similarity("revenue", "xyz"); s != 0 {
+		t.Errorf("disjoint similarity = %v, want 0", s)
+	}
+	// Case-insensitive (pg_trgm folds case).
+	if s := similarity("Revenue", "revenue"); math.Abs(s-1) > 1e-9 {
+		t.Errorf("case-folded similarity = %v, want 1", s)
+	}
+	// Partial overlap sits strictly between 0 and 1.
+	if s := similarity("revenue", "revenues"); s <= 0 || s >= 1 {
+		t.Errorf("partial similarity = %v, want in (0,1)", s)
+	}
+	// Hand-computed value: T("添付")={"  添"," 添付","添付 "},
+	// T("添付検索")={"  添"," 添付","添付検","付検索","検索 "}. Intersection
+	// {"  添"," 添付"}=2, union 3+5-2=6 -> 1/3.
+	if s := similarity("添付", "添付検索"); math.Abs(s-1.0/3.0) > 1e-9 {
+		t.Errorf("CJK substring similarity = %v, want 1/3", s)
+	}
+}
+
+func keys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
## 概要

設計 0026([#109](https://github.com/na0fu3y/ochakai/pull/109))の **builder を持たない要求駆動ストアの核**を、新パッケージ `internal/projstore` として実装。**pgx の `store.Store` は温存**し、サービス層の全面切替は後続 PR に回す(安全な seam)。オブジェクトが正本、各インスタンスがそれを in-RAM に投影する。

## 中身

| ファイル | 役割 |
|---|---|
| `objectstore.go` | 0026 が依存する狭い GCS 面(CAS / create-only / list-generation)を `ObjectStore` として抽象化 |
| `mem.go` / `gcs.go` | インメモリ実装(テスト用)/ 本番 GCS 実装(ADC、`cmd/gcsverify` で意味論確認済み) |
| `trigram.go` | `pg_trgm.show_trgm` / `similarity` をプロセス内で再現(**0026 §3 の 99.3% 一致の基盤**)。CJK はパディングで2文字クエリも引け、マルチバイトを CRC32 圧縮しないぶん PostgreSQL より忠実 |
| `store.go` | オブジェクトが正本。Create=create-only、Update=updated_at 楽観ロック(#108)+ generation CAS(§6.2 ルール1)、Get=強整合 read-your-writes、SoftDelete=versioning に履歴。**Refresh が「builder」**— 強整合 LIST を generation 差分し変更分だけ GET(§5.2) |
| `projection.go` | 採点式(similarity + 0.3 substring + 0.05 verified、>0.05)を `store.SearchLexical` と一致、ベクトルは float32 全走査(§4.1)、逆リンクは body 由来(0024)を in-RAM 反転 |

## テスト

- **単体**(mem、DB 不要): trigram 忠実性(既知値 `word`/`添付`)、CAS/create-only、楽観ロック、検索採点・フィルタ・ベクトル・逆リンク、二インスタンス間の投影追随。`-race` クリーン
- **実 GCS 統合**(`OCHAKAI_GCS_TEST_PROJECT` 指定時のみ、使い捨てバケット自動作成→削除): ochakai-example で実行し **全 PASS** — create-only 412・read-your-writes・CAS 412・LIST 追随・ベクトル往復を実バケットで確認

## スコープ外(後続)

サービス層の 35 メソッド全切替、埋め込みの Vertex 呼び出し配線、添付、Move/Revisions、ローカル開発の GCS エミュレータ、既存データ移行(§15)。本 PR は 0026 の**核が本物のコードとして動く**ことを示す土台。

Refs #109。

🤖 Generated with [Claude Code](https://claude.com/claude-code)