### PR TITLE
purge を足し、Move が塞がれた ID の逃げ道を示すようにする

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -274,9 +274,24 @@ paths:
     delete:
       operationId: deleteKnowledge
       summary: Soft-delete a knowledge entry (history retained)
+      description: >
+        Soft-deletes by default: the entry disappears from reads, its
+        history stays, and creating the same id revives it. With
+        `purge=true` the entry is hard-deleted instead — entry,
+        revisions, usage, and attachment metadata erased, the id freed
+        for a move. Two calls, deliberately: the first is reversible, the
+        second is not. Purging a live entry is a 409; delete it first.
+        Content-addressed attachment bytes are left in the blob store,
+        as detaching leaves them.
+      parameters:
+        - name: purge
+          in: query
+          description: Hard-delete an already soft-deleted entry.
+          schema: { type: string, enum: ["true"] }
       responses:
         "204": { description: Deleted. }
         "404": { $ref: "#/components/responses/Error" }
+        "409": { $ref: "#/components/responses/Error" }
   /api/v1/move:
     post:
       operationId: moveKnowledge
@@ -288,7 +303,8 @@ paths:
         (link targets in both bare and ochakai:// forms, and attrs.model)
         so nothing breaks (design doc 0021). The destination must be a
         fresh id: a live or soft-deleted entry there already owns that
-        address and its history. Lives at its own top-level path for the
+        address and its history — free an id held by a deleted entry with
+        DELETE ...?purge=true. Lives at its own top-level path for the
         same reason /usage and /revisions do — a suffix after the
         hierarchical id could be confused with an ID segment.
       requestBody:

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -33,6 +33,7 @@ var clientCommands = map[string]func(context.Context, []string) error{
 	"create":    cmdCreate,
 	"update":    cmdUpdate,
 	"delete":    cmdDelete,
+	"purge":     cmdPurge,
 	"move":      cmdMove,
 	"attach":    cmdAttach,
 	"detach":    cmdDetach,
@@ -748,6 +749,38 @@ func cmdDelete(ctx context.Context, args []string) error {
 		return err
 	}
 	fmt.Printf("deleted ochakai://%s\n", id)
+	return nil
+}
+
+// cmdPurge is the second half of a two-step destruction: delete makes an
+// entry invisible and recoverable, purge makes it gone. It exists because
+// a soft-deleted entry still owns its id — Create revives one in place,
+// but Move cannot, so without purge a renamed-away id would be blocked
+// forever (design doc 0021).
+func cmdPurge(ctx context.Context, args []string) error {
+	fs, url := newFlagSet(
+		"Usage: ochakai purge [flags] <id>\n\nHard-delete an already soft-deleted entry: the entry, its revisions,\nusage, and attachment metadata are erased and the id is freed for a\nmove. History is gone — `ochakai delete` first, then purge. A live\nentry is refused.",
+		"  ochakai delete terms/obsolete-kpi\n  ochakai purge terms/obsolete-kpi\n")
+	pos, err := parseArgs(fs, args)
+	if err != nil {
+		return err
+	}
+	if len(pos) != 1 {
+		fs.Usage()
+		return errReported
+	}
+	id, err := parseRef(pos[0])
+	if err != nil {
+		return err
+	}
+	c, err := newClient(ctx, *url)
+	if err != nil {
+		return err
+	}
+	if err := c.Purge(ctx, id); err != nil {
+		return err
+	}
+	fmt.Printf("purged ochakai://%s\n", id)
 	return nil
 }
 

--- a/cmd/ochakai/client_test.go
+++ b/cmd/ochakai/client_test.go
@@ -164,12 +164,12 @@ func TestScalar(t *testing.T) {
 // Guard: the client dispatch table and domain types stay in sync with the
 // commands documented in usage().
 func TestClientCommandsCoverDesignDoc(t *testing.T) {
-	for _, name := range []string{"search", "browse", "context", "get", "create", "update", "delete", "move", "attach", "detach", "usage", "report", "revisions", "backlinks", "compile", "export", "import", "use", "whoami", "ui", "completion"} {
+	for _, name := range []string{"search", "browse", "context", "get", "create", "update", "delete", "purge", "move", "attach", "detach", "usage", "report", "revisions", "backlinks", "compile", "export", "import", "use", "whoami", "ui", "completion"} {
 		if _, ok := clientCommands[name]; !ok {
 			t.Errorf("missing client command %q", name)
 		}
 	}
-	if len(clientCommands) != 21 {
+	if len(clientCommands) != 22 {
 		t.Errorf("unexpected extra client commands: %d", len(clientCommands))
 	}
 	_ = domain.Types // keep the import honest

--- a/cmd/ochakai/completion.go
+++ b/cmd/ochakai/completion.go
@@ -43,6 +43,7 @@ _ochakai() {
     'create:create an entry from OKF markdown or JSON'
     'update:replace an entry (kept as a revision)'
     'delete:soft-delete an entry'
+    'purge:hard-delete a soft-deleted entry, freeing its id'
     'move:move (rename) an entry; references are rewritten'
     'attach:attach files to an entry'
     'detach:remove an attachment'
@@ -106,7 +107,7 @@ _ochakai() {
     create|update)
       _arguments '-f[input file]:file:_files' '--json[print the entry as JSON]' '--url[server URL]:url:'
       ;;
-    delete|detach|move)
+    delete|purge|detach|move)
       _arguments '--url[server URL]:url:'
       ;;
     attach)
@@ -162,7 +163,7 @@ _ochakai() {
   cmd=${COMP_WORDS[1]}
 
   if [ "$COMP_CWORD" -eq 1 ]; then
-    COMPREPLY=($(compgen -W "search browse context get create update delete move attach detach usage report revisions backlinks compile export import use whoami ui completion serve serve-ui version help" -- "$cur"))
+    COMPREPLY=($(compgen -W "search browse context get create update delete purge move attach detach usage report revisions backlinks compile export import use whoami ui completion serve serve-ui version help" -- "$cur"))
     return
   fi
 
@@ -187,7 +188,7 @@ _ochakai() {
       fi
       opts="--note --json --url" ;;
     create|update) opts="-f --json --url" ;;
-    delete|detach|move) opts="--url" ;;
+    delete|purge|detach|move) opts="--url" ;;
     attach)        opts="--name --json --url" ;;
     compile)       opts="--metric --dimension --filter --grain --model --limit --json --url" ;;
     export)        opts="--url --no-attachments" ;;
