### PR TITLE
MCP: actor をツール呼び出しごとのヘッダから解決する(0027 の誤帰属)

### DIFF
--- a/internal/httpauth/httpauth.go
+++ b/internal/httpauth/httpauth.go
@@ -30,44 +30,46 @@ type ctxKey struct{}
 // from any caller, so a delegating integration can be developed and its
 // mistakes seen locally.
 func Middleware(cfg *config.Config, next http.Handler) http.Handler {
-	if cfg.InsecureDev {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Delegation is processed here too, and every caller may
-			// delegate: someone building an embedding host develops
-			// against this mode, and short-circuiting past delegate()
-			// would let them ship a header that silently did nothing —
-			// exactly the failure design doc 0027 §5.2 refuses to allow in
-			// production, hidden until the first deployment.
-			actor, status, err := delegate(
-				domain.Actor{Kind: domain.ActorHuman, Name: "anonymous"},
-				r.Header.Get(OnBehalfOfHeader), []string{"*"})
-			if err != nil {
-				http.Error(w, "auth: "+err.Error(), status)
-				return
-			}
-			next.ServeHTTP(w, r.WithContext(WithActor(r.Context(), actor)))
-		})
-	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// When both headers are present, Cloud Run validates only
-		// X-Serverless-Authorization — so it must take precedence here,
-		// or an authorized caller could impersonate via Authorization.
-		token := bearerFrom(r.Header.Get("X-Serverless-Authorization"))
-		if token == "" {
-			token = bearerFrom(r.Header.Get("Authorization"))
-		}
-		actor, err := actorFromIDToken(token)
-		if err != nil {
-			http.Error(w, "auth: "+err.Error(), http.StatusUnauthorized)
-			return
-		}
-		actor, status, err := delegate(actor, r.Header.Get(OnBehalfOfHeader), cfg.Delegators)
+		actor, status, err := ActorFromHeader(cfg, r.Header)
 		if err != nil {
 			http.Error(w, "auth: "+err.Error(), status)
 			return
 		}
 		next.ServeHTTP(w, r.WithContext(WithActor(r.Context(), actor)))
 	})
+}
+
+// ActorFromHeader resolves the actor exactly as Middleware does, from a
+// bare header set. It exists on its own because the MCP layer must
+// re-derive the actor per tool call: a streamable session's context is
+// captured at initialize, so the context value alone would pin every
+// later call to whoever opened the session (see mcpserver).
+// The returned status accompanies a non-nil error.
+func ActorFromHeader(cfg *config.Config, h http.Header) (domain.Actor, int, error) {
+	if cfg.InsecureDev {
+		// Delegation is processed here too, and every caller may
+		// delegate: someone building an embedding host develops
+		// against this mode, and short-circuiting past delegate()
+		// would let them ship a header that silently did nothing —
+		// exactly the failure design doc 0027 §5.2 refuses to allow in
+		// production, hidden until the first deployment.
+		return delegate(
+			domain.Actor{Kind: domain.ActorHuman, Name: "anonymous"},
+			h.Get(OnBehalfOfHeader), []string{"*"})
+	}
+	// When both headers are present, Cloud Run validates only
+	// X-Serverless-Authorization — so it must take precedence here,
+	// or an authorized caller could impersonate via Authorization.
+	token := bearerFrom(h.Get("X-Serverless-Authorization"))
+	if token == "" {
+		token = bearerFrom(h.Get("Authorization"))
+	}
+	actor, err := actorFromIDToken(token)
+	if err != nil {
+		return domain.Actor{}, http.StatusUnauthorized, err
+	}
+	return delegate(actor, h.Get(OnBehalfOfHeader), cfg.Delegators)
 }
 
 // OnBehalfOfHeader carries the end-user identity a trusted caller is

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/na0fu3y/ochakai/internal/config"
 	"github.com/na0fu3y/ochakai/internal/domain"
 	"github.com/na0fu3y/ochakai/internal/httpauth"
 	"github.com/na0fu3y/ochakai/internal/okf"
@@ -32,6 +33,30 @@ const (
 func Handler(svc *service.Service, version string) http.Handler {
 	server := newServer(svc, version)
 	return mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return server }, nil)
