### PR TITLE
compile を第一級の売りから降ろし、optional として位置づけ直す

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,11 @@ ochakai context "why is revenue down?"  # the one-call read before a data questi
 ochakai search "revenue" --type Metric --status verified
 ochakai get models/sales-analytics
 ochakai attach insights/revenue-reading weekly.png   # files travel with the entry
-ochakai compile --metric revenue --grain orders.ordered_at:month
 ochakai export ./knowledge   # or: ochakai export - > okf.tar.gz
 ochakai import ./knowledge   # the inverse; works with any OKF bundle
 ochakai ui                   # web UI at http://127.0.0.1:8098, acting as you (no deploy)
+
+ochakai compile --metric revenue --grain orders.ordered_at:month  # optional: deterministic SQL from a Semantic Model
 ```
 
 `ochakai use` saves the selection locally (name more servers with
@@ -173,8 +174,8 @@ And it stays small by refusing things:
 
 | ochakai has no… | because |
 |---|---|
-| LLM | it returns deterministically compiled SQL from semantic definitions ([Apache Ossie](https://github.com/apache/ossie)) or human-verified golden queries, verbatim. Interpretation is the client agent's job |
-| SQL execution | it holds no warehouse credentials. It compiles; your agent executes |
+| LLM | it returns human-verified golden queries verbatim, and the definitions and caveats around them. Interpretation is the client agent's job |
+| SQL execution | it holds no warehouse credentials. Your agent executes |
 | connector ingestion | knowledge is curated by humans and agents, not harvested by pipelines. Trust density over volume |
 | chat UI or dashboards | it feeds your agents; it doesn't compete with them. The bundled web UI is a curation surface, not a BI tool |
 | secrets | Cloud Run IAM decides who reaches it, callers are identified by their Google identity, and Cloud SQL authenticates the service account — nothing to issue or rotate |
@@ -192,7 +193,19 @@ And it stays small by refusing things:
 | `delete_knowledge` | Soft-delete (history retained) |
 | `get_knowledge_usage` | Usage totals per entry — draft-promotion evidence, staleness signal |
 | `report_outcome` | Report worked/failed after acting on knowledge — failed reports flag verified entries for re-verification |
-| `compile_sql` | Metrics + dimensions + filters + time grain → SQL. Never executes, never guesses |
+
+One more tool, `compile_sql`, is **optional** and off the list above on
+purpose: metrics + dimensions + filters + time grain → BigQuery SQL,
+deterministically, from a `Semantic Model` entry's spec. It answers metric
+× grain × filter combinations nobody has asked before, which is real but
+narrower than it sounds — what an agent usually needs is the verified
+query and the caveat around it, both of which arrive from `get_context`.
+It also carries the largest tool schema here, and tool schemas are agent
+context. Embedding hosts should leave it out of their allowed-tools list
+unless they want compilation; nothing else degrades. What stays
+first-class either way is `Model.Validate()`: a `Metric` is checked
+against its model on write, which is what makes a metric an executable
+specification rather than a paragraph.
 
 Every entry is also an **MCP resource** addressable by its canonical URI —
 `ochakai://` plus its id (the entry's path), e.g. `ochakai://metrics/revenue`
@@ -214,7 +227,7 @@ over time, run them as canaries from your CI:
 
 | Type | What it holds |
 |---|---|
-| `Semantic Model` | Apache Ossie semantic model, spec verbatim — what `compile` reads |
+| `Semantic Model` | Apache Ossie semantic model, spec verbatim — validates its metrics, and feeds the optional `compile` |
 | `Metric` | Semantic metric definition (Apache Ossie), synonyms |
 | `Golden Query` | Golden query: natural-language question + verified SQL |
 | `Insight` | How to read a metric: baselines, seasonality, caveats, thresholds |

--- a/examples/claude-code/CLAUDE.md
+++ b/examples/claude-code/CLAUDE.md
@@ -36,11 +36,6 @@ entries. Search it before writing analytics SQL; write learnings back.
   caption is searchable). If you learn something by looking at an
   attachment, write it into the body with `ochakai update` — knowledge
   locked in pixels is invisible to search.
-- `ochakai compile --metric <name> [--dimension ds.field] [--grain ds.time_field:month] [--filter "ds.field = value"]`
-  — deterministic SQL on stdout. ochakai never executes SQL; run the result
-  with your own warehouse access. **Exit 2** means the request is outside
-  the supported subset: read the reason on stderr and prefer any suggested
-  verified golden queries.
 - `ochakai report <id> worked|failed [--note "what went wrong"]`
   — after acting on knowledge (running a golden query, executing compiled
   SQL), report whether the result was actually correct. `failed` reports
