### PR TITLE
pgvector に HNSW 索引を張る(次元が索引上限内のとき)

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ response, use `budget` instead.
 | `OCHAKAI_DB_IAM_AUTH` | `true` enables Cloud SQL IAM database authentication: the connection password is a short-lived IAM token, so the connection string carries no secret |
 | `OCHAKAI_GCS_BUCKET` | Bucket for attachment bytes (auth is ADC — no keys). Default: unset — the instance stores markdown entries only and attach operations return an error |
 | `OCHAKAI_VERTEX_PROJECT` | Set to enable hybrid semantic search via Vertex AI embeddings (default: off, trigram-only — ochakai calls no external API unless you opt in). Auth is ADC — no API keys. **Recommended for Japanese knowledge bases** (see below) |
-| `OCHAKAI_VERTEX_LOCATION` / `OCHAKAI_VERTEX_MODEL` / `OCHAKAI_EMBEDDING_DIM` | Embedding details (defaults: `us-central1`, `gemini-embedding-001`, 768). For image/PDF attachment search set model `gemini-embedding-2` with location `global` (or `us`/`eu`); switching models on an existing base leaves old vectors in the old space until entries are re-written (design doc 0020) |
+| `OCHAKAI_VERTEX_LOCATION` / `OCHAKAI_VERTEX_MODEL` / `OCHAKAI_EMBEDDING_DIM` | Embedding details (defaults: `us-central1`, `gemini-embedding-001`, 768). For image/PDF attachment search set model `gemini-embedding-2` with location `global` (or `us`/`eu`); switching models on an existing base leaves old vectors in the old space until entries are re-written (design doc 0020). Dimensions above 2000 exceed pgvector's indexing limit, so those deployments fall back to an exact scan |
 | `OCHAKAI_INSECURE_DEV` | Local development only: disables auth, everything acts as human:anonymous |
 | `PORT` | Listen port (default `8080`) |
 

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -97,8 +97,6 @@ func (s *Store) migrateEmbedding(ctx context.Context, dim int) error {
 	if _, err := s.pool.Exec(ctx, `CREATE EXTENSION IF NOT EXISTS vector`); err != nil {
 		return fmt.Errorf("pgvector extension is required for semantic search (create it as the admin user, or unset OCHAKAI_VERTEX_PROJECT): %w", err)
 	}
-	// Exact scan is fine at knowledge-base scale (thousands of rows), so no
-	// ANN index; this also keeps dimensions above index limits usable.
 	if _, err := s.pool.Exec(ctx, fmt.Sprintf(
 		`CREATE TABLE IF NOT EXISTS knowledge_embedding (
 			id         text NOT NULL PRIMARY KEY,
@@ -120,6 +118,47 @@ func (s *Store) migrateEmbedding(ctx context.Context, dim int) error {
 			PRIMARY KEY (knowledge_id, name)
 		)`, dim)); err != nil {
 		return fmt.Errorf("create attachment_embedding: %w", err)
+	}
+	return s.migrateVectorIndexes(ctx, dim)
+}
+
+// hnswMaxDim is pgvector's indexing limit for the vector type. Above it
+// no ANN index can be built (halfvec would raise it to 4000, but storing
+// half precision is a different decision than indexing), so those
+// deployments keep the exact scan.
+const hnswMaxDim = 2000
+
+// migrateVectorIndexes builds the HNSW indexes behind semantic search.
+// 0001 left them out on the grounds that an exact scan is fine at
+// knowledge-base scale — true at a few thousand rows, but a table
+// specification plus a glossary plus the Golden Queries and Insights the
+// write-back loop accumulates passes that within a year, and every search
+// reads every vector until it does not.
+//
+// The build is not deferred to a background goroutine: it runs once, on
+// the first startup after semantic search is enabled — when the table has
+// just been created and is empty — and the advisory lock in Migrate
+// already serializes instances starting together. A deployment that
+// enables it against an existing corpus pays a one-time build well inside
+// Cloud Run's startup allowance.
+//
+// vector_cosine_ops matches the `<=>` operator the searches order by; an
+// index built for another distance would simply never be used.
+func (s *Store) migrateVectorIndexes(ctx context.Context, dim int) error {
+	if dim > hnswMaxDim {
+		// Not an error: the exact scan still answers correctly, and the
+		// operator chose the dimension deliberately.
+		return nil
+	}
+	for _, stmt := range []string{
+		`CREATE INDEX IF NOT EXISTS knowledge_embedding_hnsw
+			ON knowledge_embedding USING hnsw (embedding vector_cosine_ops)`,
+		`CREATE INDEX IF NOT EXISTS attachment_embedding_hnsw
+			ON attachment_embedding USING hnsw (embedding vector_cosine_ops)`,
+	} {
+		if _, err := s.pool.Exec(ctx, stmt); err != nil {
+			return fmt.Errorf("create vector index: %w", err)
+		}
 	}
 	return nil
 }

