### PR TITLE
レキシカル検索を索引の効く形にする(search_text 列 + マイグレーション 0016)

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,22 @@ doc 0020).
 Attachment bytes live in GCS and are fetched on demand, and attachments
 round-trip through OKF bundles as plain files next to their entry.
 
+**Japanese knowledge bases should turn embeddings on.** PostgreSQL's
+full-text search does not tokenize Japanese, so the lexical half of search
+falls back to trigrams over a stored haystack — id, title, description,
+tags, body, attachment filenames — plus a substring match, which finds
+what it is given but ranks by a score with no meaning you can set a
+threshold against. `gemini-embedding-001` handles Japanese well, and with
+`OCHAKAI_VERTEX_PROJECT` set, ranking comes from rank fusion across both
+halves rather than from trigram overlap alone.
+
+Scores are not comparable across the two modes and are not calibrated:
+trigram similarity plus boosts in the lexical-only mode, RRF rank fusion
+(~0.02 scale) in the hybrid one. Treat them as an ordering, not a
+measure — `min_score` is for callers who have calibrated against their own
+corpus, which is why the MCP surface does not offer it. To bound a
+response, use `budget` instead.
+
 ## Configuration
 
 | Env var | Description |
@@ -266,7 +282,7 @@ round-trip through OKF bundles as plain files next to their entry.
 | `OCHAKAI_DATABASE_URL` | Cloud SQL connection string (required) |
 | `OCHAKAI_DB_IAM_AUTH` | `true` enables Cloud SQL IAM database authentication: the connection password is a short-lived IAM token, so the connection string carries no secret |
 | `OCHAKAI_GCS_BUCKET` | Bucket for attachment bytes (auth is ADC — no keys). Default: unset — the instance stores markdown entries only and attach operations return an error |
-| `OCHAKAI_VERTEX_PROJECT` | Set to enable hybrid semantic search via Vertex AI embeddings (default: off, trigram-only — ochakai calls no external API unless you opt in). Auth is ADC — no API keys |
+| `OCHAKAI_VERTEX_PROJECT` | Set to enable hybrid semantic search via Vertex AI embeddings (default: off, trigram-only — ochakai calls no external API unless you opt in). Auth is ADC — no API keys. **Recommended for Japanese knowledge bases** (see below) |
 | `OCHAKAI_VERTEX_LOCATION` / `OCHAKAI_VERTEX_MODEL` / `OCHAKAI_EMBEDDING_DIM` | Embedding details (defaults: `us-central1`, `gemini-embedding-001`, 768). For image/PDF attachment search set model `gemini-embedding-2` with location `global` (or `us`/`eu`); switching models on an existing base leaves old vectors in the old space until entries are re-written (design doc 0020) |
 | `OCHAKAI_INSECURE_DEV` | Local development only: disables auth, everything acts as human:anonymous |
 | `PORT` | Listen port (default `8080`) |

