### PR TITLE
Reembed: 残りを二重に差し引かず、実際に残っている数を報告する

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -715,11 +715,14 @@ func (s *Service) updateEmbedding(ctx context.Context, k *domain.Knowledge) {
 // rather than trusting it.
 const maxEmbedBytes = 5000
 
-// ReembedResult reports what a Reembed pass did.
+// ReembedResult reports what a Reembed pass did. Missing is how many
+// entries still have no vector once the pass is over — the number that
+// decides whether the operator runs it again, so it counts what is
+// actually left rather than what this pass did not get to.
 type ReembedResult struct {
 	Embedded int `json:"embedded"`
 	Failed   int `json:"failed"`
-	Missing  int `json:"missing"` // still unembedded when the batch limit was reached
+	Missing  int `json:"missing"`
 }
 
 // Reembed fills in the vectors that entry writes never produced. Vectors
@@ -763,14 +766,18 @@ func (s *Service) Reembed(ctx context.Context, limit int) (*ReembedResult, error
 		}
 		res.Embedded++
 	}
-	if len(ids) == limit {
-		// The caller asked for a bounded pass and got one; say so rather
-		// than let "done" mean "done for now".
-		remaining, err := s.Store.ListUnembedded(ctx, s.Embedder.Model(), limit+1)
-		if err == nil && len(remaining) > res.Embedded {
-			res.Missing = len(remaining) - res.Embedded
-		}
+	// Counted after the pass, so it is what is left — not what was left
+	// minus what we did, which double-counts the work and reports a
+	// bounded pass as a finished one. Entries this pass failed on are
+	// still unembedded and belong in the total.
+	missing, err := s.Store.CountUnembedded(ctx, s.Embedder.Model())
+	if err != nil {
+		// The pass itself succeeded; refusing to report it because the
+		// tally failed would be worse than reporting it without one.
+		s.Log.Warn("reembed: counting what is left failed", "error", err)
+		return res, nil
 	}
+	res.Missing = missing
 	return res, nil
 }
 

