### PR TITLE
get_context: バイト予算と、入りきらないエントリのアウトライン

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -190,6 +190,18 @@ paths:
             similarity plus boosts vs RRF rank fusion) — calibrate against
             your own corpus before use. Non-numeric values are a 400.
           schema: { type: number, default: 0 }
+        - name: budget
+          in: query
+          description: >
+            Cap the serialized bytes of entries returned in full. Entries
+            past the cap are listed under `outline` instead — an entry is
+            delivered whole or not at all, never truncated. Packing is
+            greedy, so one oversized entry high in the ranking does not
+            starve the rest. Defaults to 0 (no cap) here; the MCP
+            get_context tool defaults it on, because an agent's context
+            window is the scarce resource and an embedding host will not
+            set it.
+          schema: { type: integer, default: 0 }
       responses:
         "200":
           description: Ranked hits plus the full entries behind the top ones.
@@ -204,6 +216,16 @@ paths:
                   entries:
                     type: array
                     items: { $ref: "#/components/schemas/Knowledge" }
+                  outline:
+                    description: >
+                      Entries the budget dropped: named and sized, not
+                      delivered. Fetch any of them by id. Absent when
+                      nothing was dropped.
+                    type: array
+                    items: { $ref: "#/components/schemas/ContextOutline" }
+                  truncated:
+                    description: How many entries went to the outline.
+                    type: integer
         "400": { $ref: "#/components/responses/Error" }
   /api/v1/knowledge/{id}:
     parameters:
@@ -699,6 +721,23 @@ components:
                 Usage totals, present in the sort=usage listing (the draft
                 review feed) and the sort=failed listing (the re-verification
                 feed); absent for search results and the verified_at feed.
+    ContextOutline:
+      type: object
+      description: >
+        An entry a context pack could not afford to deliver in full:
+        enough to decide whether to spend a round trip fetching it by id,
+        and nothing more.
+      properties:
+        id: { type: string }
+        type: { $ref: "#/components/schemas/Type" }
+        title:
+          description: The display title — the entry's own, or its filename.
+          type: string
+        description: { type: string }
+        status: { $ref: "#/components/schemas/Status" }
+        bytes:
+          description: What the full entry would have cost.
+          type: integer
     Revision:
       type: object
       description: >

