### PR TITLE
verified エントリは MCP から上書き・削除できないようにする(0015 §3.1)

### DIFF
--- a/docs/design/0015-surface-consistency.md
+++ b/docs/design/0015-surface-consistency.md
@@ -48,6 +48,27 @@ CLI、Web UI。機能を足すたびに「どのサーフェスに載せるか�
   get_attachment の description が既に誘導している。
 - **バルク(export / import / import-ossie)。** 応答サイズが読めず、
   tar.gz はツール結果に載らない。管理タスクは CLI / CI の領分。
+- **verified エントリの上書き・削除。** update_knowledge /
+  delete_knowledge は、対象が verified なら拒否する(create、draft の
+  更新、verified への昇格はいずれも従来どおり)。
+
+  これは認可ではない。0002 の「認可を持たない・verified 昇格を制限
+  しない」は撤回しない — 誰が検証したかは記録され、信頼は provenance
+  で判断される、という原則はそのまま。制限するのは**前提条件を
+  表明できない面からの黙示的な置き換え**だけである。0025 §11 の
+  If-Match は REST の ETag に乗っており、MCP にはその通り道がない。
+  つまり MCP の update は last-write-wins で、draft には許容できるが
+  人間がキュレーションしたものには許容できない。
+
+  非対称性の根拠は復旧可能性ではなく**可視性**にある。soft-delete は
+  目に見えて、かつ create で復活する。verified なゴールデンクエリの
+  本文が黙って置き換わった場合、誰かがそれを実行して間違った数字を
+  得るまで誰も気づかない。
+
+  エージェント側の正しい行動は 0025 が既に用意している: 誤りなら
+  report_outcome failed(sort=failed の再検証フィードに乗る)、
+  より良いものがあるなら新しい draft を create する。どちらも
+  書き戻しループの正規の経路であり、この規則はむしろそこへ誘導する。
 
 ### 3.2 REST に載せないもの
 

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -221,12 +221,19 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"an omitted title clears it, making the filename the name). " +
 			"Links are not a field: they come from the markdown links in body, so keep the ones you want to keep. " +
 			"Every change is kept as a revision; an update identical to the stored content writes nothing. " +
+			"Verified entries cannot be updated from this surface: if one is wrong, report_outcome failed, " +
+			"or create_knowledge a better draft — a human promotes it. " +
 			"Setting status=verified records you as verified_by — " +
 			"do it only for knowledge you have actually validated. Setting status=rejected records you " +
 			"as rejected_by; put the reason in status_note (also useful when deprecating).",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in writeIn) (*mcp.CallToolResult, knowledgeOut, error) {
-		// MCP has no conditional-update channel; it does not opt into the
-		// If-Match precondition (nil), keeping last-write-wins here.
+		// MCP has no conditional-update channel, so it cannot opt into the
+		// If-Match precondition (nil) and writes are last-write-wins. That
+		// is tolerable for drafts and not for curated knowledge, so
+		// verified entries are refused here rather than clobbered.
+		if err := svc.RefuseIfVerified(ctx, in.ID, "update"); err != nil {
+			return nil, knowledgeOut{}, err
+		}
 		k, _, err := svc.Update(ctx, in.toKnowledge(), httpauth.Actor(ctx), nil)
 		if err != nil {
 			return nil, knowledgeOut{}, err
@@ -238,8 +245,12 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 		Name:        "delete_knowledge",
 		Annotations: destructive,
 		Description: "Soft-delete a knowledge entry. History is retained as revisions; " +
-			"create_knowledge on the same id revives it.",
+			"create_knowledge on the same id revives it. Verified entries cannot be deleted from " +
+			"this surface — report_outcome failed if one is wrong.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in getIn) (*mcp.CallToolResult, deleteOut, error) {
+		if err := svc.RefuseIfVerified(ctx, in.ID, "delete"); err != nil {
+			return nil, deleteOut{}, err
+		}
 		if err := svc.Delete(ctx, in.ID, httpauth.Actor(ctx)); err != nil {
 			return nil, deleteOut{}, err
 		}

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -372,3 +372,34 @@ func TestContextHint(t *testing.T) {
 		}
 	}
 }