--- a/internal/service/service_integration_test.go
+++ b/internal/service/service_integration_test.go
@@ -284,19 +284,19 @@ func TestRefuseIfCuratedIntegration(t *testing.T) {
 // past the store to simulate.
 func TestReembedIntegration(t *testing.T) {
 	ctx := context.Background()
-	svc := newIntegrationService(t, ctx)
 	actor := domain.Actor{Kind: "human", Name: "test"}
+	svc := newEmbeddingService(t, ctx, "test-embedder-v1")
 
 	// Without a provider the operator gets told which setting is missing,
 	// not a nil dereference.
+	embedder := svc.Embedder
 	svc.Embedder = nil
 	_, err := svc.Reembed(ctx, 10)
 	var unsupported *UnsupportedError
 	if !errors.As(err, &unsupported) {
 		t.Errorf("without an embedder: got %v, want an UnsupportedError naming the setting", err)
 	}
-
-	svc.Embedder = &fixedEmbedder{model: "test-embedder-v1", dim: 4}
+	svc.Embedder = embedder
 	id := "insights/" + uid("reembed")
 	if _, err := svc.Create(ctx, &domain.Knowledge{
 		Type: domain.TypeInsights, ID: id, Title: "reembed me", Body: "text",
@@ -340,12 +340,80 @@ func TestReembedIntegration(t *testing.T) {
 	}
 
 	// And it is idempotent: a second pass finds this entry already done.
-	if _, err := svc.Reembed(ctx, 5000); err != nil {
+	done, err := svc.Reembed(ctx, 5000)
+	if err != nil {
 		t.Fatal(err)
 	}
 	if unembedded(t, "test-embedder-v2") {
 		t.Error("a second pass unembedded the entry")
 	}
+	if done.Missing != 0 {
+		t.Errorf("nothing is left, but Missing = %d", done.Missing)
+	}
+}
+
+// Missing is the number the operator acts on: it decides whether to run
+// the command again. Reporting 0 while entries are still unembedded turns
+// a half-done backfill into a finished one, and hybrid search stays
+// quietly lexical for whatever was left — the exact failure this command
+// exists to end.
+func TestReembedReportsWhatIsLeft(t *testing.T) {
+	ctx := context.Background()
+	actor := domain.Actor{Kind: "human", Name: "test"}
+	svc := newEmbeddingService(t, ctx, uid("m"))
+	model := svc.Embedder.Model()
+
+	// Entries written before a provider was configured: created with no
+	// embedder, so nothing wrote a vector. That is the state enabling
+	// semantic search on an existing corpus leaves behind.
+	svc.Embedder = nil
+	for i := range 3 {
+		id := "insights/" + uid("missing")
+		if _, err := svc.Create(ctx, &domain.Knowledge{
+			Type: domain.TypeInsights, ID: id, Title: fmt.Sprintf("filler %d", i),
+		}, actor); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = svc.Delete(ctx, id, actor) })
+	}
+	svc.Embedder = &fixedEmbedder{model: model, dim: 4}
+
+	total, err := svc.Store.CountUnembedded(ctx, model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total < 3 {
+		t.Fatalf("setup left %d unembedded entries, want at least 3", total)
+	}
+
+	// A pass smaller than the corpus must say what it did not reach.
+	res, err := svc.Reembed(ctx, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Embedded != 2 {
+		t.Fatalf("bounded pass embedded %d, want 2", res.Embedded)
+	}
+	if want := total - 2; res.Missing != want {
+		t.Errorf("Missing = %d, want %d (%d unembedded, %d done)", res.Missing, want, total, res.Embedded)
+	}
+	if res.Missing == 0 {
+		t.Error("a bounded pass over a larger corpus reported nothing left")
+	}
+}
+
+// newEmbeddingService is newIntegrationService plus the pgvector schema,
+// which exists only where an embedding dimension was configured. Reembed
+// reads knowledge_embedding, so a test that skipped this would depend on
+// some other package having migrated the shared database first.
+func newEmbeddingService(t *testing.T, ctx context.Context, model string) *Service {
+	t.Helper()
+	svc := newIntegrationService(t, ctx)
+	if err := svc.Store.Migrate(ctx, 4); err != nil {
+		t.Fatal(err)
+	}
+	svc.Embedder = &fixedEmbedder{model: model, dim: 4}
+	return svc
 }
 
 // fixedEmbedder stands in for Vertex: the integration database has no

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1012,6 +1012,18 @@ func (s *Store) ListUnembedded(ctx context.Context, model string, limit int) ([]
 	return pgx.CollectRows(rows, pgx.RowTo[string])
 }
 
+// CountUnembedded counts the live entries with no vector for the named
+// model. Reembed reports it so a bounded pass cannot be mistaken for a
+// finished one.
+func (s *Store) CountUnembedded(ctx context.Context, model string) (int, error) {
+	var n int
+	err := s.pool.QueryRow(ctx,
+		`SELECT count(*) FROM knowledge k
+		 LEFT JOIN knowledge_embedding e ON e.id = k.id AND e.model = $1
+		 WHERE k.deleted_at IS NULL AND e.id IS NULL`, model).Scan(&n)
+	return n, err
+}
+
 // UpsertEmbedding stores the document embedding for a knowledge entry.
 func (s *Store) UpsertEmbedding(ctx context.Context, id, model string, vec []float32) error {
 	_, err := s.pool.Exec(ctx, `INSERT INTO knowledge_embedding (id, model, embedding, updated_at)


### PR DESCRIPTION
A-1。指摘のとおりの明確なバグで、**この機能が終わらせるはずだった失敗が別の形で再発**していました。

`ListUnembedded` は埋め込み処理の**後**に呼ばれるので、結果からは今回埋めた分が既に除かれています。そこからさらに `res.Embedded` を引くのは二重控除でした。

| 状況 | 実際の残り | 旧 `Missing` |
|---|---|---|
| 1000 件・limit 500・全成功 | 500 | **0** |
| 600 件・limit 500・全成功 | 100 | **0** |
| 501 件・limit 500・全成功 | 1 | **0** |

CLI は `Missing > 0` のときだけ再実行を促すので、「embedded 500, failed 0, still missing 0」と出てオペレータは完了したと信じます。**半分がベクトル検索から欠けたまま、ハイブリッド検索が無言で片肺運転**になります。私が自分で書いたコメント（"say so rather than let 'done' mean 'done for now'"）が指しているまさにその失敗でした。

## 修正

`CountUnembedded` を足し、パスの後に**実際に残っている数**を数えます。今回失敗した分も未埋め込みなので当然そこに含まれます（提案の `len(remaining)` でも直りますが、`limit+1` で打ち切った値は「以上」の意味しか持てないので、正確な数を返す方を選びました）。

`len(ids) == limit` のときだけ数える条件も外しました — 失敗があれば limit 未満のパスでも残りはあります。

## テスト

指摘のとおり 1 本も無かったので 2 本足しました。**コーパスより小さいパスが到達しなかった分を報告すること**（旧ロジックに戻すと確実に落ちることを確認済み）と、残りが無いときは 0 と言うこと。

あわせて埋め込みスキーマを張る専用ヘルパーを足しました。従来のテストは `knowledge_embedding` が存在することを、他パッケージが先に migrate している事実に暗黙に依存していました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)