### PR TITLE
説明を実装に合わせる: コードブロックの範囲と "trigram" の呼び名

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,8 +272,10 @@ paths (`./gross.md`) and canonical URIs (`ochakai://metrics/revenue`, bare
 or in a link) work too. This is OKF SPEC §5 taken at its word: a link
 asserts a relationship, and what kind of relationship it is comes from the
 surrounding prose, so ochakai stores no relationship type of its own
-(design doc 0024). Links in code blocks are examples, not edges, and are
-skipped. Renaming an entry rewrites the links pointing at it, prose
+(design doc 0024). Links inside fenced code blocks (``` or ~~~) and
+inline `` `code spans` `` are examples, not edges, and are skipped —
+indented code is not detected, so a link four spaces deep is read as
+prose. Renaming an entry rewrites the links pointing at it, prose
 included.
 
 Entries can carry file attachments — the dashboard screenshot behind an
@@ -325,7 +327,7 @@ back fits what you asked for.
 | `OCHAKAI_DATABASE_URL` | Cloud SQL connection string (required) |
 | `OCHAKAI_DB_IAM_AUTH` | `true` enables Cloud SQL IAM database authentication: the connection password is a short-lived IAM token, so the connection string carries no secret |
 | `OCHAKAI_GCS_BUCKET` | Bucket for attachment bytes (auth is ADC — no keys). Default: unset — the instance stores markdown entries only and attach operations return an error |
-| `OCHAKAI_VERTEX_PROJECT` | Set to enable hybrid semantic search via Vertex AI embeddings (default: off, trigram-only — ochakai calls no external API unless you opt in). Auth is ADC — no API keys. **Recommended for Japanese knowledge bases** (see below) |
+| `OCHAKAI_VERTEX_PROJECT` | Set to enable hybrid semantic search via Vertex AI embeddings (default: off, lexical-only — ochakai calls no external API unless you opt in). Auth is ADC — no API keys. **Recommended for Japanese knowledge bases** (see below) |
 | `OCHAKAI_VERTEX_LOCATION` / `OCHAKAI_VERTEX_MODEL` / `OCHAKAI_EMBEDDING_DIM` | Embedding details (defaults: `us-central1`, `gemini-embedding-001`, 768). For image/PDF attachment search set model `gemini-embedding-2` with location `global` (or `us`/`eu`). Vectors are written when an entry is written, so enabling this on an existing base — or changing the model — leaves entries unembedded until you run `ochakai reembed` (design doc 0020). Dimensions above 2000 exceed pgvector's indexing limit, so those deployments fall back to an exact scan. Changing `OCHAKAI_EMBEDDING_DIM` on a base that already holds vectors is refused at startup, with the two ways out: put it back, or drop the vector tables and re-embed |
 | `OCHAKAI_DELEGATING_CALLERS` | Comma-separated caller identities allowed to forward an end user's identity with `X-Ochakai-On-Behalf-Of: human:tanaka@example.co.jp` (`*` for any authenticated caller). For applications that embed ochakai and serve many people — without it, every one of their users collapses into the application's one service account. Both identities are recorded (`human:tanaka@… via agent:app-sa@…`), never just the forwarded one. Default: empty, delegation off; a header from an unlisted caller is a 403, not a silent downgrade (design doc 0027) |
 | `OCHAKAI_INSECURE_DEV` | Local development only: disables auth, everything acts as human:anonymous |

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -23,7 +23,7 @@ paths:
   /api/v1/knowledge:
     get:
       operationId: searchKnowledge
-      summary: Search knowledge (trigram, plus hybrid vector search when configured)
+      summary: Search knowledge (lexical, plus hybrid vector search when configured)
       description: >
         Rejected entries are excluded unless the status filter explicitly
         includes rejected (so agents can check for already-rejected proposals).
@@ -189,9 +189,10 @@ paths:
           description: >
             Drop hits scoring below this before expansion, for callers that
             inject the pack automatically and prefer nothing over junk.
-            Scores are search-mode dependent and uncalibrated (trigram
-            similarity plus boosts vs RRF rank fusion) — calibrate against
-            your own corpus before use. Non-numeric values are a 400.
+            Scores are search-mode dependent and uncalibrated
+            (matched-fragment weight plus boosts vs RRF rank fusion) —
+            calibrate against your own corpus before use. Non-numeric
+            values are a 400.
           schema: { type: number, default: 0 }
         - name: budget
           in: query

--- a/internal/domain/links.go
+++ b/internal/domain/links.go
@@ -122,6 +122,14 @@ var schemeRe = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+.-]*:`)
 // proseLines returns the body's lines with fenced code blocks dropped and
 // inline code spans blanked, so links that appear only as documentation
 // examples are not read as edges (design doc 0024 §3.4).
