### PR TITLE
get_context: outline も予算の内側に入れる

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,9 @@ matched-fragment weight plus boosts in the lexical-only mode, RRF rank
 fusion (~0.02 scale) in the hybrid one. Treat them as an ordering, not a
 measure — `min_score` is for callers who have calibrated against their own
 corpus, which is why the MCP surface does not offer it. To bound a
-response, use `budget` instead.
+response, use `budget` instead: it caps the whole payload — the entries
+delivered in full and the `outline` rows naming the rest — so what comes
+back fits what you asked for.
 
 ## Configuration
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -193,14 +193,18 @@ paths:
         - name: budget
           in: query
           description: >
-            Cap the serialized bytes of entries returned in full. Entries
-            past the cap are listed under `outline` instead — an entry is
-            delivered whole or not at all, never truncated. Packing is
-            greedy, so one oversized entry high in the ranking does not
-            starve the rest. Defaults to 0 (no cap) here; the MCP
-            get_context tool defaults it on, because an agent's context
-            window is the scarce resource and an embedding host will not
-            set it.
+            Cap the serialized bytes of the response. Entries past the
+            cap are listed under `outline` instead — an entry is delivered
+            whole or not at all, never truncated — and those rows count
+            against the same cap, because naming what was left out is not
+            free (an outline row carries a description). Packing is greedy,
+            so one oversized entry high in the ranking does not starve the
+            rest. The floor is the outline of everything that matched: a
+            budget too small even for the names still gets them, since a
+            caller cannot raise a budget for entries it never heard about.
+            Defaults to 0 (no cap) here; the MCP get_context tool defaults
+            it on, because an agent's context window is the scarce resource
+            and an embedding host will not set it.
           schema: { type: integer, default: 0 }
       responses:
         "200":

