### PR TITLE
Move: 移動するエントリ自身の相対リンクを絶対形にする(0024 §3.5)

### DIFF
--- a/internal/domain/links.go
+++ b/internal/domain/links.go
@@ -152,17 +152,62 @@ func proseLines(body string) []string {
 // normalizing to absolute is the one predictable outcome (design doc
 // 0024 §3.5).
 func RewriteBodyLinks(id, body, oldID, newID string) string {
-	if body == "" {
-		return body
-	}
-	rewriteTarget := func(target string) string {
+	return rewriteBody(body, func(target string) string {
+		target, frag := splitFragment(target)
 		if resolveTarget(id, target) != oldID {
-			return target
+			return target + frag
 		}
 		if strings.HasPrefix(target, "ochakai://") {
-			return "ochakai://" + newID
+			return "ochakai://" + newID + frag
 		}
-		return "/" + newID + ".md"
+		return "/" + newID + ".md" + frag
+	})
+}
+
+// AbsolutizeBodyLinks rewrites the body's relative links into
+// bundle-absolute form, resolved as if the body still lived at id.
+//
+// This is what a move owes the entry that moved. Links are derived from
+// the body against the entry's own id (design doc 0024), so a relative
+// target reads differently the moment the entry changes directory:
+// "./gross.md" in metrics/revenue means metrics/gross, and the same three
+// words in insights/revenue mean insights/gross. Nothing in the body
+// changed, so nothing looks wrong — the edge just points somewhere else,
+// or nowhere, the next time the entry is written.
+//
+// Absolute is the one form a move cannot reinterpret, which is the same
+// reasoning 0024 §3.5 applies to the links that point at a moved entry.
+// Targets that already carry a fragment keep it.
+func AbsolutizeBodyLinks(id, body string) string {
+	return rewriteBody(body, func(target string) string {
+		path, frag := splitFragment(target)
+		if path == "" || strings.HasPrefix(path, "/") || schemeRe.MatchString(path) {
+			return target // already absolute, or not an entry link at all
+		}
+		resolved := resolveTarget(id, path)
+		if resolved == "" {
+			return target
+		}
+		return "/" + resolved + ".md" + frag
+	})
+}
+
+// splitFragment separates a link target from its "#anchor" or "?query"
+// tail, which a rewrite must carry over rather than drop.
+func splitFragment(target string) (path, frag string) {
+	if i := strings.IndexAny(target, "#?"); i >= 0 {
+		return target[:i], target[i:]
+	}
+	return target, ""
+}
+
+// rewriteBody applies rewriteTarget to every link target in the body's
+// prose, leaving fenced code blocks and inline code spans alone — the
+// same reading LinksFromBody gives them, so a rewrite never invents an
+// edge an example was not.
+func rewriteBody(body string, rewriteTarget func(string) string) string {
+	if body == "" {
+		return body
 	}
 	var b strings.Builder
 	var fence string

--- a/internal/domain/links_test.go
+++ b/internal/domain/links_test.go
@@ -148,6 +148,66 @@ func TestRewriteBodyLinksMultiplePerLine(t *testing.T) {
 	}
 }
 
+// A move changes what a relative target means, because links are derived
+// from the body against the entry's own id. Absolutizing against the old
+// id is what keeps the edge pointing where the author pointed it.
+func TestAbsolutizeBodyLinks(t *testing.T) {
+	for _, tc := range []struct {
+		name, id, body, want string
+	}{
+		{
+			name: "relative target resolves against the old location",
+			id:   "metrics/revenue",
+			body: "See [gross](./gross.md) and [net](net.md).",
+			want: "See [gross](/metrics/gross.md) and [net](/metrics/net.md).",
+		}, {
+			name: "a parent-relative target too",
+			id:   "metrics/sales/revenue",
+			body: "See [orders](../orders.md).",
+			want: "See [orders](/metrics/orders.md).",
+		}, {
+			name: "absolute and canonical forms are already stable",
+			id:   "metrics/revenue",
+			body: "See [g](/metrics/gross.md), ochakai://metrics/net, <ochakai://metrics/net>.",
+			want: "See [g](/metrics/gross.md), ochakai://metrics/net, <ochakai://metrics/net>.",
+		}, {
+			name: "non-entry targets are left alone",
+			id:   "metrics/revenue",
+			body: "See [site](https://example.com/x.md), [chart](./chart.png), [top](#summary).",
+			want: "See [site](https://example.com/x.md), [chart](./chart.png), [top](#summary).",
+		}, {
+			name: "a fragment survives the rewrite",
+			id:   "metrics/revenue",
+			body: "See [gross](./gross.md#caveats).",
+			want: "See [gross](/metrics/gross.md#caveats).",
+		}, {
+			name: "code is left alone",
+			id:   "metrics/revenue",
+			body: "Real [g](./gross.md), inline `[g](./gross.md)`\n```\n[g](./gross.md)\n```",
+			want: "Real [g](/metrics/gross.md), inline `[g](./gross.md)`\n```\n[g](./gross.md)\n```",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := AbsolutizeBodyLinks(tc.id, tc.body)
+			if got != tc.want {
+				t.Errorf("AbsolutizeBodyLinks =\n%q\nwant\n%q", got, tc.want)
+			}
+			// The point of the exercise: the edges read the same from the
+			// new location as they did from the old one.
+			before := LinksFromBody(tc.id, tc.body)
+			after := LinksFromBody("elsewhere/revenue", got)
+			if len(before) != len(after) {
+				t.Fatalf("edge count changed: %v -> %v", before, after)
+			}
+			for i := range before {
+				if before[i].Target != after[i].Target {
+					t.Errorf("edge %d moved: %q -> %q", i, before[i].Target, after[i].Target)
+				}
+			}
+		})
+	}
+}
+
 func TestLinkDisplayText(t *testing.T) {
 	if got := (Link{Target: "metrics/revenue", Text: "売上"}).DisplayText(); got != "売上" {
 		t.Errorf("DisplayText = %q, want the anchor text", got)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -621,15 +622,25 @@ func (s *Store) rewriteReferences(ctx context.Context, tx pgx.Tx, oldID, newID s
 		return err
 	}
 	now := nowStored()
+	movedDirs := path.Dir(oldID) != path.Dir(newID)
 	for i := range referrers {
 		r := &referrers[i]
 		// The moved entry resolves its own relative links against its old
 		// directory, so it is rewritten as if it still lived at oldID.
 		from := r.ID
+		body := r.Body
 		if r.ID == newID {
 			from = oldID
+			// Its own outbound relative links point at the old directory,
+			// and links are derived from the body against the entry's
+			// current id: left alone, "./gross.md" silently starts meaning
+			// a different entry (or none) the next time this row is
+			// written. Absolute is the form a move cannot reinterpret.
+			if movedDirs {
+				body = domain.AbsolutizeBodyLinks(oldID, body)
+			}
 		}
-		body := domain.RewriteBodyLinks(from, r.Body, oldID, newID)
+		body = domain.RewriteBodyLinks(from, body, oldID, newID)
 		modelMoved := false
 		if m, ok := r.Attrs["model"].(string); ok && m == oldID {
 			r.Attrs["model"] = newID

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -1579,3 +1579,73 @@ func TestIntegrationVerifyClearsTheReviewFeed(t *testing.T) {
 		t.Errorf("verification must be recorded as a revision, got %+v", revs)
 	}
 }
+
+// A move rewrites the links that point at the moved entry — and must also
+// keep the moved entry's own outbound links pointing where they pointed.
+// Relative targets are resolved against the entry's id, so changing the
+// directory silently re-aims them (design doc 0024 §3.5).
+func TestIntegrationMoveKeepsOutboundRelativeLinks(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	for _, table := range []string{"knowledge", "knowledge_revision"} {
+		if _, err := s.pool.Exec(ctx, `DELETE FROM `+table+` WHERE id LIKE 'it-relmove%'`); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	actor := domain.Actor{Kind: "human", Name: "test"}
+	const neighbour = "it-relmove-src/gross"
+	const mover = "it-relmove-src/revenue"
+	const dest = "it-relmove-dst/revenue"
+	for _, k := range []*domain.Knowledge{
+		{Type: domain.TypeMetrics, ID: neighbour, Title: "gross", Status: domain.StatusDraft, CreatedBy: actor},
+		{Type: domain.TypeMetrics, ID: mover, Title: "revenue", Status: domain.StatusDraft, CreatedBy: actor,
+			Body:  "Net of [gross](./gross.md).",
+			Links: []domain.Link{{Target: neighbour, Text: "gross"}}},
+	} {
+		if err := s.Create(ctx, k); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Cleanup(func() {
+		for _, table := range []string{"knowledge", "knowledge_revision"} {
+			_, _ = s.pool.Exec(ctx, `DELETE FROM `+table+` WHERE id LIKE 'it-relmove%'`)
+		}
+	})
+
+	if _, err := s.Move(ctx, mover, dest, actor); err != nil {
+		t.Fatal(err)
+	}
+	moved, err := s.Get(ctx, dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(moved.Links) != 1 || moved.Links[0].Target != neighbour {
+		t.Errorf("the moved entry's edge moved with it: %+v", moved.Links)
+	}
+	// The stored links column and what the body says must agree: the
+	// column is a derivation, and the next write re-derives it.
+	derived := domain.LinksFromBody(moved.ID, moved.Body)
+	if len(derived) != 1 || derived[0].Target != neighbour {
+		t.Errorf("body re-derives to %+v, want a link to %s (body: %q)", derived, neighbour, moved.Body)
+	}
+	// Backlinks are the same edge read the other way round.
+	back, err := s.ListLinkingTo(ctx, neighbour, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(back) != 1 || back[0].ID != dest {
+		t.Errorf("backlinks from %s = %+v, want the moved entry", neighbour, back)
+	}
+}


### PR DESCRIPTION
## 何が成立していなかったか

設計ドキュメント 0024 §3.5 は、こう決めている:

> **移動するエントリ自身の本文も対象**である。`x/a` の `./b.md` は `x/b` を指すが、`y/a` に移ると `y/b` を指してしまう。移動前の id で解決してから絶対形に書き換える

実装されたのは **`oldID` を指すリンクの書き換えだけ**だった。第三者を指す相対リンクは素通しで、`rewriteReferences` は書き換え後に `LinksFromBody(r.ID, r.Body)` を**新しい id** で再導出する。

つまり `metrics/revenue`(本文に `[gross](./gross.md)` = `metrics/gross`)を `insights/revenue` に移すと、そのエッジは `insights/gross` — 別のエントリ、たいていは存在しない id — を指すようになる。**本文は 1 文字も変わらないので、どこにも異常は見えない。** 自己参照があるエントリでは移動と同時に、無ければ次にそのエントリが書かれたときに、黙って切り替わる。

README が約束している「Renaming an entry rewrites the links pointing at it」は入方向の話で、出方向のこれは誰も見ていなかった。

## 直し方

- `domain.AbsolutizeBodyLinks(id, body)` — 相対 target を、その id を基準に解決してバンドル絶対形(`/dir/x.md`)にする。絶対形は移動が読み替えられない唯一の形で、0024 §3.5 が参照元に対して与えている理由がそのまま当てはまる。
- `rewriteReferences` が、移動するエントリの本文に**移動前の id を基準として**適用する。ディレクトリが変わらない移動(同ディレクトリ内のリネーム)では何もしない — 意味が変わらないので本文を汚す理由がない。
- 書き換え系を `rewriteBody` に集約(フェンス・インラインコードの扱いは `LinksFromBody` と同じ。コードブロック内の例は依然としてエッジではない)。
- ついでに、リンク書き換えが `#anchor` / `?query` を落としていたのを直した(`splitFragment`)。

## 検証

- `internal/domain`: 相対 / 親相対 / 絶対 / 非エントリ / フラグメント / コードの各ケース。加えて **「新しい場所から読んでもエッジが同じ」** ことをテスト自身が `LinksFromBody` で確認している。
- `internal/store`: `it-relmove-src/revenue` → `it-relmove-dst/revenue` の移動後、`links` 列・本文からの再導出・backlinks の 3 方向が元の隣人を指し続けること。**修正を外すと `it-relmove-dst/gross` に化けて落ちる**ことを確認済み。
- `gofmt` / `go vet` / `go test -race ./...`(PostgreSQL 17 + pgvector 込み)。

設計ドキュメントの変更なし — 既に決まっていたことの実装である。

🤖 Generated with [Claude Code](https://claude.com/claude-code)