### PR TITLE
ローカル開発でも委譲を処理し、デプロイガイドに手順を書く

### DIFF
--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -415,6 +415,63 @@ Notes from exercising this end-to-end:
   configure IAP with a custom OAuth client. Browsers are the intended
   clients here — MCP and CLI use the §5 path.
 
+## 5c. Optional: an application that serves many people (delegated provenance)
+
+Embedding ochakai in your own product — a data-analytics chat app, an
+internal agent with a web front end — hits a problem the §5 path does not:
+the application reaches Cloud Run with *its* service account, so every
+entry its users write is recorded as that one identity. Provenance, which
+is most of what ochakai sells, collapses.
+
+Let the application forward the identity of the person using it
+(design doc 0027). Both identities are recorded — `human:tanaka@…
+via agent:app-sa@…` — never just the forwarded one, so a write made
+through the application stays distinguishable from one the person made
+directly.
+
+```sh
+# 1. The application's identity needs to reach ochakai at all (§3's grant).
+gcloud run services add-iam-policy-binding ochakai \
+  --region="$REGION" \
+  --member="serviceAccount:$APP_SA" \
+  --role=roles/run.invoker
+
+# 2. Allow that identity — and only it — to speak for its users.
+gcloud run services update ochakai --region="$REGION" \
+  --update-env-vars="OCHAKAI_DELEGATING_CALLERS=$APP_SA"
+```
+
+The application then sends the header with each request:
+
+```
+X-Ochakai-On-Behalf-Of: human:tanaka@example.co.jp
+```
+
+The kind (`human:` / `agent:`) is required and never guessed — the
+application knows whether it is forwarding a person or another agent.
+
+Notes:
+
+- **Delegation is off by default.** With `OCHAKAI_DELEGATING_CALLERS`
+  unset, the header is a **403**, not a silent downgrade: an application
+  that believes it writes as its users must not discover months later
+  that every entry says otherwise.
+- **A 403 mentioning the header means the caller is not on the list.**
+  Compare the `member` you granted in step 1 with the value in step 2 —
+  they are the same service-account email, and a mismatch is the usual
+  cause. A **400** means the header itself is malformed (missing kind,
+  whitespace in the identity).
+- `OCHAKAI_DELEGATING_CALLERS` takes a comma-separated list; `*` trusts
+  every authenticated caller, which is only sensible when IAM already
+  admits nothing but your own applications.
+- **This is not authorization.** It decides whose identity is recorded,
+  not what anyone may do — every caller that reaches ochakai can already
+  read and write everything (design doc 0002). Reachability stays IAM's
+  job.
+- Developing the integration locally? `OCHAKAI_INSECURE_DEV=true` honors
+  the header too (as `via human:anonymous`), so a malformed header fails
+  on your machine instead of on first deploy.
+
 ## 6. Security hardening checklist
 
 The default §1–§5 deployment is already secret-zero and least-privilege:

--- a/internal/httpauth/httpauth.go
+++ b/internal/httpauth/httpauth.go
@@ -26,11 +26,26 @@ type ctxKey struct{}
 // must therefore never run publicly invokable.
 //
 // With cfg.InsecureDev (local development only), every request acts as