--- a/internal/apiclient/apiclient.go
+++ b/internal/apiclient/apiclient.go
@@ -143,9 +143,13 @@ func (c *Client) Search(ctx context.Context, p SearchParams) ([]domain.SearchHit
 
 // ContextResult mirrors the /api/v1/context response: ranked hits plus
 // the full entries behind the top ones, expanded one hop through links.
+// Outline lists entries the server's budget dropped; it stays empty for
+// the CLI, which asks for everything and caps at render time instead.
 type ContextResult struct {
-	Hits    []domain.SearchHit `json:"hits"`
-	Entries []domain.Knowledge `json:"entries"`
+	Hits      []domain.SearchHit      `json:"hits"`
+	Entries   []domain.Knowledge      `json:"entries"`
+	Outline   []domain.ContextOutline `json:"outline,omitempty"`
+	Truncated int                     `json:"truncated,omitempty"`
 }
 
 func (c *Client) Context(ctx context.Context, query string, types, statuses, tags []string, limit int, minScore float64) (*ContextResult, error) {

--- a/internal/domain/knowledge.go
+++ b/internal/domain/knowledge.go
@@ -374,3 +374,17 @@ type SearchHit struct {
 	Score float64 `json:"score"`
 	Usage *Usage  `json:"usage,omitempty"`
 }
+
+// ContextOutline names an entry a context pack could not afford to deliver
+// in full: enough for the caller to decide whether to spend a round trip
+// fetching it by id, and nothing more. The description carries the weight
+// here — an entry with an empty description is nearly invisible in an
+// outline, which is one more reason curation pays.
+type ContextOutline struct {
+	ID          string `json:"id"`
+	Type        Type   `json:"type"`
+	Title       string `json:"title"`
+	Description string `json:"description,omitempty"`
+	Status      Status `json:"status"`
+	Bytes       int    `json:"bytes"`
+}

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -151,15 +151,28 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"base (verified entries rank higher), returns the full entries behind the top hits, " +
 			"and expands one hop through links so the insight explaining a metric and the golden " +
 			"query answering the question arrive together. Prefer this over search+get chains; " +
-			"fall back to search_knowledge/get_knowledge for precise lookups.",
+			"fall back to search_knowledge/get_knowledge for precise lookups. Entries that do not " +
+			"fit the byte budget are listed under \"outline\" — fetch any of them by id with " +
+			"get_knowledge.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in contextIn) (*mcp.CallToolResult, contextOut, error) {
-		res, err := svc.Context(ctx, in.Query, store.Filter{
-			Types: domain.ToTypes(in.Types), Statuses: domain.ToStatuses(in.Statuses), Tags: in.Tags,
-		}, in.Limit, in.MinScore)
+		budget := in.Budget
+		if budget <= 0 {
+			budget = defaultContextBudget
+		}
+		res, err := svc.Context(ctx, service.ContextRequest{
+			Query: in.Query,
+			Filter: store.Filter{
+				Types: domain.ToTypes(in.Types), Statuses: domain.ToStatuses(in.Statuses), Tags: in.Tags,
+			},
+			Limit: in.Limit, Budget: budget,
+		})
 		if err != nil {
 			return nil, contextOut{}, err
 		}
-		return nil, contextOut{Hits: res.Hits, Entries: res.Entries}, nil
+		return nil, contextOut{
+			Hits: res.Hits, Entries: res.Entries, Outline: res.Outline,
+			Truncated: res.Truncated, Hint: contextHint(res.Truncated),
+		}, nil
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
@@ -370,20 +383,50 @@ type searchOut struct {
 	Hits []domain.SearchHit `json:"hits"`
 }
 
+// contextIn deliberately omits min_score, which the REST surface still
+// carries. A score floor is only usable once calibrated against a corpus
+// in a known search mode (trigram vs hybrid RRF), and an agent cannot
+// calibrate anything — offering it here spends tool-schema context on a
+// parameter whose own documentation says to leave it alone. What an agent
+// actually needs to bound a response is budget.
 type contextIn struct {
 	Query    string   `json:"query" jsonschema:"the data question to gather context for"`
 	Types    []string `json:"types,omitempty" jsonschema:"filter by type (Metric, Golden Query, Insight, Glossary Term, BigQuery Dataset, BigQuery Table, Reference, or any custom type); matched case-insensitively"`
 	Statuses []string `json:"statuses,omitempty" jsonschema:"filter by status: draft, verified, deprecated, rejected"`
 	Tags     []string `json:"tags,omitempty" jsonschema:"filter by tag"`
 	Limit    int      `json:"limit,omitempty" jsonschema:"max primary entries: default 5, max 20 (out-of-range falls back to the default); linked companions share a 2x limit total cap"`
-	// MinScore drops hits below it; scores are search-mode dependent
-	// (trigram vs hybrid RRF), so leave it 0 unless calibrated.
-	MinScore float64 `json:"min_score,omitempty" jsonschema:"drop hits scoring below this; scores are search-mode dependent and uncalibrated, so leave 0 (off) unless calibrated against your corpus"`
+	Budget   int      `json:"budget,omitempty" jsonschema:"max bytes of entries returned in full (default 12000); entries past it are listed under \"outline\" with their size, fetchable by id with get_knowledge. Raise it when you need whole entries, lower it when context is tight"`
 }
 
 type contextOut struct {
-	Hits    []domain.SearchHit `json:"hits"`
-	Entries []domain.Knowledge `json:"entries"`
+	Hits      []domain.SearchHit      `json:"hits"`
+	Entries   []domain.Knowledge      `json:"entries"`
+	Outline   []domain.ContextOutline `json:"outline,omitempty"`
+	Truncated int                     `json:"truncated,omitempty"`
+	Hint      string                  `json:"hint"`
+}
+
+// defaultContextBudget bounds an unparameterized get_context. It is on by
+// default because the callers that most need it — hosts that embed ochakai
+// and never touch the tool arguments — are exactly the ones that will not
+// set it. Roughly 3000 tokens of entries, English or Japanese.
+const defaultContextBudget = 12000
+
+// contextHint rides along with every context pack. Claude Code sites can
+// install the write-back habit with a Stop hook; a browser-based host has
+// no shell to hang one on, so the server supplies it — same words for
+// every host, no LLM involved (the MCP server's Instructions field carries
+// the same habit, but hosts are free to drop instructions and many do).
+func contextHint(truncated int) string {
+	hint := "After acting on this knowledge, call report_outcome (worked/failed) on the entries you " +
+		"used — failed reports are how stale verified knowledge gets caught. If this session " +
+		"produced reusable knowledge, write it back with create_knowledge as a draft; search " +
+		"statuses=[\"rejected\"] first so you do not re-propose something already turned down."
+	if truncated > 0 {
+		hint += fmt.Sprintf(" %d entries did not fit the budget and are listed under \"outline\" — "+
+			"fetch any of them by id with get_knowledge.", truncated)
+	}
+	return hint
 }
 
 type getIn struct {

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -307,3 +307,68 @@ func TestReportOutcomeValidation(t *testing.T) {
 		})
 	}
 }
