### PR TITLE
export: エントリもストリームし、ヘッダ送出後の失敗を必ずログに残す

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -549,10 +549,13 @@ paths:
         yours.
 
 
-        Written one file at a time, so the server never holds the whole
-        bundle in memory. Because the response starts before the last
-        file is read, a failure mid-export can only truncate the stream:
-        verify a backup by reading the archive, not by the status code.
+        Written as it is read — indexes first, then entries in batches,
+        then one attachment at a time — so the server never holds the
+        whole bundle in memory. Because the response starts before the
+        last file is read, a failure mid-export can only truncate the
+        stream: verify a backup by reading the archive, not by the status
+        code. The server logs every such failure at error level, naming
+        the file it stopped on.
       parameters:
         - name: attachments
           in: query

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -29,6 +29,11 @@ import (
 	"github.com/na0fu3y/ochakai/internal/store"
 )
 
+// exportBatch is how many entries the exporter holds at once. Small
+// enough that a knowledge base of any size costs the same peak memory;
+// large enough that the round trips disappear against the transfer.
+const exportBatch = 100
+
 func Handler(svc *service.Service) http.Handler {
 	mux := http.NewServeMux()
 
@@ -418,15 +423,18 @@ func Handler(svc *service.Service) http.Handler {
 	// (tar.gz of markdown + YAML frontmatter, plus attachment files).
 	// Your knowledge is yours.
 	//
-	// Written straight to the response one file at a time. Collecting the
-	// bundle first would mean holding every entry and every attachment's
-	// bytes in memory at once — a periodic CI backup would be the largest
-	// allocation the process ever makes, on the instance size Cloud Run
-	// runs it at. With ?attachments=false the bytes are skipped entirely:
-	// they live in GCS, so a backup can copy them from there far more
-	// cheaply than through this endpoint.
+	// Written straight to the response, a batch of entries and one
+	// attachment at a time. Collecting the bundle first would mean holding
+	// every entry and every attachment's bytes in memory at once — a
+	// periodic CI backup would be the largest allocation the process ever
+	// makes, on the instance size Cloud Run runs it at. With
+	// ?attachments=false the bytes are skipped entirely: they live in GCS,
+	// so a backup can copy them from there far more cheaply than through
+	// this endpoint.
 	mux.HandleFunc("GET /api/v1/export", func(w http.ResponseWriter, r *http.Request) {
-		entries, err := svc.Store.ListAll(r.Context())
+		// index.md files need every id, but only the id, title and
+		// description — never a body.
+		rows, err := svc.Store.ListAllIndexRows(r.Context())
 		if err != nil {
 			writeError(w, err)
 			return
@@ -440,23 +448,31 @@ func Handler(svc *service.Service) http.Handler {
 				return
 			}
 		}
-		// Indexes need every id, but only the ids. Rendering them up front
-		// keeps the concept documents streaming one at a time.
-		indexes := okf.Indexes(entries) // also sorts entries by id
+		indexes := okf.Indexes(rows) // also sorts rows by id
+		ids := make([]string, len(rows))
+		for i := range rows {
+			ids[i] = rows[i].ID
+		}
 
 		// Past this point the status is already sent, so a failure can only
 		// truncate the stream. Everything that can fail cheaply — the
-		// listings above — has already run.
+		// listings above — has already run; everything below is logged,
+		// because a silently short archive is the worst possible outcome
+		// for the backup this endpoint exists to serve.
 		w.Header().Set("Content-Type", "application/gzip")
 		w.Header().Set("Content-Disposition", `attachment; filename="ochakai-okf.tar.gz"`)
 		tgz := okf.NewTarGzWriter(w, time.Now())
-		written := make(map[string]bool, len(entries)+len(indexes))
-		add := func(p string, data []byte) bool {
+		written := make(map[string]bool, len(ids)+len(indexes))
+		fail := func(what string, err error) {
+			svc.Log.Error("export truncated after the response began",
+				"at", what, "error", err, "files_written", len(written))
+		}
+		add := func(p string, data []byte) error {
 			if err := tgz.Add(p, data); err != nil {
-				return false
+				return err
 			}
 			written[p] = true
-			return true
+			return nil
 		}
 		// Sorted so a backup taken twice from the same content produces the
 		// same archive: map iteration order is not an ordering.
@@ -466,17 +482,30 @@ func Handler(svc *service.Service) http.Handler {
 		}
 		sort.Strings(indexPaths)
 		for _, path := range indexPaths {
-			if !add(path, indexes[path]) {
+			if err := add(path, indexes[path]); err != nil {
+				fail("index "+path, err)
 				return
 			}
 		}
-		for i := range entries {
-			doc, err := okf.Document(&entries[i])
+		// Entries in batches: one batch in memory at a time, and no pool
+		// connection held for the length of the download.
+		for start := 0; start < len(ids); start += exportBatch {
+			end := min(start+exportBatch, len(ids))
+			batch, err := svc.Store.ListByIDs(r.Context(), ids[start:end])
 			if err != nil {
-				return // headers are out; nothing to report but a short stream
-			}
-			if !add(entries[i].ID+".md", doc) {
+				fail(fmt.Sprintf("entries %d-%d", start, end), err)
 				return
+			}
+			for i := range batch {
+				doc, err := okf.Document(&batch[i])
+				if err != nil {
+					fail("render "+batch[i].ID, err)
+					return
+				}
+				if err := add(batch[i].ID+".md", doc); err != nil {
+					fail("write "+batch[i].ID, err)
+					return
+				}
 			}
 		}
 		// Attachments go next to their entries: "<id>/<name>", or the
@@ -489,17 +518,21 @@ func Handler(svc *service.Service) http.Handler {
 			a := &atts[i]
 			data, err := svc.Store.AttachmentBytes(r.Context(), a.Att.SHA256)
 			if err != nil {
+				fail("fetch attachment "+a.ID+"/"+a.Att.Name, err)
 				return
 			}
 			p := okf.AttachmentPath(a.ID, &a.Att)
 			if written[p] {
 				p = a.ID + "/" + a.Att.Name
 			}
-			if !add(p, data) {
+			if err := add(p, data); err != nil {
+				fail("write attachment "+p, err)
 				return
 			}
 		}
-		_ = tgz.Close()
+		if err := tgz.Close(); err != nil {
+			fail("close", err)
+		}
 	})
 
 	mux.HandleFunc("POST /api/v1/compile", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/restapi/restapi_integration_test.go
+++ b/internal/restapi/restapi_integration_test.go
@@ -190,6 +190,55 @@ func TestRESTIntegration(t *testing.T) {
 		t.Errorf("attachments=false dropped the entries too")
 	}
 
+	// The export must survive crossing a batch boundary: entries are
+	// fetched in groups so that peak memory does not scale with the
+	// knowledge base, and an off-by-one there would silently drop
+	// whichever entries fall past the first group.
+	var planted []string
+	for i := range exportBatch + 3 {
+		id := fmt.Sprintf("%s/batch/%d", typ, i)
+		planted = append(planted, id)
+		body, _ := json.Marshal(map[string]any{"type": typ, "id": id, "title": fmt.Sprintf("batch %d", i)})
+		resp, err := http.Post(srv.URL+"/api/v1/knowledge", "application/json", bytes.NewReader(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+	}
+	t.Cleanup(func() {
+		for _, id := range planted {
+			req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/knowledge/"+id, nil)
+			if resp, err := http.DefaultClient.Do(req); err == nil {
+				resp.Body.Close()
+			}
+		}
+	})
+	resp, err = http.Get(srv.URL + "/api/v1/export?attachments=false")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	gz, err = gzip.NewReader(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inBundle := map[string]bool{}
+	for tr := tar.NewReader(gz); ; {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("bundle truncated: %v", err)
+		}
+		inBundle[hdr.Name] = true
+	}
+	for _, id := range planted {
+		if !inBundle[id+".md"] {
+			t.Errorf("export dropped %s across a batch boundary", id)
+		}
+	}
+
 	// Delete, then the entry is gone.
 	req, _ = http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/knowledge/"+typ+"/sales/orders", nil)
 	resp, err = http.DefaultClient.Do(req)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -837,6 +837,37 @@ func (s *Store) ListAll(ctx context.Context) ([]domain.Knowledge, error) {
 	return pgx.CollectRows(rows, scanKnowledge)
 }
 
+// ListAllIndexRows returns every live entry with only the fields the
+// bundle's index.md files are rendered from — id, type, title,
+// description. The bodies are the bulk of a knowledge base, and the
+// indexes need none of them, so the exporter reads this first and pulls
+// the documents themselves in batches (ListByIDs).
+func (s *Store) ListAllIndexRows(ctx context.Context) ([]domain.Knowledge, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT type, id, title, description FROM knowledge WHERE deleted_at IS NULL ORDER BY id`)
+	if err != nil {
+		return nil, err
+	}
+	return pgx.CollectRows(rows, func(row pgx.CollectableRow) (domain.Knowledge, error) {
+		var k domain.Knowledge
+		err := row.Scan(&k.Type, &k.ID, &k.Title, &k.Description)
+		return k, err
+	})
+}
+
+// ListByIDs returns the named live entries in id order. The exporter walks
+// the id list in batches so that neither the whole knowledge base nor a
+// pool connection is held for the length of a download.
+func (s *Store) ListByIDs(ctx context.Context, ids []string) ([]domain.Knowledge, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT `+knowledgeCols+` FROM knowledge
+		 WHERE deleted_at IS NULL AND id = ANY($1) ORDER BY id`, ids)
+	if err != nil {
+		return nil, err
+	}
+	return pgx.CollectRows(rows, scanKnowledge)
+}
+
 // UpsertEmbedding stores the document embedding for a knowledge entry.
 func (s *Store) UpsertEmbedding(ctx context.Context, id, model string, vec []float32) error {
 	_, err := s.pool.Exec(ctx, `INSERT INTO knowledge_embedding (id, model, embedding, updated_at)


### PR DESCRIPTION
A-4。指摘のとおり **#117 でストリーミング化したのは添付バイトだけ**でした。

> コメントは「every entry and every attachment's bytes in memory at once」が問題だったと書いていますが、修正されたのは後半だけ。テキスト中心のナレッジベース(InsightFlow のテーブル仕様がまさにそれ)では、直っていない方が支配的です。

## エントリもストリームする

index.md は全 ID を要りますが、**必要なのは id / title / description だけ**で本文は 1 バイトも要りません(`dirEntry` の描画は Title と Description しか読んでいない)。

1. `ListAllIndexRows` — 軽い列挙で索引を作る
2. `ListByIDs` で本文を **100 件ずつ**引いて書き出す

ピーク時のメモリがナレッジベースの大きさに比例しなくなり、かつ**ダウンロードの間ずっとプール接続を握り続けない**(1 行ずつのカーソルにしなかったのはこのためです)。

## 失敗が無言だった件

裸の `return` でログもなし、というのもそのとおりでした。サーバー側に痕跡ゼロ、クライアントには HTTP 200 + 切り詰められた tar.gz。**CI バックアップが静かに壊れる形**です。

`svc.Log` は既に渡っていた(`Handler(svc)` の svc が持っている)ので、そこに error レベルで出します。止まった場所とそこまでに書いたファイル数を添えます:

```
export truncated after the response began  at=entries 100-200  error=...  files_written=137
```

openapi にも「サーバーはこの失敗を error レベルで記録する」と書き足しました。

## テスト

**バッチ境界をまたぐ回帰テスト**を追加しました(`exportBatch + 3` 件を植えて全件がアーカイブに入ることを確認)。オフバイワンがあれば最初のバッチ以降が黙って落ちるので、ここは押さえておく価値があります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)