+
+// TestVerifiedGuardIsAdvertised pins the half of the verified-write rule
+// that agents can act on: the tool descriptions must say what to do
+// instead, or an agent meets the refusal with no next move. The refusal
+// itself is exercised in the service integration test.
+func TestVerifiedGuardIsAdvertised(t *testing.T) {
+	cs := connect(t)
+	res, err := cs.ListTools(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	want := map[string][]string{
+		"update_knowledge": {"Verified entries cannot be updated", "report_outcome failed", "create_knowledge"},
+		"delete_knowledge": {"Verified entries cannot be deleted", "report_outcome failed"},
+	}
+	for _, tool := range res.Tools {
+		substrs, ok := want[tool.Name]
+		if !ok {
+			continue
+		}
+		delete(want, tool.Name)
+		for _, s := range substrs {
+			if !strings.Contains(tool.Description, s) {
+				t.Errorf("%s description does not mention %q:\n%s", tool.Name, s, tool.Description)
+			}
+		}
+	}
+	for name := range want {
+		t.Errorf("tool %s not found", name)
+	}
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -134,6 +134,35 @@ func (s *Service) Update(ctx context.Context, k *domain.Knowledge, actor domain.
 	return k, true, nil
 }
 
+// RefuseIfVerified reports an error when id names a verified entry, for
+// surfaces that must not overwrite curated knowledge in place.
+//
+// The rule is about preconditions, not authority. Design doc 0002 settled
+// that ochakai has no authorization and that verification is judged from
+// provenance, and this does not reopen it: an agent may still verify, may
+// still create, may still edit drafts. What it may not do from a surface
+// with no If-Match channel (MCP, design doc 0025 §11) is silently replace
+// an entry a human already curated — a bad overwrite of a verified golden
+// query is invisible until someone runs it and gets a wrong number, while
+// a soft-delete is both visible and revivable.
+//
+// It reads through the store rather than Service.Get so a refused write
+// does not record a fetch: nobody used the knowledge.
+func (s *Service) RefuseIfVerified(ctx context.Context, id, op string) error {
+	k, err := s.Store.Get(ctx, domain.Normalize(id))
+	if err != nil {
+		return err
+	}
+	if k.Status != domain.StatusVerified {
+		return nil
+	}
+	return Invalidf("cannot %s %s from this surface: it is verified, and this surface has no "+
+		"If-Match precondition to overwrite curated knowledge safely. If it is wrong, say so with "+
+		"report_outcome failed (that puts it in the re-verification feed); if you have something "+
+		"better, create_knowledge a new draft. A human changes verified entries from the web UI or CLI.",
+		op, id)
+}
+
 func (s *Service) Delete(ctx context.Context, id string, actor domain.Actor) error {
 	return s.Store.SoftDelete(ctx, domain.Normalize(id), actor)
 }

--- a/internal/service/service_integration_test.go
+++ b/internal/service/service_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -164,5 +165,62 @@ func TestUpdateIfMatchIntegration(t *testing.T) {
 	// Opting out (nil) keeps last-write-wins — no precondition, always writes.
 	if _, _, err := svc.Update(ctx, mk("v4-lww"), actor, nil); err != nil {
 		t.Fatalf("opt-out update: %v", err)
+	}
+}
+
+// The verified-write rule: a surface with no If-Match precondition (MCP)
+// must not replace curated knowledge in place. Everything else an agent
+// does stays open — creating, editing drafts, and promoting to verified
+// are all still allowed, because this is about preconditions, not
+// authority (design docs 0002, 0015 §3.1).
+func TestRefuseIfVerifiedIntegration(t *testing.T) {
+	ctx := context.Background()
+	svc := newIntegrationService(t, ctx)
+	actor := domain.Actor{Kind: "agent", Name: "insightflow@example.iam.gserviceaccount.com"}
+
+	id := "queries/" + uid("guard")
+	k, err := svc.Create(ctx, &domain.Knowledge{
+		Type: domain.TypeQueries, ID: id, Title: "monthly revenue",
+		Attrs: map[string]any{"sql": "SELECT 1"},
+	}, actor)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// A draft is fair game: the agent that drafted it can keep working.
+	if err := svc.RefuseIfVerified(ctx, id, "update"); err != nil {
+		t.Errorf("draft must be writable: %v", err)
+	}
+
+	// Promotion to verified is not restricted — 0002 stands.
+	k.Status = domain.StatusVerified
+	if _, _, err := svc.Update(ctx, k, actor, nil); err != nil {
+		t.Fatalf("promote to verified: %v", err)
+	}
+
+	err = svc.RefuseIfVerified(ctx, id, "update")
+	var invalid *InvalidInputError
+	if !errors.As(err, &invalid) {
+		t.Fatalf("verified entry: got %v, want a refusal", err)
+	}
+	// The refusal has to name the way forward, or an agent stalls here.
+	for _, want := range []string{"report_outcome failed", "create_knowledge", id} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("refusal does not mention %q: %v", want, err)
+		}
+	}
+
+	// Demoting a verified entry is how a human reopens it; after that the
+	// entry is writable again.
+	k.Status = domain.StatusDeprecated
+	if _, _, err := svc.Update(ctx, k, domain.Actor{Kind: "human", Name: "na0"}, nil); err != nil {
+		t.Fatalf("deprecate: %v", err)
+	}
+	if err := svc.RefuseIfVerified(ctx, id, "update"); err != nil {
+		t.Errorf("deprecated entry must be writable again: %v", err)
+	}
+
+	if err := svc.Delete(ctx, id, actor); err != nil {
+		t.Fatalf("cleanup: %v", err)
 	}
 }


