### PR TITLE
export をストリーミングにし、添付を外す選択肢を足す

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -507,7 +507,22 @@ paths:
       description: >
         Streams a tar.gz of the whole knowledge base in Open Knowledge
         Format (markdown + YAML frontmatter, one concept per entry, with
-        index.md files). Your knowledge is yours.
+        index.md files), attachment files included. Your knowledge is
+        yours.
+
+
+        Written one file at a time, so the server never holds the whole
+        bundle in memory. Because the response starts before the last
+        file is read, a failure mid-export can only truncate the stream:
+        verify a backup by reading the archive, not by the status code.
+      parameters:
+        - name: attachments
+          in: query
+          description: >
+            `false` exports the markdown only. Attachment bytes live in
+            GCS, so a periodic backup can copy them from there directly
+            instead of pulling them through this endpoint.
+          schema: { type: string, enum: ["false"] }
       responses:
         "200":
           description: OKF bundle.

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -851,7 +851,8 @@ func cmdCompile(ctx context.Context, args []string) error {
 func cmdExport(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
 		"Usage: ochakai export [flags] <dir | ->\n\nDownload the whole knowledge base as an OKF bundle (markdown + YAML\nfrontmatter) into dir, or stream the tar.gz to stdout with \"-\".\nYour knowledge is yours.",
-		"  ochakai export ./knowledge\n  ochakai export - > ochakai-okf.tar.gz\n")
+		"  ochakai export ./knowledge\n  ochakai export - > ochakai-okf.tar.gz\n  ochakai export --no-attachments - > entries.tar.gz   # bytes are in GCS; copy them from there\n")
+	noAtt := fs.Bool("no-attachments", false, "export the markdown only, skipping attachment files")
 	pos, err := parseArgs(fs, args)
 	if err != nil {
 		return err
@@ -864,7 +865,7 @@ func cmdExport(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	rc, err := c.Export(ctx)
+	rc, err := c.Export(ctx, !*noAtt)
 	if err != nil {
 		return err
 	}

--- a/cmd/ochakai/completion.go
+++ b/cmd/ochakai/completion.go
@@ -124,7 +124,7 @@ _ochakai() {
         '--url[server URL]:url:'
       ;;
     export)
-      _arguments '--url[server URL]:url:' '1:directory:_files -/'
+      _arguments '--no-attachments[export the markdown only]' '--url[server URL]:url:' '1:directory:_files -/'
       ;;
     import)
       _arguments '--dry-run[parse and list, write nothing]' '--url[server URL]:url:' '1:bundle:_files'
@@ -190,7 +190,7 @@ _ochakai() {
     delete|detach|move) opts="--url" ;;
     attach)        opts="--name --json --url" ;;
     compile)       opts="--metric --dimension --filter --grain --model --limit --json --url" ;;
-    export)        opts="--url" ;;
+    export)        opts="--url --no-attachments" ;;
     import)        opts="--dry-run --url" ;;
     whoami)        opts="--json --url" ;;
     ui)            opts="--port --url" ;;
@@ -268,5 +268,6 @@ complete -c ochakai -n '__fish_seen_subcommand_from compile' -l model -x -d 'mod
 complete -c ochakai -n '__fish_seen_subcommand_from use' -l name -x -d 'name to save the URL under'
 complete -c ochakai -n '__fish_seen_subcommand_from use' -a '(ochakai use 2>/dev/null | cut -c3- | cut -f1)'
 complete -c ochakai -n '__fish_seen_subcommand_from completion' -a 'zsh bash fish'