+}
+
+// requestActor resolves the actor to record for a tool call from the
+// HTTP headers that carried the call. httpauth.Middleware puts the
+// actor on the request context, but a streamable session is connected
+// once — at initialize — and every later call runs on a context derived
+// from that first request, so the context value is pinned to whoever
+// opened the session. A delegating host (design doc 0027) that reuses
+// one session across end users would then have every write silently
+// misattributed to the first user — the exact failure 0027 §5.2
+// refuses. The middleware has already vetted these headers (a rejected
+// delegation never reaches a handler), so resolution here cannot newly
+// fail; if it somehow does, refuse the write rather than misattribute
+// it. In-process transports (tests, embedding without HTTP) carry no
+// request headers and fall back to the context actor.
+func requestActor(ctx context.Context, cfg *config.Config, req *mcp.CallToolRequest) (domain.Actor, error) {
+	if extra := req.GetExtra(); cfg != nil && extra != nil && extra.Header != nil {
+		actor, _, err := httpauth.ActorFromHeader(cfg, extra.Header)
+		if err != nil {
+			return domain.Actor{}, fmt.Errorf("resolving actor: %w", err)
+		}
+		return actor, nil
+	}
+	return httpauth.Actor(ctx), nil
 }
 
 func newServer(svc *service.Service, version string) *mcp.Server {
@@ -207,7 +232,11 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"An id whose entry was deleted can be reused, which revives it as your draft — unless a human had " +
 			"ruled on it (verified, rejected, deprecated), in which case this surface refuses: propose at a " +
 			"different id instead.",
-	}, func(ctx context.Context, _ *mcp.CallToolRequest, in writeIn) (*mcp.CallToolResult, knowledgeOut, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, in writeIn) (*mcp.CallToolResult, knowledgeOut, error) {
+		actor, err := requestActor(ctx, svc.Config, req)
+		if err != nil {
+			return nil, knowledgeOut{}, err
+		}
 		// Creating on a soft-deleted id revives that row in place, status
 		// and status_note included — the other way to overwrite a ruling
 		// from a surface with no If-Match channel, and the one the update
@@ -215,7 +244,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 		if err := svc.RefuseIfRevivingCurated(ctx, in.ID); err != nil {
 			return nil, knowledgeOut{}, err
 		}
-		k, err := svc.Create(ctx, in.toKnowledge(), httpauth.Actor(ctx))
+		k, err := svc.Create(ctx, in.toKnowledge(), actor)
 		if err != nil {
 			return nil, knowledgeOut{}, err
 		}
@@ -235,7 +264,11 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"Setting status=verified records you as verified_by — " +
 			"do it only for knowledge you have actually validated. Setting status=rejected records you " +
 			"as rejected_by; put the reason in status_note (also useful when deprecating).",
-	}, func(ctx context.Context, _ *mcp.CallToolRequest, in writeIn) (*mcp.CallToolResult, knowledgeOut, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, in writeIn) (*mcp.CallToolResult, knowledgeOut, error) {
+		actor, err := requestActor(ctx, svc.Config, req)
+		if err != nil {
+			return nil, knowledgeOut{}, err
+		}
 		// MCP has no conditional-update channel, so it cannot opt into the
 		// If-Match precondition (nil) and writes are last-write-wins. That
 		// is tolerable for drafts and not for curated knowledge, so
@@ -248,7 +281,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 		// entry curated in the window between the two is a conflict rather
 		// than a clobber — the surface has no If-Match channel of its own,
 		// but the check can supply one.
-		k, _, err := svc.Update(ctx, in.toKnowledge(), httpauth.Actor(ctx), version)
+		k, _, err := svc.Update(ctx, in.toKnowledge(), actor, version)
 		if err != nil {
 			return nil, knowledgeOut{}, err
 		}
@@ -262,14 +295,18 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"create_knowledge on the same id revives it. Entries a human has ruled on — verified, " +
 			"rejected, or deprecated — cannot be deleted from this surface; deleting a rejected " +
 			"entry and recreating it would erase the record of why it was turned down.",
-	}, func(ctx context.Context, _ *mcp.CallToolRequest, in getIn) (*mcp.CallToolResult, deleteOut, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, in getIn) (*mcp.CallToolResult, deleteOut, error) {
+		actor, err := requestActor(ctx, svc.Config, req)
+		if err != nil {
+			return nil, deleteOut{}, err
+		}
 		// Delete has no precondition channel in the store, so a curation
 		// landing in the window between check and delete still wins. The
 		// window is a single round trip and the delete is revivable.
 		if _, err := svc.RefuseIfCurated(ctx, in.ID, "delete"); err != nil {
 			return nil, deleteOut{}, err
 		}
-		if err := svc.Delete(ctx, in.ID, httpauth.Actor(ctx)); err != nil {
+		if err := svc.Delete(ctx, in.ID, actor); err != nil {
 			return nil, deleteOut{}, err
 		}
 		return nil, deleteOut{Deleted: true, URI: uriScheme + in.ID}, nil

--- a/internal/mcpserver/mcpserver_integration_test.go
+++ b/internal/mcpserver/mcpserver_integration_test.go
@@ -1,0 +1,106 @@
+package mcpserver
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/na0fu3y/ochakai/internal/config"
+	"github.com/na0fu3y/ochakai/internal/domain"
+	"github.com/na0fu3y/ochakai/internal/httpauth"
+	"github.com/na0fu3y/ochakai/internal/service"
+	"github.com/na0fu3y/ochakai/internal/store"
+)
+
+// headerSwitcher injects the delegation header into every outgoing MCP
+// request, with a value that the test can change between calls — the
+// shape of an embedding host serving several end users over one session.
+type headerSwitcher struct {
+	mu    sync.Mutex
+	value string
+	next  http.RoundTripper
+}
+
+func (h *headerSwitcher) RoundTrip(r *http.Request) (*http.Response, error) {
+	h.mu.Lock()
+	v := h.value
+	h.mu.Unlock()
+	if v != "" {
+		r.Header.Set(httpauth.OnBehalfOfHeader, v)
+	}
+	return h.next.RoundTrip(r)
+}
+
+func (h *headerSwitcher) set(v string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.value = v
+}
+
+// TestIntegrationDelegatedActorFollowsEachCall pins the 0027 contract on
+// the MCP surface: the recorded actor comes from the headers of the POST
+// that carried the tool call, not from whoever initialized the session.
+// A delegating host reuses one session across end users; before the fix,
+// every write was attributed to the first user's identity.
+func TestIntegrationDelegatedActorFollowsEachCall(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := t.Context()
+	s, err := store.New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{InsecureDev: true}
+	svc := &service.Service{Store: s, Config: cfg, Log: slog.New(slog.NewTextHandler(os.Stderr, nil))}
+	srv := httptest.NewServer(httpauth.Middleware(cfg, Handler(svc, "test")))
+	defer srv.Close()
+
+	sw := &headerSwitcher{value: "human:alice@example.co.jp", next: http.DefaultTransport}
+	transport := &mcp.StreamableClientTransport{
+		Endpoint:   srv.URL,
+		HTTPClient: &http.Client{Transport: sw},
+	}
+	cs, err := mcp.NewClient(&mcp.Implementation{Name: "host", Version: "0"}, nil).Connect(ctx, transport, nil)
+	if err != nil {
+		t.Fatalf("connect (as alice): %v", err)
+	}
+	defer cs.Close()
+
+	// The session now exists, initialized under alice's identity. The
+	// next call arrives on the same session but on behalf of bob.
+	sw.set("human:bob@example.co.jp")
+	id := fmt.Sprintf("mcpit%d/delegation", time.Now().UnixNano())
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "create_knowledge",
+		Arguments: map[string]any{"id": id, "type": "glossary", "body": "written on behalf of bob"},
+	})
+	if err != nil {
+		t.Fatalf("create_knowledge: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("create_knowledge failed: %+v", res.Content)
+	}
+
+	k, err := svc.Get(context.Background(), id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := domain.Actor{Kind: domain.ActorHuman, Name: "bob@example.co.jp", Via: "human:anonymous"}
+	if k.CreatedBy != want {
+		t.Errorf("created_by = %+v, want %+v (actor pinned to the session initializer?)", k.CreatedBy, want)
+	}
+}

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -3,12 +3,15 @@ package mcpserver
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/na0fu3y/ochakai/internal/config"
 	"github.com/na0fu3y/ochakai/internal/domain"
+	"github.com/na0fu3y/ochakai/internal/httpauth"
 	"github.com/na0fu3y/ochakai/internal/service"
 )
 