--- a/internal/store/migrate_integration_test.go
+++ b/internal/store/migrate_integration_test.go
@@ -570,3 +570,72 @@ func sortLinks(l []domain.Link) {
 		return l[i].Text < l[j].Text
 	})
 }
+
+// The HNSW indexes exist once semantic search is configured, and the
+// searches can use them: an index built for the wrong operator class is
+// simply never chosen, which looks exactly like having no index at all.
+// Above pgvector's 2000-dimension indexing limit the migration must skip
+// them rather than fail — the exact scan still answers correctly.
+func TestIntegrationVectorIndexes(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.Migrate(ctx, 4); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, index := range []string{"knowledge_embedding_hnsw", "attachment_embedding_hnsw"} {
+		var exists bool
+		if err := s.pool.QueryRow(ctx,
+			`SELECT EXISTS (SELECT 1 FROM pg_class WHERE relname = $1)`, index).Scan(&exists); err != nil {
+			t.Fatal(err)
+		}
+		if !exists {
+			t.Errorf("%s was not created", index)
+		}
+	}
+
+	// The planner must be able to reach it through the `<=>` ordering the
+	// searches use. enable_seqscan=off is a cost penalty, not a
+	// prohibition, so a wrong operator class would still show a scan.
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback(ctx)
+	if _, err := tx.Exec(ctx, `SET LOCAL enable_seqscan = off`); err != nil {
+		t.Fatal(err)
+	}
+	rows, err := tx.Query(ctx, `EXPLAIN SELECT id FROM knowledge_embedding
+		ORDER BY embedding <=> $1::vector LIMIT 5`, encodeVector([]float32{1, 0, 0, 0}))
+	if err != nil {
+		t.Fatalf("EXPLAIN: %v", err)
+	}
+	plan := ""
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			t.Fatal(err)
+		}
+		plan += line + "\n"
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(plan, "knowledge_embedding_hnsw") {
+		t.Errorf("vector search cannot use the HNSW index; plan was:\n%s", plan)
+	}
+
+	// A dimension above pgvector's indexing limit skips the index instead
+	// of failing the migration.
+	if err := s.migrateVectorIndexes(ctx, hnswMaxDim+1); err != nil {
+		t.Errorf("migrateVectorIndexes above the dimension limit: %v", err)
+	}
+}


### PR DESCRIPTION
「数千行規模なら全走査で十分というコメントで意図的に張っていないが、蓄積されるので年単位で超える」という指摘。同意。

## ただし「次元が設定依存でも張れる」は不正確

[migrate.go](internal/store/migrate.go) の元コメント(「索引上限を超える次元も使えるようにするため」)は建前ではなく実際の制約で、**pgvector の `vector` 型は 2000 次元が索引の上限**。`OCHAKAI_EMBEDDING_DIM` の既定は 768 なので通常は張れるが、`gemini-embedding-001` のフル出力 3072 を指定した構成では張れない。

なので `dim <= 2000` のときだけ張り、超える場合は**失敗させずに全走査のまま**にする(答えは正しい。次元は運用者が意図して選んだもの)。README にも明記した。

## 演算子クラス

`vector_cosine_ops`。検索が `ORDER BY` する `<=>` と一致していなければ索引は選ばれず、**無いのと同じ**になる。統合テストで `EXPLAIN` が実際に `knowledge_embedding_hnsw` に到達することを確認している(`enable_seqscan=off` はコストペナルティであって禁止ではないので、演算子クラスが違えばスキャンのまま出る)。

## ビルドのタイミング

バックグラウンド goroutine に逃がしていない。走るのは semantic search を有効化した最初の起動時で、そのとき `knowledge_embedding` は直前に作られた空のテーブル。同時起動するインスタンスは `Migrate` の advisory lock で直列化される。既存コーパスに対して後から有効化する場合だけ一度ビルドを払うが、Cloud Run の起動許容時間には十分収まる規模。

🤖 Generated with [Claude Code](https://claude.com/claude-code)