+complete -c ochakai -n '__fish_seen_subcommand_from export' -l no-attachments -d 'export the markdown only'
 complete -c ochakai -n '__fish_seen_subcommand_from export' -a '(__fish_complete_directories)'
 `

--- a/internal/apiclient/apiclient.go
+++ b/internal/apiclient/apiclient.go
@@ -354,8 +354,12 @@ func (c *Client) Compile(ctx context.Context, req CompileRequest) (*CompileResul
 
 // Export streams the knowledge base as an OKF tar.gz bundle. The caller
 // must close the reader.
-func (c *Client) Export(ctx context.Context) (io.ReadCloser, error) {
-	resp, err := c.do(ctx, http.MethodGet, "/api/v1/export", nil, nil)
+func (c *Client) Export(ctx context.Context, attachments bool) (io.ReadCloser, error) {
+	var q url.Values
+	if !attachments {
+		q = url.Values{"attachments": {"false"}}
+	}
+	resp, err := c.do(ctx, http.MethodGet, "/api/v1/export", q, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/apiclient/apiclient_test.go
+++ b/internal/apiclient/apiclient_test.go
@@ -252,20 +252,34 @@ func TestCreateSendsJSONBodyAndDelete204(t *testing.T) {
 }
 
 func TestExportStreamsBody(t *testing.T) {
-	c := newTestPair(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v1/export" {
-			t.Errorf("path = %s", r.URL.Path)
-		}
-		_, _ = w.Write([]byte("tarball-bytes"))
-	})
-	rc, err := c.Export(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer rc.Close()
-	data, _ := io.ReadAll(rc)
-	if string(data) != "tarball-bytes" {
-		t.Errorf("body = %q", data)
+	for _, tc := range []struct {
+		name        string
+		attachments bool
+		wantParam   string
+	}{
+		{"with attachments", true, ""},
+		{"markdown only", false, "false"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newTestPair(t, func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/api/v1/export" {
+					t.Errorf("path = %s", r.URL.Path)
+				}
+				if got := r.URL.Query().Get("attachments"); got != tc.wantParam {
+					t.Errorf("attachments = %q, want %q", got, tc.wantParam)
+				}
+				_, _ = w.Write([]byte("tarball-bytes"))
+			})
+			rc, err := c.Export(context.Background(), tc.attachments)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer rc.Close()
+			data, _ := io.ReadAll(rc)
+			if string(data) != "tarball-bytes" {
+				t.Errorf("body = %q", data)
+			}
+		})
 	}
 }
 

--- a/internal/okf/okf.go
+++ b/internal/okf/okf.go
@@ -66,20 +66,30 @@ var reservedKeys = map[string]bool{
 // the directories. Every directory level gets an index.md for
 // progressive disclosure.
 func Bundle(entries []domain.Knowledge) (map[string][]byte, error) {
-	sort.Slice(entries, func(i, j int) bool { return entries[i].ID < entries[j].ID })
+	files := Indexes(entries)
+	for i := range entries {
+		doc, err := Document(&entries[i])
+		if err != nil {
+			return nil, fmt.Errorf("render %s: %w", entries[i].URI(), err)
+		}
+		files[entries[i].ID+".md"] = doc
+	}
+	return files, nil
+}
 
-	files := map[string][]byte{}
+// Indexes renders a bundle's directory index.md files and nothing else,
+// sorting entries by id on the way (Bundle's ordering). Split out so a
+// streaming exporter can render one concept document at a time — the
+// indexes need every id, but only the ids.
+func Indexes(entries []domain.Knowledge) map[string][]byte {
+	sort.Slice(entries, func(i, j int) bool { return entries[i].ID < entries[j].ID })
 	root := &dir{}
 	for _, k := range entries {
-		doc, err := Document(&k)
-		if err != nil {
-			return nil, fmt.Errorf("render %s: %w", k.URI(), err)
-		}
-		files[k.ID+".md"] = doc
 		root.insert(strings.Split(k.ID, "/"), k)
 	}
+	files := map[string][]byte{}
 	root.writeIndexes(files, "")
-	return files, nil
+	return files
 }
 
 // dir is one directory level of a bundle, used to generate index.md files.
@@ -227,23 +237,49 @@ func WriteTarGz(w io.Writer, files map[string][]byte, modTime time.Time) error {
 	}
 	sort.Strings(paths)
 
-	gz := gzip.NewWriter(w)
-	tw := tar.NewWriter(gz)
+	tgz := NewTarGzWriter(w, modTime)
 	for _, p := range paths {
-		if err := tw.WriteHeader(&tar.Header{
-			Name:    p,
-			Mode:    0o644,
-			Size:    int64(len(files[p])),
-			ModTime: modTime.UTC(),
-		}); err != nil {
-			return err
-		}
-		if _, err := tw.Write(files[p]); err != nil {
+		if err := tgz.Add(p, files[p]); err != nil {
 			return err
 		}
 	}
-	if err := tw.Close(); err != nil {
+	return tgz.Close()
+}
+
+// TarGzWriter writes a bundle one file at a time. A caller that can
+// produce its files lazily — the export endpoint, pulling attachment
+// bytes from the blob store as it goes — then never holds more than one
+// file in memory, instead of the whole knowledge base plus every
+// attachment.
+type TarGzWriter struct {
+	gz      *gzip.Writer
+	tw      *tar.Writer
+	modTime time.Time
+}
+
+func NewTarGzWriter(w io.Writer, modTime time.Time) *TarGzWriter {
+	gz := gzip.NewWriter(w)
+	return &TarGzWriter{gz: gz, tw: tar.NewWriter(gz), modTime: modTime.UTC()}
+}
+
+// Add appends one file. Callers that care about ordering add in order:
+// unlike WriteTarGz, nothing is sorted here because nothing is collected.
+func (t *TarGzWriter) Add(path string, data []byte) error {
+	if err := t.tw.WriteHeader(&tar.Header{
+		Name:    path,
+		Mode:    0o644,
+		Size:    int64(len(data)),
+		ModTime: t.modTime,
+	}); err != nil {
 		return err
 	}
-	return gz.Close()
+	_, err := t.tw.Write(data)
+	return err
+}
+
+func (t *TarGzWriter) Close() error {
+	if err := t.tw.Close(); err != nil {
+		return err
+	}
+	return t.gz.Close()
 }

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -392,16 +393,67 @@ func Handler(svc *service.Service) http.Handler {
 	// GET /api/v1/export — the whole knowledge base as an OKF bundle
 	// (tar.gz of markdown + YAML frontmatter, plus attachment files).
 	// Your knowledge is yours.
+	//
+	// Written straight to the response one file at a time. Collecting the
+	// bundle first would mean holding every entry and every attachment's
+	// bytes in memory at once — a periodic CI backup would be the largest
+	// allocation the process ever makes, on the instance size Cloud Run
+	// runs it at. With ?attachments=false the bytes are skipped entirely:
+	// they live in GCS, so a backup can copy them from there far more
+	// cheaply than through this endpoint.
 	mux.HandleFunc("GET /api/v1/export", func(w http.ResponseWriter, r *http.Request) {
 		entries, err := svc.Store.ListAll(r.Context())
 		if err != nil {
 			writeError(w, err)
 			return
 		}
-		files, err := okf.Bundle(entries)
-		if err != nil {
-			writeError(w, err)
-			return
+		withAttachments := r.URL.Query().Get("attachments") != "false"
+		var atts []store.ExportAttachment
+		if withAttachments {
+			// Metadata only; bytes are pulled one attachment at a time below.
+			if atts, err = svc.Store.ListAllAttachmentMeta(r.Context()); err != nil {
+				writeError(w, err)
+				return
+			}
+		}
+		// Indexes need every id, but only the ids. Rendering them up front
+		// keeps the concept documents streaming one at a time.
+		indexes := okf.Indexes(entries) // also sorts entries by id
+
+		// Past this point the status is already sent, so a failure can only
+		// truncate the stream. Everything that can fail cheaply — the
+		// listings above — has already run.
+		w.Header().Set("Content-Type", "application/gzip")
+		w.Header().Set("Content-Disposition", `attachment; filename="ochakai-okf.tar.gz"`)
+		tgz := okf.NewTarGzWriter(w, time.Now())
+		written := make(map[string]bool, len(entries)+len(indexes))
+		add := func(p string, data []byte) bool {
+			if err := tgz.Add(p, data); err != nil {
+				return false
+			}
+			written[p] = true
+			return true
+		}
+		// Sorted so a backup taken twice from the same content produces the
+		// same archive: map iteration order is not an ordering.
+		indexPaths := make([]string, 0, len(indexes))
+		for path := range indexes {
+			indexPaths = append(indexPaths, path)
+		}
+		sort.Strings(indexPaths)
+		for _, path := range indexPaths {
+			if !add(path, indexes[path]) {
+				return
+			}
+		}
+		for i := range entries {
+			doc, err := okf.Document(&entries[i])
+			if err != nil {
+				return // headers are out; nothing to report but a short stream
+			}
+			if !add(entries[i].ID+".md", doc) {
+				return
+			}
 		}
 		// Attachments go next to their entries: "<id>/<name>", or the
 		// foreign path they were imported at (okf_path) so original body
@@ -409,25 +461,21 @@ func Handler(svc *service.Service) http.Handler {
 		// document falls back to the canonical layout — identical content
 		// at the same path (the same image referenced by two entries) is
 		// no conflict.
-		atts, err := svc.Store.ListAllAttachments(r.Context())
-		if err != nil {
-			writeError(w, err)
-			return
-		}
 		for i := range atts {
 			a := &atts[i]
+			data, err := svc.Store.AttachmentBytes(r.Context(), a.Att.SHA256)
+			if err != nil {
+				return
+			}
 			p := okf.AttachmentPath(a.ID, &a.Att)
-			if _, taken := files[p]; taken {
+			if written[p] {
 				p = a.ID + "/" + a.Att.Name
 			}
-			files[p] = a.Data
+			if !add(p, data) {
+				return
+			}
 		}
-		w.Header().Set("Content-Type", "application/gzip")
-		w.Header().Set("Content-Disposition", `attachment; filename="ochakai-okf.tar.gz"`)
-		if err := okf.WriteTarGz(w, files, time.Now()); err != nil {
-			// Headers already sent; nothing to do but log via server.
-			return
-		}
+		_ = tgz.Close()
 	})
 
 	mux.HandleFunc("POST /api/v1/compile", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/restapi/restapi_integration_test.go
+++ b/internal/restapi/restapi_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -152,6 +153,41 @@ func TestRESTIntegration(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("export bundle misses %s/sales/orders.md", typ)
+	}
+
+	// ?attachments=false skips the bytes: a CI backup can take the
+	// entries from here and the files straight from GCS, which is both
+	// cheaper and the only sane path once attachments outweigh the text.
+	resp, err = http.Get(srv.URL + "/api/v1/export?attachments=false")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("export without attachments: status = %d", resp.StatusCode)
+	}
+	gz, err = gzip.NewReader(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found = false
+	for tr := tar.NewReader(gz); ; {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.HasSuffix(hdr.Name, ".md") {
+			t.Errorf("attachments=false still carried %s", hdr.Name)
+		}
+		if hdr.Name == typ+"/sales/orders.md" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("attachments=false dropped the entries too")
 	}
 
 	// Delete, then the entry is gone.

--- a/internal/store/attachment.go
+++ b/internal/store/attachment.go
@@ -228,8 +228,46 @@ type ExportAttachment struct {
 	Data []byte
 }
 
+// ListAllAttachmentMeta returns every live entry's attachment metadata,
+// ordered by id then name, without any bytes. The OKF exporter walks this
+// and pulls one attachment's bytes at a time (AttachmentBytes), so peak
+// memory is one attachment rather than all of them.
+func (s *Store) ListAllAttachmentMeta(ctx context.Context) ([]ExportAttachment, error) {
+	rows, err := s.pool.Query(ctx, `SELECT a.knowledge_id, `+attachmentCols+`
+		FROM attachment a
+		JOIN blob b ON b.sha256 = a.sha256
+		JOIN knowledge k ON k.id = a.knowledge_id AND k.deleted_at IS NULL
+		ORDER BY a.knowledge_id, a.name`)
+	if err != nil {
+		return nil, err
+	}
+	atts, err := pgx.CollectRows(rows, func(row pgx.CollectableRow) (ExportAttachment, error) {
+		var e ExportAttachment
+		err := row.Scan(&e.ID, &e.Att.Name, &e.Att.MediaType, &e.Att.Size, &e.Att.SHA256, &e.Att.OKFPath,
+			&e.Att.CreatedBy.Kind, &e.Att.CreatedBy.Name, &e.Att.CreatedAt)
+		return e, err
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(atts) > 0 && s.blobs == nil {
+		return nil, errNoBlobStore
+	}
+	return atts, nil
+}
+
+// AttachmentBytes returns the content-addressed bytes behind an
+// attachment. Paired with ListAllAttachmentMeta for streaming export.
+func (s *Store) AttachmentBytes(ctx context.Context, sha256 string) ([]byte, error) {
+	if s.blobs == nil {
+		return nil, errNoBlobStore
+	}
+	return s.blobs.Get(ctx, sha256)
+}
+
 // ListAllAttachments returns every live entry's attachments with bytes,
-// ordered by id then name. Used by the OKF exporter.
+// ordered by id then name. Holds every attachment in memory at once —
+// prefer ListAllAttachmentMeta plus AttachmentBytes.
 func (s *Store) ListAllAttachments(ctx context.Context) ([]ExportAttachment, error) {
 	rows, err := s.pool.Query(ctx, `SELECT a.knowledge_id, `+attachmentCols+`
 		FROM attachment a


