### PR TITLE
purge に監査を残し、blob が回収されないことを明記する

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -281,8 +281,10 @@ paths:
         revisions, usage, and attachment metadata erased, the id freed
         for a move. Two calls, deliberately: the first is reversible, the
         second is not. Purging a live entry is a 409; delete it first.
-        Content-addressed attachment bytes are left in the blob store,
-        as detaching leaves them.
+        Content-addressed attachment bytes are left in the blob store, as
+        detaching leaves them; nothing reclaims them afterwards. The purge
+        itself is recorded — who destroyed which id, and how much history
+        went with it — in the one table a purge does not touch.
       parameters:
         - name: purge
           in: query

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -380,7 +380,7 @@ func Handler(svc *service.Service) http.Handler {
 	mux.HandleFunc("DELETE /api/v1/knowledge/{id...}", func(w http.ResponseWriter, r *http.Request) {
 		var err error
 		if r.URL.Query().Get("purge") == "true" {
-			err = svc.Purge(r.Context(), r.PathValue("id"))
+			err = svc.Purge(r.Context(), r.PathValue("id"), httpauth.Actor(r.Context()))
 		} else {
 			err = svc.Delete(r.Context(), r.PathValue("id"), httpauth.Actor(r.Context()))
 		}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -170,10 +170,20 @@ func (s *Service) Delete(ctx context.Context, id string, actor domain.Actor) err
 // Purge hard-deletes an already soft-deleted entry, freeing its id for a
 // move (design doc 0021: Move cannot revive a tombstone the way Create
 // can). Not an MCP tool: this is the one operation that destroys history,
-// so it belongs to the human surfaces (design doc 0015). No actor is
-// recorded because nothing survives to record it on.
-func (s *Service) Purge(ctx context.Context, id string) error {
-	return s.Store.Purge(ctx, domain.Normalize(id))
+// so it belongs to the human surfaces (design doc 0015).
+//
+// Which surface exposes it is not the same as who can reach it — ochakai
+// has no authorization, so any caller that reaches the REST API can purge.
+// The actor is therefore recorded twice over: in knowledge_purge, the one
+// table a purge does not touch, and in the log. An operation that leaves
+// no trace has no place in a product whose value is provenance.
+func (s *Service) Purge(ctx context.Context, id string, actor domain.Actor) error {
+	id = domain.Normalize(id)
+	if err := s.Store.Purge(ctx, id, actor); err != nil {
+		return err
+	}
+	s.Log.Info("knowledge purged", "id", id, "actor", actor.String())
+	return nil
 }
 
 // Move renames an entry to newID, carrying every id-keyed record along

--- a/internal/store/attachment.go
+++ b/internal/store/attachment.go
@@ -198,6 +198,8 @@ func (s *Store) GetAttachmentMeta(ctx context.Context, id, name string) (*domain
 
 // DeleteAttachment removes the entry→blob mapping. The blob itself stays:
 // revisions still name its hash, and content-addressed rows are cheap.
+// Nothing reclaims a blob that no revision names any more — there is no
+// sweep, so the bucket only grows.
 func (s *Store) DeleteAttachment(ctx context.Context, id, name string, actor domain.Actor) error {
 	return s.withTx(ctx, func(tx pgx.Tx) error {
 		k, err := s.Get(ctx, id)

--- a/internal/store/migrations/0018_purge_log.sql
+++ b/internal/store/migrations/0018_purge_log.sql
@@ -1,0 +1,21 @@
+-- Purge is the one operation that leaves no trace: it erases the entry,
+-- its revisions, its usage, and its events. In a product whose value is
+-- provenance, an untraceable destruction path is the wrong kind of hole —
+-- and ochakai has no authorization, so "only humans call it" (design doc
+-- 0015) is a statement about which surface exposes it, not about who can
+-- reach it.
+--
+-- So the fact of the purge outlives the entry. Not its content: this
+-- records that an id was destroyed, by whom, and how much history went
+-- with it. The body is gone, which is what the caller asked for.
+CREATE TABLE IF NOT EXISTS knowledge_purge (
+    id              text        NOT NULL,
+    type            text        NOT NULL,
+    title           text        NOT NULL,
+    revisions       integer     NOT NULL,
+    purged_by_kind  text        NOT NULL,
+    purged_by_name  text        NOT NULL,
+    purged_by_via   text        NOT NULL DEFAULT '',
+    purged_at       timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (id, purged_at)
+);

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -380,8 +380,14 @@ func (s *Store) SoftDelete(ctx context.Context, id string, actor domain.Actor) e
 //
 // Attachment bytes are left in the blob store, as DeleteAttachment leaves
 // them: blobs are content-addressed and shared between entries, so
-// reclaiming them is a separate sweep, not a side effect of one purge.
-func (s *Store) Purge(ctx context.Context, id string) error {
+// reclaiming them cannot be a side effect of one purge. No sweep that
+// reclaims them exists yet — GCS grows monotonically, and an operator who
+// cares has to write the sweep themselves.
+//
+// The purge itself is recorded in knowledge_purge (migration 0018), which
+// is the one table it does not touch: the entry is gone, but the fact
+// that someone destroyed it is not.
+func (s *Store) Purge(ctx context.Context, id string, actor domain.Actor) error {
 	return s.withTx(ctx, func(tx pgx.Tx) error {
 		var deleted bool
 		err := tx.QueryRow(ctx,
@@ -394,6 +400,15 @@ func (s *Store) Purge(ctx context.Context, id string) error {
 		}
 		if !deleted {
 			return ErrNotDeleted
+		}
+		if _, err := tx.Exec(ctx, `INSERT INTO knowledge_purge
+			(id, type, title, revisions, purged_by_kind, purged_by_name, purged_by_via)
+			SELECT k.id, k.type, k.title,
+			       (SELECT count(*) FROM knowledge_revision r WHERE r.id = k.id),
+			       $2, $3, $4
+			  FROM knowledge k WHERE k.id = $1`,
+			id, actor.Kind, actor.Name, actor.Via); err != nil {
+			return err
 		}
 		for _, q := range []string{
 			`DELETE FROM attachment WHERE knowledge_id=$1`,

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -1216,12 +1216,29 @@ func TestIntegrationPurgeFreesIDForMove(t *testing.T) {
 	}
 
 	// Purging a live entry is refused: delete first, purge second.
-	if err := s.Purge(ctx, src); !errors.Is(err, ErrNotDeleted) {
+	if err := s.Purge(ctx, src, actor); !errors.Is(err, ErrNotDeleted) {
 		t.Errorf("purge of a live entry: got %v, want ErrNotDeleted", err)
 	}
 
-	if err := s.Purge(ctx, dst); err != nil {
+	if err := s.Purge(ctx, dst, actor); err != nil {
 		t.Fatalf("Purge: %v", err)
+	}
+	// The one record a purge leaves: who destroyed what, and how much
+	// history went with it. Everything else about the entry is gone, so
+	// without this row nobody can answer "where did it go?".
+	var purgedBy string
+	var purgedRevs int
+	if err := s.pool.QueryRow(ctx,
+		`SELECT purged_by_kind || ':' || purged_by_name, revisions
+		   FROM knowledge_purge WHERE id = $1 ORDER BY purged_at DESC LIMIT 1`, dst).
+		Scan(&purgedBy, &purgedRevs); err != nil {
+		t.Fatalf("purge left no audit row: %v", err)
+	}
+	if purgedBy != actor.Kind+":"+actor.Name {
+		t.Errorf("audit row records %q, want %q", purgedBy, actor.Kind+":"+actor.Name)
+	}
+	if purgedRevs == 0 {
+		t.Error("audit row lost the revision count")
 	}
 	var revs int
 	if err := s.pool.QueryRow(ctx,
@@ -1231,7 +1248,7 @@ func TestIntegrationPurgeFreesIDForMove(t *testing.T) {
 	if revs != 0 {
 		t.Errorf("purge left %d revisions behind", revs)
 	}
-	if err := s.Purge(ctx, dst); !errors.Is(err, ErrNotFound) {
+	if err := s.Purge(ctx, dst, actor); !errors.Is(err, ErrNotFound) {
 		t.Errorf("purge of a purged entry: got %v, want ErrNotFound", err)
 	}
 


### PR DESCRIPTION
C-1 と C-6。どちらも指摘のとおりです。

## C-1: 痕跡ゼロの破壊経路

`purge` は actor を取らず、`knowledge_event` も `knowledge_revision` も消し、ログも出していませんでした。**provenance を商品にしている製品で、唯一まったく痕跡を残さない破壊経路**です。

そして指摘の一文が的確でした:

> 「human decision だから MCP には出さない」(0015)という理由づけは、ochakai に認可が無い以上、願望にとどまります。

そのとおりで、どのサーフェスが露出させるかと誰が到達できるかは別の話です。REST に到達できる呼び出し元は誰でも purge できます。

**purge が唯一触らないテーブル**を 1 つ足しました(マイグレーション 0018 `knowledge_purge`)。残すのは事実だけです — どの id を誰がいつ破壊し、履歴が何件消えたか。本文は残しません、それは呼び出し元が消せと言ったものなので。あわせて actor 付きで `slog` にも出します。

委譲された provenance(0027)もそのまま乗るので、`purged_by_via` に「アプリ経由で誰が消したか」が残ります。

## C-6: blob の回収スイープは存在しない

コメントが「reclaiming them is a separate sweep, not a side effect of one purge」と書いていて、**存在するスイープを指しているように読めました**。存在しません。`Purge` / `DeleteAttachment` / openapi の 3 箇所を「そのスイープは無く、バケットは単調増加する。必要なら運用側で書く必要がある」に改めました。

実装しなかったのは、正しい回収には全リビジョンのスナップショットが名指すハッシュを集める必要があり(履歴は content-addressed な参照を持つ)、purge の後始末とは別の設計判断だからです。優先度は低いという指摘にも同意します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)