### PR TITLE
添付検索のテストを、コーパスの大きさに依存しない形にする

### DIFF
--- a/internal/service/attachment_integration_test.go
+++ b/internal/service/attachment_integration_test.go
@@ -106,7 +106,16 @@ func TestAttachmentSearchIntegration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	id := fmt.Sprintf("svcit-att-%d", time.Now().UnixNano())
+	// The search below runs against one run-unique type, not the whole
+	// database. Reciprocal rank fusion gives an entry that matches in one
+	// list ~1/61 and an entry that matches in two ~2/61, so "an
+	// attachment-only match lands in the top 10" holds until ten entries
+	// match both lexically and by vector — a property of the corpus, not
+	// of the code under test. The shared test database (CONTRIBUTING)
+	// grows past that, and the test would then fail for a reason that has
+	// nothing to do with attachments. Scoping the search fixes the field.
+	typ := domain.Type(fmt.Sprintf("svcatt%d", time.Now().UnixNano()))
+	id := string(typ) + "/z-target" // sorts last: an RRF tie must not favor it
 	content := "quarterly revenue by region, expected results"
 	query := "四半期の地域別売上の検証結果"
 	emb := stubEmbedder{vecs: map[string][]float32{
@@ -118,7 +127,7 @@ func TestAttachmentSearchIntegration(t *testing.T) {
 	actor := domain.Actor{Kind: domain.ActorHuman, Name: "test"}
 
 	if _, err := svc.Create(ctx, &domain.Knowledge{
-		Type: domain.TypeQueries, ID: id, Title: "golden query",
+		Type: typ, ID: id, Title: "golden query",
 		Status: domain.StatusDraft, Body: "SELECT 1", CreatedBy: actor,
 	}, actor); err != nil {
 		t.Fatal(err)
@@ -126,22 +135,41 @@ func TestAttachmentSearchIntegration(t *testing.T) {
 	// Leave no live attachments behind: the store package's blob test
 	// resolves every live attachment against its own blob fake.
 	defer func() { _ = s.SoftDelete(ctx, id, actor) }()
+
+	// Company for the target: same type, no overlap with the query in
+	// either half of search. They are in the vector list (it returns the
+	// nearest N whatever the distance) and nowhere else, so each scores
+	// one RRF term — which is what makes the target's second term visible.
+	for i := range 3 {
+		decoy := fmt.Sprintf("%s/a-decoy-%d", typ, i)
+		if _, err := svc.Create(ctx, &domain.Knowledge{
+			Type: typ, ID: decoy, Title: "参考資料", Status: domain.StatusDraft,
+			Body: "参考資料の置き場", CreatedBy: actor,
+		}, actor); err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = s.SoftDelete(ctx, decoy, actor) }()
+	}
+
 	if _, err := svc.Attach(ctx, id, "expected.txt", "", []byte(content), actor); err != nil {
 		t.Fatalf("Attach: %v", err)
 	}
 
-	// The Japanese query shares no trigrams with the entry or filename;
-	// only the attachment vector can surface it.
-	hits, err := svc.Search(ctx, query, store.Filter{}, 10)
+	// The Japanese query shares no fragment with any of these entries or
+	// filenames; only the attachment vector can tell them apart.
+	hits, err := svc.Search(ctx, query, store.Filter{Types: []domain.Type{typ}}, 10)
 	if err != nil {
 		t.Fatalf("Search: %v", err)
 	}
-	found := false
-	for _, h := range hits {
-		found = found || h.ID == id
+	if len(hits) == 0 || hits[0].ID != id {
+		t.Fatalf("the entry whose attachment matches the query must rank first: %+v", hits)
 	}
-	if !found {
-		t.Errorf("hybrid search missed the entry whose attachment matches the query: %+v", hits)
+	// Strictly first, not first by tie-break: without the attachment
+	// vector every entry here carries the same single RRF term.
+	for _, h := range hits[1:] {
+		if h.Score >= hits[0].Score {
+			t.Errorf("attachment match scored %v, no better than %s at %v", hits[0].Score, h.ID, h.Score)
+		}
 	}
 
 	// Non-text attachments are not embeddable yet (design doc 0020 §3):
@@ -183,7 +211,7 @@ func TestAttachmentSearchIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	found = false
+	found := false
 	for _, h := range vhits {
 		if h.ID == id && h.Score > 0.9 {
 			found = true


### PR DESCRIPTION
## 何が起きていたか

`TestAttachmentSearchIntegration` は**コーパス全体**に対して検索し、添付だけで当たるエントリが上位 10 件に入ることを要求していた。これはコードの性質ではなく**コーパスの性質**である。

RRF(k=60)では、1 つのリストで当たったエントリは約 `1/61 = 0.0164`、2 つのリストで当たったエントリは約 `2/61 = 0.033`。添付でしか当たらないエントリが取れる最大値は前者なので、**語彙でも本文ベクトルでも当たるエントリが 10 件たまった時点で、添付の一致が正しく動いていても 10 位から押し出される**。

テスト用データベースは全パッケージで共有され(CONTRIBUTING)、ローカルでは実行のたびに育つので、このテストは添付と無関係な理由で落ちるようになる。実際に落ちたときの上位は、`売上` や `検証` を含む他テストのエントリが両リストから寄与を得て並んでいた。

これは設計 0020 §2.2 が意図したとおりの挙動(「本文でも添付でも当たるエントリは両リストから寄与を得て上がる」)であって、直すべきは検索ではなくテストの立て方である。

## 直し方

検索を**実行ごとに一意な type** に絞り、その中にデコイを 3 件置く。デコイはクエリと語彙でもベクトルでも重ならないので、全員がベクトルリスト(距離に関わらず上位 N を返す)にだけ載る — つまり全員が 1 項目だけ持つ。そこに対象の添付の 1 項目が乗るので、差が可視になる。

アサーションは 2 つ:

1. **1 位であること。** 対象の id は `z-target` でデコイ(`a-decoy-*`)より後ろにソートされるので、RRF の同点タイブレーク(id 昇順)では 1 位になれない。
2. **2 位以降よりスコアが厳密に大きいこと。** 添付の寄与が無ければ全員が同じ 1 項目になる。

## 検証

- **偽陽性の確認**: `updateAttachmentEmbedding` を無効化すると、対象は最下位(0.015625)に落ちてテストは落ちる。空振りしていない。
- **元の症状の再現と解消**: クエリと語彙で当たり、かつクエリベクトルと同じ向きの埋め込みを持つ競合エントリを 1500 件投入した状態で、**修正前は落ち、修正後は 3 回とも通る**。
- `gofmt` / `go vet` / `go test -race ./...`(PostgreSQL 17 + pgvector)。

テストのみの変更で、製品コードは触っていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)