### PR DESCRIPTION
「`GET /api/v1/export` が全エントリ + 全添付バイトをメモリに載せてから tar.gz を書く → CI で定期バックアップを回すなら OOM リスク」という指摘。そのとおり。

## ストリーミング化

1 ファイルずつ応答へ直接書く。`okf.TarGzWriter` を足して、呼び出し側が遅延生成できるようにした。

| | 前 | 後 |
|---|---|---|
| index.md | 全ファイル map に蓄積 | `okf.Indexes` で先に描画(全 ID が要るが、ID だけで足りる) |
| 本文 | 全エントリ分をレンダリングして map に保持 | 1 エントリずつ描画して書き出し |
| 添付 | **全添付のバイトを一度にメモリへ** | メタデータだけ先に引き、バイトは 1 件ずつ取得(ピークが「全添付」→「1 添付」= 最大 5 MiB) |

## `?attachments=false`

添付バイトは GCS にある。定期バックアップなら **そちらを直接コピーするほうが安い**し、添付が本文より重くなった時点でそれが唯一まともな経路になる。CLI は `--no-attachments`。

```bash
ochakai export --no-attachments - > entries.tar.gz   # + gcloud storage rsync
```

## トレードオフ(明記)

ヘッダは最初のファイルより前に出るので、**途中の失敗はストリームの切断としてしか表れない**。失敗しうる列挙(`ListAll` / `ListAllAttachmentMeta`)は全部ヘッダより前で走らせてあるが、バックアップの検証はステータスコードではなくアーカイブを読んで行うべき。openapi.yaml にもそう書いた。

書き出し順は index → 本文(ID 順)→ 添付(ID, 名前順)。以前の「全パスをソート」ではなくなったが決定的なので、同じ内容からは同じアーカイブが出る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)