### PR TITLE
レキシカル検索を質問文に答えられる形にする(クエリ断片 + IDF)

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,16 +274,23 @@ round-trip through OKF bundles as plain files next to their entry.
 
 **Japanese knowledge bases should turn embeddings on.** PostgreSQL's
 full-text search does not tokenize Japanese, so the lexical half of search
-falls back to trigrams over a stored haystack — id, title, description,
-tags, body, attachment filenames — plus a substring match, which finds
-what it is given but ranks by a score with no meaning you can set a
-threshold against. `gemini-embedding-001` handles Japanese well, and with
+matches a query by its fragments against a stored haystack — id, title,
+description, tags, body, attachment filenames. Latin words stay whole;
+Japanese, which has no spaces, is cut into two-character windows, and only
+the windows carrying a kanji or katakana are kept, because an all-hiragana
+window is grammar and matches nearly everything. Entries are then ranked
+by how much of the *rare* part of the query they contain.
+
+That finds the right entries for a keyword and for a Japanese question,
+but it is still a bag of words: ask an English question and an entry
+sharing three of its function words can outrank the one that names the
+subject. `gemini-embedding-001` handles Japanese well, and with
 `OCHAKAI_VERTEX_PROJECT` set, ranking comes from rank fusion across both
-halves rather than from trigram overlap alone.
+halves rather than from term overlap alone.
 
 Scores are not comparable across the two modes and are not calibrated:
-trigram similarity plus boosts in the lexical-only mode, RRF rank fusion
-(~0.02 scale) in the hybrid one. Treat them as an ordering, not a
+matched-fragment weight plus boosts in the lexical-only mode, RRF rank
+fusion (~0.02 scale) in the hybrid one. Treat them as an ordering, not a
 measure — `min_score` is for callers who have calibrated against their own
 corpus, which is why the MCP surface does not offer it. To bound a
 response, use `budget` instead.

