### PR TITLE
create による墓標の復活も塞ぐ(0015 §3.1)

### DIFF
--- a/docs/design/0015-surface-consistency.md
+++ b/docs/design/0015-surface-consistency.md
@@ -81,6 +81,23 @@ CLI、Web UI。機能を足すたびに「どのサーフェスに載せるか�
   2 コールで消せる。しかも verified の消失と違い、rejected の消失は
   誰も使っていなかったので誰も気づかない。
 
+  **create による復活も塞ぐ(2026-07-25 追記)。** delete を塞いだだけ
+  では足りなかった。Create は soft-delete 済みの行を
+  `ON CONFLICT ... WHERE deleted_at IS NOT NULL` でその場で復活させ、
+  status と status_note を入力で上書きする。つまり**すでに存在する
+  墓標**——このルール以前に消されたもの、あるいは人間が REST/CLI で
+  整理として消したもの(rejected を消すのは正当な運用である)——は、
+  create 1 コールで「一度も判断されていない draft」として戻せる。
+  update / delete のガードはこれを見られない。読む行が live ではない
+  からである。
+
+  そこで create も、対象 id が verified / rejected / deprecated の墓標
+  なら拒否する(`RefuseIfRevivingCurated`)。draft の墓標は従来どおり
+  復活できる — 誰も判断を下していないし、放棄された draft の id を
+  再利用するのは create の想定どおりの使い方である。人間の面(REST /
+  CLI / Web UI)は従来どおり復活でき、id を完全に解放したければ purge
+  がある(0021)。
+
   **状態遷移も同じ扱いにする。** verified → deprecated も MCP からは
   できない。廃止は「正しかったが今は推奨しない」という判断であって、
   エージェントの観測ではない。観測の通り道は report_outcome であり、

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -205,8 +205,18 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"attrs.expression holding the expression, so the definitions are searchable and compile " +
 			"usage is attributed to them; have table entries link to the Semantic Model entry from their body. " +
 			"Links are never a field: write a markdown link to the other entry's path in body — " +