@@ -442,5 +445,46 @@ func TestContextHitsCarryRankingNotKnowledge(t *testing.T) {
 	// 0022), so a hit is readable without fetching.
 	if got.Title != "monthly-revenue" {
 		t.Errorf("hit title = %q, want the display title", got.Title)
+	}
+}
+
+// requestActor must prefer the headers of the call's own HTTP request
+// over the session context: the context actor is captured at initialize
+// and would misattribute every later call on a shared session.
+func TestRequestActorUsesCallHeaders(t *testing.T) {
+	cfg := &config.Config{InsecureDev: true}
+	h := http.Header{}
+	h.Set(httpauth.OnBehalfOfHeader, "human:tanaka@example.co.jp")
+	req := &mcp.CallToolRequest{Extra: &mcp.RequestExtra{Header: h}}
+	ctx := httpauth.WithActor(context.Background(),
+		domain.Actor{Kind: domain.ActorHuman, Name: "initializer@example.co.jp"})
+
+	actor, err := requestActor(ctx, cfg, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := domain.Actor{Kind: domain.ActorHuman, Name: "tanaka@example.co.jp", Via: "human:anonymous"}
+	if actor != want {
+		t.Errorf("actor = %+v, want %+v", actor, want)
+	}
+}
+
+// Without an HTTP request (in-process transports), the context actor is
+// all there is — and correct, since such callers cannot share a session
+// across identities.
+func TestRequestActorFallsBackToContext(t *testing.T) {
+	want := domain.Actor{Kind: domain.ActorAgent, Name: "sa@example.gserviceaccount.com"}
+	ctx := httpauth.WithActor(context.Background(), want)
+	for _, req := range []*mcp.CallToolRequest{
+		{},
+		{Extra: &mcp.RequestExtra{}},
+	} {
+		actor, err := requestActor(ctx, &config.Config{InsecureDev: true}, req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if actor != want {
+			t.Errorf("actor = %+v, want %+v", actor, want)
+		}
 	}
 }


### PR DESCRIPTION
## 問題

streamable HTTP トランスポートはセッションを **initialize 時に一度だけ** Connect し、以後のツール呼び出しはその最初のリクエスト由来の ctx で動く。`httpauth.Middleware` は actor をリクエスト ctx に載せるため、ハンドラが見る actor は**セッションを開いた人に固定**されていた。

委譲ホスト(設計ドキュメント 0027)が 1 つの MCP セッションを複数のエンドユーザーで使い回すと、リクエストごとに `X-Ochakai-On-Behalf-Of` を変えても**全ての書き込みが最初のユーザー名義で記録**される。エラーは出ない — 0027 §5.2 が「静かな降格は明示的な失敗より高くつく」として明確に拒否した故障そのもの。

## 修正

- `httpauth.ActorFromHeader` を切り出し、ミドルウェアと MCP 層が同じ解決経路を共有するようにした
- 書き込みツール(create / update / delete)は `req.Extra.Header` — その呼び出しを実際に運んだ POST のヘッダ — から actor を再解決する。ミドルウェアが既に検証済みのヘッダなので、ここで新たに失敗することはない(万一失敗したら誤帰属させず書き込みを拒否する)
- HTTP を経ない in-process トランスポート(テスト・埋め込み)はヘッダを持たないので従来どおり ctx の actor にフォールバックする

## テスト

統合テスト `TestIntegrationDelegatedActorFollowsEachCall` を追加。1 つのセッションを alice で initialize した後、bob のヘッダで `create_knowledge` を呼び、`created_by` が bob になることを確認する。**修正前のコードでは alice が記録されて失敗する**ことを確認済み(実 DB に対して検証)。`requestActor` のユニットテスト 2 件も追加。

`gofmt` / `go vet` / `CGO_ENABLED=0 go build` / `go test -race ./...`(pgvector 実 DB 込み)green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)