### PR TITLE
get_context: hits を順位だけにし、予算が応答全体を縛るようにする

### DIFF
--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -151,9 +151,9 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"base (verified entries rank higher), returns the full entries behind the top hits, " +
 			"and expands one hop through links so the insight explaining a metric and the golden " +
 			"query answering the question arrive together. Prefer this over search+get chains; " +
-			"fall back to search_knowledge/get_knowledge for precise lookups. Entries that do not " +
-			"fit the byte budget are listed under \"outline\" — fetch any of them by id with " +
-			"get_knowledge.",
+			"fall back to search_knowledge/get_knowledge for precise lookups. \"entries\" is the " +
+			"knowledge; \"hits\" is only the ranking behind it. Entries that do not fit the byte " +
+			"budget are listed under \"outline\" — fetch any of them by id with get_knowledge.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in contextIn) (*mcp.CallToolResult, contextOut, error) {
 		budget := in.Budget
 		if budget <= 0 {
@@ -170,7 +170,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			return nil, contextOut{}, err
 		}
 		return nil, contextOut{
-			Hits: res.Hits, Entries: res.Entries, Outline: res.Outline,
+			Hits: contextRanks(res.Hits), Entries: res.Entries, Outline: res.Outline,
 			Truncated: res.Truncated, Hint: contextHint(res.Truncated),
 		}, nil
 	})
@@ -410,11 +410,43 @@ type contextIn struct {
 }
 
 type contextOut struct {
-	Hits      []domain.SearchHit      `json:"hits"`
+	Hits      []contextRank           `json:"hits"`
 	Entries   []domain.Knowledge      `json:"entries"`
 	Outline   []domain.ContextOutline `json:"outline,omitempty"`
 	Truncated int                     `json:"truncated,omitempty"`
 	Hint      string                  `json:"hint"`
+}
+
+// contextRank is what a hit is worth once the entries are in the same
+// response: an ordering, not a second copy of the knowledge.
+//
+// domain.SearchHit embeds the whole Knowledge — body, attrs and all — so
+// returning hits verbatim would send every top entry twice and leave the
+// budget governing only one of the copies. Worse, an entry too large for
+// the budget would arrive in full through hits while outline told the
+// agent to go fetch it. The Semantic Model case packWithinBudget exists
+// for (attrs.spec is the largest payload in the base) walked straight
+// past it.
+//
+// search_knowledge keeps returning full hits: there the entries are the
+// answer, not a duplicate of one.
+type contextRank struct {
+	ID     string        `json:"id"`
+	Type   domain.Type   `json:"type"`
+	Title  string        `json:"title"`
+	Status domain.Status `json:"status"`
+	Score  float64       `json:"score"`
+}
+
+func contextRanks(hits []domain.SearchHit) []contextRank {
+	out := make([]contextRank, len(hits))
+	for i, h := range hits {
+		out[i] = contextRank{
+			ID: h.ID, Type: h.Type, Title: h.DisplayTitle(),
+			Status: h.Status, Score: h.Score,
+		}
+	}
+	return out
 }
 
 // defaultContextBudget bounds an unparameterized get_context. It is on by

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/na0fu3y/ochakai/internal/domain"
 	"github.com/na0fu3y/ochakai/internal/service"
 )
 
@@ -401,5 +402,42 @@ func TestVerifiedGuardIsAdvertised(t *testing.T) {
 	}
 	for name := range want {
 		t.Errorf("tool %s not found", name)
+	}
+}
+
+// The budget governs the whole response or it governs nothing.
+// domain.SearchHit embeds Knowledge, so returning hits verbatim would send
+// every top entry a second time, uncapped — and an entry pushed into
+// outline for being too large would arrive in full through hits anyway,
+// while the outline row told the agent to go fetch what it already had.
+func TestContextHitsCarryRankingNotKnowledge(t *testing.T) {
+	body := strings.Repeat("x", 4000)
+	hits := []domain.SearchHit{{
+		Knowledge: domain.Knowledge{
+			Type: domain.TypeQueries, ID: "queries/monthly-revenue",
+			Status: domain.StatusVerified, Body: body,
+			Attrs: map[string]any{"sql": "SELECT 1"},
+		},
+		Score: 0.9,
+	}}
+	out := contextOut{Hits: contextRanks(hits)}
+	encoded, err := json.Marshal(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), body) {
+		t.Error("hits carried the body; the budget covers only entries")
+	}
+	if strings.Contains(string(encoded), "SELECT 1") {
+		t.Error("hits carried attrs; the budget covers only entries")
+	}
+	got := out.Hits[0]
+	if got.ID != "queries/monthly-revenue" || got.Score != 0.9 || got.Status != domain.StatusVerified {
+		t.Errorf("a hit must still rank and address the entry: %+v", got)
+	}
+	// Title falls back to the filename when the entry has none (design doc
+	// 0022), so a hit is readable without fetching.
+	if got.Title != "monthly-revenue" {
+		t.Errorf("hit title = %q, want the display title", got.Title)
 	}
 }


### PR DESCRIPTION
A-2 の指摘は完全に正しく、**#114 で入れた予算機能が半分しか効いていませんでした**。

`domain.SearchHit` は `Knowledge` を埋め込んでいます(本文も attrs も込み)。`contextOut` は `hits` と `entries` の両方を返し、`Search` は `2*limit` 件呼ばれるので、既定 `limit=5` なら:

- `hits` = 最大 10 件の**フルエントリ、予算の対象外**
- `entries` = 同じ内容が再度、12000 バイトに制限されて入る

結果として指摘のとおり 3 つの問題が同時に起きていました:

1. 主要エントリがレスポンス内に 2 回現れる
2. 予算はペイロードの半分しか縛っていない
3. **`outline` に落としたエントリが `hits` にフルで入っている** — 「大きすぎるので `get_knowledge` で取ってこい」と案内している対象が既に手元にある

`packWithinBudget` のコメントが名指しで想定した「Semantic Model が `attrs.spec` 丸ごとを運ぶので rank 1 でも outline に落とす」ケースが、まさに `hits` 経由で素通りしていました。

## 修正

MCP の `hits` を `{id, type, title, status, score}` に射影します。`entries` が本体なので情報は失われません。`title` は `DisplayTitle()` 経由なので、title 未設定のエントリもファイル名で読めます(0022)。

**`search_knowledge` はフルのまま**にしました。あちらは**エントリが答えそのもの**であって、同じ応答内の複製ではありません。この区別が射影を get_context だけに限る根拠です。

**REST の `/api/v1/context` も現状維持**です。呼び出し元はプログラムで、Web UI は hits の添付メタデータを使います。予算の既定値を面ごとに変えた #114 と同じ理由づけです。

## テスト

`contextOut` をシリアライズして、本文と `attrs.sql` が含まれないこと、それでも順位・アドレス・表示名は残ることを固定しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)