### PR TITLE
埋め込みテキストの切り詰めをルーン境界に揃え、上限を 6000 バイトに上げる

### DIFF
--- a/internal/service/attachment.go
+++ b/internal/service/attachment.go
@@ -53,11 +53,14 @@ func (s *Service) updateAttachmentEmbedding(ctx context.Context, id string, att 
 	}
 	var vec []float32
 	if att.MediaType == "text/plain" {
-		body := data
-		if len(body) > 4000 {
-			body = body[:4000] // same truncation as the entry body
+		head := data
+		if len(head) > maxEmbedBodyBytes {
+			head = head[:maxEmbedBodyBytes] // cap before the copy
 		}
-		vecs, err := s.Embedder.Embed(ctx, embed.TaskDocument, []string{att.Name + "\n" + string(body)})
+		// truncateUTF8 still runs on the capped slice: the cut above may
+		// have landed inside a character.
+		body := truncateUTF8(string(head), maxEmbedBodyBytes)
+		vecs, err := s.Embedder.Embed(ctx, embed.TaskDocument, []string{att.Name + "\n" + body})
 		if err != nil {
 			s.Log.Warn("attachment embedding failed; attachment remains findable by name", "id", id, "name", att.Name, "error", err)
 			return

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/na0fu3y/ochakai/internal/compiler"
 	"github.com/na0fu3y/ochakai/internal/config"
@@ -558,6 +559,15 @@ func (s *Service) updateEmbedding(ctx context.Context, k *domain.Knowledge) {
 	}
 }
 
+// maxEmbedBodyBytes caps the body text handed to the embedding model. The
+// real limit is tokens (2048 for gemini-embedding-001), and UTF-8 bytes
+// track tokens across scripts far better than characters do: roughly 4
+// bytes per token in English, 4-5 in Japanese. Capping by rune count
+// instead would let Japanese overrun the model's window while English
+// stayed far under it — 6000 bytes lands near 1300-1500 tokens either way,
+// with headroom for the envelope fields above.
+const maxEmbedBodyBytes = 6000
+
 // embeddingText builds the document text to embed: envelope fields plus the
 // golden query question, body truncated to keep within model input limits.
 // The id leads (design doc 0022): with title optional, the filename may be
@@ -567,12 +577,26 @@ func embeddingText(k *domain.Knowledge) string {
 	if q, ok := k.Attrs["question"].(string); ok {
 		parts = append(parts, q)
 	}
-	body := k.Body
-	if len(body) > 4000 {
-		body = body[:4000]
-	}
-	parts = append(parts, body)
+	parts = append(parts, truncateUTF8(k.Body, maxEmbedBodyBytes))
 	return strings.TrimSpace(strings.Join(parts, "\n"))
+}
+
+// truncateUTF8 caps s at max bytes and then drops a trailing partial rune.
+// A plain s[:max] lands mid-character two times in three on Japanese text
+// (3 bytes per character), and half a character is not valid UTF-8.
+func truncateUTF8(s string, max int) string {
+	if len(s) > max {
+		s = s[:max]
+	}
+	for len(s) > 0 {
+		// DecodeLastRuneInString reports (RuneError, 1) for a byte that
+		// cannot end a valid encoding; a real U+FFFD decodes with size 3.
+		if r, size := utf8.DecodeLastRuneInString(s); r != utf8.RuneError || size > 1 {
+			break
+		}
+		s = s[:len(s)-1]
+	}
+	return s
 }
 
 // --- compile ---

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/na0fu3y/ochakai/internal/compiler"
 	"github.com/na0fu3y/ochakai/internal/domain"
@@ -129,13 +130,53 @@ func TestEmbeddingText(t *testing.T) {
 // The body is truncated to stay within embedding-model input limits;
 // the envelope fields must survive untouched.
 func TestEmbeddingTextTruncatesBody(t *testing.T) {
-	k := &domain.Knowledge{Title: "T", Body: strings.Repeat("x", 5000)}
+	k := &domain.Knowledge{Title: "T", Body: strings.Repeat("x", maxEmbedBodyBytes+1000)}
 	got := embeddingText(k)
-	if len(got) > 4100 {
-		t.Errorf("embeddingText length = %d, want body capped at 4000", len(got))
+	if len(got) > maxEmbedBodyBytes+100 {
+		t.Errorf("embeddingText length = %d, want body capped at %d", len(got), maxEmbedBodyBytes)
 	}
 	if !strings.HasPrefix(got, "T") {
 		t.Errorf("title must lead the text: %q", got[:20])
+	}
+}
+
+// Japanese is 3 bytes per character in UTF-8, so a byte cap lands inside a
+// character unless it backs off. Half a character is not valid UTF-8, and
+// the API request carries it as a replacement char.
+func TestEmbeddingTextTruncatesOnRuneBoundary(t *testing.T) {
+	// 2001 characters * 3 bytes = 6003 bytes: the cap falls mid-character.
+	k := &domain.Knowledge{Body: strings.Repeat("売", 2001)}
+	got := embeddingText(k)
+	if !utf8.ValidString(got) {
+		t.Errorf("embeddingText produced invalid UTF-8 (length %d)", len(got))
+	}
+	if len(got) > maxEmbedBodyBytes {
+		t.Errorf("embeddingText length = %d, want <= %d", len(got), maxEmbedBodyBytes)
+	}
+	if want := maxEmbedBodyBytes / 3 * 3; len(got) != want {
+		t.Errorf("embeddingText length = %d, want %d (whole characters only)", len(got), want)
+	}
+}
+
+func TestTruncateUTF8(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		max  int
+		want string
+	}{
+		{"under the cap", "abc", 10, "abc"},
+		{"exactly the cap", "abc", 3, "abc"},
+		{"ascii cut", "abcdef", 3, "abc"},
+		{"cut one byte into a character", "あい", 4, "あ"},
+		{"cut two bytes into a character", "あい", 5, "あ"},
+		{"cut on a boundary", "あい", 3, "あ"},
+		{"cap smaller than one character", "あ", 2, ""},
+		{"a real U+FFFD survives", "x�", 4, "x�"},
+	} {
+		if got := truncateUTF8(tc.in, tc.max); got != tc.want {
+			t.Errorf("%s: truncateUTF8(%q, %d) = %q, want %q", tc.name, tc.in, tc.max, got, tc.want)
+		}
 	}
 }
 


### PR DESCRIPTION
埋め込み用途のレビューで「本文の埋め込みが先頭 4000 バイトなので、日本語は英語の 1/3 の情報量しか入らない」と指摘を受けた件。**問題意識は正しいが、提案された修正(rune 基準に変える)は逆効果**だったので、別の直し方をした。

## 1. 実バグ: 文字の途中で切れている

`body[:4000]` は日本語(UTF-8 で 1 文字 3 バイト)だと **3 回に 2 回、文字の途中で切れる**。不正な UTF-8 が Vertex へのリクエストに乗り、末尾が置換文字になっていた。添付テキストの埋め込み([attachment.go](internal/service/attachment.go))も同じ。

`truncateUTF8` で切ったあとの半端なバイト列を落とす。

## 2. rune 基準にしない理由

制約は文字数ではなく**トークン数**(gemini-embedding-001 の入力上限は 2048 トークン)。そして UTF-8 のバイト数は、文字数よりずっとよくトークン数を追う:

| | バイト/文字 | バイト/トークン |
|---|---|---|
| 英語 | 1 | 約 4 |
| 日本語 | 3 | 約 4〜5 |

つまり **4000 バイトは日英どちらも約 1000 トークンで、すでにほぼ公平**だった。ここを rune 基準(4000 文字)にすると、日本語は 12000 バイト・約 2700 トークンで **2048 の上限を超え**、英語は逆に大きく余らせる。指摘のまま実装すると悪化する。

## 3. 上限は上げる — 保守的すぎた

日英とも上限 2048 トークンの半分しか使っていなかった。**6000 バイト**なら 1300〜1500 トークンで、エンベロープ分の余裕を残しつつ上限内に収まる。日本語の実効情報量は 1333 文字 → 2000 文字で 1.5 倍。

## 反映のタイミング

既存エントリのベクトルは次に書き込まれるまで 4000 バイト時代のまま(モデル切り替え時と同じ性質、design 0020)。全体を揃えたい場合は再保存が要る。

## テスト

`truncateUTF8` の表駆動テスト(境界のちょうど上/下、1〜2 バイト食い込んだ場合、1 文字も入らない場合、本物の U+FFFD を消さないこと)と、日本語本文が有効な UTF-8 のまま丸ごとの文字数で切れることの確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)