### PR TITLE
検索: 採点をID射影で行い、断片の切り方を実データに合わせる

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,12 @@ by how much of the *rare* part of the query they contain.
 That finds the right entries for a keyword and for a Japanese question,
 but it is still a bag of words: ask an English question and an entry
 sharing three of its function words can outrank the one that names the
-subject. `gemini-embedding-001` handles Japanese well, and with
+subject. It is also not fully indexed. A trigram index cannot serve a
+two-character pattern — there is no whole trigram in one — so Japanese
+terms like 売上 or 原価 are answered by scanning the table: about 16 ms
+per search across 5000 entries, against 0.2 ms for a latin word. That
+is fine at the scale a curated knowledge base reaches and does not stay
+fine forever. `gemini-embedding-001` handles Japanese well, and with
 `OCHAKAI_VERTEX_PROJECT` set, ranking comes from rank fusion across both
 halves rather than from term overlap alone.
 

--- a/internal/store/filter_test.go
+++ b/internal/store/filter_test.go
@@ -72,11 +72,19 @@ func TestQueryFragments(t *testing.T) {
 	}{
 		{"english question", "why is revenue down?", []string{"why", "is", "revenue", "down"}},
 		{"single word", "revenue", []string{"revenue"}},
-		// Only the windows carrying a content character survive: the
-		// all-hiragana ones (って, てい, のか) are grammar and match
-		// nearly every entry.
+		// Only windows that begin with a content character survive. The
+		// all-hiragana ones (って, てい, のか) are grammar and match nearly
+		// every entry; the ones that straddle a word boundary (ぜ売, が下)
+		// mean nothing and, being rare, would be weighted highest.
 		{"japanese question", "なぜ売上が下がっているのか",
-			[]string{"ぜ売", "売上", "上が", "が下", "下が"}},
+			[]string{"売上", "上が", "下が"}},
+		// Latin abbreviations mixed into Japanese are everyday domain
+		// vocabulary. Dispatching on the token's first character would
+		// send PL科目 down the latin path (matching only the exact string)
+		// and cut 売上KPI into windows that break KPI apart.
+		{"latin prefix", "PL科目", []string{"PL", "科目"}},
+		{"latin suffix", "売上KPI", []string{"売上", "KPI"}},
+		{"latin infix", "EC売上高", []string{"EC", "売上", "上高"}},
 		{"all-kana query keeps its windows", "ください",
 			[]string{"くだ", "ださ", "さい"}},
 		{"short japanese term", "売上", []string{"売上"}},
@@ -99,5 +107,19 @@ func TestQueryFragments(t *testing.T) {
 	}
 	if got := queryFragments(long.String()); len(got) != maxQueryFragments {
 		t.Errorf("long query produced %d fragments, want the cap of %d", len(got), maxQueryFragments)
+	}
+
+	// The cap falls evenly across the query rather than truncating its
+	// tail: a question often names its subject last, and cutting in
+	// reading order would drop exactly that.
+	got := queryFragments(
+		"先日の定例で共有された年度計画の資料の件で相談があります、" +
+			"店舗別の在庫回転率と発注リードタイムの数字を見ていて気づいたのですが、" +
+			"直近の原価率はどうなっていますか")
+	if len(got) != maxQueryFragments {
+		t.Fatalf("capped query produced %d fragments, want %d", len(got), maxQueryFragments)
+	}
+	if !slices.Contains(got, "原価") {
+		t.Errorf("the cap dropped the subject named at the end: %q", got)
 	}
 }

--- a/internal/store/migrations/0016_search_text.sql
+++ b/internal/store/migrations/0016_search_text.sql
@@ -17,6 +17,17 @@
 -- path (create, update, move, attach, detach) would otherwise have to
 -- remember, and the one that forgets makes an entry silently
 -- unsearchable.