--- a/internal/store/migrations/0016_search_text.sql
+++ b/internal/store/migrations/0016_search_text.sql
@@ -1,0 +1,66 @@
+-- The lexical search haystack becomes a stored column, so the trigram
+-- index and the query can finally be about the same text.
+--
+-- 0001 indexed (title || description || body). SearchLexical has since
+-- grown to score over id (0022), tags, and attachment names (0020), and
+-- those three cannot join an index expression at all: array_to_string is
+-- not IMMUTABLE, and attachment names live in another table. So the index
+-- and the query drifted apart and could never be reconciled in place.
+--
+-- The deeper problem was that the index was unusable regardless of the
+-- expression: similarity() was computed in the SELECT list and the score
+-- floor applied outside the subquery, so every row was scanned and scored
+-- no matter what. An index needs a predicate in WHERE, which needs one
+-- column holding the whole haystack.
+--
+-- search_text is maintained by trigger rather than in Go: every write
+-- path (create, update, move, attach, detach) would otherwise have to
+-- remember, and the one that forgets makes an entry silently
+-- unsearchable.
+
+ALTER TABLE knowledge ADD COLUMN IF NOT EXISTS search_text text NOT NULL DEFAULT '';
+
+-- One definition of the haystack, used by both triggers and the backfill.
+CREATE OR REPLACE FUNCTION ochakai_search_text(
+    p_id text, p_title text, p_description text, p_tags text[], p_body text
+) RETURNS text LANGUAGE sql STABLE AS $$
+    SELECT p_id || ' ' || p_title || ' ' || p_description || ' '
+        || array_to_string(p_tags, ' ') || ' ' || p_body || ' '
+        || COALESCE((SELECT string_agg(a.name, ' ')
+                       FROM attachment a WHERE a.knowledge_id = p_id), '')
+$$;
+
+CREATE OR REPLACE FUNCTION ochakai_knowledge_search_text() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+    NEW.search_text := ochakai_search_text(NEW.id, NEW.title, NEW.description, NEW.tags, NEW.body);
+    RETURN NEW;
+END $$;
+
+DROP TRIGGER IF EXISTS knowledge_search_text ON knowledge;
+CREATE TRIGGER knowledge_search_text BEFORE INSERT OR UPDATE ON knowledge
+    FOR EACH ROW EXECUTE FUNCTION ochakai_knowledge_search_text();
+
+-- Attaching or detaching a file changes the owning entry's haystack
+-- (design doc 0020: a filename is a name the entry can be found by).
+CREATE OR REPLACE FUNCTION ochakai_attachment_search_text() RETURNS trigger
+LANGUAGE plpgsql AS $$
+DECLARE
+    target text := COALESCE(NEW.knowledge_id, OLD.knowledge_id);
+BEGIN
+    -- The UPDATE fires the knowledge trigger above, which recomputes from
+    -- the current attachment rows; assigning here would be redundant.
+    UPDATE knowledge SET search_text = search_text WHERE id = target;
+    RETURN NULL;
+END $$;
+
+DROP TRIGGER IF EXISTS attachment_search_text ON attachment;
+CREATE TRIGGER attachment_search_text AFTER INSERT OR UPDATE OR DELETE ON attachment
+    FOR EACH ROW EXECUTE FUNCTION ochakai_attachment_search_text();
+
+UPDATE knowledge SET search_text = ochakai_search_text(id, title, description, tags, body);
+
+-- Same name as the 0001 index, new expression: there is only ever one
+-- lexical search index, and keeping the name makes that obvious in \di.
+DROP INDEX IF EXISTS knowledge_search_trgm;
+CREATE INDEX knowledge_search_trgm ON knowledge USING gin (search_text gin_trgm_ops);

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -529,10 +529,20 @@ func (s *Store) addRevision(ctx context.Context, tx pgx.Tx, k *domain.Knowledge,
 
 // SearchLexical ranks by trigram similarity with a substring-match floor
 // (trigram alone misses short Japanese terms), verified entries boosted.
-// Attachment filenames join the haystack (design doc 0020): "seeds" finds
-// the entry carrying seeds.txt, embedder or not. So does the id (design
-// doc 0022): with title optional, the filename may be the entry's only
-// name.
+// The haystack is the search_text column (migration 0016): the id (design
+// doc 0022 — with title optional, the filename may be the entry's only
+// name), the envelope fields, the body, and the attachment filenames
+// (design doc 0020 — "seeds" finds the entry carrying seeds.txt, embedder
+// or not), maintained by trigger.
+//
+// The candidate predicate and the score read the same column as the GIN
+// trigram index, which is what makes the index usable: `%` (trigram
+// similarity above pg_trgm.similarity_threshold, 0.3 by default — an
+// operator can retune it per database without touching this query) and
+// ILIKE both have index support. Before 0016 the score was computed in
+// the SELECT list over a concatenation no index could match, and the
+// floor was applied outside the subquery, so every search scanned and
+// scored every row.
 func (s *Store) SearchLexical(ctx context.Context, query string, f Filter, limit int) ([]domain.SearchHit, error) {
 	where, args := f.buildWhere("k.")
 	// The trigram term takes the raw query; the substring floor takes a
@@ -546,18 +556,14 @@ func (s *Store) SearchLexical(ctx context.Context, query string, f Filter, limit
 	likeParam := len(args)
 	q := fmt.Sprintf(`
 		SELECT `+knowledgeCols+`, score FROM (
-			SELECT k.*, similarity(k.id || ' ' || k.title || ' ' || k.description || ' ' || array_to_string(k.tags, ' ') || ' ' || k.body || ' ' || att.names, $%d)
-				+ CASE WHEN k.id || ' ' || k.title || ' ' || k.description || ' ' || k.body || ' ' || att.names ILIKE $%d THEN 0.3 ELSE 0 END
+			SELECT k.*, similarity(k.search_text, $%[1]d)
+				+ CASE WHEN k.search_text ILIKE $%[2]d THEN 0.3 ELSE 0 END
 				+ CASE WHEN k.status = 'verified' THEN 0.05 ELSE 0 END AS score
 			FROM knowledge k
-			LEFT JOIN LATERAL (
-				SELECT COALESCE(string_agg(a.name, ' '), '') AS names
-				FROM attachment a WHERE a.knowledge_id = k.id
-			) att ON true
-			WHERE %s
+			WHERE (k.search_text %% $%[1]d OR k.search_text ILIKE $%[2]d) AND %[3]s
 		) ranked
 		WHERE score > 0.05
-		ORDER BY score DESC LIMIT %d`, simParam, likeParam, where, limit)
+		ORDER BY score DESC LIMIT %[4]d`, simParam, likeParam, where, limit)
 	rows, err := s.pool.Query(ctx, q, args...)
 	if err != nil {
 		return nil, err

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1025,4 +1026,135 @@ func (f *fakeBlobStore) Get(_ context.Context, sum string) ([]byte, error) {
 		return nil, fmt.Errorf("fake blob store: %s not found", sum)
 	}
 	return append([]byte(nil), data...), nil
+}
+
+// The point of migration 0016: the trigram index and the search query are
+// about the same text, so the index can actually serve the search. Before
+// it, similarity() was computed in the SELECT list over a concatenation no
+// index expression could match (tags need array_to_string, which is not
+// IMMUTABLE; attachment names live in another table), and the score floor
+// sat outside the subquery — every search scanned every row.
+//
+// enable_seqscan=off is a cost penalty, not a prohibition: PostgreSQL
+// still picks a sequential scan when no index can answer the predicate.
+// So this asserts index usability, not planner preference — which is
+// exactly the property that was missing.
+func TestIntegrationLexicalSearchUsesTrigramIndex(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback(ctx)
+	if _, err := tx.Exec(ctx, `SET LOCAL enable_seqscan = off`); err != nil {
+		t.Fatal(err)
+	}
+	rows, err := tx.Query(ctx, `EXPLAIN
+		SELECT k.id FROM knowledge k
+		WHERE (k.search_text % $1 OR k.search_text ILIKE $2) AND k.deleted_at IS NULL`,
+		"revenue", "%revenue%")
+	if err != nil {
+		t.Fatalf("EXPLAIN: %v", err)
+	}
+	plan := ""
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			t.Fatal(err)
+		}
+		plan += line + "\n"
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(plan, "knowledge_search_trgm") {
+		t.Errorf("lexical search cannot use the trigram index; plan was:\n%s", plan)
+	}
+}
+
+// search_text is maintained by trigger, so every write path keeps the
+// haystack current without remembering to. These are the two paths a
+// Go-side implementation would most easily miss: a file attached after
+// the entry was written (design doc 0020), and an entry renamed into a
+// new id (design doc 0022 put the id in the haystack).
+func TestIntegrationSearchTextFollowsAttachmentsAndMoves(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	s.UseBlobStore(newFakeBlobStore())
+	actor := domain.Actor{Kind: "human", Name: "test"}
+
+	searchText := func(id string) string {
+		var got string
+		if err := s.pool.QueryRow(ctx, `SELECT search_text FROM knowledge WHERE id = $1`, id).Scan(&got); err != nil {
+			t.Fatalf("read search_text for %s: %v", id, err)
+		}
+		return got
+	}
+
+	const id, moved = "it-haystack", "it-haystack-moved"
+	for _, dead := range []string{id, moved} {
+		_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge WHERE id = $1`, dead)
+		_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_revision WHERE id = $1`, dead)
+	}
+	k := &domain.Knowledge{
+		Type: domain.TypeTerms, ID: id, Title: "haystack", Tags: []string{"ledger"},
+		Status: domain.StatusDraft, CreatedBy: actor, Body: "prose",
+	}
+	if err := s.Create(ctx, k); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{id, "haystack", "ledger", "prose"} {
+		if !strings.Contains(searchText(id), want) {
+			t.Errorf("search_text misses %q after create: %q", want, searchText(id))
+		}
+	}
+
+	if _, err := s.PutAttachment(ctx, id, "seeds.txt", "text/plain", "", []byte("x"), actor); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(searchText(id), "seeds.txt") {
+		t.Errorf("attaching a file left search_text stale: %q", searchText(id))
+	}
+
+	if _, err := s.Move(ctx, id, moved, actor); err != nil {
+		t.Fatal(err)
+	}
+	after := searchText(moved)
+	if !strings.Contains(after, moved) {
+		t.Errorf("move left the old id in search_text: %q", after)
+	}
+	if !strings.Contains(after, "seeds.txt") {
+		t.Errorf("move dropped the attachment name from search_text: %q", after)
+	}
+
+	if err := s.DeleteAttachment(ctx, moved, "seeds.txt", actor); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(searchText(moved), "seeds.txt") {
+		t.Errorf("detaching left the filename in search_text: %q", searchText(moved))
+	}
 }


### PR DESCRIPTION
「trigram インデックスの式と検索式が一致していない」という指摘。**結論は正しいが、原因は式の不一致だけではなく、式を揃えても索引は効かない**ので、直し方を変えた。

## 何が起きていたか

索引は [0001](internal/store/migrations/0001_init.sql#L30) の `(title || description || body)`、スコア対象は [store.go](internal/store/store.go) の `id || title || description || tags || body || 添付名`。指摘のとおりズレている。そして **この 3 つは索引式に入れられない** — `array_to_string` は IMMUTABLE でなく、添付名は別テーブル。式を一致させることは原理的に不可能だった。

さらに根本的に、**式を揃えても索引は使われなかった**。`similarity()` は SELECT リストで計算され、スコアの足切り (`score > 0.05`) はサブクエリの外。内側の WHERE にはフィルタ条件しかなく、GIN trigram 索引が働く述語(`%` か LIKE)が 1 つも無い。実測:

```
SET enable_seqscan=off;
EXPLAIN SELECT k.id, similarity(k.id||' '||k.title||' '||k.body, 'revenue') FROM knowledge k WHERE k.deleted_at IS NULL;
--  Seq Scan on knowledge k  (cost=10000000000.00..10000000007.39 rows=56)
```

`enable_seqscan=off` はコストペナルティであって禁止ではないので、索引で答えられない述語では Seq Scan のまま出る。

## 直し方

haystack を `search_text` 列に固め、索引と検索述語を同じ列にする:

```sql
WHERE (search_text % $1 OR search_text ILIKE $2) AND <filters>
```

```
 Bitmap Heap Scan on knowledge k  (cost=99.86..105.99 rows=7)
   ->  BitmapOr
         ->  Bitmap Index Scan on knowledge_search_trgm   (search_text % 'revenue')
         ->  Bitmap Index Scan on knowledge_search_trgm   (search_text ~~* '%revenue%')
```

**両方の枝**が索引で処理される。ILIKE も pg_trgm が索引で扱えるので、日本語の再現率を実際に支えている部分文字列一致の経路も速くなる。LATERAL JOIN も消えて、クエリ自体が短くなった。

## 列はトリガで保守する

Go 側で書くと create / update / move / attach / detach のどれか 1 つが忘れた瞬間、そのエントリが**黙って検索不能**になる。定義を 1 箇所に置いて、DB に強制させる。統合テストで、添付の追加・削除とエントリの move が haystack に反映されることを確認している(Go 実装なら最も落としやすい 2 経路)。

## 再現率の変化(意図的)

従来の足切りは、実質「トリグラムを 1 つでも共有する verified エントリは全部通る」だった — verified 加点 0.05 と閾値 `> 0.05` の組み合わせで、`similarity > 0` なら通ってしまう。今後は `pg_trgm.similarity_threshold`(既定 0.3)を下回るファジー一致のみのエントリは落ちる。

- **部分文字列一致は従来どおり**。日本語の再現率はこちらが支えており、影響しない
- 精度は上がる方向。閾値は `ALTER DATABASE ... SET pg_trgm.similarity_threshold` で運用側から調整でき、コード変更を要しない

## 同時に(P0-3b のドキュメント部分)

README に、**日本語ナレッジベースでは embedding を有効にする構成を推奨**として明記した。あわせてスコアが較正されていないこと — 閾値運用は自分のコーパスで較正した利用者のためのもので、だから MCP には `min_score` を出さない(#114)、応答を絞るなら `budget` を使う — を書いた。

## 移行

マイグレーション 0016 が列の追加・トリガ作成・全件バックフィル・索引の張り替えを行う。既存デプロイは起動時に自動適用される。エントリ数に比例するので、大きなベースでは初回起動が少し延びる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)