### PR TITLE
MCP の保護を verified から「人間が判断を下した状態」全体へ広げる

### DIFF
--- a/docs/design/0015-surface-consistency.md
+++ b/docs/design/0015-surface-consistency.md
@@ -48,9 +48,10 @@ CLI、Web UI。機能を足すたびに「どのサーフェスに載せるか�
   get_attachment の description が既に誘導している。
 - **バルク(export / import / import-ossie)。** 応答サイズが読めず、
   tar.gz はツール結果に載らない。管理タスクは CLI / CI の領分。
-- **verified エントリの上書き・削除。** update_knowledge /
-  delete_knowledge は、対象が verified なら拒否する(create、draft の
-  更新、verified への昇格はいずれも従来どおり)。
+- **人間が判断を下したエントリ(verified / rejected / deprecated)の
+  上書き・削除。** update_knowledge / delete_knowledge は対象がこの
+  いずれかなら拒否する(create、draft の更新、draft から verified への
+  昇格はいずれも従来どおり)。
 
   これは認可ではない。0002 の「認可を持たない・verified 昇格を制限
   しない」は撤回しない — 誰が検証したかは記録され、信頼は provenance
@@ -69,6 +70,28 @@ CLI、Web UI。機能を足すたびに「どのサーフェスに載せるか�
   report_outcome failed(sort=failed の再検証フィードに乗る)、
   より良いものがあるなら新しい draft を create する。どちらも
   書き戻しループの正規の経路であり、この規則はむしろそこへ誘導する。
+
+  **rejected は verified と同じかそれ以上に重要である。** Create は
+  live なエントリがあれば ErrAlreadyExists を返す(rejected を含む)
+  ので、rejected に阻まれたエージェントには delete → create という
+  2 手の迂回路がある。soft-delete 済みエントリは Create が draft として
+  復活させるので、却下の理由(status_note)ごと消える。README が
+  memory layer との差別化の筆頭に挙げ、配布する指示がエージェントに
+  「再提案の前に --status rejected を見ろ」と言っている当のものが、
+  2 コールで消せる。しかも verified の消失と違い、rejected の消失は
+  誰も使っていなかったので誰も気づかない。
+
+  **状態遷移も同じ扱いにする。** verified → deprecated も MCP からは
+  できない。廃止は「正しかったが今は推奨しない」という判断であって、
+  エージェントの観測ではない。観測の通り道は report_outcome であり、
+  判断は人間の面で行う。
+
+  **TOCTOU。** チェックと書き込みの間に別の書き込みが挟まりうる。
+  update はチェック時に読んだ updated_at を If-Match として渡すことで
+  構造的に閉じてある(0025 §11 の機構をそのまま使う)ので、窓の中で
+  キュレーションされた場合は上書きではなく衝突になる。delete には
+  ストア側に precondition の通り道が無く、窓は 1 往復ぶん残る —
+  delete は復活可能なので許容している。
 
 ### 3.2 REST に載せないもの
 

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -221,8 +221,9 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"an omitted title clears it, making the filename the name). " +
 			"Links are not a field: they come from the markdown links in body, so keep the ones you want to keep. " +
 			"Every change is kept as a revision; an update identical to the stored content writes nothing. " +
-			"Verified entries cannot be updated from this surface: if one is wrong, report_outcome failed, " +
-			"or create_knowledge a better draft — a human promotes it. " +
+			"Entries a human has ruled on — verified, rejected, or deprecated — cannot be updated from " +
+			"this surface: if a verified entry is wrong, report_outcome failed; otherwise create_knowledge " +
+			"a better draft and let a human promote it. " +
 			"Setting status=verified records you as verified_by — " +
 			"do it only for knowledge you have actually validated. Setting status=rejected records you " +
 			"as rejected_by; put the reason in status_note (also useful when deprecating).",
@@ -231,10 +232,15 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 		// If-Match precondition (nil) and writes are last-write-wins. That
 		// is tolerable for drafts and not for curated knowledge, so
 		// verified entries are refused here rather than clobbered.