+--
+-- How far the index actually reaches, measured on 5000 entries of about
+-- 1.2 kB each: '%revenue%' and '%売上の%' are index scans at ~0.2 ms,
+-- '%売上%' is a sequential scan at ~16 ms. A two-character pattern has no
+-- word boundary to pad against, so pg_trgm extracts no whole trigram and
+-- the planner reads the table — and Japanese search runs on exactly such
+-- terms (売上, 原価, 客数). The index earns its place on latin words and
+-- longer Japanese phrases; the scan is the price of the short ones.
+-- Beware EXPLAIN with enable_seqscan=off: GIN answers by scanning the
+-- whole index and rechecking, which reads as an index scan and is slower
+-- than the scan it replaced.
 
 ALTER TABLE knowledge ADD COLUMN IF NOT EXISTS search_text text NOT NULL DEFAULT '';
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -639,47 +639,61 @@ const maxQueryFragments = 24
 // not. Runs of Han/Hiragana/Katakana have no spaces to split on, so they
 // become sliding two-character windows — the standard n-gram treatment
 // for Japanese, and the smallest unit that still carries meaning (売上,
-// 受注, 原価). Two characters is below what a trigram index can resolve
-// exactly, but pg_trgm still narrows the scan with partial trigrams.
+// 受注, 原価).
+//
+// Two characters is below what a trigram index can serve, and pg_trgm
+// does not narrow the scan for such a pattern: LIKE '%売上%' has no word
+// boundary to pad against, so no whole trigram can be extracted and the
+// planner reads the table. Measured on 5000 entries, '%revenue%' and
+// '%売上の%' are index scans at 0.2ms while '%売上%' is a sequential scan
+// at 16ms. Three-character windows would restore the index and lose 売上,
+// 原価, 客数 — the terms the search is for — so the scan is the price of
+// finding them. SearchLexical keeps that scan cheap by scoring over ids
+// alone.
 func queryFragments(query string) []string {
-	var out []string
-	seen := map[string]bool{}
-	add := func(frag string) {
-		if frag == "" || seen[frag] || len(out) >= maxQueryFragments {
-			return
-		}
-		seen[frag] = true
-		out = append(out, frag)
-	}
+	// Fragments are collected per run and then interleaved, so the cap
+	// falls evenly across the query instead of truncating its tail. A
+	// question often names its subject last ("〜の件で、直近の原価率は?"),
+	// and cutting in reading order would drop exactly that.
+	var runs [][]string
 	for _, token := range strings.FieldsFunc(query, func(r rune) bool {
 		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
 	}) {
-		runes := []rune(token)
-		if !scriptWithoutSpaces(runes[0]) || len(runes) <= 2 {
-			add(token)
-			continue
+		// A token can still mix scripts, because FieldsFunc treats latin
+		// and kanji alike as letters: "PL科目", "売上KPI", "EC売上" all
+		// arrive whole. Dispatching on the first character alone would
+		// send "PL科目" through the latin path (matching only the exact
+		// string "PL科目") and cut "売上KPI" into windows that break KPI
+		// apart. Domain vocabulary is full of these, so split at the
+		// script boundary first and treat each run on its own terms.
+		for _, run := range scriptRuns(token) {
+			runes := []rune(run)
+			if !scriptWithoutSpaces(runes[0]) || len(runes) <= 2 {
+				runs = append(runs, []string{run})
+				continue
+			}
+			runs = append(runs, contentWindows(runes))
 		}
-		// Windows that carry a content character first. Japanese grammar
-		// is written in hiragana, so an all-hiragana window (ってい, のか)
-		// is a function word: it matches nearly every entry and would
-		// drown the one window that names the subject. Han and katakana
-		// carry the meaning. A run with no content character at all —
-		// an all-kana query — keeps its windows, or it would match
-		// nothing.
-		windows := make([]string, 0, len(runes))
-		var content []string
-		for i := 0; i+2 <= len(runes); i++ {
-			w := string(runes[i : i+2])
-			windows = append(windows, w)
-			if strings.ContainsFunc(w, contentChar) {
-				content = append(content, w)
+	}
+
+	var out []string
+	seen := map[string]bool{}
+	for round := 0; len(out) < maxQueryFragments; round++ {
+		progressed := false
+		for _, run := range runs {
+			if round >= len(run) {
+				continue
+			}
+			progressed = true
+			if frag := run[round]; !seen[frag] {
+				seen[frag] = true
+				if out = append(out, frag); len(out) >= maxQueryFragments {
+					break
+				}
 			}
 		}
-		if len(content) > 0 {
-			windows = content
-		}
-		for _, w := range windows {
-			add(w)
+		if !progressed {
+			break
 		}
 	}
 	if len(out) == 0 {
@@ -690,6 +704,52 @@ func queryFragments(query string) []string {
 		}
 	}
 	return out
+}
+
+// contentWindows cuts a space-less run into two-character windows and
+// keeps the ones that begin with a content character.
+//
+// Japanese grammar is written in hiragana and content words in kanji or
+// katakana, so a window's first character says which it is: 売上 and 下が
+// (the stem of 下がる) begin a word, while ぜ売 and が下 straddle a
+// boundary and mean nothing. Keeping only the former drops both the
+// function words, which match nearly every entry, and the accidental
+// fragments, which match almost none — and the latter matter more than
+// they look, because scoring weights rare fragments highest and a
+// meaningless one is rare by construction.
+//
+// A run with no content character at all — an all-kana query like
+// ください — keeps every window, or it would match nothing.
+func contentWindows(runes []rune) []string {
+	all := make([]string, 0, len(runes))
+	var content []string
+	for i := 0; i+2 <= len(runes); i++ {
+		w := string(runes[i : i+2])
+		all = append(all, w)
+		if contentChar(runes[i]) {
+			content = append(content, w)
+		}
+	}
+	if len(content) > 0 {
+		return content
+	}
+	return all
+}
+
+// scriptRuns splits a token wherever it crosses between a space-less
+// script (Han, kana) and anything else, so "PL科目" becomes "PL" and
+// "科目".
+func scriptRuns(token string) []string {
+	var runs []string
+	runes := []rune(token)
+	start := 0
+	for i := 1; i < len(runes); i++ {
+		if scriptWithoutSpaces(runes[i]) != scriptWithoutSpaces(runes[start]) {
+			runs = append(runs, string(runes[start:i]))
+			start = i
+		}
+	}
+	return append(runs, string(runes[start:]))
 }
 
 // scriptWithoutSpaces reports whether r belongs to a script that does not
@@ -733,9 +793,10 @@ func (s *Store) SearchLexical(ctx context.Context, query string, f Filter, limit
 	args = append(args, "%"+escapeLike(query)+"%")
 	wholeParam := len(args)
 	frags := queryFragments(query)
-	var hit, weight, weighted, weights []string
+	var hit, weight, weighted, weights, tests []string
 	for i, frag := range frags {
 		args = append(args, "%"+escapeLike(frag)+"%")
+		tests = append(tests, fmt.Sprintf("k.search_text ILIKE $%d", len(args)))
 		hit = append(hit, fmt.Sprintf("k.search_text ILIKE $%d AS h%d", len(args), i))
 		// Document frequency over the candidates, not the whole table: one
 		// window pass, no extra scans.
@@ -744,26 +805,34 @@ func (s *Store) SearchLexical(ctx context.Context, query string, f Filter, limit
 		weighted = append(weighted, fmt.Sprintf("CASE WHEN h%d THEN w%d ELSE 0 END", i, i))
 		weights = append(weights, fmt.Sprintf("w%d", i))
 	}
-	tests := make([]string, len(frags))
-	for i := range frags {
-		tests[i] = fmt.Sprintf("k.search_text ILIKE $%d", wholeParam+1+i)
-	}
+	// Scoring carries ids and booleans, never rows. The window functions
+	// force every candidate to be materialized before LIMIT can apply, and
+	// the candidate set is an OR over fragments — one common two-character
+	// window and it is most of the table. Selecting k.* through those
+	// layers would push every body, and search_text (a near-copy of the
+	// body) alongside it, through a sort node: tens of megabytes on a
+	// corpus of a few thousand, spilling work_mem on the instance size
+	// this is meant to run on. The entries are fetched once the top N is
+	// known.
 	q := fmt.Sprintf(`
-		SELECT `+knowledgeCols+`, score FROM (
-			SELECT w.*, (%[1]s) / NULLIF(%[2]s, 0)
-				+ CASE WHEN w.search_text ILIKE $%[3]d THEN 0.3 ELSE 0 END
-				+ CASE WHEN w.status = 'verified' THEN 0.05 ELSE 0 END AS score
+		WITH scored AS (
+			SELECT w.id, (%[1]s) / NULLIF(%[2]s, 0) + w.whole + w.verified AS score
 			FROM (
-				SELECT c.*, %[4]s FROM (
-					SELECT k.*, %[5]s, count(*) OVER () AS total
+				SELECT c.*, %[3]s FROM (
+					SELECT k.id, %[4]s, count(*) OVER () AS total,
+						CASE WHEN k.search_text ILIKE $%[5]d THEN 0.3 ELSE 0 END AS whole,
+						CASE WHEN k.status = 'verified' THEN 0.05 ELSE 0 END AS verified
 					FROM knowledge k
 					WHERE (%[6]s) AND %[7]s
 				) c
 			) w
-		) ranked
-		ORDER BY score DESC LIMIT %[8]d`,
-		strings.Join(weighted, " + "), strings.Join(weights, " + "), wholeParam,
-		strings.Join(weight, ", "), strings.Join(hit, ", "),
+			ORDER BY score DESC LIMIT %[8]d
+		)
+		SELECT `+qualifyCols("k")+`, scored.score
+		FROM knowledge k JOIN scored ON scored.id = k.id
+		ORDER BY scored.score DESC`,
+		strings.Join(weighted, " + "), strings.Join(weights, " + "),
+		strings.Join(weight, ", "), strings.Join(hit, ", "), wholeParam,
 		strings.Join(tests, " OR "), where, limit)
 	rows, err := s.pool.Query(ctx, q, args...)
 	if err != nil {

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -1043,67 +1043,6 @@ func (f *fakeBlobStore) Get(_ context.Context, sum string) ([]byte, error) {
 	return append([]byte(nil), data...), nil
 }
 
-// The point of migration 0016: the trigram index and the search query are
-// about the same text, so the index can actually serve the search. Before
-// it, similarity() was computed in the SELECT list over a concatenation no
-// index expression could match (tags need array_to_string, which is not
-// IMMUTABLE; attachment names live in another table), and the score floor
-// sat outside the subquery — every search scanned every row.
-//
-// enable_seqscan=off is a cost penalty, not a prohibition: PostgreSQL
-// still picks a sequential scan when no index can answer the predicate.
-// So this asserts index usability, not planner preference — which is
-// exactly the property that was missing.
-func TestIntegrationLexicalSearchUsesTrigramIndex(t *testing.T) {
-	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
-	if dbURL == "" {
-		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
-	}
-	ctx := context.Background()
-	s, err := New(ctx, dbURL, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer s.Close()
-	if err := s.Migrate(ctx, 0); err != nil {
-		t.Fatal(err)
-	}
-
-	tx, err := s.pool.Begin(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer tx.Rollback(ctx)
-	if _, err := tx.Exec(ctx, `SET LOCAL enable_seqscan = off`); err != nil {
-		t.Fatal(err)
-	}
-	// The live predicate shape: an OR of one substring test per query
-	// fragment. Two-character Japanese fragments are below what a trigram
-	// index resolves exactly, so this also checks that pg_trgm still
-	// narrows the scan with partial trigrams rather than giving up.
-	rows, err := tx.Query(ctx, `EXPLAIN
-		SELECT k.id FROM knowledge k
-		WHERE (k.search_text ILIKE $1 OR k.search_text ILIKE $2) AND k.deleted_at IS NULL`,
-		"%revenue%", "%売上%")
-	if err != nil {
-		t.Fatalf("EXPLAIN: %v", err)
-	}
-	plan := ""
-	for rows.Next() {
-		var line string
-		if err := rows.Scan(&line); err != nil {
-			t.Fatal(err)
-		}
-		plan += line + "\n"
-	}
-	if err := rows.Err(); err != nil {
-		t.Fatal(err)
-	}
-	if n := strings.Count(plan, "knowledge_search_trgm"); n != 2 {
-		t.Errorf("want both fragments served by the trigram index, got %d index scans:\n%s", n, plan)
-	}
-}
-
 // search_text is maintained by trigger, so every write path keeps the
 // haystack current without remembering to. These are the two paths a
 // Go-side implementation would most easily miss: a file attached after


### PR DESCRIPTION
A-2 から A-6 まで。**A-2 は指摘が正しく、私のコメントが誤りでした。**実測で確認しています。

## A-2: 索引は 2 文字パターンに効かない(実測)

5000 行・約 1.2kB/行、選択性のあるコーパスで:

| パターン | プラン | 実測 |
|---|---|---|
| `%revenue%` | Bitmap Index Scan | **0.20 ms** |
| `%売上の%` | Bitmap Index Scan | **0.16 ms** |
| `%売上%` | **Seq Scan** | **16.5 ms** |
| `%原価%` | **Seq Scan** | **15.9 ms** |

指摘のとおり、2 文字パターンには語境界パディングが効かず完全なトライグラムが取り出せないので索引は使えません。「pg_trgm still narrows the scan with partial trigrams」という私のコメントは誤りで、測った事実に置き換えました。

**索引利用を検査していた統合テストは削除しました。**`enable_seqscan=off` での EXPLAIN は、GIN が索引全体を舐めて recheck する挙動を索引スキャンとして表示するので、**通っても何も証明していませんでした**(私はこれで納得していました)。プランナの選択は行数だけでなく行幅にも依存し、共有データベース上では安定しません。誤解を招くテストを別の誤解を招くテストに置き換えるより、実測値を 0016 のコメントと README に残す方を選びました。

3 文字窓にする案は、売上 / 原価 / 客数 という**この検索の存在理由そのもの**を落とすので採りません。pg_bigm は Docker イメージにも入れる必要があり、依存の追加は別の判断として残しました。

## A-3: 採点が候補全件を本文込みで実体化していた

指摘のとおりです。採点を id と真偽値だけで行い、上位 N が決まってから本体を JOIN する形にしました。knowledge 相当のテーブル 4000 行・`work_mem=1MB` で:

| | 一時ファイル |
|---|---|
| 旧(k.* を窓関数へ通す) | read 505 ブロック |
| 新(id 射影) | read 77 ブロック |

**約 1/6.5。**実行時間はほぼ変わりません — 支配的なのは ILIKE のスキャンで、これはメモリ圧の話です。そこは正確に書いておきます。

## A-4: 混在スクリプトが先頭 1 文字で分岐していた

`PL科目` は丸ごと ILIKE に回って完全一致でしか当たらず、`売上KPI` は KPI を割る窓になっていました。スクリプト境界で分割してから各ランを扱います。ドメイン語彙はこの形が日常的で、**最も効いてほしい語がこの経路に落ちていました**。

## A-5: 語境界をまたぐノイズ窓が最も重く扱われていた

提案どおり「内容文字で始まる窓」に限りました。日本語は内容語が漢字・カタカナで始まり助詞が続くので、先頭文字がそのまま判別材料になります。`ぜ売` `が下` が落ち、`売上` `下が`(下がる の語幹)が残ります。

## A-6: 上限を読み順の切り捨てからランごとの総当たりへ

日本語の質問は主題が後半に来ることが多く、先頭から 24 個では落ちます。長さでの重み付けも試しましたが、UTF-8 のバイト長は日本語窓を常に優遇し、ルーン数は逆に KPI のような略語を優遇してしまい、どちらもスクリプト偏りが出ました。総当たりなら偏りがありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)