--- a/internal/store/filter_test.go
+++ b/internal/store/filter_test.go
@@ -1,7 +1,9 @@
 package store
 
 import (
+	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -55,5 +57,47 @@ func TestEscapeLike(t *testing.T) {
 		if got := escapeLike(in); got != want {
 			t.Errorf("escapeLike(%q) = %q, want %q", in, got, want)
 		}
+	}
+}
+
+// A query is matched by its fragments, not as a whole: the flagship input
+// is a question, and a question appears verbatim in no document. Latin
+// words stay whole; Japanese, which has no spaces to split on, becomes
+// sliding two-character windows.
+func TestQueryFragments(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		query string
+		want  []string
+	}{
+		{"english question", "why is revenue down?", []string{"why", "is", "revenue", "down"}},
+		{"single word", "revenue", []string{"revenue"}},
+		// Only the windows carrying a content character survive: the
+		// all-hiragana ones (って, てい, のか) are grammar and match
+		// nearly every entry.
+		{"japanese question", "なぜ売上が下がっているのか",
+			[]string{"ぜ売", "売上", "上が", "が下", "下が"}},
+		{"all-kana query keeps its windows", "ください",
+			[]string{"くだ", "ださ", "さい"}},
+		{"short japanese term", "売上", []string{"売上"}},
+		{"mixed scripts", "revenue 売上高", []string{"revenue", "売上", "上高"}},
+		{"punctuation only falls back to the query", "???", []string{"???"}},
+		{"duplicate windows collapse", "ををを", []string{"をを"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := queryFragments(tc.query)
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("queryFragments(%q) = %q, want %q", tc.query, got, tc.want)
+			}
+		})
+	}
+
+	// A pasted paragraph must not turn one search into hundreds of probes.
+	var long strings.Builder
+	for i := range 100 {
+		fmt.Fprintf(&long, "term%d ", i)
+	}
+	if got := queryFragments(long.String()); len(got) != maxQueryFragments {
+		t.Errorf("long query produced %d fragments, want the cap of %d", len(got), maxQueryFragments)
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"unicode"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -602,43 +603,153 @@ func (s *Store) addRevision(ctx context.Context, tx pgx.Tx, k *domain.Knowledge,
 	return err
 }
 
-// SearchLexical ranks by trigram similarity with a substring-match floor
-// (trigram alone misses short Japanese terms), verified entries boosted.
-// The haystack is the search_text column (migration 0016): the id (design
-// doc 0022 — with title optional, the filename may be the entry's only
-// name), the envelope fields, the body, and the attachment filenames
-// (design doc 0020 — "seeds" finds the entry carrying seeds.txt, embedder
-// or not), maintained by trigger.
+// maxQueryFragments bounds how many pieces a query is split into, so a
+// pasted paragraph cannot turn one search into a hundred index probes.
+const maxQueryFragments = 24
+
+// queryFragments splits a search query into the pieces a document might
+// actually contain.
 //
-// The candidate predicate and the score read the same column as the GIN
-// trigram index, which is what makes the index usable: `%` (trigram
-// similarity above pg_trgm.similarity_threshold, 0.3 by default — an
-// operator can retune it per database without touching this query) and
-// ILIKE both have index support. Before 0016 the score was computed in
-// the SELECT list over a concatenation no index could match, and the
-// floor was applied outside the subquery, so every search scanned and
-// scored every row.
+// Matching the query as a whole is useless for the input get_context is
+// built for. Its documented argument is a data question, and the recall
+// hook feeds it a raw user prompt — "why is revenue down?" appears
+// verbatim in no body, and trigram similarity between a short query and a
+// multi-kilobyte document is 0.01-0.1 at best (for Japanese, where the
+// three-character windows of a question and a body almost never align, it
+// is routinely exactly 0). Neither a substring test nor a similarity
+// threshold can find anything from that. The signal is not the question;
+// it is the terms inside it.
+//
+// Latin-script tokens stay whole: "revenue" is a word, and its pieces are
+// not. Runs of Han/Hiragana/Katakana have no spaces to split on, so they
+// become sliding two-character windows — the standard n-gram treatment
+// for Japanese, and the smallest unit that still carries meaning (売上,
+// 受注, 原価). Two characters is below what a trigram index can resolve
+// exactly, but pg_trgm still narrows the scan with partial trigrams.
+func queryFragments(query string) []string {
+	var out []string
+	seen := map[string]bool{}
+	add := func(frag string) {
+		if frag == "" || seen[frag] || len(out) >= maxQueryFragments {
+			return
+		}
+		seen[frag] = true
+		out = append(out, frag)
+	}
+	for _, token := range strings.FieldsFunc(query, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	}) {
+		runes := []rune(token)
+		if !scriptWithoutSpaces(runes[0]) || len(runes) <= 2 {
+			add(token)
+			continue
+		}
+		// Windows that carry a content character first. Japanese grammar
+		// is written in hiragana, so an all-hiragana window (ってい, のか)
+		// is a function word: it matches nearly every entry and would
+		// drown the one window that names the subject. Han and katakana
+		// carry the meaning. A run with no content character at all —
+		// an all-kana query — keeps its windows, or it would match
+		// nothing.
+		windows := make([]string, 0, len(runes))
+		var content []string
+		for i := 0; i+2 <= len(runes); i++ {
+			w := string(runes[i : i+2])
+			windows = append(windows, w)
+			if strings.ContainsFunc(w, contentChar) {
+				content = append(content, w)
+			}
+		}
+		if len(content) > 0 {
+			windows = content
+		}
+		for _, w := range windows {
+			add(w)
+		}
+	}
+	if len(out) == 0 {
+		// A single character, or punctuation only: match it as written
+		// rather than matching nothing.
+		if q := strings.TrimSpace(query); q != "" {
+			out = append(out, q)
+		}
+	}
+	return out
+}
+
+// scriptWithoutSpaces reports whether r belongs to a script that does not
+// separate words with spaces, so a token of it needs windowing rather than
+// taking whole.
+func scriptWithoutSpaces(r rune) bool {
+	return unicode.Is(unicode.Han, r) || unicode.Is(unicode.Hiragana, r) || unicode.Is(unicode.Katakana, r)
+}
+
+// contentChar reports whether r is the kind of character a Japanese
+// content word is written in, as opposed to the hiragana that spells the
+// grammar around it.
+func contentChar(r rune) bool {
+	return unicode.Is(unicode.Han, r) || unicode.Is(unicode.Katakana, r)
+}
+
+// SearchLexical ranks entries by how much of the query they contain,
+// verified entries boosted. The haystack is the search_text column
+// (migration 0016): the id (design doc 0022 — with title optional, the
+// filename may be the entry's only name), the envelope fields, the body,
+// and the attachment filenames (design doc 0020 — "seeds" finds the entry
+// carrying seeds.txt, embedder or not), maintained by trigger.
+//
+// The score is the fraction of the query's fragments the entry contains,
+// plus a bonus when the whole query appears verbatim (a keyword search
+// should outrank an entry that merely shares terms with a question), plus
+// the verified boost. An entry containing none of the fragments is not a
+// result — the floor is "matched something", not a magic number.
+//
+// Every term of that is a substring test against one column, which is
+// what the GIN trigram index serves, so the candidate predicate and the
+// score read the same expressions (migration 0016). Fragment matching
+// replaced a similarity()/`%` pair that could not work: `%` is true only
+// above pg_trgm.similarity_threshold (0.3) and a real query never scores
+// that against a real document, so the candidate set was whatever the
+// whole-query substring test found — nothing, for a question.
 func (s *Store) SearchLexical(ctx context.Context, query string, f Filter, limit int) ([]domain.SearchHit, error) {
 	where, args := f.buildWhere("k.")
-	// The trigram term takes the raw query; the substring floor takes a
-	// separate, escaped LIKE pattern. Without escaping, a query containing
-	// '%' or '_' is read as an ILIKE wildcard — '%' matches every entry and
-	// hands them all the +0.3 boost, flattening the ranking (and '_' matches
-	// any one character). similarity() is unaffected; only the ILIKE floor.
-	args = append(args, query)
-	simParam := len(args)
+	// Each pattern is escaped: unescaped, a query containing '%' matches
+	// every entry and flattens the ranking ('_' matches any one character).
 	args = append(args, "%"+escapeLike(query)+"%")
-	likeParam := len(args)
+	wholeParam := len(args)
+	frags := queryFragments(query)
+	var hit, weight, weighted, weights []string
+	for i, frag := range frags {
+		args = append(args, "%"+escapeLike(frag)+"%")
+		hit = append(hit, fmt.Sprintf("k.search_text ILIKE $%d AS h%d", len(args), i))
+		// Document frequency over the candidates, not the whole table: one
+		// window pass, no extra scans.
+		weight = append(weight, fmt.Sprintf(
+			"ln(1 + total::float / GREATEST(count(*) FILTER (WHERE h%d) OVER (), 1)) AS w%d", i, i))
+		weighted = append(weighted, fmt.Sprintf("CASE WHEN h%d THEN w%d ELSE 0 END", i, i))
+		weights = append(weights, fmt.Sprintf("w%d", i))
+	}
+	tests := make([]string, len(frags))
+	for i := range frags {
+		tests[i] = fmt.Sprintf("k.search_text ILIKE $%d", wholeParam+1+i)
+	}
 	q := fmt.Sprintf(`
 		SELECT `+knowledgeCols+`, score FROM (
-			SELECT k.*, similarity(k.search_text, $%[1]d)
-				+ CASE WHEN k.search_text ILIKE $%[2]d THEN 0.3 ELSE 0 END
-				+ CASE WHEN k.status = 'verified' THEN 0.05 ELSE 0 END AS score
-			FROM knowledge k
-			WHERE (k.search_text %% $%[1]d OR k.search_text ILIKE $%[2]d) AND %[3]s
+			SELECT w.*, (%[1]s) / NULLIF(%[2]s, 0)
+				+ CASE WHEN w.search_text ILIKE $%[3]d THEN 0.3 ELSE 0 END
+				+ CASE WHEN w.status = 'verified' THEN 0.05 ELSE 0 END AS score
+			FROM (
+				SELECT c.*, %[4]s FROM (
+					SELECT k.*, %[5]s, count(*) OVER () AS total
+					FROM knowledge k
+					WHERE (%[6]s) AND %[7]s
+				) c
+			) w
 		) ranked
-		WHERE score > 0.05
-		ORDER BY score DESC LIMIT %[4]d`, simParam, likeParam, where, limit)
+		ORDER BY score DESC LIMIT %[8]d`,
+		strings.Join(weighted, " + "), strings.Join(weights, " + "), wholeParam,
+		strings.Join(weight, ", "), strings.Join(hit, ", "),
+		strings.Join(tests, " OR "), where, limit)
 	rows, err := s.pool.Query(ctx, q, args...)
 	if err != nil {
 		return nil, err

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -1062,10 +1062,14 @@ func TestIntegrationLexicalSearchUsesTrigramIndex(t *testing.T) {
 	if _, err := tx.Exec(ctx, `SET LOCAL enable_seqscan = off`); err != nil {
 		t.Fatal(err)
 	}
+	// The live predicate shape: an OR of one substring test per query
+	// fragment. Two-character Japanese fragments are below what a trigram
+	// index resolves exactly, so this also checks that pg_trgm still
+	// narrows the scan with partial trigrams rather than giving up.
 	rows, err := tx.Query(ctx, `EXPLAIN
 		SELECT k.id FROM knowledge k
-		WHERE (k.search_text % $1 OR k.search_text ILIKE $2) AND k.deleted_at IS NULL`,
-		"revenue", "%revenue%")
+		WHERE (k.search_text ILIKE $1 OR k.search_text ILIKE $2) AND k.deleted_at IS NULL`,
+		"%revenue%", "%売上%")
 	if err != nil {
 		t.Fatalf("EXPLAIN: %v", err)
 	}
