### PR TITLE
export: 1 つのスナップショットから出し、決定性の主張を実態に合わせる

### DIFF
--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -9,6 +9,7 @@
 package restapi
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -450,9 +451,21 @@ func Handler(svc *service.Service) http.Handler {
 	// so a backup can copy them from there far more cheaply than through
 	// this endpoint.
 	mux.HandleFunc("GET /api/v1/export", func(w http.ResponseWriter, r *http.Request) {
+		// Every read below comes from one snapshot. Streaming means the id
+		// list, the attachment metadata and the entries are read at
+		// different moments, and a write landing between them produces an
+		// archive that disagrees with its own index — an index.md naming a
+		// file that is not there, an entry that moved appearing twice or
+		// not at all. The archive would look fine.
+		snap, err := svc.Store.BeginExport(r.Context())
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		defer snap.Close(context.WithoutCancel(r.Context()))
 		// index.md files need every id, but only the id, title and
 		// description — never a body.
-		rows, err := svc.Store.ListAllIndexRows(r.Context())
+		rows, err := snap.IndexRows(r.Context())
 		if err != nil {
 			writeError(w, err)
 			return
@@ -461,7 +474,7 @@ func Handler(svc *service.Service) http.Handler {
 		var atts []store.ExportAttachment
 		if withAttachments {
 			// Metadata only; bytes are pulled one attachment at a time below.
-			if atts, err = svc.Store.ListAllAttachmentMeta(r.Context()); err != nil {
+			if atts, err = snap.AttachmentMeta(r.Context()); err != nil {
 				writeError(w, err)
 				return
 			}
@@ -492,8 +505,10 @@ func Handler(svc *service.Service) http.Handler {
 			written[p] = true
 			return nil
 		}
-		// Sorted so a backup taken twice from the same content produces the
-		// same archive: map iteration order is not an ordering.
+		// Sorted so the archive's file order is stable across runs: map
+		// iteration order is not an ordering. The bytes still differ run to
+		// run — every tar header carries the export's timestamp — so this
+		// buys a diffable listing, not a checksum.
 		indexPaths := make([]string, 0, len(indexes))
 		for path := range indexes {
 			indexPaths = append(indexPaths, path)
@@ -509,7 +524,7 @@ func Handler(svc *service.Service) http.Handler {
 		// connection held for the length of the download.
 		for start := 0; start < len(ids); start += exportBatch {
 			end := min(start+exportBatch, len(ids))
-			batch, err := svc.Store.ListByIDs(r.Context(), ids[start:end])
+			batch, err := snap.ListByIDs(r.Context(), ids[start:end])
 			if err != nil {
 				fail(fmt.Sprintf("entries %d-%d", start, end), err)
 				return

--- a/internal/store/attachment.go
+++ b/internal/store/attachment.go
@@ -230,36 +230,9 @@ type ExportAttachment struct {
 	Data []byte
 }
 
-// ListAllAttachmentMeta returns every live entry's attachment metadata,
-// ordered by id then name, without any bytes. The OKF exporter walks this
-// and pulls one attachment's bytes at a time (AttachmentBytes), so peak
-// memory is one attachment rather than all of them.
-func (s *Store) ListAllAttachmentMeta(ctx context.Context) ([]ExportAttachment, error) {
-	rows, err := s.pool.Query(ctx, `SELECT a.knowledge_id, `+attachmentCols+`
-		FROM attachment a
-		JOIN blob b ON b.sha256 = a.sha256
-		JOIN knowledge k ON k.id = a.knowledge_id AND k.deleted_at IS NULL
-		ORDER BY a.knowledge_id, a.name`)
-	if err != nil {
-		return nil, err
-	}
-	atts, err := pgx.CollectRows(rows, func(row pgx.CollectableRow) (ExportAttachment, error) {
-		var e ExportAttachment
-		err := row.Scan(&e.ID, &e.Att.Name, &e.Att.MediaType, &e.Att.Size, &e.Att.SHA256, &e.Att.OKFPath,
-			&e.Att.CreatedBy.Kind, &e.Att.CreatedBy.Name, &e.Att.CreatedAt)
-		return e, err
-	})
-	if err != nil {
-		return nil, err
-	}
-	if len(atts) > 0 && s.blobs == nil {
-		return nil, errNoBlobStore
-	}
-	return atts, nil
-}
-
 // AttachmentBytes returns the content-addressed bytes behind an
-// attachment. Paired with ListAllAttachmentMeta for streaming export.
+// attachment. Paired with ExportSnapshot.AttachmentMeta for streaming
+// export.
 func (s *Store) AttachmentBytes(ctx context.Context, sha256 string) ([]byte, error) {
 	if s.blobs == nil {
 		return nil, errNoBlobStore

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -1,0 +1,123 @@
+package store
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/na0fu3y/ochakai/internal/domain"
+)
+
+// ExportSnapshot reads a knowledge base as it stood at one instant.
+//
+// An export is streamed: the id list and the attachment metadata are read
+// first, then the entries in batches while the archive is already on the
+// wire. Each of those reads is its own statement, so without a snapshot
+// they see different databases. An entry deleted after the id list was
+// taken leaves an index.md entry pointing at a file the archive does not
+// contain; an entry renamed mid-stream can appear twice or not at all; a
+// title edited between the two reads disagrees with itself across the
+// bundle. Nothing in the result says any of this happened — the archive
+// is well-formed, just not a picture of anything that ever existed.
+//
+// A REPEATABLE READ transaction costs one pooled connection for the
+// length of the download. That is the trade this makes: the endpoint
+// exists to produce a backup, and a backup that is not a point in time is
+// not a backup. The batching still matters for memory — the snapshot
+// bounds what the reads see, not how much of it is held at once.
+type ExportSnapshot struct {
+	store *Store
+	conn  *pgxpool.Conn
+	tx    pgx.Tx
+}
+
+// BeginExport opens the snapshot. PostgreSQL fixes a REPEATABLE READ
+// snapshot at the transaction's first query, not at BEGIN, so the instant
+// the archive describes is the first IndexRows call. Close it when the
+// archive is done.
+func (s *Store) BeginExport(ctx context.Context) (*ExportSnapshot, error) {
+	conn, err := s.pool.Acquire(ctx)
+	if err != nil {
+		return nil, err
+	}
+	tx, err := conn.BeginTx(ctx, pgx.TxOptions{
+		IsoLevel:   pgx.RepeatableRead,
+		AccessMode: pgx.ReadOnly,
+	})
+	if err != nil {
+		conn.Release()
+		return nil, err
+	}
+	return &ExportSnapshot{store: s, conn: conn, tx: tx}, nil
+}
+
+// Close ends the snapshot and returns the connection to the pool. Read-only
+// and never committed: there is nothing to keep.
+func (e *ExportSnapshot) Close(ctx context.Context) {
+	_ = e.tx.Rollback(ctx)
+	e.conn.Release()
+}
+
+// IndexRows returns the id, type, title and description of every live
+// entry, in id order — what index.md files are built from, and the id list
+// the rest of the export walks. Never a body: the index names entries, it
+// does not carry them.
+func (e *ExportSnapshot) IndexRows(ctx context.Context) ([]domain.Knowledge, error) {
+	rows, err := e.tx.Query(ctx,
+		`SELECT type, id, title, description FROM knowledge WHERE deleted_at IS NULL ORDER BY id`)
+	if err != nil {
+		return nil, err
+	}
+	return pgx.CollectRows(rows, func(row pgx.CollectableRow) (domain.Knowledge, error) {
+		var k domain.Knowledge
+		err := row.Scan(&k.Type, &k.ID, &k.Title, &k.Description)
+		return k, err
+	})
+}
+
+// ListByIDs returns the named live entries in id order. The exporter walks
+// the id list in batches so the whole knowledge base is never held in
+// memory at once.
+func (e *ExportSnapshot) ListByIDs(ctx context.Context, ids []string) ([]domain.Knowledge, error) {
+	rows, err := e.tx.Query(ctx,
+		`SELECT `+knowledgeCols+` FROM knowledge
+		 WHERE deleted_at IS NULL AND id = ANY($1) ORDER BY id`, ids)
+	if err != nil {
+		return nil, err
+	}
+	return pgx.CollectRows(rows, scanKnowledge)
+}
+
+// AttachmentMeta returns every live entry's attachment metadata, ordered
+// by owning entry then name; the bytes are fetched one at a time as the
+// archive is written (design doc 0013). An entry with attachments in a
+// deployment that has no blob store is an error, not an empty archive.
+//
+// Blobs live in GCS, outside this snapshot: a blob deleted mid-export
+// still fails when it is reached. The metadata being consistent is what
+// makes that failure visible as a missing file rather than as an archive
+// quietly disagreeing with its own index.
+func (e *ExportSnapshot) AttachmentMeta(ctx context.Context) ([]ExportAttachment, error) {
+	rows, err := e.tx.Query(ctx, `SELECT a.knowledge_id, `+attachmentCols+`
+		FROM attachment a
+		JOIN blob b ON b.sha256 = a.sha256
+		JOIN knowledge k ON k.id = a.knowledge_id AND k.deleted_at IS NULL
+		ORDER BY a.knowledge_id, a.name`)
+	if err != nil {
+		return nil, err
+	}
+	atts, err := pgx.CollectRows(rows, func(row pgx.CollectableRow) (ExportAttachment, error) {
+		var a ExportAttachment
+		err := row.Scan(&a.ID, &a.Att.Name, &a.Att.MediaType, &a.Att.Size, &a.Att.SHA256, &a.Att.OKFPath,
+			&a.Att.CreatedBy.Kind, &a.Att.CreatedBy.Name, &a.Att.CreatedAt)
+		return a, err
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(atts) > 0 && e.store.blobs == nil {
+		return nil, errNoBlobStore
+	}
+	return atts, nil
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1134,37 +1134,6 @@ func (s *Store) ListAll(ctx context.Context) ([]domain.Knowledge, error) {
 	return pgx.CollectRows(rows, scanKnowledge)
 }
 
-// ListAllIndexRows returns every live entry with only the fields the
-// bundle's index.md files are rendered from — id, type, title,
-// description. The bodies are the bulk of a knowledge base, and the
-// indexes need none of them, so the exporter reads this first and pulls
-// the documents themselves in batches (ListByIDs).
-func (s *Store) ListAllIndexRows(ctx context.Context) ([]domain.Knowledge, error) {
-	rows, err := s.pool.Query(ctx,
-		`SELECT type, id, title, description FROM knowledge WHERE deleted_at IS NULL ORDER BY id`)
-	if err != nil {
-		return nil, err
-	}
-	return pgx.CollectRows(rows, func(row pgx.CollectableRow) (domain.Knowledge, error) {
-		var k domain.Knowledge
-		err := row.Scan(&k.Type, &k.ID, &k.Title, &k.Description)
-		return k, err
-	})
-}
-
-// ListByIDs returns the named live entries in id order. The exporter walks
-// the id list in batches so that neither the whole knowledge base nor a
-// pool connection is held for the length of a download.
-func (s *Store) ListByIDs(ctx context.Context, ids []string) ([]domain.Knowledge, error) {
-	rows, err := s.pool.Query(ctx,
-		`SELECT `+knowledgeCols+` FROM knowledge
-		 WHERE deleted_at IS NULL AND id = ANY($1) ORDER BY id`, ids)
-	if err != nil {
-		return nil, err
-	}
-	return pgx.CollectRows(rows, scanKnowledge)
-}
-
 // ListUnembedded returns the ids of live entries with no vector for the
 // named model, oldest first, up to limit. That covers both halves of the
 // same gap: entries written before semantic search was configured (there

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -1669,3 +1669,69 @@ func TestIntegrationMoveKeepsOutboundRelativeLinks(t *testing.T) {
 		t.Errorf("backlinks from %s = %+v, want the moved entry", neighbour, back)
 	}
 }
+
+// An export is streamed, so its reads happen at different moments. The
+// snapshot is what keeps the archive a picture of one instant: an entry
+// deleted after the id list was taken still has to be in the bundle the
+// index promises, or the archive contradicts itself.
+func TestIntegrationExportSnapshotIsConsistent(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	const doomed = "it-exportsnap/doomed"
+	for _, table := range []string{"knowledge", "knowledge_revision"} {
+		if _, err := s.pool.Exec(ctx, `DELETE FROM `+table+` WHERE id LIKE 'it-exportsnap%'`); err != nil {
+			t.Fatal(err)
+		}
+	}
+	actor := domain.Actor{Kind: "human", Name: "test"}
+	if err := s.Create(ctx, &domain.Knowledge{Type: domain.TypeInsights, ID: doomed,
+		Title: "deleted mid-export", Status: domain.StatusDraft, CreatedBy: actor}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		for _, table := range []string{"knowledge", "knowledge_revision"} {
+			_, _ = s.pool.Exec(ctx, `DELETE FROM `+table+` WHERE id LIKE 'it-exportsnap%'`)
+		}
+	})
+
+	snap, err := s.BeginExport(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer snap.Close(ctx)
+	rows, err := snap.IndexRows(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.ContainsFunc(rows, func(k domain.Knowledge) bool { return k.ID == doomed }) {
+		t.Fatalf("%s missing from the index rows", doomed)
+	}
+
+	// The world moves on while the archive is being written.
+	if err := s.SoftDelete(ctx, doomed, actor); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := snap.ListByIDs(ctx, []string{doomed})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].ID != doomed {
+		t.Errorf("the entry the index promised is missing from the bundle: %+v", entries)
+	}
+	// And the snapshot is only the export's: the live database has moved.
+	if _, err := s.Get(ctx, doomed); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Get after delete = %v, want ErrNotFound", err)
+	}
+}


### PR DESCRIPTION
## 何が成立していなかったか

**1. スナップショットが破れている。** #129 でエントリもストリームするようになり、エクスポートの読み取りは「id 一覧 → 添付メタデータ → エントリのバッチ(ダウンロード中)」と別々の時点に分かれた。プール上の独立した文なので、それぞれ違うデータベースを見る:

- id 一覧の後に消されたエントリ → `index.md` が名指しするファイルがアーカイブに入っていない
- 移動したエントリ → 2 回出るか 1 回も出ない
- 途中で編集された `title` → `index.md` とファイル本体で食い違う

しかも出来上がる tar は整形式なので、**何も起きなかったように見える**。このエンドポイントはバックアップのためにあり(「a silently short archive is the worst possible outcome for the backup this endpoint exists to serve」とコード自身が書いている)、ある時点の姿になっていないバックアップはバックアップではない。

**2. 「同じ内容なら同じアーカイブ」は成立しない。** 順序を固定する箇所のコメントがそう書いているが、`okf.NewTarGzWriter(w, time.Now())` が全ファイルの tar ヘッダに実行時刻を書くので、バイト列は毎回変わる。安定するのはファイルの**順序**である。

## 直し方

- `Store.BeginExport` が REPEATABLE READ / READ ONLY のトランザクションを開き、`IndexRows` / `AttachmentMeta` / `ListByIDs` を全部そこから読む(`internal/store/export.go`)。プール直読みだった 3 メソッドは移設した(他に呼び出し元は無い)。
- 代償はダウンロード中にプール接続を 1 本占有すること。**意識的な取引**として書いてある — バッチ読みはメモリのためのもので、スナップショットは「何を見るか」を縛るだけなので、両方要る。
- blob は GCS にあってこのスナップショットの外なので、途中で消された添付は従来どおりそこで失敗する(ログ済み)。メタデータが一貫していることで、その失敗が「アーカイブが自分の index と食い違う」ではなく「1 ファイル欠け」として見えるようになる。
- 決定性のコメントを実態(順序は安定、バイト列は変わる)に書き直した。

## 検証

`internal/store` に統合テストを追加: スナップショットを開き、index 行を読み、**その後にエントリを削除**してから `ListByIDs` を呼ぶ。index が約束したエントリが依然として返ること、同時に live なデータベース側では既に消えていることを確認する。

`gofmt` / `go vet` / `go test -race ./...`(PostgreSQL 17 + pgvector 込み、既存の REST エクスポート往復テストを含む)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)