+//
+// Fences and code spans only: an indented code block (four spaces) reads
+// as prose, and a link inside one becomes an edge. Detecting indentation
+// as code means deciding whether a four-space line is a code block or the
+// continuation of a list item, and getting that wrong in the other
+// direction drops an edge the author meant — a link that is missing is
+// worse than an example that is counted, because nothing in the entry
+// shows it is gone.
 func proseLines(body string) []string {
 	var out []string
 	var fence string

--- a/internal/domain/links_test.go
+++ b/internal/domain/links_test.go
@@ -91,6 +91,16 @@ func TestLinksFromBodySkipsCode(t *testing.T) {
 
 // A "# Links" section is ordinary prose now: its links are read like any
 // other, and its non-entry links are ignored like any other.
+// Fenced and inline code are skipped; indented code is not. Pinned so the
+// gap is a decision rather than a surprise (see proseLines).
+func TestLinksFromBodyIndentedCodeIsRead(t *testing.T) {
+	body := "Example:\n\n    [r](/metrics/revenue.md)\n"
+	links := LinksFromBody("insights/a", body)
+	if len(links) != 1 || links[0].Target != "metrics/revenue" {
+		t.Errorf("links = %+v, want the indented link read as prose", links)
+	}
+}
+
 func TestLinksFromBodyReadsLegacyLinksSection(t *testing.T) {
 	body := "Intro.\n\n# Links\n\n- [about](/metrics/revenue.md)\n- [the dashboard](https://example.com)\n"
 	want := []Link{{Target: "metrics/revenue", Text: "about"}}

--- a/internal/embed/embedder.go
+++ b/internal/embed/embedder.go
@@ -1,5 +1,5 @@
 // Package embed provides text embeddings for hybrid search. Embeddings are
-// opt-in: without a configured provider, ochakai serves trigram-only search
+// opt-in: without a configured provider, ochakai serves lexical-only search
 // and never calls out of the network. Encoders are deterministic and do no
 // interpretation, so this does not conflict with the no-LLM principle.
 package embed

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -416,7 +416,7 @@ type searchOut struct {
 
 // contextIn deliberately omits min_score, which the REST surface still
 // carries. A score floor is only usable once calibrated against a corpus
-// in a known search mode (trigram vs hybrid RRF), and an agent cannot
+// in a known search mode (lexical vs hybrid RRF), and an agent cannot
 // calibrate anything — offering it here spends tool-schema context on a
 // parameter whose own documentation says to leave it alone. What an agent
 // actually needs to bound a response is budget.

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -377,8 +377,8 @@ func validateModel(k *domain.Knowledge) error {
 
 // --- search ---
 
-// Search runs trigram search, and when an embedder is configured, fuses it
-// with vector search via reciprocal rank fusion.
+// Search runs lexical search, and when an embedder is configured, fuses
+// it with vector search via reciprocal rank fusion.
 func (s *Service) Search(ctx context.Context, query string, f store.Filter, limit int) ([]domain.SearchHit, error) {
 	// Stored text is NFC (design doc 0022); an NFD query (pasted from a
 	// macOS path) must still match it byte-wise.
@@ -413,7 +413,7 @@ func (s *Service) search(ctx context.Context, query string, f store.Filter, limi
 	vecs, err := s.Embedder.Embed(ctx, embed.TaskQuery, []string{query})
 	if err != nil {
 		// Degrade to lexical-only rather than failing the search.
-		s.Log.Warn("query embedding failed; falling back to trigram-only", "error", err)
+		s.Log.Warn("query embedding failed; falling back to lexical-only", "error", err)
 		if len(lexical) > limit {
 			lexical = lexical[:limit]
 		}
@@ -467,7 +467,7 @@ type ContextRequest struct {
 // req.MinScore drops hits scoring below it before expansion, for callers
 // that inject the pack automatically (hooks) and prefer nothing over
 // junk. It defaults to 0 (off) because scores are search-mode dependent
-// and uncalibrated: trigram similarity plus boosts in lexical mode, RRF
+// and uncalibrated: matched-fragment weight plus boosts in lexical mode, RRF
 // rank fusion (~0.02 scale) in hybrid mode — a floor meaningful in one
 // mode is nonsense in the other.
 //
@@ -831,7 +831,7 @@ func (s *Service) updateEmbedding(ctx context.Context, k *domain.Knowledge) {
 	}
 	vecs, err := s.embedDocument(ctx, embeddingText(k, s.embedBytes()))
 	if err != nil {
-		s.Log.Warn("document embedding failed; entry remains searchable via trigram", "type", k.Type, "id", k.ID, "error", err)
+		s.Log.Warn("document embedding failed; entry remains findable by the lexical half of search", "type", k.Type, "id", k.ID, "error", err)
 		return
 	}
 	if err := s.Store.UpsertEmbedding(ctx, k.ID, s.Embedder.Model(), vecs[0]); err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -709,8 +709,9 @@ func (s *Store) addRevision(ctx context.Context, tx pgx.Tx, k *domain.Knowledge,
 	return err
 }
 
-// maxQueryFragments bounds how many pieces a query is split into, so a
-// pasted paragraph cannot turn one search into a hundred index probes.
+// maxQueryFragments bounds how many pieces a query is split into: every
+// fragment is another ILIKE term on the same scan, and a pasted paragraph
+// would otherwise put a hundred of them there.
 const maxQueryFragments = 24
 
 // queryFragments splits a search query into the pieces a document might
@@ -870,9 +871,11 @@ func contentChar(r rune) bool {
 // the verified boost. An entry containing none of the fragments is not a
 // result — the floor is "matched something", not a magic number.
 //
-// Every term of that is a substring test against one column, which is
-// what the GIN trigram index serves, so the candidate predicate and the
-// score read the same expressions (migration 0016). Fragment matching
+// Every term of that is a substring test against one column, so the
+// candidate predicate and the score read the same expressions, and the
+// GIN trigram index serves the ones it can — patterns of three characters
+// or more (migration 0016; two-character Japanese windows are answered by
+// a scan, see queryFragments). Fragment matching
 // replaced a similarity()/`%` pair that could not work: `%` is true only
 // above pg_trgm.similarity_threshold (0.3) and a real query never scores
 // that against a real document, so the candidate set was whatever the


### PR DESCRIPTION
挙動の変更なし。**利用を検討する側が読む文だけが実装より先に進んでいた**箇所を直す。

## 1. 「コードブロック内のリンクはエッジにならない」の範囲

README:

> Links in code blocks are examples, not edges, and are skipped.

`proseLines` が除外するのは**フェンス(``` / ~~~)とインラインコードだけ**。Markdown のもう一方の記法、**インデント(4 スペース)のコードブロックは検出しない**ので、そこに書いた例はエッジになる。

実装をそちらに寄せる選択肢もあるが、採らなかった: 4 スペースの行がコードブロックなのかリスト項目の継続なのかの判定を誤ると、**著者が意図したリンクが消える**。消えたリンクはエントリのどこにも痕跡が残らないので、例が 1 本エッジに混ざるより悪い(混ざったほうは本文を見れば分かる)。範囲を README とコードに書き、テストで固定した。

## 2. "trigram" という呼び名

#124 以降、語彙側の検索は**断片 ILIKE + IDF** であって trigram 類似度ではない。索引は 3 文字以上の断片にだけ効く — main のマイグレーション 0016 のコメントが実測でそう書いている(`'%売上%'` は seq scan)。それでも以下は "trigram" のままだった:

- README の `OCHAKAI_VERTEX_PROJECT` 行「default: off, trigram-only」
- `internal/embed` のパッケージコメント「trigram-only search」
- `Service.Search` の説明、埋め込み失敗時のログ 2 本(「remains searchable via trigram」)
- `min_score` の説明「trigram similarity plus boosts」(README 本文では既に「matched-fragment weight」に直っている)
- openapi の summary と `min_score` の説明、MCP 側の同じ説明
- `SearchLexical` の「Every term of that is … what the GIN trigram index serves」— **すべての項を索引が捌く**という読みになる

呼び名を "lexical" に統一し、`SearchLexical` には索引が届く範囲(3 文字以上、2 文字の日本語窓はスキャン)を書いた。`maxQueryFragments` の「index probes」も実態(同じスキャン上の ILIKE 項)に直した。

## 検証

`gofmt` / `go vet` / `go test -race ./...`(PostgreSQL 17 + pgvector 込み)。追加したのはインデントコードの挙動を固定するテスト 1 本のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)