### PR TITLE
Web UI: 委譲された provenance の "via" を表示する

### DIFF
--- a/docs/design/0002-authn-authz.md
+++ b/docs/design/0002-authn-authz.md
@@ -51,13 +51,15 @@ agent、それ以外は human。署名の再検証はしない(IAM 通過 = 検�
 |---|---|---|
 | Claude Code / MCP | gcloud proxy → cloudrun-iam | human:本人メール |
 | ヘッドレスエージェント | 専用 SA → cloudrun-iam | agent:SA メール |
-| sample webui | webui の SA が IAM 通過 | agent:webui SA(全利用者が集約される。per-user が必要になったら IAP 検証を将来検討) |
+| sample webui | webui の SA が IAM 通過 | agent:webui SA(全利用者が集約される。解消手段は [0027](0027-delegated-provenance.md) — webui が IAP の検証済み JWT からユーザーを取り出し `X-Ochakai-On-Behalf-Of` に載せる。webui 側は未実装) |
 | 非 GCP | clients モード | トークンのマップ通り |
 
 ## 4. 将来の選択肢(作らない、必要になったら)
 
 - MCP OAuth(Issue #5): 公開エンドポイントで proxy なし直結が必要になったら
-- IAP JWT 検証: webui 利用者の per-user provenance が必要になったら
+- IAP JWT 検証: webui 利用者の per-user provenance が必要になったら。
+  ochakai 側の受け口は [0027](0027-delegated-provenance.md) で用意済みなので、
+  残るのは webui が IAP の JWT を検証してヘッダに載せる実装だけである
 - 認可(role / スコープ): 「読めるが書けない人」を作る必要が生まれたら
 
 ## 5. v0.2 実装スコープ

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -451,9 +451,13 @@ function fmtDate(s) {
   const d = new Date(s);
   return isNaN(d) ? s : d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
 }
+// The delegating caller is part of the name, never dropped: an entry
+// written by a person through an embedded application must not read like
+// one they wrote themselves (design doc 0027). This is the curation
+// surface, so it is where the distinction has to be visible.
 function actorStr(a) {
   if (!a || !a.name) return '';
-  return (a.kind === 'agent' ? '🤖 ' : '👤 ') + a.name;
+  return (a.kind === 'agent' ? '🤖 ' : '👤 ') + a.name + (a.via ? ' via ' + a.via : '');
 }
 // Whole days since an ISO timestamp (null for unparseable input).
 function daysSince(s) {

--- a/internal/webui/webui_test.go
+++ b/internal/webui/webui_test.go
@@ -1,0 +1,29 @@
+package webui
+
+import (
+	"strings"
+	"testing"
+)
+
+// The page is plain JavaScript with no build step and no test runner, so
+// the few invariants worth pinning are pinned by reading the source.
+//
+// Provenance rendering is one of them: an entry written by a person
+// through an embedded application carries the delegating caller in
+// actor.via (design doc 0027), and dropping it here would make that write
+// indistinguishable from one the person made directly — on the very
+// surface where a human decides whether to trust it.
+func TestActorRenderingKeepsDelegation(t *testing.T) {
+	page := string(Index)
+	i := strings.Index(page, "function actorStr(")
+	if i < 0 {
+		t.Fatal("actorStr is gone; provenance rendering moved without updating this guard")
+	}
+	body := page[i:]
+	if end := strings.Index(body, "\n}"); end >= 0 {
+		body = body[:end]
+	}
+	if !strings.Contains(body, "a.via") {
+		t.Errorf("actorStr drops the delegating caller:\n%s", body)
+	}
+}


### PR DESCRIPTION
#122 の取りこぼし。`via` を記録するようにしたのに、Web UI の `actorStr` が `name` しか描画していなかった。

```js
// before
return (a.kind === 'agent' ? '🤖 ' : '👤 ') + a.name;
```

アプリ経由で書かれたエントリが「👤 tanaka@example.co.jp」とだけ表示され、**tanaka が自分の資格情報で直接書いたものと区別できない**。0027 が「区別できない委譲は偽装と同義」として避けた状態そのもので、しかも Web UI は人間が provenance を見て信頼を判断するキュレーション面 — いちばん見えていなければならない場所だった。

CLI・OKF フロントマター・リビジョン一覧は #122 で `Actor.String()` に集約済みだったが、Web UI だけは JavaScript 側に同じロジックの写しがあり、そこが漏れていた。

ページはビルド無しの素の JavaScript でテストランナーが無いので、ソースを読む形の guard テストを 1 本置いた(#112 で配布指示に対してやったのと同じ手)。

あわせて [0002](docs/design/0002-authn-authz.md) §3 の表と §4 の「将来の選択肢」から 0027 を参照するようにした。sample webui の集約問題は ochakai 側の受け口が揃ったので、残るのは webui が IAP の JWT を検証してヘッダに載せる実装だけである、と明記している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)