### PR DESCRIPTION
## `OCHAKAI_WRITE_MODE` は採らなかった

提案されたインスタンス単位フラグは、目的に対して大きすぎる:

1. **MCP のツール集合がデプロイ依存になる** — 0015「サーフェス一貫性」に条件分岐が入り、openapi.yaml・例・ドキュメントが全部「モードによる」になる
2. **0002 が拒否した認可への滑り台の一段目**になる。今回の改訂自体は正当だが、次に「型ごとに」「パスごとに」と来たとき同じ論法で正当化できてしまう
3. 埋め込みホストが「どのモードで動いているか」を知る必要が出て、結局ケーパビリティ探索の話になる

**設定を増やさずに実害の本体を消せる。**

## 実害の本体は delete ではない

指摘の最小案(`delete_knowledge` を MCP から外す)では、いちばん危ないものが残る。delete は soft で、[Create](internal/store/store.go) が復活させ、履歴も残る — **目に見えて、かつ戻せる**。

危ないのは `update_knowledge` で、[mcpserver.go](internal/mcpserver/mcpserver.go) が明示しているとおり MCP には If-Match(0025 §11 / #108)の通り道が無く、last-write-wins のまま全置換できる。verified なゴールデンクエリの本文が黙って置き換わると、**誰かがそれを実行して間違った数字を得るまで誰も気づかない**。非対称性の根拠は復旧可能性ではなく可視性にある。

## 規則: 権限ではなく前提条件

> 前提条件を表明できない面は、キュレーション済みの状態を上書きしない。

`update_knowledge` / `delete_knowledge` は対象が `verified` なら拒否する。それだけ。

| | |
|---|---|
| 従来どおり許可 | create、draft の更新、**verified への昇格**、attach、report_outcome |
| 拒否 | verified エントリの update / delete(MCP のみ。REST / CLI / Web UI は従来どおり) |

**0002 は撤回しない。**「認可を持たない・verified 昇格を制限しない・信頼は provenance で判断する」はそのまま。制限するのは前提条件を持てない面からの黙示的な置き換えだけで、これはデータ喪失の話であって権限の話ではない。

**設定項目ゼロ、概念追加ゼロ。**0015 の「面ごとに載せるものを変える」という既存の判断軸にそのまま乗る(browse / revisions / export で既にやっていること)。

## エージェントの行き先を必ず示す

拒否メッセージとツール description の両方が代替行動を名指しする:

> If it is wrong, say so with `report_outcome failed` (that puts it in the re-verification feed); if you have something better, `create_knowledge` a new draft.

どちらも 0025 が用意した書き戻しループの正規の経路で、**この規則はむしろそこへ誘導する**。テストで、拒否メッセージが行き先を含むことと、draft・昇格・deprecated 後の再編集がすべて通ることを固定した。

## 残る穴と、それが解ける場所

`create_knowledge` で最初から `status: verified` を作れる点は残る。これは **P0-1(委譲 provenance)が入れば記録で担保される** — `via agent:dataagent-sa` が残るので、参照側が「人間の検証ではない」と判断できる。順序として P0-1 が先で正しい。

インスタンス単位の保証を顧客が契約上要求した場合の `OCHAKAI_WRITE_MODE` は温存する。作るなら ladder ではなく `full | propose` の 2 値だけ(`none` は 0025 の書き戻しループを殺すので実質使えない)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)