+
+// TestContextSchemaBoundsResponse pins the get_context input schema: an
+// embedding host that never touches the tool arguments must still get a
+// bounded response, so budget is documented with its default and
+// min_score — usable only after calibration an agent cannot do — is off
+// this surface entirely.
+func TestContextSchemaBoundsResponse(t *testing.T) {
+	cs := connect(t)
+	res, err := cs.ListTools(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	for _, tool := range res.Tools {
+		if tool.Name != "get_context" {
+			continue
+		}
+		raw, err := json.Marshal(tool.InputSchema)
+		if err != nil {
+			t.Fatalf("marshal schema: %v", err)
+		}
+		var schema struct {
+			Properties map[string]struct {
+				Description string `json:"description"`
+			} `json:"properties"`
+		}
+		if err := json.Unmarshal(raw, &schema); err != nil {
+			t.Fatalf("unmarshal schema: %v", err)
+		}
+		if _, ok := schema.Properties["min_score"]; ok {
+			t.Error("get_context must not expose min_score: an agent cannot calibrate a score floor")
+		}
+		budget, ok := schema.Properties["budget"]
+		if !ok {
+			t.Fatal("get_context must expose budget")
+		}
+		for _, want := range []string{"12000", "outline"} {
+			if !strings.Contains(budget.Description, want) {
+				t.Errorf("budget description %q does not mention %q", budget.Description, want)
+			}
+		}
+		return
+	}
+	t.Fatal("get_context tool not found")
+}
+
+// TestContextHint pins the habit the server hands every host. Claude Code
+// sites can install it as a Stop hook; a browser-based host has no shell,
+// so this string is the only copy it will ever see.
+func TestContextHint(t *testing.T) {
+	plain := contextHint(0)
+	for _, want := range []string{"report_outcome", "create_knowledge", "rejected"} {
+		if !strings.Contains(plain, want) {
+			t.Errorf("hint does not mention %q: %s", want, plain)
+		}
+	}
+	if strings.Contains(plain, "outline") {
+		t.Errorf("nothing was dropped; hint must not mention the outline: %s", plain)
+	}
+	truncated := contextHint(3)
+	for _, want := range []string{"3 entries", "outline", "get_knowledge"} {
+		if !strings.Contains(truncated, want) {
+			t.Errorf("truncated hint does not mention %q: %s", want, truncated)
+		}
+	}
+}

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -92,9 +92,14 @@ func Handler(svc *service.Service) http.Handler {
 		writeJSON(w, http.StatusOK, res)
 	})
 
