### PR TITLE
SIGTERM 後のドレイン時間を縮め、最後の usage フラッシュに余地を残す

### DIFF
--- a/cmd/ochakai/main.go
+++ b/cmd/ochakai/main.go
@@ -165,6 +165,11 @@ func serve(log *slog.Logger) error {
 	if err != nil {
 		return err
 	}
+	// Runs after runServer returns, i.e. after the HTTP server has drained:
+	// Close stops the usage flush loop and drains its buffer one last time,
+	// so a SIGTERM does not discard the events recorded in the last few
+	// seconds (design doc 0025 §10). Ordering matters — flushing before the
+	// server drains would miss the requests still in flight.
 	defer svc.Store.Close()
 
 	mux := http.NewServeMux()
@@ -202,6 +207,15 @@ then open http://127.0.0.1:8098. See also: ochakai --help
 	return runServer(ctx, cfg.Addr, mux)
 }
 
+// drainTimeout bounds how long in-flight requests get after SIGTERM.
+// Cloud Run allows 10 seconds between SIGTERM and SIGKILL, and the final
+// usage flush happens after the drain (see serve) — spending the whole
+// allowance here would leave the flush to be killed mid-write, losing the
+// events the drained requests just recorded. Five seconds is more than
+// any handler here needs; export streams longer, and a truncated backup
+// is the cheapest thing in the process to lose.
+const drainTimeout = 5 * time.Second
+
 func runServer(ctx context.Context, addr string, handler http.Handler) error {
 	server := &http.Server{
 		Addr:              addr,
@@ -210,7 +224,7 @@ func runServer(ctx context.Context, addr string, handler http.Handler) error {
 	}
 	go func() {
 		<-ctx.Done()
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), drainTimeout)
 		defer cancel()
 		_ = server.Shutdown(shutdownCtx)
 	}()

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -1246,3 +1246,59 @@ func TestIntegrationPurgeFreesIDForMove(t *testing.T) {
 	_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge WHERE id = $1`, dst)
 	_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_revision WHERE id = $1`, dst)
 }
+
+// Close is the last thing a SIGTERM'd process does with the usage buffer:
+// stop the flush loop, drain what is still in it. Events recorded in the
+// seconds before shutdown — a whole request's worth on a Cloud Run
+// instance scaling to zero — would otherwise never reach the database.
+func TestIntegrationCloseFlushesBufferedUsage(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Migrate(ctx, 0); err != nil {
+		s.Close()
+		t.Fatal(err)
+	}
+	const id = "it-flush-on-close"
+	_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge WHERE id = $1`, id)
+	_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_revision WHERE id = $1`, id)
+	_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_usage WHERE knowledge_id = $1`, id)
+	_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_event WHERE knowledge_id = $1`, id)
+	actor := domain.Actor{Kind: "human", Name: "test"}
+	if err := s.Create(ctx, &domain.Knowledge{
+		Type: domain.TypeTerms, ID: id, Title: "flush", Status: domain.StatusDraft, CreatedBy: actor,
+	}); err != nil {
+		s.Close()
+		t.Fatal(err)
+	}
+	// Buffered, not written: the flush interval is far longer than this
+	// test, so only Close can get it to the database.
+	if err := s.RecordEvents(ctx, domain.EventFetched, actor, []string{id}); err != nil {
+		s.Close()
+		t.Fatal(err)
+	}
+	s.Close()
+
+	verify, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer verify.Close()
+	u, err := verify.Usage(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u.Fetches != 1 {
+		t.Errorf("fetches = %d after Close, want 1 — the buffer was dropped", u.Fetches)
+	}
+	_, _ = verify.pool.Exec(ctx, `DELETE FROM knowledge WHERE id = $1`, id)
+	_, _ = verify.pool.Exec(ctx, `DELETE FROM knowledge_revision WHERE id = $1`, id)
+	_, _ = verify.pool.Exec(ctx, `DELETE FROM knowledge_usage WHERE knowledge_id = $1`, id)
+	_, _ = verify.pool.Exec(ctx, `DELETE FROM knowledge_event WHERE knowledge_id = $1`, id)
+}


### PR DESCRIPTION
「利用イベントのメモリバッファ … Cloud Run の SIGTERM ハンドリングは確認する価値があります」という指摘。**確認したところ、経路自体は既に正しく出来ていた。**

## 既に出来ていたこと

- [main.go](cmd/ochakai/main.go) — `signal.NotifyContext(… syscall.SIGTERM)`
- graceful `server.Shutdown`
- `defer svc.Store.Close()` → [Store.Close](internal/store/store.go) がフラッシュループを止めて最終ドレインをかける

**通常のインスタンス終了(min 0 のスケールインを含む)ではイベントは失われない。**「Cloud Run の min 0 ではインスタンス落ちが日常なので usage の欠損は想像より多い」という見立ては、実装上は当たっていない。欠損するのは SIGTERM を経ないハードキル時の最大 5 秒分。

## 残っていた穴: 時間配分

Cloud Run の SIGTERM → SIGKILL の猶予は 10 秒。こちらの `Shutdown` のタイムアウトも 10 秒だった。**in-flight のリクエストが猶予を使い切ると、その後に走る最終フラッシュが書き込みの途中で殺される** — ドレインしたリクエストが今まさに記録したイベントを落とすことになる。

ドレインを 5 秒にした。ここのハンドラで 5 秒を要するものは export のストリームくらいで、途中で切れたバックアップはこのプロセスで最も失って安いもの。

## テスト

`Close` がバッファを実際にデータベースへ落とすことを統合テストで固定した(フラッシュ間隔より短い時間で `Close` し、別接続から `usage` を読む)。順序が効いていること — ドレインより先にフラッシュすると in-flight のリクエストを取りこぼす — はコメントで明示した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)