@@ -224,6 +225,7 @@ complete -c ochakai -n __fish_use_subcommand -a get -d 'print one entry as an OK
 complete -c ochakai -n __fish_use_subcommand -a create -d 'create an entry from OKF markdown or JSON'
 complete -c ochakai -n __fish_use_subcommand -a update -d 'replace an entry (kept as a revision)'
 complete -c ochakai -n __fish_use_subcommand -a delete -d 'soft-delete an entry'
+complete -c ochakai -n __fish_use_subcommand -a purge -d 'hard-delete a soft-deleted entry, freeing its id'
 complete -c ochakai -n __fish_use_subcommand -a move -d 'move (rename) an entry; references are rewritten'
 complete -c ochakai -n __fish_use_subcommand -a attach -d 'attach files to an entry'
 complete -c ochakai -n __fish_use_subcommand -a detach -d 'remove an attachment'
@@ -242,7 +244,7 @@ complete -c ochakai -n __fish_use_subcommand -a serve -d 'start the MCP + REST s
 complete -c ochakai -n __fish_use_subcommand -a serve-ui -d 'serve the team web UI as a deployed service'
 complete -c ochakai -n __fish_use_subcommand -a version -d 'print the version'
 
-complete -c ochakai -n '__fish_seen_subcommand_from search browse context get create update delete move attach detach usage report revisions backlinks compile export import whoami ui' -l url -x -d 'server URL'
+complete -c ochakai -n '__fish_seen_subcommand_from search browse context get create update delete purge move attach detach usage report revisions backlinks compile export import whoami ui' -l url -x -d 'server URL'
 complete -c ochakai -n '__fish_seen_subcommand_from ui' -l port -x -d 'port on 127.0.0.1'
 complete -c ochakai -n '__fish_seen_subcommand_from import' -l dry-run -d 'parse and list, write nothing'
 complete -c ochakai -n '__fish_seen_subcommand_from import' -F

--- a/cmd/ochakai/main.go
+++ b/cmd/ochakai/main.go
@@ -93,6 +93,7 @@ Client commands (talk to a server; --url > $OCHAKAI_URL > "use" selection):
   create [id] [-f file]   create an entry from OKF markdown or JSON
   update <id>             replace an entry (every change kept as a revision)
   delete <id>             soft-delete an entry (history retained)
+  purge <id>              hard-delete a soft-deleted entry, freeing its id
   move <id> <new-id>      move (rename) an entry; references are rewritten
   attach <id> <file...>   attach files to an entry (png/jpeg/webp/pdf/text)
   detach <id> <name>      remove an attachment

