### PR TITLE
SIGTERM ドレインを実際に待つ(#119 が守れていなかった)

### DIFF
--- a/cmd/ochakai/drain_test.go
+++ b/cmd/ochakai/drain_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Guard: serveAndDrain must not return before in-flight requests have
+// finished. Serve returns ErrServerClosed as soon as Shutdown is called;
+// returning then would let main close the store (final usage flush, pool
+// close) under requests that are still running — the exact loss the
+// SIGTERM drain exists to prevent.
+func TestServeAndDrainWaitsForInFlightRequests(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inHandler := make(chan struct{})
+	release := make(chan struct{})
+	var handlerDone atomic.Bool
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(inHandler)
+		<-release
+		handlerDone.Store(true)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	served := make(chan error, 1)
+	go func() {
+		served <- serveAndDrain(ctx, &http.Server{Handler: handler}, ln)
+	}()
+
+	resp := make(chan error, 1)
+	go func() {
+		r, err := http.Get("http://" + ln.Addr().String())
+		if err == nil {
+			_, _ = io.Copy(io.Discard, r.Body)
+			r.Body.Close()
+		}
+		resp <- err
+	}()
+
+	<-inHandler
+	cancel() // SIGTERM arrives while the request is in flight
+
+	select {
+	case err := <-served:
+		t.Fatalf("serveAndDrain returned before the in-flight request finished (err=%v)", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+	select {
+	case err := <-served:
+		if err != nil {
+			t.Fatalf("serveAndDrain: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("serveAndDrain did not return after the drain completed")
+	}
+	if !handlerDone.Load() {
+		t.Fatal("handler did not run to completion before serveAndDrain returned")
+	}
+	if err := <-resp; err != nil {
+		t.Fatalf("in-flight request failed: %v", err)
+	}
+}

--- a/cmd/ochakai/main.go
+++ b/cmd/ochakai/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -218,18 +219,37 @@ then open http://127.0.0.1:8098. See also: ochakai --help
 const drainTimeout = 5 * time.Second
 
 func runServer(ctx context.Context, addr string, handler http.Handler) error {
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
 	server := &http.Server{
-		Addr:              addr,
 		Handler:           handler,
 		ReadHeaderTimeout: 10 * time.Second,
 	}
-	go func() {
-		<-ctx.Done()
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), drainTimeout)
-		defer cancel()
-		_ = server.Shutdown(shutdownCtx)
-	}()
-	if err := server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+	return serveAndDrain(ctx, server, ln)
+}
+
+// serveAndDrain serves ln until ctx is cancelled, then returns only once
+// the drain has finished. Serve returns ErrServerClosed the moment
+// Shutdown is *called*, not when the drain completes — returning on it
+// alone would run the caller's deferred Store.Close (final usage flush,
+// pool close) while requests are still in flight, failing them on a
+// closed pool and losing the usage events they just recorded.
+func serveAndDrain(ctx context.Context, server *http.Server, ln net.Listener) error {
+	errc := make(chan error, 1)
+	go func() { errc <- server.Serve(ln) }()
+	select {
+	case err := <-errc:
+		return err // stopped before any shutdown was asked for
+	case <-ctx.Done():
+	}
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), drainTimeout)
+	defer cancel()
+	// Best-effort: past drainTimeout the stragglers are cut off and the
+	// process exits; nothing useful to do with the error.
+	_ = server.Shutdown(shutdownCtx)
+	if err := <-errc; !errors.Is(err, http.ErrServerClosed) {
 		return err
 	}
 	return nil


### PR DESCRIPTION
## 問題

`runServer` は `server.Shutdown` をゴルーチンで呼ぶだけで、完了を待っていなかった。Go の仕様では **Shutdown が呼ばれた瞬間に `ListenAndServe` は `ErrServerClosed` で戻る**ため、`runServer` → `serve` が即座に返り、`defer svc.Store.Close()`(最終 usage フラッシュ + プール close)が処理中のリクエストの下で走っていた。

その結果:

- ドレイン中のリクエストは閉じたプールで失敗するか、プロセス終了で切断される
- ドレイン中に記録された usage イベントは最終フラッシュの**後**にバッファへ積まれて失われる — #119 が守ろうとしたイベントそのもの

`serve` の defer コメント(「Runs after runServer returns, i.e. after the HTTP server has drained」)は事実と異なっていた。`serve-ui` も同じ `runServer` を使うため同じ問題を抱えていた。

## 修正

ドレイン処理をリスナー注入可能な `serveAndDrain` に切り出し、`Shutdown` が返ってから `runServer` を返すようにした。順序を固定するテストを追加している(処理中のリクエストがある状態で ctx をキャンセルし、ハンドラが完了するまで `serveAndDrain` が返らないこと・リクエストが成功することを確認)。

## テスト

`gofmt` / `go vet` / `CGO_ENABLED=0 go build` / `go test -race ./...` 全て green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)