@@ -52,6 +47,15 @@ entries. Search it before writing analytics SQL; write learnings back.
   `draft`; your identity is recorded as provenance automatically.
 - `ochakai export <dir>` — snapshot the whole knowledge base as markdown;
   `ochakai import <dir>` loads a bundle back (any OKF bundle works).
+- `ochakai compile --metric <name> [--dimension ds.field] [--grain ds.time_field:month] [--filter "ds.field = value"]`
+  — optional, and rarely the first move: deterministic SQL on stdout from a
+  `Semantic Model` entry, for a metric × grain × filter combination no
+  golden query covers. Search for a verified golden query first — it is a
+  query a human confirmed against the real data, which compiled SQL is not.
+  ochakai never executes SQL; run the result with your own warehouse
+  access. **Exit 2** means the request is outside the supported subset:
+  read the reason on stderr and prefer any suggested verified golden
+  queries.
 
 Types beyond these are welcome (any slug works — e.g. `runbook/…`), and
 IDs may be hierarchical (`queries/sales/monthly-revenue`) to group

--- a/internal/compiler/model.go
+++ b/internal/compiler/model.go
@@ -2,6 +2,22 @@
 // Apache Ossie semantic models. Phase 1 scope (design doc §4): single fact
 // table + star joins, BigQuery output only (design doc 0016). Requests outside the
 // supported subset fail with a clear error — never a guess.
+//
+// The package holds two things of quite different standing. Model and its
+// Validate are load-bearing: they are what makes a Metric an executable
+// specification rather than a paragraph, and they run on every write of a
+// Semantic Model entry whether or not anyone ever compiles anything.
+// Compile itself is optional surface (README) — valuable for metric ×
+// grain × filter combinations nobody has written a golden query for, but
+// narrower than a verified query plus the caveat around it, which is what
+// an agent usually needs and what get_context already returns.
+//
+// That standing decides how the dialect gap is handled. BigQuery is wide
+// and this subset is narrow, and the gap does not close on its own: the
+// rule is that an unsupported construct returns an Error, never
+// approximate SQL. A compiler that says "outside the supported subset" is
+// working as intended; one that emits a plausible-looking date literal
+// with the wrong semantics costs more trust than the whole feature earns.
 package compiler
 
 import (


### PR DESCRIPTION
「`compile_sql` + Semantic Model + compiler 一式を第一級の売りから降ろすべき。完全削除までは勧めないが、位置づけを変えるべき」という指摘。このお客さまでの使用予定もないため、降格に同意。

## 論拠の整理

指摘の「ゴールデンクエリをそのまま返すだけで 8 割達成」は、**既出の質問については**正しい。compile が効くのは metric × grain × filter の未出の組み合わせという軸で、実在するが狭い。エージェントが普通に必要とするのは検証済みクエリとその周りの但し書きで、どちらも `get_context` が既に返している。

一方「完全に消すと Metric がただの文章になる」も正しい。**ただしその心配は `compile` ではなく `Model.Validate()` にかかっている** — 検証は `model.go`、SQL 生成は `compiler.go` と既に分かれており、前者は Semantic Model エントリの書き込みごとに走る。誰も compile しなくても Metric は実行可能な仕様であり続ける。なので**降格は生成側だけで足りる**。

## 変えたもの(コードの挙動は変えていない)

| 箇所 | 変更 |
|---|---|
| README「LLM を持たない」の説明 | 「決定論的にコンパイルされた SQL」主体 → 検証済みゴールデンクエリ主体 |
| README の MCP ツール表 | `compile_sql` を表から外し、optional として別記。埋め込みホストは allowedTools から外してよく他は何も劣化しない、と明記(**ツールスキーマは文脈予算で、これが 10 個中最大**) |
| README クイックスタートの CLI 一覧 | 末尾へ移し optional と注記 |
| 配布する `examples/claude-code/CLAUDE.md` | 順序を下げ「まず検証済みゴールデンクエリを探せ — 人間が実データで確認したものであり、compile された SQL はそうではない」 |
| `Semantic Model` 型の説明 | 「compile が読むもの」→「メトリクスを検証し、optional な compile にも使われる」 |
| compiler パッケージのドキュメント | 二層の位置づけと、方言の穴に対する原則を明記 |

## 方言の穴に対する原則

BigQuery は広く、このサブセットは狭く、その差は自然には縮まらない。**未対応の構文は近似 SQL ではなく Error を返す**(実装は既にそうなっている。exit 2)。「サポート範囲外」と言うコンパイラは仕様どおりに動いており、もっともらしい日付リテラルを黙って出すほうが機能全体の稼ぐ信頼より高くつく。

## 判断材料が手元にある

`knowledge_usage` は compile イベントを記録している。実インスタンスで `ochakai search --sort usage` / `ochakai usage <id>` を引けば、compile が実際に何回使われたかが出る。**さらに踏み込んで削除するかどうかは、議論ではなくその数字で決められる。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)