--- a/internal/apiclient/apiclient.go
+++ b/internal/apiclient/apiclient.go
@@ -261,6 +261,12 @@ func (c *Client) Delete(ctx context.Context, id string) error {
 	return c.doJSON(ctx, http.MethodDelete, entryPath(id), nil, nil, nil)
 }
 
+// Purge hard-deletes an entry that is already soft-deleted, freeing its
+// id (DELETE ...?purge=true). A live entry is a 409: delete it first.
+func (c *Client) Purge(ctx context.Context, id string) error {
+	return c.doJSON(ctx, http.MethodDelete, entryPath(id), url.Values{"purge": {"true"}}, nil, nil)
+}
+
 // Move renames the entry at id to newID (POST /api/v1/move). The server
 // carries revisions, usage, and attachments along and rewrites inbound
 // references so nothing breaks (design doc 0021).

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -372,8 +372,18 @@ func Handler(svc *service.Service) http.Handler {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
+	// DELETE soft-deletes; ?purge=true hard-deletes an entry that is
+	// already soft-deleted, freeing its id (a tombstone still owns the
+	// primary key, so a move onto it fails). Two calls, deliberately: the
+	// first is reversible, the second is not. Not on MCP — destroying
+	// history is a human decision (design doc 0015).
 	mux.HandleFunc("DELETE /api/v1/knowledge/{id...}", func(w http.ResponseWriter, r *http.Request) {
-		err := svc.Delete(r.Context(), r.PathValue("id"), httpauth.Actor(r.Context()))
+		var err error
+		if r.URL.Query().Get("purge") == "true" {
+			err = svc.Purge(r.Context(), r.PathValue("id"))
+		} else {
+			err = svc.Delete(r.Context(), r.PathValue("id"), httpauth.Actor(r.Context()))
+		}
 		if err != nil {
 			writeError(w, err)
 			return
@@ -566,7 +576,7 @@ func writeError(w http.ResponseWriter, err error) {
 	case errors.Is(err, store.ErrConflict):
 		// The If-Match precondition failed: the entry changed since read.
 		status = http.StatusPreconditionFailed
-	case errors.Is(err, store.ErrAlreadyExists):
+	case errors.Is(err, store.ErrAlreadyExists), errors.Is(err, store.ErrNotDeleted):
 		status = http.StatusConflict
 	case errors.As(err, &compileErr):
 		status = http.StatusUnprocessableEntity

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -138,6 +138,15 @@ func (s *Service) Delete(ctx context.Context, id string, actor domain.Actor) err
 	return s.Store.SoftDelete(ctx, domain.Normalize(id), actor)
 }
 
+// Purge hard-deletes an already soft-deleted entry, freeing its id for a
+// move (design doc 0021: Move cannot revive a tombstone the way Create
+// can). Not an MCP tool: this is the one operation that destroys history,
+// so it belongs to the human surfaces (design doc 0015). No actor is
+// recorded because nothing survives to record it on.
+func (s *Service) Purge(ctx context.Context, id string) error {
+	return s.Store.Purge(ctx, domain.Normalize(id))
+}
+
 // Move renames an entry to newID, carrying every id-keyed record along
 // (revisions, usage, attachments, embeddings) and rewriting inbound
 // references so nothing breaks (design doc 0021). Moving to the current

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -27,6 +27,11 @@ var ErrAlreadyExists = errors.New("knowledge already exists")
 // (design doc 0025 §11). The entry exists — a missing entry is ErrNotFound.
 var ErrConflict = errors.New("knowledge changed since it was read")
 
+// ErrNotDeleted is returned by Purge for an entry that is still live.
+// Purging is the second step of a two-step destruction: delete first, so
+// no single call can erase history that was in use a moment ago.
+var ErrNotDeleted = errors.New("knowledge is live; soft-delete it before purging")
+
 // nowStored is the current UTC time truncated to the microsecond precision
 // PostgreSQL timestamptz stores. Setting entity timestamps from it means an
 // in-memory updated_at always equals the value that round-trips through the
@@ -355,6 +360,58 @@ func (s *Store) SoftDelete(ctx context.Context, id string, actor domain.Actor) e
 	})
 }
 
+// Purge hard-deletes a soft-deleted entry and everything keyed by its id:
+// revisions, usage totals and events, embeddings, attachment metadata.
+// This is how an id comes back into circulation for a move — Create
+// already revives a soft-deleted entry in place, but Move cannot, because
+// the tombstone still owns the primary key and its revisions still own
+// (id, rev).
+//
+// Only a soft-deleted entry can be purged. Delete first, purge second: no
+// single call erases history, and the entry stays recoverable (Create
+// revives it) right up until someone deliberately asks for it to be gone.
+//
+// Attachment bytes are left in the blob store, as DeleteAttachment leaves
+// them: blobs are content-addressed and shared between entries, so
+// reclaiming them is a separate sweep, not a side effect of one purge.
+func (s *Store) Purge(ctx context.Context, id string) error {
+	return s.withTx(ctx, func(tx pgx.Tx) error {
+		var deleted bool
+		err := tx.QueryRow(ctx,
+			`SELECT deleted_at IS NOT NULL FROM knowledge WHERE id=$1`, id).Scan(&deleted)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrNotFound
+		}
+		if err != nil {
+			return err
+		}
+		if !deleted {
+			return ErrNotDeleted
+		}
+		for _, q := range []string{
+			`DELETE FROM attachment WHERE knowledge_id=$1`,
+			`DELETE FROM knowledge_usage WHERE knowledge_id=$1`,
+			`DELETE FROM knowledge_event WHERE knowledge_id=$1`,
+			`DELETE FROM knowledge_revision WHERE id=$1`,
+			`DELETE FROM knowledge WHERE id=$1`,
+		} {
+			if _, err := tx.Exec(ctx, q, id); err != nil {
+				return err
+			}
+		}
+		// Embedding tables exist only once semantic search has been enabled.
+		for _, q := range []string{
+			`DELETE FROM knowledge_embedding WHERE id=$1`,
+			`DELETE FROM attachment_embedding WHERE knowledge_id=$1`,
+		} {
+			if err := execTolerateMissingTable(ctx, tx, q, id); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
 // Move renames an entry to a new id. The id is the address (design doc
 // 0017), so everything keyed by it follows in one transaction — the row,
 // its revisions, attachments, usage, events, and embeddings — and live
@@ -370,12 +427,23 @@ func (s *Store) Move(ctx context.Context, oldID, newID string, actor domain.Acto
 	}
 	k.UpdatedAt = nowStored()
 	err = s.withTx(ctx, func(tx pgx.Tx) error {
-		var taken bool
+		// A soft-deleted entry still owns the id — the row holds the primary
+		// key and its revisions hold (id, rev) — so the destination is taken
+		// either way. Create can revive such an entry in place; a move
+		// cannot, because the arriving entry brings revisions of its own.
+		// Say which case it is: "already exists" sends someone looking for
+		// an entry they cannot see, and without purge the id would be
+		// blocked forever.
+		var occupied, occupantDeleted bool
 		if err := tx.QueryRow(ctx,
-			`SELECT EXISTS (SELECT 1 FROM knowledge WHERE id=$1)`, newID).Scan(&taken); err != nil {
+			`SELECT true, deleted_at IS NOT NULL FROM knowledge WHERE id=$1`, newID).
+			Scan(&occupied, &occupantDeleted); err != nil && !errors.Is(err, pgx.ErrNoRows) {
 			return err
 		}
-		if taken {
+		if occupied {
+			if occupantDeleted {
+				return fmt.Errorf("%w: %s holds a deleted entry; purge it to free the id", ErrAlreadyExists, newID)
+			}
 			return ErrAlreadyExists
 		}
 		// deleted_at IS NULL guards the race with a concurrent delete,

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -1158,3 +1158,91 @@ func TestIntegrationSearchTextFollowsAttachmentsAndMoves(t *testing.T) {
 		t.Errorf("detaching left the filename in search_text: %q", searchText(moved))
 	}
 }
+
+// Move onto an id held by a soft-deleted entry, and the purge that frees
+// it. Create revives a tombstone in place (it brings no history of its
+// own), but Move cannot: the arriving entry has revisions, and (id, rev)
+// is a primary key. Without purge the id would be blocked forever — the
+// exact outcome Create's own comment calls out as unacceptable.
+func TestIntegrationPurgeFreesIDForMove(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	actor := domain.Actor{Kind: "human", Name: "test"}
+
+	const src, dst = "it-purge-src", "it-purge-dst"
+	for _, id := range []string{src, dst} {
+		_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge WHERE id = $1`, id)
+		_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_revision WHERE id = $1`, id)
+	}
+	create := func(id string) {
+		t.Helper()
+		if err := s.Create(ctx, &domain.Knowledge{
+			Type: domain.TypeTerms, ID: id, Title: id,
+			Status: domain.StatusDraft, CreatedBy: actor,
+		}); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+	create(src)
+	create(dst)
+
+	// A live occupant is a plain conflict.
+	if _, err := s.Move(ctx, src, dst, actor); !errors.Is(err, ErrAlreadyExists) {
+		t.Fatalf("move onto a live entry: got %v, want ErrAlreadyExists", err)
+	}
+
+	if err := s.SoftDelete(ctx, dst, actor); err != nil {
+		t.Fatal(err)
+	}
+	// Still taken — but the error must say so, or the caller goes looking
+	// for an entry they cannot see.
+	_, err = s.Move(ctx, src, dst, actor)
+	if !errors.Is(err, ErrAlreadyExists) {
+		t.Fatalf("move onto a tombstone: got %v, want ErrAlreadyExists", err)
+	}
+	if !strings.Contains(err.Error(), "purge") {
+		t.Errorf("error does not point at the way out: %v", err)
+	}
+
+	// Purging a live entry is refused: delete first, purge second.
+	if err := s.Purge(ctx, src); !errors.Is(err, ErrNotDeleted) {
+		t.Errorf("purge of a live entry: got %v, want ErrNotDeleted", err)
+	}
+
+	if err := s.Purge(ctx, dst); err != nil {
+		t.Fatalf("Purge: %v", err)
+	}
+	var revs int
+	if err := s.pool.QueryRow(ctx,
+		`SELECT count(*) FROM knowledge_revision WHERE id = $1`, dst).Scan(&revs); err != nil {
+		t.Fatal(err)
+	}
+	if revs != 0 {
+		t.Errorf("purge left %d revisions behind", revs)
+	}
+	if err := s.Purge(ctx, dst); !errors.Is(err, ErrNotFound) {
+		t.Errorf("purge of a purged entry: got %v, want ErrNotFound", err)
+	}
+
+	// The id is free again.
+	moved, err := s.Move(ctx, src, dst, actor)
+	if err != nil {
+		t.Fatalf("move after purge: %v", err)
+	}
+	if moved.ID != dst {
+		t.Errorf("moved entry id = %q, want %q", moved.ID, dst)
+	}
+	_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge WHERE id = $1`, dst)
+	_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_revision WHERE id = $1`, dst)
+}


### PR DESCRIPTION
「Move の宛先が soft-delete 済みでも ErrAlreadyExists → ID が事実上永久にブロックされる」という指摘。**そのとおりで、しかも Create 自身の論拠と矛盾している。**

## 矛盾

[store.go](internal/store/store.go) の Create のコメント:

> A soft-deleted entry is revived instead: the ID would otherwise be dead forever

Create はこの理由でちゃんと復活させる。Move だけが `SELECT EXISTS (... WHERE id=$1)` で `deleted_at` を見ずに弾いていた。

## ただし Move 側を緩めるだけでは直らない

`deleted_at IS NULL` を足すと主キー違反になる。墓標の行が宛先 ID を保持したまま `UPDATE knowledge SET id=$2` が走るため。さらに [store.go](internal/store/store.go) の `UPDATE knowledge_revision SET id=$2` が墓標のリビジョンと `(id, rev)` で衝突する。**Create が復活できるのは自分の履歴を持ち込まないからで、Move は持ち込む。**

つまり「宛先の死んだエントリの履歴をどうするか」を決めない限り Move は直せない。黙って捨てるのは Move の副作用として重すぎる。

## purge

soft-delete 済みのエントリだけをハード削除する操作を足した。エントリ・リビジョン・usage・イベント・埋め込み・添付メタデータを消し、ID を解放する。

- **二段階は意図的**。1 回目(delete)は取り消せる(Create で復活)、2 回目(purge)は取り消せない。単一の呼び出しで履歴が消えることはない
- **生きているエントリの purge は 409**(`ErrNotDeleted`)。先に delete しろ、というメッセージ
- **Move のエラーが逃げ道を示す**: `... holds a deleted entry; purge it to free the id`
- **面は REST / CLI のみ**。履歴を破壊する唯一の操作なので人間の面に置く(design 0015 の線引き)。MCP には出さない
- **添付のバイトは残す**。content-addressed で複数エントリに共有されうるので、回収は別の掃除。`DeleteAttachment` も同じ方針で、そこと揃えた

```bash
ochakai delete terms/obsolete-kpi && ochakai purge terms/obsolete-kpi
```

## テスト

統合テストで一連の遷移を通す: 生きた宛先 → 素の `ErrAlreadyExists` / 墓標の宛先 → purge を案内するメッセージ付き / 生きたエントリの purge → `ErrNotDeleted` / purge 後 → リビジョンが 0 件、二度目の purge は `ErrNotFound`、そして **move が成功する**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)