-			"[revenue](/metrics/revenue.md) — and it becomes a link both ways (the other entry gains a backlink).",
+			"[revenue](/metrics/revenue.md) — and it becomes a link both ways (the other entry gains a backlink). " +
+			"An id whose entry was deleted can be reused, which revives it as your draft — unless a human had " +
+			"ruled on it (verified, rejected, deprecated), in which case this surface refuses: propose at a " +
+			"different id instead.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in writeIn) (*mcp.CallToolResult, knowledgeOut, error) {
+		// Creating on a soft-deleted id revives that row in place, status
+		// and status_note included — the other way to overwrite a ruling
+		// from a surface with no If-Match channel, and the one the update
+		// and delete guards cannot see (design doc 0015 §3.1).
+		if err := svc.RefuseIfRevivingCurated(ctx, in.ID); err != nil {
+			return nil, knowledgeOut{}, err
+		}
 		k, err := svc.Create(ctx, in.toKnowledge(), httpauth.Actor(ctx))
 		if err != nil {
 			return nil, knowledgeOut{}, err

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -387,6 +387,10 @@ func TestCuratedGuardIsAdvertised(t *testing.T) {
 	want := map[string][]string{
 		"update_knowledge": {"verified, rejected, or deprecated", "report_outcome failed", "create_knowledge"},
 		"delete_knowledge": {"verified, rejected, or deprecated", "erase the record of why"},
+		// Reviving a curated tombstone is the third way to overwrite a
+		// ruling, and an agent that only learns of it from an error has
+		// already written the draft (design doc 0015 §3.1).
+		"create_knowledge": {"deleted can be reused", "verified, rejected, deprecated", "different id"},
 	}
 	for _, tool := range res.Tools {
 		substrs, ok := want[tool.Name]

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -181,6 +181,52 @@ func (s *Service) RefuseIfCurated(ctx context.Context, id, op string) (*time.Tim
 		"entries from the web UI or CLI.", op, id, k.Status, instead)
 }
 
+// RefuseIfRevivingCurated reports an error when id names a soft-deleted
+// entry that was ruled on — verified, rejected or deprecated — before it
+// was deleted. For surfaces that must not overwrite a ruling in place,
+// create is the second way to do it: Create revives a tombstone (ON
+// CONFLICT ... WHERE deleted_at IS NOT NULL) with the incoming status and
+// status_note, so the reason an entry was turned down is replaced by a
+// fresh draft, and the entry that comes back looks like it was never
+// judged.
+//
+// RefuseIfCurated cannot see this: the row it reads is not live. Closing
+// the delete step alone (design doc 0015 §3.1) leaves every tombstone that
+// already exists — deleted before that rule, deleted from the REST/CLI
+// surfaces where deleting a rejection is legitimate housekeeping — still
+// revivable in one call. A draft tombstone stays revivable: nobody ruled
+// on it, and reviving an abandoned draft is how a create on a deleted id
+// is supposed to work.
+func (s *Service) RefuseIfRevivingCurated(ctx context.Context, id string) error {
+	k, err := s.Store.GetTombstone(ctx, domain.Normalize(id))
+	if errors.Is(err, store.ErrNotFound) {
+		// A free id, or a live entry — Create's own ErrAlreadyExists
+		// covers the second case.
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	var instead string
+	switch k.Status {
+	case domain.StatusRejected:
+		instead = "The rejection is the record of a decision and status_note says why; read it " +
+			"(search_knowledge with status=rejected) before proposing this again. If you disagree, " +
+			"create_knowledge a new entry at a different id and let a human judge it."
+	case domain.StatusVerified:
+		instead = "It was verified knowledge when it was deleted. Propose the replacement at a " +
+			"different id and let a human judge it against the history this id still holds."
+	case domain.StatusDeprecated:
+		instead = "Deprecated means it was correct and is no longer recommended. If it is worth " +
+			"reviving, create_knowledge a draft at a different id that says why."
+	default:
+		return nil
+	}
+	return Invalidf("cannot create %s from this surface: the id holds a deleted %s entry, and "+
+		"creating here would revive it as a fresh draft, replacing that ruling. %s A human reuses "+
+		"the id from the web UI or CLI.", id, k.Status, instead)
+}
+
 func (s *Service) Delete(ctx context.Context, id string, actor domain.Actor) error {
 	return s.Store.SoftDelete(ctx, domain.Normalize(id), actor)
 }

--- a/internal/service/service_integration_test.go
+++ b/internal/service/service_integration_test.go
@@ -274,6 +274,86 @@ func TestRefuseIfCuratedIntegration(t *testing.T) {
 			t.Errorf("the rejection and its reason must survive: %+v", stored)
 		}
 	})
+
+	// Closing the delete step is not enough: a tombstone that already
+	// exists — deleted before the rule, or deleted from a human surface as
+	// housekeeping — is revived in place by Create, status_note included.
+	t.Run("a curated tombstone cannot be revived", func(t *testing.T) {
+		for status, wantAdvice := range map[domain.Status]string{
+			domain.StatusRejected:   "status_note",
+			domain.StatusVerified:   "different id",
+			domain.StatusDeprecated: "no longer recommended",
+		} {
+			id := "queries/" + uid("guard-tomb-"+string(status))
+			k, err := svc.Create(ctx, &domain.Knowledge{
+				Type: domain.TypeQueries, ID: id, Title: "ruled on then deleted",
+				StatusNote: "duplicate of an existing golden query",
+			}, actor)
+			if err != nil {
+				t.Fatal(err)
+			}
+			setStatus(t, k, status, human)
+			// A human deletes it: legitimate on the REST/CLI surfaces.
+			if err := svc.Delete(ctx, id, human); err != nil {
+				t.Fatal(err)
+			}
+			err = svc.RefuseIfRevivingCurated(ctx, id)
+			var invalid *InvalidInputError
+			if !errors.As(err, &invalid) {
+				t.Fatalf("reviving a deleted %s entry: got %v, want a refusal", status, err)
+			}
+			if !strings.Contains(err.Error(), wantAdvice) {
+				t.Errorf("%s refusal does not offer %q: %v", status, wantAdvice, err)
+			}
+			// The human surfaces still revive it, ruling and all.
+			revived, err := svc.Create(ctx, &domain.Knowledge{
+				Type: domain.TypeQueries, ID: id, Title: "revived by a human"}, human)
+			if err != nil {
+				t.Fatalf("a human surface must still be able to reuse the id: %v", err)
+			}
+			t.Cleanup(func() { _ = svc.Delete(ctx, revived.ID, human) })
+		}
+	})
+
+	// A draft tombstone is not a ruling: reviving an abandoned draft is
+	// what create-on-a-deleted-id is for.
+	t.Run("a draft tombstone stays revivable", func(t *testing.T) {
+		id := "queries/" + uid("guard-tomb-draft")
+		if _, err := svc.Create(ctx, &domain.Knowledge{
+			Type: domain.TypeQueries, ID: id, Title: "abandoned draft"}, actor); err != nil {
+			t.Fatal(err)
+		}
+		if err := svc.Delete(ctx, id, actor); err != nil {
+			t.Fatal(err)
+		}
+		if err := svc.RefuseIfRevivingCurated(ctx, id); err != nil {
+			t.Fatalf("a deleted draft must stay revivable: %v", err)
+		}
+		if _, err := svc.Create(ctx, &domain.Knowledge{
+			Type: domain.TypeQueries, ID: id, Title: "second attempt"}, actor); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = svc.Delete(ctx, id, actor) })
+	})
+
+	// A free id is not a refusal, and neither is a live one: Create's own
+	// ErrAlreadyExists covers that case.
+	t.Run("free and live ids are untouched", func(t *testing.T) {
+		if err := svc.RefuseIfRevivingCurated(ctx, "queries/"+uid("guard-tomb-free")); err != nil {
+			t.Errorf("free id: %v", err)
+		}
+		id := "queries/" + uid("guard-tomb-live")
+		k, err := svc.Create(ctx, &domain.Knowledge{
+			Type: domain.TypeQueries, ID: id, Title: "live"}, actor)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = svc.Delete(ctx, id, actor) })
+		setStatus(t, k, domain.StatusRejected, human)
+		if err := svc.RefuseIfRevivingCurated(ctx, id); err != nil {
+			t.Errorf("live entry: %v", err)
+		}
+	})
 }
 
 // Reembed closes the gap between "semantic search is configured" and

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -192,6 +192,27 @@ func (s *Store) Get(ctx context.Context, id string) (*domain.Knowledge, error) {
 	return &k, nil
 }
 