-		if err := svc.RefuseIfVerified(ctx, in.ID, "update"); err != nil {
+		version, err := svc.RefuseIfCurated(ctx, in.ID, "update")
+		if err != nil {
 			return nil, knowledgeOut{}, err
 		}
-		k, _, err := svc.Update(ctx, in.toKnowledge(), httpauth.Actor(ctx), nil)
+		// The version read by the guard becomes the precondition, so an
+		// entry curated in the window between the two is a conflict rather
+		// than a clobber — the surface has no If-Match channel of its own,
+		// but the check can supply one.
+		k, _, err := svc.Update(ctx, in.toKnowledge(), httpauth.Actor(ctx), version)
 		if err != nil {
 			return nil, knowledgeOut{}, err
 		}
@@ -245,10 +251,14 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 		Name:        "delete_knowledge",
 		Annotations: destructive,
 		Description: "Soft-delete a knowledge entry. History is retained as revisions; " +
-			"create_knowledge on the same id revives it. Verified entries cannot be deleted from " +
-			"this surface — report_outcome failed if one is wrong.",
+			"create_knowledge on the same id revives it. Entries a human has ruled on — verified, " +
+			"rejected, or deprecated — cannot be deleted from this surface; deleting a rejected " +
+			"entry and recreating it would erase the record of why it was turned down.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in getIn) (*mcp.CallToolResult, deleteOut, error) {
-		if err := svc.RefuseIfVerified(ctx, in.ID, "delete"); err != nil {
+		// Delete has no precondition channel in the store, so a curation
+		// landing in the window between check and delete still wins. The
+		// window is a single round trip and the delete is revivable.
+		if _, err := svc.RefuseIfCurated(ctx, in.ID, "delete"); err != nil {
 			return nil, deleteOut{}, err
 		}
 		if err := svc.Delete(ctx, in.ID, httpauth.Actor(ctx)); err != nil {

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -373,19 +373,19 @@ func TestContextHint(t *testing.T) {
 	}
 }
 
-// TestVerifiedGuardIsAdvertised pins the half of the verified-write rule
+// TestCuratedGuardIsAdvertised pins the half of the curated-write rule
 // that agents can act on: the tool descriptions must say what to do
 // instead, or an agent meets the refusal with no next move. The refusal
 // itself is exercised in the service integration test.
-func TestVerifiedGuardIsAdvertised(t *testing.T) {
+func TestCuratedGuardIsAdvertised(t *testing.T) {
 	cs := connect(t)
 	res, err := cs.ListTools(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("ListTools: %v", err)
 	}
 	want := map[string][]string{
-		"update_knowledge": {"Verified entries cannot be updated", "report_outcome failed", "create_knowledge"},
-		"delete_knowledge": {"Verified entries cannot be deleted", "report_outcome failed"},
+		"update_knowledge": {"verified, rejected, or deprecated", "report_outcome failed", "create_knowledge"},
+		"delete_knowledge": {"verified, rejected, or deprecated", "erase the record of why"},
 	}
 	for _, tool := range res.Tools {
 		substrs, ok := want[tool.Name]

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -134,33 +134,51 @@ func (s *Service) Update(ctx context.Context, k *domain.Knowledge, actor domain.
 	return k, true, nil
 }
 
-// RefuseIfVerified reports an error when id names a verified entry, for
-// surfaces that must not overwrite curated knowledge in place.
+// RefuseIfCurated reports an error when id names an entry a human has
+// already ruled on — verified, rejected, or deprecated — for surfaces that
+// must not overwrite that ruling in place. It returns the entry's version
+// so the caller can pass it as an If-Match precondition and close the
+// window between this check and the write.
 //
 // The rule is about preconditions, not authority. Design doc 0002 settled
 // that ochakai has no authorization and that verification is judged from
-// provenance, and this does not reopen it: an agent may still verify, may
-// still create, may still edit drafts. What it may not do from a surface
-// with no If-Match channel (MCP, design doc 0025 §11) is silently replace
-// an entry a human already curated — a bad overwrite of a verified golden
-// query is invisible until someone runs it and gets a wrong number, while
-// a soft-delete is both visible and revivable.
+// provenance, and this does not reopen it: an agent may still create, may
+// still edit drafts, may still promote a draft to verified. What it may
+// not do from a surface with no If-Match channel (MCP, design doc 0025
+// §11) is silently replace a state a human put there.
 //
-// It reads through the store rather than Service.Get so a refused write
-// does not record a fetch: nobody used the knowledge.
-func (s *Service) RefuseIfVerified(ctx context.Context, id, op string) error {
+// Rejected matters at least as much as verified, and it is the one the
+// obvious rule would have missed. Create refuses a live entry, so an agent
+// blocked by a rejection has a two-call path around it — delete, then
+// create, which revives the tombstone as a fresh draft and takes the
+// status_note with it. That erases the memory of no that the write-back
+// loop is built on (design doc 0025) and that the shipped instructions
+// tell agents to consult before re-proposing. Nobody notices: unlike a
+// deleted verified entry, a deleted rejection leaves nothing anyone was
+// using.
+func (s *Service) RefuseIfCurated(ctx context.Context, id, op string) (*time.Time, error) {
 	k, err := s.Store.Get(ctx, domain.Normalize(id))
 	if err != nil {
-		return err
+		return nil, err
 	}
-	if k.Status != domain.StatusVerified {
-		return nil
+	var instead string
+	switch k.Status {
+	case domain.StatusVerified:
+		instead = "If it is wrong, say so with report_outcome failed — that puts it in the " +
+			"re-verification feed. If you have something better, create_knowledge a new draft."
+	case domain.StatusRejected:
+		instead = "The rejection is the record of a decision, and status_note says why; read it " +
+			"before proposing this again. If you disagree, create_knowledge a new entry at a " +
+			"different id and let a human judge it."
+	case domain.StatusDeprecated:
+		instead = "Deprecated means it was correct and is no longer recommended. If it is worth " +
+			"reviving, create_knowledge a draft that says why."
+	default:
+		return &k.UpdatedAt, nil
 	}
-	return Invalidf("cannot %s %s from this surface: it is verified, and this surface has no "+
-		"If-Match precondition to overwrite curated knowledge safely. If it is wrong, say so with "+
-		"report_outcome failed (that puts it in the re-verification feed); if you have something "+
-		"better, create_knowledge a new draft. A human changes verified entries from the web UI or CLI.",
-		op, id)
+	return nil, Invalidf("cannot %s %s from this surface: it is %s, and this surface has no "+
+		"If-Match precondition to replace curated knowledge safely. %s A human changes curated "+
+		"entries from the web UI or CLI.", op, id, k.Status, instead)
 }
 
 func (s *Service) Delete(ctx context.Context, id string, actor domain.Actor) error {

--- a/internal/service/service_integration_test.go
+++ b/internal/service/service_integration_test.go
@@ -168,59 +168,108 @@ func TestUpdateIfMatchIntegration(t *testing.T) {
 	}
 }
 
-// The verified-write rule: a surface with no If-Match precondition (MCP)
-// must not replace curated knowledge in place. Everything else an agent
-// does stays open — creating, editing drafts, and promoting to verified
-// are all still allowed, because this is about preconditions, not
-// authority (design docs 0002, 0015 §3.1).
-func TestRefuseIfVerifiedIntegration(t *testing.T) {
+// The curated-write rule: a surface with no If-Match precondition (MCP)
+// must not replace a state a human put there. Everything else an agent
+// does stays open — creating, editing drafts, and promoting a draft to
+// verified are all still allowed, because this is about preconditions,
+// not authority (design docs 0002, 0015 §3.1).
+func TestRefuseIfCuratedIntegration(t *testing.T) {
 	ctx := context.Background()
 	svc := newIntegrationService(t, ctx)
 	actor := domain.Actor{Kind: "agent", Name: "insightflow@example.iam.gserviceaccount.com"}
+	human := domain.Actor{Kind: "human", Name: "na0"}
 
-	id := "queries/" + uid("guard")
-	k, err := svc.Create(ctx, &domain.Knowledge{
-		Type: domain.TypeQueries, ID: id, Title: "monthly revenue",
-		Attrs: map[string]any{"sql": "SELECT 1"},
-	}, actor)
-	if err != nil {
-		t.Fatalf("create: %v", err)
-	}
-
-	// A draft is fair game: the agent that drafted it can keep working.
-	if err := svc.RefuseIfVerified(ctx, id, "update"); err != nil {
-		t.Errorf("draft must be writable: %v", err)
-	}
-
-	// Promotion to verified is not restricted — 0002 stands.
-	k.Status = domain.StatusVerified
-	if _, _, err := svc.Update(ctx, k, actor, nil); err != nil {
-		t.Fatalf("promote to verified: %v", err)
-	}
-
-	err = svc.RefuseIfVerified(ctx, id, "update")
-	var invalid *InvalidInputError
-	if !errors.As(err, &invalid) {
-		t.Fatalf("verified entry: got %v, want a refusal", err)
-	}
-	// The refusal has to name the way forward, or an agent stalls here.
-	for _, want := range []string{"report_outcome failed", "create_knowledge", id} {
-		if !strings.Contains(err.Error(), want) {
-			t.Errorf("refusal does not mention %q: %v", want, err)
+	setStatus := func(t *testing.T, k *domain.Knowledge, status domain.Status, by domain.Actor) {
+		t.Helper()
+		k.Status = status
+		updated, _, err := svc.Update(ctx, k, by, nil)
+		if err != nil {
+			t.Fatalf("set status %s: %v", status, err)
 		}
+		*k = *updated
 	}
 
-	// Demoting a verified entry is how a human reopens it; after that the
-	// entry is writable again.
-	k.Status = domain.StatusDeprecated
-	if _, _, err := svc.Update(ctx, k, domain.Actor{Kind: "human", Name: "na0"}, nil); err != nil {
-		t.Fatalf("deprecate: %v", err)
-	}
-	if err := svc.RefuseIfVerified(ctx, id, "update"); err != nil {
-		t.Errorf("deprecated entry must be writable again: %v", err)
+	t.Run("drafts stay writable", func(t *testing.T) {
+		id := "queries/" + uid("guard-draft")
+		k, err := svc.Create(ctx, &domain.Knowledge{Type: domain.TypeQueries, ID: id, Title: "draft"}, actor)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = svc.Delete(ctx, id, actor) })
+		version, err := svc.RefuseIfCurated(ctx, id, "update")
+		if err != nil {
+			t.Fatalf("draft must be writable: %v", err)
+		}
+		// The guard hands back a usable precondition, not just a verdict.
+		if version == nil || !version.Equal(k.UpdatedAt) {
+			t.Errorf("version = %v, want the entry's updated_at %v", version, k.UpdatedAt)
+		}
+		// Promotion to verified is not restricted — 0002 stands.
+		setStatus(t, k, domain.StatusVerified, actor)
+	})
+
+	// Each curated state is refused, and each refusal names a way forward:
+	// an agent that meets a wall with no door stalls or works around it.
+	for status, wantAdvice := range map[domain.Status]string{
+		domain.StatusVerified:   "report_outcome failed",
+		domain.StatusRejected:   "status_note",
+		domain.StatusDeprecated: "create_knowledge",
+	} {
+		t.Run(string(status)+" is refused", func(t *testing.T) {
+			id := "queries/" + uid("guard-"+string(status))
+			k, err := svc.Create(ctx, &domain.Knowledge{
+				Type: domain.TypeQueries, ID: id, Title: string(status),
+				StatusNote: "because the numbers were wrong",
+			}, actor)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = svc.Delete(ctx, id, actor) })
+			setStatus(t, k, status, human)
+
+			for _, op := range []string{"update", "delete"} {
+				_, err := svc.RefuseIfCurated(ctx, id, op)
+				var invalid *InvalidInputError
+				if !errors.As(err, &invalid) {
+					t.Fatalf("%s %s: got %v, want a refusal", op, status, err)
+				}
+				if !strings.Contains(err.Error(), wantAdvice) {
+					t.Errorf("%s refusal does not offer %q: %v", status, wantAdvice, err)
+				}
+			}
+
+			// A human reopening it makes it writable again.
+			setStatus(t, k, domain.StatusDraft, human)
+			if _, err := svc.RefuseIfCurated(ctx, id, "update"); err != nil {
+				t.Errorf("reopened entry must be writable: %v", err)
+			}
+		})
 	}
 
-	if err := svc.Delete(ctx, id, actor); err != nil {
-		t.Fatalf("cleanup: %v", err)
-	}
+	// The path this rule exists to close: Create refuses a live rejected
+	// entry, so without the guard an agent could delete it and recreate it
+	// as a draft, taking the reason for the rejection with it.
+	t.Run("a rejection cannot be laundered into a draft", func(t *testing.T) {
+		id := "queries/" + uid("guard-launder")
+		k, err := svc.Create(ctx, &domain.Knowledge{
+			Type: domain.TypeQueries, ID: id, Title: "rejected proposal",
+			StatusNote: "duplicate of an existing golden query",
+		}, actor)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = svc.Delete(ctx, id, actor) })
+		setStatus(t, k, domain.StatusRejected, human)
+
+		if _, err := svc.RefuseIfCurated(ctx, id, "delete"); err == nil {
+			t.Fatal("deleting a rejected entry was allowed; the memory of no is erasable")
+		}
+		stored, err := svc.Get(ctx, id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if stored.Status != domain.StatusRejected || stored.StatusNote == "" {
+			t.Errorf("the rejection and its reason must survive: %+v", stored)
+		}
+	})
 }


### PR DESCRIPTION
C-2 の指摘は**この一連のレビューで最も重要**だと思います。#121 で verified を守ったのに、書き戻しループが実際に依存しているのは rejected の方でした。

## 2 手で消せていた

```
1. create_knowledge metrics/foo  → 409 already exists（rejected も live 扱い）
2. delete_knowledge metrics/foo  → 成功（rejected は保護されていない）
3. create_knowledge metrics/foo  → soft-delete 済みなので draft として復活
```

却下の理由(`status_note`)ごと消えます。README が memory layer との差別化の筆頭に挙げている「a memory of no」、配布する write-back フックが「再提案の前に `--status rejected` を見ろ」と指示している当のものが、2 コールで消せていました。

そして **verified の消失と違い、rejected の消失は誰も気づきません**。誰も使っていなかったものなので、消えても何も壊れない。0015 §3.1 に私が書いた「可視性」の論法が、そのまま rejected を守る理由になります。

## 修正

`RefuseIfVerified` → `RefuseIfCurated`(verified / rejected / deprecated)。**draft だけが自由に書ける**、という線引きです。

拒否メッセージは状態ごとに行き先を変えます。壁に扉が無いとエージェントは止まるか迂回するので、ここは状態ごとに具体的に:

| 状態 | 代替行動 |
|---|---|
| verified | `report_outcome failed`(再検証フィードに乗る) |
| rejected | `status_note` を読み、異議があれば**別の id** で `create_knowledge` |
| deprecated | 復活させる価値があるなら理由を書いた draft を `create_knowledge` |

## C-4(TOCTOU)も閉じました

update については**構造的に**閉じています。ガードが読んだ `updated_at` をそのまま `If-Match` として `Update` へ渡すので(#108 の機構をそのまま利用)、窓の中でキュレーションされた場合は上書きではなく衝突になります。**この面には If-Match の通り道が無い、という規則の前提そのものを、ガード自身が供給する形**になりました。

delete はストア側に precondition が無いため窓が 1 往復ぶん残ります。delete は復活可能なので許容し、design doc に明記しました。

## C-3(verified → deprecated)も明文化

**MCP からはできません**、という判断を 0015 に書きました。廃止は「正しかったが今は推奨しない」という判断であって、エージェントの観測ではありません。観測の通り道は `report_outcome` で、判断は人間の面で行う — 0025 のループと一貫します。

## テスト

3 つの状態それぞれで update / delete が拒否され、拒否文が行き先を含むこと。draft は書けること。ガードが使える precondition を返すこと。人間が draft に戻せば再び書けること。そして**「rejected を draft に洗浄する」経路が塞がり、理由が残ること**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)