--- a/internal/domain/knowledge.go
+++ b/internal/domain/knowledge.go
@@ -400,7 +400,9 @@ type SearchHit struct {
 // in full: enough for the caller to decide whether to spend a round trip
 // fetching it by id, and nothing more. The description carries the weight
 // here — an entry with an empty description is nearly invisible in an
-// outline, which is one more reason curation pays.
+// outline, which is one more reason curation pays. It is also the only
+// unbounded field, so the packer caps it: these rows are counted against
+// the same budget as the entries.
 type ContextOutline struct {
 	ID          string `json:"id"`
 	Type        Type   `json:"type"`

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -416,7 +416,7 @@ type contextIn struct {
 	Statuses []string `json:"statuses,omitempty" jsonschema:"filter by status: draft, verified, deprecated, rejected"`
 	Tags     []string `json:"tags,omitempty" jsonschema:"filter by tag"`
 	Limit    int      `json:"limit,omitempty" jsonschema:"max primary entries: default 5, max 20 (out-of-range falls back to the default); linked companions share a 2x limit total cap"`
-	Budget   int      `json:"budget,omitempty" jsonschema:"max bytes of entries returned in full (default 12000); entries past it are listed under \"outline\" with their size, fetchable by id with get_knowledge. Raise it when you need whole entries, lower it when context is tight"`
+	Budget   int      `json:"budget,omitempty" jsonschema:"max bytes of the response body (default 12000); entries past it are listed under \"outline\" with their size, fetchable by id with get_knowledge, and those rows are counted against the same budget. Raise it when you need whole entries, lower it when context is tight"`
 }
 
 type contextOut struct {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -375,7 +375,9 @@ type ContextResult struct {
 }
 
 // ContextRequest is the input to Context. Budget caps the serialized size
-// of the entries returned in full; 0 means no cap.
+// of the response — the entries returned in full and the outline rows
+// naming the rest, which carry a description and are not free; 0 means no
+// cap.
 type ContextRequest struct {
 	Query    string
 	Filter   store.Filter
@@ -491,27 +493,86 @@ func (s *Service) Context(ctx context.Context, req ContextRequest) (*ContextResu
 // otherwise starve everything below it. An entry larger than the whole
 // budget always becomes an outline row, even at rank 1 — the caller sees
 // its size and can fetch it deliberately.
+//
+// The outline is inside the budget, not on top of it. Naming what was left
+// out costs bytes too, and an outline row carries a description, which is
+// unbounded on an entry: a budget that governed only the delivered entries
+// left the response as a whole ungoverned, which is the thing callers
+// actually have to fit in a context window. So rows are counted, their
+// descriptions are capped, and entries are demoted from the bottom of the
+// ranking until the two halves fit together.
+//
+// The floor is the outline of everything: a request whose budget cannot
+// even hold the names of what matched gets those names anyway. Silently
+// dropping entries the caller never hears about is worse than a response
+// slightly over budget, and the caller can raise the budget only if it
+// knows there was something there.
 func packWithinBudget(entries []domain.Knowledge, budget int) ([]domain.Knowledge, []domain.ContextOutline) {
 	if budget <= 0 {
 		return entries, nil
 	}
-	kept := make([]domain.Knowledge, 0, len(entries))
-	var outline []domain.ContextOutline
-	used := 0
+	sizes := make([]int, len(entries))
+	rows := make([]domain.ContextOutline, len(entries))
+	rowSizes := make([]int, len(entries))
+	deliver := make([]bool, len(entries))
 	for i := range entries {
-		k := &entries[i]
-		size := serializedSize(k)
-		if used+size <= budget {
-			kept = append(kept, *k)
-			used += size
+		sizes[i] = serializedSize(&entries[i])
+		rows[i] = outlineRow(&entries[i], sizes[i])
+		rowSizes[i] = jsonSize(rows[i])
+	}
+	used, outlineBytes := 0, 0
+	for i := range entries {
+		if used+sizes[i] <= budget {
+			deliver[i] = true
+			used += sizes[i]
 			continue
 		}
-		outline = append(outline, domain.ContextOutline{
-			ID: k.ID, Type: k.Type, Title: k.DisplayTitle(),
-			Description: k.Description, Status: k.Status, Bytes: size,
-		})
+		outlineBytes += rowSizes[i]
+	}
+	// Demote from the bottom of the ranking until the outline the skipped
+	// entries cost fits alongside what was kept. Each demotion frees the
+	// entry's bytes and pays for its row, which is strictly smaller — the
+	// guard is there so a pathological entry cannot spin this loop.
+	for used+outlineBytes > budget {
+		last := -1
+		for i := range deliver {
+			if deliver[i] {
+				last = i
+			}
+		}
+		if last < 0 || sizes[last] <= rowSizes[last] {
+			break
+		}
+		deliver[last] = false
+		used -= sizes[last]
+		outlineBytes += rowSizes[last]
+	}
+	kept := make([]domain.Knowledge, 0, len(entries))
+	var outline []domain.ContextOutline
+	for i := range entries {
+		if deliver[i] {
+			kept = append(kept, entries[i])
+			continue
+		}
+		outline = append(outline, rows[i])
 	}
 	return kept, outline
+}
+
+// outlineDescriptionBytes caps the description an outline row carries.
+// The description is what makes a row worth reading — it is the caller's
+// only basis for spending a round trip — but nothing bounds it on the
+// entry, so one entry with a page-long description could outweigh the
+// budget on its own. Enough for a sentence or two; the rest is what the
+// fetch is for.
+const outlineDescriptionBytes = 200
+
+func outlineRow(k *domain.Knowledge, size int) domain.ContextOutline {
+	return domain.ContextOutline{
+		ID: k.ID, Type: k.Type, Title: k.DisplayTitle(),
+		Description: truncateUTF8(k.Description, outlineDescriptionBytes),
+		Status:      k.Status, Bytes: size,
+	}
 }
 
 // serializedSize is what the entry costs on the wire — attrs included. A
@@ -521,6 +582,15 @@ func serializedSize(k *domain.Knowledge) int {
 	b, err := json.Marshal(k)
 	if err != nil {
 		return len(k.Body) // unreachable in practice; never drop on a marshal quirk
+	}
+	return len(b)
+}
+
+// jsonSize is what any part of the response costs on the wire.
+func jsonSize(v any) int {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return 0
 	}
 	return len(b)
 }

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -345,7 +345,11 @@ func TestPackWithinBudgetKeepsEntriesWhole(t *testing.T) {
 	}
 	small := entry("insights/small", 100)
 	big := entry("insights/big", 5000)
+	// Room for the small entry plus the row that names the big one: the
+	// outline is inside the budget, so "room for one entry" has to include
+	// what saying "and there was another" costs.
 	one := serializedSize(&small)
+	oneAndARow := one + jsonSize(outlineRow(&big, serializedSize(&big))) + 10
 
 	t.Run("no budget keeps everything", func(t *testing.T) {
 		kept, outline := packWithinBudget([]domain.Knowledge{small, big}, 0)
@@ -355,7 +359,7 @@ func TestPackWithinBudgetKeepsEntriesWhole(t *testing.T) {
 	})
 
 	t.Run("overflow becomes an outline row", func(t *testing.T) {
-		kept, outline := packWithinBudget([]domain.Knowledge{small, big}, one+10)
+		kept, outline := packWithinBudget([]domain.Knowledge{small, big}, oneAndARow)
 		if len(kept) != 1 || kept[0].ID != small.ID {
 			t.Fatalf("want only the small entry in full, got %d", len(kept))
 		}
@@ -374,7 +378,7 @@ func TestPackWithinBudgetKeepsEntriesWhole(t *testing.T) {
 	// entire budget. A prefix cut would let it starve everything below it;
 	// greedy packing keeps the rest and names the giant.
 	t.Run("an oversized leader does not starve the rest", func(t *testing.T) {
-		kept, outline := packWithinBudget([]domain.Knowledge{big, small}, one+10)
+		kept, outline := packWithinBudget([]domain.Knowledge{big, small}, oneAndARow)
 		if len(kept) != 1 || kept[0].ID != small.ID {
 			t.Fatalf("want the small entry delivered behind the giant, got %+v", kept)
 		}
@@ -385,11 +389,45 @@ func TestPackWithinBudgetKeepsEntriesWhole(t *testing.T) {
 
 	// Budgets below one entry outline everything rather than shipping a
 	// fragment: an empty entries list with a populated outline is a usable
-	// answer, a half-entry is not.
+	// answer, a half-entry is not. Naming everything is also the floor —
+	// a caller cannot raise a budget for entries it never heard about.
 	t.Run("a budget below one entry outlines everything", func(t *testing.T) {
 		kept, outline := packWithinBudget([]domain.Knowledge{small, big}, 1)
 		if len(kept) != 0 || len(outline) != 2 {
 			t.Errorf("want everything outlined, got %d kept / %d outlined", len(kept), len(outline))
+		}
+	})
+
+	// The budget governs the response, not half of it. An outline row
+	// carries a description — unbounded on the entry — so a budget that
+	// only counted delivered entries left the actual payload unbounded.
+	t.Run("the outline is inside the budget", func(t *testing.T) {
+		wordy := make([]domain.Knowledge, 6)
+		for i := range wordy {
+			wordy[i] = entry(fmt.Sprintf("insights/wordy-%d", i), 900)
+			wordy[i].Description = strings.Repeat("長い説明。", 400) // ~6 kB each
+		}
+		const budget = 4000
+		kept, outline := packWithinBudget(wordy, budget)
+		total := 0
+		for i := range kept {
+			total += serializedSize(&kept[i])
+		}
+		for _, row := range outline {
+			total += jsonSize(row)
+		}
+		if total > budget {
+			t.Errorf("response = %d bytes over a budget of %d (%d kept, %d outlined)",
+				total, budget, len(kept), len(outline))
+		}
+		if len(kept)+len(outline) != len(wordy) {
+			t.Errorf("every entry must be delivered or named: %d kept, %d outlined, want %d total",
+				len(kept), len(outline), len(wordy))
+		}
+		for _, row := range outline {
+			if len(row.Description) > outlineDescriptionBytes {
+				t.Errorf("outline description = %d bytes, want <= %d", len(row.Description), outlineDescriptionBytes)
+			}
 		}
 	})
 


### PR DESCRIPTION
## 何が成立していなかったか

#125 は「予算が応答全体を縛るようにする」と題して `hits` を順位だけに射影したが、**`outline` は予算の外に残っていた**。

- outline 行は `description` を運ぶ。
- `description` にはどこにも長さ制限が無い(`validate` は type / id / status / semantic model spec しか見ない)。
- 予算に入らないエントリが増えるほど、予算の**外側**のバイト数が増える。

つまり `budget=12000` の応答が 12000 バイトを大きく超えうる。README の「To bound a response, use `budget` instead」も openapi の説明も、それを保証していなかった。予算は「呼び出し元のコンテキストウィンドウに収める」ためのものなので、応答の半分しか縛らないなら意味がない。

## 直し方

- `packWithinBudget` が outline 行のバイト数も同じ予算で数える。貪欲に詰めたあと、**収まるまで下位から outline に落とす**。1 回の降格で解放されるエントリのバイト数はその行のバイト数より必ず大きいので収束する(病的な入力のためのガードも入れた)。
- outline 行の `description` を 200 バイトで切る(ルーン境界)。行が読む価値を持つのは description のおかげだが、唯一の無制限フィールドでもある。
- **下限は「全部を outline にする」。** 名前すら入らない予算でも名前は返す。黙って落とすほうが悪い — 呼び出し元は、存在を知らないエントリのために予算を上げられない。

## 挙動の変化

「エントリ 1 つぶんの予算」の意味が変わる: 1 件を全文で返しつつ残りを名指しするには、その名指しのぶんも要る。既存テストの予算はこれに合わせて `one + outline 行` に直した(テストの意図 — エントリは丸ごとか出さないか、貪欲詰め — は不変)。

## 検証

- 6 件 × 6kB の description を持つエントリを 4000 バイトの予算に通し、**delivered + outline の合計が予算内**であること、全件が「配送か名指し」のどちらかになること、各行の description が上限内であることを確認。
- 既存の subtest(丸ごと配送・貪欲詰め・attrs を数える・下限)は維持。
- `gofmt` / `go vet` / `go test -race ./...`(PostgreSQL 17 + pgvector 込み)。

openapi / MCP スキーマ / README / `ContextRequest` の説明を、実際の保証(応答全体を縛る)に合わせた。

🤖 Generated with [Claude Code](https://claude.com/claude-code)