### PR TITLE
エージェントに配る指示の型語彙とアドレスを現行仕様に揃える

### DIFF
--- a/cmd/ochakai/main.go
+++ b/cmd/ochakai/main.go
@@ -89,17 +89,17 @@ Client commands (talk to a server; --url > $OCHAKAI_URL > "use" selection):
   search [query]          search knowledge; verified entries rank higher
   browse [type[/prefix]]  list one level of the ID hierarchy (folder view)
   context <question>      the one-call read before a data question (full entries)
-  get <type>/<id>         print one entry as an OKF document
-  create [-f file]        create an entry from OKF markdown or JSON
-  update <type>/<id>      replace an entry (every change kept as a revision)
-  delete <type>/<id>      soft-delete an entry (history retained)
+  get <id>                print one entry as an OKF document
+  create [id] [-f file]   create an entry from OKF markdown or JSON
+  update <id>             replace an entry (every change kept as a revision)
+  delete <id>             soft-delete an entry (history retained)
   move <id> <new-id>      move (rename) an entry; references are rewritten
-  attach <type>/<id> <f>  attach files to an entry (png/jpeg/webp/pdf/text)
-  detach <type>/<id> <n>  remove an attachment
-  usage <type>/<id>       show usage totals (search hits, fetches, compiles, outcomes)
-  report <type>/<id> <o>  report an outcome: worked | failed (--note for why)
-  revisions <type>/<id>   list an entry's change history (newest first)
-  backlinks <type>/<id>   list entries whose links point at this one
+  attach <id> <file...>   attach files to an entry (png/jpeg/webp/pdf/text)
+  detach <id> <name>      remove an attachment
+  usage <id>              show usage totals (search hits, fetches, compiles, outcomes)
+  report <id> <outcome>   report an outcome: worked | failed (--note for why)
+  revisions <id>          list an entry's change history (newest first)
+  backlinks <id>          list entries whose links point at this one
   compile --metric <m>    compile metrics into BigQuery SQL (exit 2 = outside subset)
   export <dir | ->        download the knowledge base as an OKF bundle
   import <dir | tgz | ->  upload an OKF bundle (any producer's, not just ours)

--- a/cmd/ochakai/main_test.go
+++ b/cmd/ochakai/main_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// Guard: the help text addresses entries by path (design doc 0017). The
+// two-part "<type>/<id>" form predates it and no longer parses as two
+// arguments — an id is one path.
+func TestUsageAddressesEntriesByPath(t *testing.T) {
+	var b strings.Builder
+	usage(&b)
+	if strings.Contains(b.String(), "<type>/<id>") {
+		t.Errorf("usage() still documents the pre-0017 <type>/<id> address:\n%s", b.String())
+	}
+}
+
+// Guard: instructions we ship to agents name types in the 0023 vocabulary.
+// Free types mean a stale name is not rejected — an agent following the old
+// wording silently grows a "query"-typed entry beside the Golden Queries,
+// so these files are the only thing standing between the vocabulary and
+// drift.
+func TestShippedInstructionsUseCurrentTypeVocabulary(t *testing.T) {
+	for _, f := range []string{
+		"../../examples/claude-code/hooks/ochakai-write-back.sh",
+		"../../docs/guides/golden-query-canary.md",
+	} {
+		content, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		s := string(content)
+		for _, stale := range []string{"type: query", "type: insight", "type=query", "type=insight"} {
+			if strings.Contains(s, stale) {
+				t.Errorf("%s uses the pre-0023 type name %q", f, stale)
+			}
+		}
+		if !strings.Contains(s, "Golden Query") {
+			t.Errorf("%s never names the Golden Query type", f)
+		}
+	}
+}

--- a/docs/guides/golden-query-canary.md
+++ b/docs/guides/golden-query-canary.md
@@ -19,7 +19,7 @@ ochakai search --sort verified_at --type 'Golden Query' --status verified --limi
 ```
 
 REST 直接なら
-`GET /api/v1/knowledge?type=query&status=verified&sort=verified_at&limit=100`、
+`GET /api/v1/knowledge?type=Golden%20Query&status=verified&sort=verified_at&limit=100`、
 MCP なら `search_knowledge` の `sort: "verified_at"` が同じフィードを返す。
 `sort=verified_at` は検証日時の古い順(未検証は最後)に返す。「90 日以上
 再検証されていない verified query」がカナリアの起点になる。OKF エクスポート
@@ -79,7 +79,7 @@ jobs:
         run: |
           TOKEN=$(gcloud auth print-identity-token --audiences="$OCHAKAI_URL")
           curl -s -H "Authorization: Bearer $TOKEN" \
-            "$OCHAKAI_URL/api/v1/knowledge?type=query&status=verified&sort=verified_at&limit=50" \
+            "$OCHAKAI_URL/api/v1/knowledge?type=Golden%20Query&status=verified&sort=verified_at&limit=50" \
           | jq -c '.hits[]' | while read -r hit; do
               id=$(jq -r .id <<<"$hit")
               sql=$(jq -r .attrs.sql <<<"$hit")

--- a/examples/claude-code/hooks/ochakai-write-back.sh
+++ b/examples/claude-code/hooks/ochakai-write-back.sh
@@ -28,5 +28,5 @@ grep -qiE 'SELECT|ochakai|bigquery|warehouse' "$transcript" || exit 0
 
 jq -n '{
   decision: "block",
-  reason: "Before finishing: this session did data work. If a query you wrote proved correct and reusable, or you learned how to read a metric (a baseline, a seasonality, a caveat), write it back to ochakai — search first (including --status rejected) to avoid re-proposing, then `ochakai create` (type: query with attrs.question + attrs.sql, or type: insight). If nothing durable was learned, finish now without creating anything — do not invent knowledge."
+  reason: "Before finishing: this session did data work. If a query you wrote proved correct and reusable, or you learned how to read a metric (a baseline, a seasonality, a caveat), write it back to ochakai — search first (including --status rejected) to avoid re-proposing, then `ochakai create <path>` (type \"Golden Query\" with attrs.question + attrs.sql, or type \"Insight\"). If nothing durable was learned, finish now without creating anything — do not invent knowledge."
 }'


### PR DESCRIPTION
埋め込み用途のレビューで指摘を受けた、我々がエージェントと利用者に配っている指示文の陳腐化。3 箇所とも「今すぐ直せるバグ」で、実害の出方が違う。

## 直したもの

| 箇所 | 症状 |
|---|---|
| `examples/claude-code/hooks/ochakai-write-back.sh` | 指示文が 0023 以前の `type: query` / `type: insight`。**自由型なのでエラーにならず**、指示通りに従ったエージェントが `query` という型のエントリを Golden Query の隣に静かに生やす |
| `docs/guides/golden-query-canary.md` | REST 例が `type=query`。0023 後の正規表記は `Golden Query` なので、この URL をコピーした CI ジョブは**常に 0 件を返し、カナリアが 1 本も走らない**。すぐ上の CLI 例だけが `--type 'Golden Query'` で正しかった |
| `cmd/ochakai/main.go` の usage | 0017(パス addressing)以前の `get <type>/<id>` が残存。id は 1 本のパスであって 2 引数ではない |

型フィルタは #102 で大小文字非依存になったが、`query` と `Golden Query` は別語なので救われない。

## 別名解決を入れなかった理由

0023 が自由型を認めた以上、`query` → `Golden Query` の自動変換は「利用者が意図して付けた `query` という型」と区別できない。語彙のドリフトは変換で吸収するのではなく、配る指示の側を正しく保つのが筋。

## テスト

`cmd/ochakai/main_test.go` に回帰テストを 2 本。usage が `<type>/<id>` を含まないこと、配布する指示ファイルが旧語彙を含まず `Golden Query` を名指ししていること。ここが再び腐るのを検出する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)