-// human:anonymous instead.
+// human:anonymous instead — but X-Ochakai-On-Behalf-Of is still honored,
+// from any caller, so a delegating integration can be developed and its
+// mistakes seen locally.
 func Middleware(cfg *config.Config, next http.Handler) http.Handler {
 	if cfg.InsecureDev {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			next.ServeHTTP(w, r.WithContext(WithActor(r.Context(), domain.Actor{Kind: domain.ActorHuman, Name: "anonymous"})))
+			// Delegation is processed here too, and every caller may
+			// delegate: someone building an embedding host develops
+			// against this mode, and short-circuiting past delegate()
+			// would let them ship a header that silently did nothing —
+			// exactly the failure design doc 0027 §5.2 refuses to allow in
+			// production, hidden until the first deployment.
+			actor, status, err := delegate(
+				domain.Actor{Kind: domain.ActorHuman, Name: "anonymous"},
+				r.Header.Get(OnBehalfOfHeader), []string{"*"})
+			if err != nil {
+				http.Error(w, "auth: "+err.Error(), status)
+				return
+			}
+			next.ServeHTTP(w, r.WithContext(WithActor(r.Context(), actor)))
 		})
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/httpauth/httpauth_test.go
+++ b/internal/httpauth/httpauth_test.go
@@ -2,6 +2,8 @@ package httpauth
 
 import (
 	"encoding/base64"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -177,5 +179,45 @@ func TestDelegate(t *testing.T) {
 				t.Errorf("status = %d, want 400", status)
 			}
 		})
+	}
+}
+
+// Local development is where an embedding host's delegation gets written,
+// so the header has to work there. Ignoring it would hide a malformed
+// header until the first deployment, which is the silent downgrade design
+// doc 0027 §5.2 exists to prevent — just relocated to the place it is
+// hardest to notice.
+func TestInsecureDevHonorsDelegation(t *testing.T) {
+	srv := httptest.NewServer(Middleware(&config.Config{InsecureDev: true},
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, Actor(r.Context()).String())
+		})))
+	defer srv.Close()
+
+	get := func(t *testing.T, header string) (int, string) {
+		t.Helper()
+		req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+		if header != "" {
+			req.Header.Set(OnBehalfOfHeader, header)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+		return resp.StatusCode, string(body)
+	}
+
+	if _, got := get(t, ""); got != "human:anonymous" {
+		t.Errorf("without the header: got %q, want human:anonymous", got)
+	}
+	_, got := get(t, "human:tanaka@example.co.jp")
+	if want := "human:tanaka@example.co.jp via human:anonymous"; got != want {
+		t.Errorf("with the header: got %q, want %q", got, want)
+	}
+	// A malformed header must fail here, where the developer can see it.
+	if status, _ := get(t, "tanaka@example.co.jp"); status != http.StatusBadRequest {
+		t.Errorf("malformed header status = %d, want 400", status)
 	}
 }


### PR DESCRIPTION
B-1 と C-5。

## B-1: InsecureDev が委譲を丸ごとバイパスしていた

`OCHAKAI_INSECURE_DEV` は `delegate()` の手前で短絡していたので、`X-Ochakai-On-Behalf-Of` が**黙って無視**されていました。指摘のとおりです:

> InsightFlow の統合を書く開発者は `OCHAKAI_INSECURE_DEV=true` で開発し、ヘッダを付けているつもりで全部 `human:anonymous` になっていることに気づけません。

0027 §5.2 が本番で禁じた「静かな降格」が、**最も気づきにくい場所**に残っていました。開発モードでも委譲を処理します(全呼び出し元を許可、via は `human:anonymous`)。形式が不正なヘッダは開発者の手元で 400 になります。

```
X-Ochakai-On-Behalf-Of: human:tanaka@example.co.jp
→ human:tanaka@example.co.jp via human:anonymous
```

## C-5: デプロイガイドに §5c

「完全な、コスト最適化されたデプロイのウォークスルー」に、第一級ユースケースの設定手順が無い、というのはそのとおりでした。§5c を追加:

- ホスト側 SA への `roles/run.invoker` 付与
- `OCHAKAI_DELEGATING_CALLERS` の設定
- ヘッダの形式と、kind を推測しない理由
- **切り分け**: 403 = 呼び出し元がリストに無い(§1 の member と §2 の値を突き合わせる)、400 = ヘッダの形式が不正
- 既定は無効で、無効時のヘッダは 403 であって黙殺ではないこと
- 「これは認可ではない」こと — 記録される identity を決めるだけで、到達性は IAM の仕事
- ローカル開発でも動くこと(B-1 の内容)

🤖 Generated with [Claude Code](https://claude.com/claude-code)