-	// GET /api/v1/context?q=...&type=...&status=...&tag=...&limit=...
+	// GET /api/v1/context?q=...&type=...&status=...&tag=...&limit=...&budget=...
 	// The one-call read before answering a data question: full entries
 	// behind the top hits, expanded one hop through links.
+	//
+	// budget defaults to 0 (no cap) here, unlike MCP where it is on by
+	// default: a REST caller is a program with a pipe, not an agent with a
+	// context window, and `ochakai context` does its own rendering-side
+	// capping.
 	mux.HandleFunc("GET /api/v1/context", func(w http.ResponseWriter, r *http.Request) {
 		q := r.URL.Query()
 		limit, err := queryInt(q, "limit")
@@ -107,11 +112,20 @@ func Handler(svc *service.Service) http.Handler {
 			writeError(w, err)
 			return
 		}
-		res, err := svc.Context(r.Context(), q.Get("q"), store.Filter{
-			Types:    domain.ToTypes(q["type"]),
-			Statuses: domain.ToStatuses(q["status"]),
-			Tags:     q["tag"],
-		}, limit, minScore)
+		budget, err := queryInt(q, "budget")
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		res, err := svc.Context(r.Context(), service.ContextRequest{
+			Query: q.Get("q"),
+			Filter: store.Filter{
+				Types:    domain.ToTypes(q["type"]),
+				Statuses: domain.ToStatuses(q["status"]),
+				Tags:     q["tag"],
+			},
+			Limit: limit, MinScore: minScore, Budget: budget,
+		})
 		if err != nil {
 			writeError(w, err)
 			return

--- a/internal/service/context_integration_test.go
+++ b/internal/service/context_integration_test.go
@@ -71,7 +71,7 @@ func TestContextIntegration(t *testing.T) {
 		}
 	}
 
-	res, err := svc.Context(ctx, id+"-revenue", store.Filter{}, 5, 0)
+	res, err := svc.Context(ctx, ContextRequest{Query: id + "-revenue", Limit: 5})
 	if err != nil {
 		t.Fatalf("Context: %v", err)
 	}
@@ -89,7 +89,7 @@ func TestContextIntegration(t *testing.T) {
 	}
 
 	// A prohibitive min_score empties the pack instead of shipping junk.
-	filtered, err := svc.Context(ctx, id+"-revenue", store.Filter{}, 5, 1e9)
+	filtered, err := svc.Context(ctx, ContextRequest{Query: id + "-revenue", Limit: 5, MinScore: 1e9})
 	if err != nil {
 		t.Fatalf("Context with min_score: %v", err)
 	}
@@ -100,7 +100,7 @@ func TestContextIntegration(t *testing.T) {
 
 	// A blank question is the client's mistake.
 	var invalid *InvalidInputError
-	if _, err := svc.Context(ctx, "  ", store.Filter{}, 5, 0); !errors.As(err, &invalid) {
+	if _, err := svc.Context(ctx, ContextRequest{Query: "  ", Limit: 5}); !errors.As(err, &invalid) {
 		t.Errorf("empty query: want InvalidInputError, got %v", err)
 	}
 }
@@ -279,5 +279,94 @@ func TestDeleteIntegration(t *testing.T) {
 	}
 	if err := svc.Delete(ctx, id, actor); !errors.Is(err, store.ErrNotFound) {
 		t.Errorf("double delete: want ErrNotFound, got %v", err)
+	}
+}
+
+// TestContextBudgetIntegration pins the embedding-host path end to end: a
+// budget too small for everything delivers whole entries up to the cap and
+// names the rest, and the named ones are not counted as fetched — an
+// outline row is not a use of the knowledge.
+func TestContextBudgetIntegration(t *testing.T) {
+	ctx := context.Background()
+	svc := newIntegrationService(t, ctx)
+	actor := domain.Actor{Kind: "human", Name: "test"}
+
+	// The shared test database carries other tests' entries, and fuzzy
+	// search does not respect test boundaries — assert over our own ids.
+	id := uid("budgetit")
+	mine := map[string]bool{}
+	for i := range 4 {
+		k := &domain.Knowledge{
+			Type: domain.TypeInsights, ID: fmt.Sprintf("insights/%s-%d", id, i),
+			Title: id + " budget", Description: "an entry about " + id,
+			Body: strings.Repeat("x", 2000),
+		}
+		if _, err := svc.Create(ctx, k, actor); err != nil {
+			t.Fatalf("create %s: %v", k.ID, err)
+		}
+		mine[k.ID] = true
+	}
+
+	full, err := svc.Context(ctx, ContextRequest{Query: id, Limit: 5})
+	if err != nil {
+		t.Fatalf("Context: %v", err)
+	}
+	if full.Truncated != 0 || full.Outline != nil {
+		t.Errorf("no budget must not truncate: %d outlined", full.Truncated)
+	}
+	delivered := 0
+	for _, e := range full.Entries {
+		if mine[e.ID] {
+			delivered++
+		}
+	}
+	if delivered != len(mine) {
+		t.Fatalf("unbudgeted pack carries %d of our %d entries", delivered, len(mine))
+	}
+
+	// Room for roughly one entry.
+	const budget = 2500
+	capped, err := svc.Context(ctx, ContextRequest{Query: id, Limit: 5, Budget: budget})
+	if err != nil {
+		t.Fatalf("Context with budget: %v", err)
+	}
+	used := 0
+	for i := range capped.Entries {
+		used += serializedSize(&capped.Entries[i])
+	}
+	if used > budget {
+		t.Errorf("delivered %d bytes over a %d budget", used, budget)
+	}
+	if len(capped.Entries) >= len(full.Entries) {
+		t.Errorf("budget delivered %d entries, unbudgeted %d — nothing was capped",
+			len(capped.Entries), len(full.Entries))
+	}
+	if capped.Truncated != len(capped.Outline) || capped.Truncated == 0 {
+		t.Fatalf("truncated = %d, outline = %d; want both nonzero and equal",
+			capped.Truncated, len(capped.Outline))
+	}
+	// Nothing is lost: every entry the unbudgeted pack carried is either
+	// delivered or named.
+	seen := map[string]bool{}
+	for _, e := range capped.Entries {
+		seen[e.ID] = true
+	}
+	for _, o := range capped.Outline {
+		seen[o.ID] = true
+		if o.Bytes == 0 {
+			t.Errorf("outline row carries no size: %+v", o)
+		}
+		if mine[o.ID] && o.Description == "" {
+			t.Errorf("outline row dropped the description: %+v", o)
+		}
+	}
+	for _, e := range full.Entries {
+		if !seen[e.ID] {
+			t.Errorf("%s vanished under a budget: neither delivered nor outlined", e.ID)
+		}
+	}
+	// Hits still name everything that matched — the ranking is not cut.
+	if len(capped.Hits) != len(full.Hits) {
+		t.Errorf("budget changed the hit list: %d vs %d", len(capped.Hits), len(full.Hits))
 	}
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -297,10 +298,23 @@ func (s *Service) search(ctx context.Context, query string, f store.Filter, limi
 
 // ContextResult is the one-call context pack behind get_context and
 // `ochakai context`: the ranked hits, plus the full entries behind the
-// top ones expanded one hop through links.
+// top ones expanded one hop through links. Entries that did not fit the
+// caller's budget are listed in Outline instead — named, not delivered.
 type ContextResult struct {
-	Hits    []domain.SearchHit `json:"hits"`
-	Entries []domain.Knowledge `json:"entries"`
+	Hits      []domain.SearchHit      `json:"hits"`
+	Entries   []domain.Knowledge      `json:"entries"`
+	Outline   []domain.ContextOutline `json:"outline,omitempty"`
+	Truncated int                     `json:"truncated,omitempty"`
+}
+
+// ContextRequest is the input to Context. Budget caps the serialized size
+// of the entries returned in full; 0 means no cap.
+type ContextRequest struct {
+	Query    string
+	Filter   store.Filter
+	Limit    int
+	MinScore float64
+	Budget   int
 }
 
 // Context gathers what an agent should read before answering a data
@@ -310,27 +324,32 @@ type ContextResult struct {
 // metric, the golden query that answers the question — arrives without
 // further round trips.
 //
-// minScore drops hits scoring below it before expansion, for callers
+// req.MinScore drops hits scoring below it before expansion, for callers
 // that inject the pack automatically (hooks) and prefer nothing over
 // junk. It defaults to 0 (off) because scores are search-mode dependent
 // and uncalibrated: trigram similarity plus boosts in lexical mode, RRF
 // rank fusion (~0.02 scale) in hybrid mode — a floor meaningful in one
 // mode is nonsense in the other.
-func (s *Service) Context(ctx context.Context, query string, f store.Filter, limit int, minScore float64) (*ContextResult, error) {
-	if strings.TrimSpace(query) == "" {
+//
+// req.Budget caps how many bytes of full entries come back; the rest
+// become outline rows (packWithinBudget). Callers whose context window is
+// the scarce resource — an agent, not a UI — should always set it.
+func (s *Service) Context(ctx context.Context, req ContextRequest) (*ContextResult, error) {
+	if strings.TrimSpace(req.Query) == "" {
 		return nil, Invalidf("invalid context request: query is required")
 	}
+	limit := req.Limit
 	if limit <= 0 || limit > 20 {
 		limit = 5
 	}
-	hits, err := s.Search(ctx, query, f, 2*limit)
+	hits, err := s.Search(ctx, req.Query, req.Filter, 2*limit)
 	if err != nil {
 		return nil, err
 	}
-	if minScore > 0 {
+	if req.MinScore > 0 {
 		kept := hits[:0]
 		for _, h := range hits {
-			if h.Score >= minScore {
+			if h.Score >= req.MinScore {
 				kept = append(kept, h)
 			}
 		}
@@ -379,12 +398,64 @@ func (s *Service) Context(ctx context.Context, query string, f store.Filter, lim
 			addFetched(&linking[j])
 		}
 	}
+	entries, outline := packWithinBudget(entries, req.Budget)
+	// Only delivered entries count as fetched. An outline row names an
+	// entry; it does not hand over the knowledge, so counting it as a use
+	// would inflate the demand signal that drives the review feeds.
 	ids := make([]string, len(entries))
 	for i := range entries {
 		ids[i] = entries[i].ID
 	}
 	s.recordUsage(ctx, domain.EventFetched, ids)
-	return &ContextResult{Hits: hits, Entries: entries}, nil
+	return &ContextResult{Hits: hits, Entries: entries, Outline: outline, Truncated: len(outline)}, nil
+}
+
+// packWithinBudget splits entries into the ones that fit within budget
+// serialized bytes and outline rows for the rest, preserving rank order in
+// both. budget <= 0 means no cap.
+//
+// Entries are atomic: an entry is delivered whole or not at all. Cutting a
+// body mid-way would be worse than dropping it — half of a Golden Query's
+// attrs.sql still looks executable, and half a semantic model spec is not
+// a spec. Nothing downstream can tell a truncated field from a short one.
+//
+// Packing is greedy rather than a prefix cut: one oversized entry high in
+// the ranking (a Semantic Model carries its entire spec in attrs) would
+// otherwise starve everything below it. An entry larger than the whole
+// budget always becomes an outline row, even at rank 1 — the caller sees
+// its size and can fetch it deliberately.
+func packWithinBudget(entries []domain.Knowledge, budget int) ([]domain.Knowledge, []domain.ContextOutline) {
+	if budget <= 0 {
+		return entries, nil
+	}
+	kept := make([]domain.Knowledge, 0, len(entries))
+	var outline []domain.ContextOutline
+	used := 0
+	for i := range entries {
+		k := &entries[i]
+		size := serializedSize(k)
+		if used+size <= budget {
+			kept = append(kept, *k)
+			used += size
+			continue
+		}
+		outline = append(outline, domain.ContextOutline{
+			ID: k.ID, Type: k.Type, Title: k.DisplayTitle(),
+			Description: k.Description, Status: k.Status, Bytes: size,
+		})
+	}
+	return kept, outline
+}
+
+// serializedSize is what the entry costs on the wire — attrs included. A
+// body-only measure would miss the largest payload in the base, a
+// Semantic Model's attrs.spec.
+func serializedSize(k *domain.Knowledge) int {
+	b, err := json.Marshal(k)
+	if err != nil {
+		return len(k.Body) // unreachable in practice; never drop on a marshal quirk
+	}
+	return len(b)
 }
 
 // ListByVerifiedAt lists entries by verification age, oldest first — the

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -272,3 +272,73 @@ func TestExampleSemanticModelRegisters(t *testing.T) {
 		t.Errorf("compiled SQL wrong:\n%s", res.SQL)
 	}
 }
+
+// packWithinBudget delivers whole entries or none: a body cut in half
+// still looks like a body, and half of a golden query's SQL still looks
+// executable.
+func TestPackWithinBudgetKeepsEntriesWhole(t *testing.T) {
+	entry := func(id string, bodyBytes int) domain.Knowledge {
+		return domain.Knowledge{Type: domain.TypeInsights, ID: id, Title: id,
+			Description: "desc " + id, Status: domain.StatusDraft, Body: strings.Repeat("x", bodyBytes)}
+	}
+	small := entry("insights/small", 100)
+	big := entry("insights/big", 5000)
+	one := serializedSize(&small)
+
+	t.Run("no budget keeps everything", func(t *testing.T) {
+		kept, outline := packWithinBudget([]domain.Knowledge{small, big}, 0)
+		if len(kept) != 2 || outline != nil {
+			t.Errorf("budget 0 must not truncate: %d kept, %d outlined", len(kept), len(outline))
+		}
+	})
+
+	t.Run("overflow becomes an outline row", func(t *testing.T) {
+		kept, outline := packWithinBudget([]domain.Knowledge{small, big}, one+10)
+		if len(kept) != 1 || kept[0].ID != small.ID {
+			t.Fatalf("want only the small entry in full, got %d", len(kept))
+		}
+		if len(outline) != 1 || outline[0].ID != big.ID {
+			t.Fatalf("want the big entry outlined, got %v", outline)
+		}
+		if outline[0].Bytes != serializedSize(&big) || outline[0].Description != big.Description {
+			t.Errorf("outline row must carry size and description: %+v", outline[0])
+		}
+		if outline[0].Title != big.DisplayTitle() {
+			t.Errorf("outline title = %q, want the display title %q", outline[0].Title, big.DisplayTitle())
+		}
+	})
+
+	// A Semantic Model carries its whole spec in attrs and can outweigh the
+	// entire budget. A prefix cut would let it starve everything below it;
+	// greedy packing keeps the rest and names the giant.
+	t.Run("an oversized leader does not starve the rest", func(t *testing.T) {
+		kept, outline := packWithinBudget([]domain.Knowledge{big, small}, one+10)
+		if len(kept) != 1 || kept[0].ID != small.ID {
+			t.Fatalf("want the small entry delivered behind the giant, got %+v", kept)
+		}
+		if len(outline) != 1 || outline[0].ID != big.ID {
+			t.Fatalf("want the giant outlined, got %v", outline)
+		}
+	})
+
+	// Budgets below one entry outline everything rather than shipping a
+	// fragment: an empty entries list with a populated outline is a usable
+	// answer, a half-entry is not.
+	t.Run("a budget below one entry outlines everything", func(t *testing.T) {
+		kept, outline := packWithinBudget([]domain.Knowledge{small, big}, 1)
+		if len(kept) != 0 || len(outline) != 2 {
+			t.Errorf("want everything outlined, got %d kept / %d outlined", len(kept), len(outline))
+		}
+	})
+
+	// attrs, not just the body: a Semantic Model's spec is the largest
+	// payload in the base and lives entirely in attrs.
+	t.Run("size counts attrs", func(t *testing.T) {
+		bare := domain.Knowledge{Type: domain.TypeModels, ID: "models/m"}
+		withSpec := bare
+		withSpec.Attrs = map[string]any{"spec": strings.Repeat("y", 2000)}
+		if serializedSize(&withSpec) <= serializedSize(&bare)+1000 {
+			t.Error("serializedSize ignores attrs")
+		}
+	})
+}


### PR DESCRIPTION
CLI には `--budget` があるのに MCP ツールには相当パラメータが無い、という指摘。埋め込みホストにとって本番は MCP 経路で、`limit=5` でも entries は最大 `2*limit`=10 件フル返却なので、本文次第で一撃数万トークンになる。

## 「要約だけ返す」モードは作らなかった

代案として「本文を返さず要約と詳細取得方法だけを返す」を検討したが、単独のモードとしては採らない:

- **ochakai は LLM を持たないので「要約」は `description` そのもの**。書き手が書いた説明であって本文の代替ではない。エージェントが description だけ読んで SQL を推測する(＝ゴールデンクエリを使わずに自作する)のは、ochakai が防ぎたい失敗そのもの
- get_context の約束("the one call to make before answering")が壊れる。常に往復が発生し、`maxTurns` の小さいホストでは turn を食う

代わりに**段階的詳細度**にした。要約は独立モードではなく、予算の劣化形として現れる:

```
entries[]  … 予算を使い切るまで、上位から完全なエントリ
outline[]  … 残り。id / type / title / description / status / bytes
truncated  … outline に落ちた件数
```

上位は往復なしで完全に届き、落ちた分も id と大きさが分かるので `get_knowledge` で取りに行ける。「他 N 件」という数字だけを返すより情報量が多く、全件要約より安全。

## 設計上の判断

**エントリは原子的**。本文を途中で切らない。これは容量ではなく安全性の問題で、`Golden Query` の `attrs.sql` が半分で切れたものは**実行できそうに見える**し、`Semantic Model` の spec の半分は spec ではない。受け取った側は短いのか切られたのか区別できない。

**単体で予算を超えるエントリは順位 1 位でも outline に落とす**。CLI は「1 件目は budget に関わらず出す」実装だが、MCP でこれをやると `attrs.spec` を抱えた Semantic Model が 1 位に来た瞬間に破綻する。

**詰め方は貪欲**(先頭からの prefix cut ではない)。巨大な 1 件が下位を飢えさせないため。順位は両方のリストで保たれる。

**予算はシリアライズ後の総バイト**で数える。本文だけだとナレッジベース最大の payload である `attrs.spec` を勘定に入れられない。

## 既定値

| 面 | 既定 | 理由 |
|---|---|---|
| MCP | 12000 バイト(≒3000 トークン) | 設定しないホストこそ予算を必要とする |
| REST | 0(無制限) | 呼び出し元はプログラム。`ochakai context` は描画側で切っており、サーバー側で削ると `(N more entries beyond --budget)` の表示が嘘になる |

## 同時に入れた 2 つ

**`hint` フィールド**(指摘 P1-4)。書き戻しの習慣は Claude Code なら Stop フックで配れるが、ブラウザのホストにはシェルが無い。なお **MCP の `Instructions` フィールドには既に同じ内容が入っている**(`create_knowledge` / `report_outcome` / rejected の確認)ので、指摘の 8 割は実装済みだった。残る差分は「instructions を落とすホストがある」ことなので、応答本体にも載せる。LLM は不要。

**MCP から `min_score` を降ろす**。スキーマ説明が「較正していないなら 0 のままにしろ」と書いてあるパラメータをエージェントに見せる意味がない(スキーマはツール数と同じく文脈予算)。REST と CLI には残す — フック用途では calibrate する人間がいる。

## 互換性

`svc.Context` の引数が `ContextRequest` 構造体になった(int 3 つが並ぶのを避けるため)。REST の応答は `outline` / `truncated` が増えるだけで、既存フィールドは不変。openapi.yaml も更新済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)