@@ -1080,8 +1084,8 @@ func TestIntegrationLexicalSearchUsesTrigramIndex(t *testing.T) {
 	if err := rows.Err(); err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(plan, "knowledge_search_trgm") {
-		t.Errorf("lexical search cannot use the trigram index; plan was:\n%s", plan)
+	if n := strings.Count(plan, "knowledge_search_trgm"); n != 2 {
+		t.Errorf("want both fragments served by the trigram index, got %d index scans:\n%s", n, plan)
 	}
 }
 
@@ -1379,4 +1383,120 @@ func TestIntegrationDelegatedProvenance(t *testing.T) {
 
 	_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge WHERE id = $1`, id)
 	_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_revision WHERE id = $1`, id)
+}
+
+// get_context is documented to take a data question, and the recall hook
+// feeds it a raw user prompt — so a question, not a keyword, is the
+// flagship input. Matching the query as a whole cannot serve one: a
+// question appears verbatim in no body, and trigram similarity between a
+// short query and a long document is 0.01-0.1 (for Japanese, where the
+// three-character windows of a question and a body rarely align, often
+// exactly 0). Before fragment matching this search returned nothing at
+// all for either language.
+//
+// Recall alone is not enough, though. Split a question into fragments and
+// most of them are grammar — the particle windows ている / のか, the words
+// why / is / down — which nearly every entry contains. Counting matches
+// would rank an entry sharing three function words above the one sharing
+// the actual subject. So this plants a corpus where the grammar really is
+// common and checks the ordering, not just the presence.
+func TestIntegrationLexicalSearchAnswersQuestions(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	actor := domain.Actor{Kind: "human", Name: "test"}
+
+	const target, decoy = "it-q-target", "it-q-decoy"
+	ids := []string{target, decoy}
+	for i := range 20 {
+		ids = append(ids, fmt.Sprintf("it-q-filler-%d", i))
+	}
+	clean := func() {
+		for _, id := range ids {
+			_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge WHERE id = $1`, id)
+			_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_revision WHERE id = $1`, id)
+		}
+	}
+	clean()
+	t.Cleanup(clean)
+	create := func(id, title, body string) {
+		t.Helper()
+		if err := s.Create(ctx, &domain.Knowledge{
+			Type: domain.TypeInsights, ID: id, Title: title,
+			Status: domain.StatusDraft, CreatedBy: actor, Body: body,
+		}); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+	// The target shares the subject and nothing else; the decoy and the
+	// filler share the grammar and nothing else.
+	create(target, "売上の読み方", "売上は前年同期比で見ないと誤読する。monthly revenue by quarter.")
+	create(decoy, "棚卸の運用", "棚卸は毎月行っているのか、四半期ごとなのか。why is this down to the site?")
+	for i := range 20 {
+		create(fmt.Sprintf("it-q-filler-%d", i), fmt.Sprintf("運用メモ %d", i),
+			"これは毎日行っているのかを記録している。why is it down again, and is it down for long?")
+	}
+
+	rank := func(hits []domain.SearchHit, id string) int {
+		for i, h := range hits {
+			if h.ID == id {
+				return i
+			}
+		}
+		return -1
+	}
+	for _, tc := range []struct {
+		query   string
+		outrank bool // must the subject beat the grammar-only entry?
+		why     string
+	}{
+		// Recall is the regression: whole-query matching found none of
+		// these. Ranking is promised only where lexical search can
+		// honestly deliver it.
+		{"なぜ売上が下がっているのか", true, "Japanese question: similarity is 0; content windows carry it"},
+		{"売上", true, "short Japanese keyword"},
+		{"revenue", true, "English keyword"},
+		// The decoy really does contain three of this question's four
+		// words (why / is / down) against the subject's one. Ranking it
+		// higher is what a bag of words does, not a defect to paper over:
+		// English has no equivalent of the kana/kanji split to lean on.
+		// Hybrid mode is the answer — which is why the README recommends
+		// embeddings — so here we require only that the subject is found.
+		{"why is revenue down", false, "English question: recall only"},
+	} {
+		hits, err := s.SearchLexical(ctx, tc.query, Filter{}, 50)
+		if err != nil {
+			t.Fatalf("SearchLexical(%q): %v", tc.query, err)
+		}
+		got, other := rank(hits, target), rank(hits, decoy)
+		if got < 0 {
+			t.Errorf("SearchLexical(%q) did not find %s among %d hits (%s)",
+				tc.query, target, len(hits), tc.why)
+			continue
+		}
+		if tc.outrank && other >= 0 && other < got {
+			t.Errorf("SearchLexical(%q) ranked the grammar-only entry above the subject (%s)",
+				tc.query, tc.why)
+		}
+	}
+
+	// A query that shares nothing must still come back empty: fragment
+	// matching widens recall, it does not turn the floor off.
+	hits, err := s.SearchLexical(ctx, "zzzznothingmatchesthiszzzz", Filter{}, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rank(hits, target) >= 0 || rank(hits, decoy) >= 0 {
+		t.Errorf("unrelated query matched a planted entry (%d hits)", len(hits))
+	}
 }


### PR DESCRIPTION
A-1 の指摘は**正しく、しかも実測すると指摘より深刻**でした。同時に、提案された `word_similarity` / `<%` では直りません。両方を実データで確認したうえで別の直し方をしています。

## 実測(pgvector/pg17、日英の実文書)

| クエリ | `similarity` | `%` (≥0.3) | ILIKE | `word_similarity` | `<%` (≥0.6) |
|---|---|---|---|---|---|
| なぜ売上が下がっているのか | **0.000** | ✗ | ✗ | 0.071 | ✗ |
| why is revenue down | 0.092 | ✗ | ✗ | 0.40 | ✗ |
| 売上 | 0.040 | ✗ | ✓ | 1.00 | ✓ |
| revenue | 0.107 | ✗ | ✓ | 1.00 | ✓ |

- **`%` は一度も真になっていません。**英単語 1 語ですら 0.107。候補を作っていたのは実質 ILIKE だけで、質問文は 0 件 — 指摘のとおり
- **日本語の質問文は「閾値未満」ではなく厳密に 0。**質問と本文で 3 文字窓が揃わないためで、これは閾値をどう動かしても救えません
- **提案の `<%`(既定 0.6)でも質問文は救えません**(日本語 0.071 / 英語 0.40)。短いキーワードだけが通り、それは ILIKE が既に拾えていた範囲です

## 直し方: クエリを断片に割る

信号は質問そのものではなく、その中の語です。

- ラテン文字のトークンはそのまま(`revenue` は語であって部品ではない)
- 空白の無い日本語は 2 文字窓。ただし**漢字・カタカナを含む窓だけを残す** — 全ひらがなの窓(てい / のか)は文法で、ほぼ全エントリに当たって主題を名指す窓を押し流します。全て仮名のクエリは窓を落としません
- 2 文字窓でも pg_trgm は部分トライグラムで索引を使えます(`EXPLAIN` で両枝とも Bitmap Index Scan を確認、テストで固定)。0016 の目的は保てています

## 採点は候補集合内の IDF

素の一致数だと、助詞を 3 つ共有する無関係エントリが主題を 1 つ共有するエントリに勝ちます。ウィンドウ関数 1 パスで候補集合内の文書頻度を取り、稀な断片を重く見ます。filler 40 件を置いた現実的なコーパスでの実測:

| | IDF スコア | 素の一致数 |
|---|---|---|
| 主題を含むエントリ | **3.761** | 1 |
| 文法だけのエントリ | 2.116 | 3 |

素の件数なら順序が逆になります。

## 正直に書いた限界

**英語の質問文は依然 bag-of-words** です。「why is revenue down」に対して why / is / down を実際に含むエントリが、revenue だけを含むエントリを上回りえます。これは欠陥というより bag-of-words の挙動で、英語には日本語の仮名/漢字のような手掛かりがありません。ハイブリッド検索がその答えで、README の embedding 推奨はまさにそのためにあります。

テストもそこを分けました。**質問文は再現率**(これが回帰そのもの)、**順位は約束できる範囲**(日本語質問・キーワード)だけを固定。無関係クエリが 0 件で返ることも確認しています。

## 副次: 「デッドコードの `score > 0.05`」

指摘のとおりでした。フロアは「断片を 1 つ以上含むこと」に置き換わり、マジックナンバーは無くなっています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)