+// GetTombstone returns the soft-deleted entry holding id, or ErrNotFound
+// when the id is free or live. Create revives such a row in place
+// (ON CONFLICT ... WHERE deleted_at IS NOT NULL), overwriting its status
+// and status_note, so a surface that must not overwrite a ruling has to
+// be able to see the ruling a tombstone still carries.
+func (s *Store) GetTombstone(ctx context.Context, id string) (*domain.Knowledge, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT `+knowledgeCols+` FROM knowledge WHERE id = $1 AND deleted_at IS NOT NULL`, id)
+	if err != nil {
+		return nil, err
+	}
+	k, err := pgx.CollectExactlyOneRow(rows, scanKnowledge)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &k, nil
+}
+
 // ListLinkingTo returns live entries whose links point at id, most
 // recently updated first. This is the reverse edge Context needs: the
 // insight that explains a metric links to the metric, not the other way


### PR DESCRIPTION
## 何が成立していなかったか

#126 は「エージェントが人間の判断を消す 2 手の迂回路(delete → create)を塞いだ」と主張しているが、塞いだのは **delete の側だけ**である。

`Store.Create` は soft-delete 済みの行を `ON CONFLICT (id) DO UPDATE ... WHERE knowledge.deleted_at IS NOT NULL` でその場で復活させ、`status` と `status_note` を入力で上書きする。したがって**すでに存在する墓標**に対しては、MCP の `create_knowledge` 1 コールで「一度も判断されていない draft」として戻せる:

- #126 以前に消されたもの
- 人間が Web UI / CLI で整理として消したもの — rejected な提案を消すのは正当な運用である
- REST から消されたもの(人間の面には create のガードも delete のガードも無い)

`RefuseIfCurated` はこれを見られない。読む行が live ではないからである。リビジョンには履歴が残るが、エージェントが「再提案の前に見ろ」と指示されている `search --status rejected` が読むのは生存行のほうである。

## 直し方

- `Store.GetTombstone(id)` — 墓標だけを読む。
- `Service.RefuseIfRevivingCurated(id)` — verified / rejected / deprecated の墓標への create を拒否し、状態ごとに行き先を示す(rejected なら status_note を読んでから別 id、verified / deprecated なら別 id で提案)。
- MCP の `create_knowledge` ハンドラの先頭で呼ぶ。**draft の墓標は従来どおり復活できる** — 誰も判断を下していないし、放棄された draft の id を再利用するのは create の想定どおりの使い方である。
- 人間の面は従来どおり復活でき、id を完全に解放したければ `purge` がある(0021)。
- `create_knowledge` の description にも書いた。エラーで初めて知るのでは遅く、エージェントはその時点で draft を書き終えている。

設計ドキュメント 0015 §3.1 に追記した。

## 検証

`internal/service` の統合テストに 3 つ追加:
- verified / rejected / deprecated の墓標への create が拒否され、各拒否が行き先を示すこと。同じ id を**人間の面からは**復活できること。
- draft の墓標は従来どおり復活できること。
- 空き id と live な id は素通しであること(live は Create 自身の ErrAlreadyExists の担当)。

MCP 側は description の告知をツール一覧のテストに追加。`gofmt` / `go vet` / `go test -race ./...`(PostgreSQL 17 + pgvector 込み)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)