### PR TITLE
検索: 空クエリを 400 にする(#124 の退行)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -39,10 +39,12 @@ paths:
         drops out once it is verified after its last failure report
         (POST /api/v1/verify/{id}), so a base that is kept up shows an
         empty feed.
-        q and sort are mutually exclusive; combining them is a 400.
+        Exactly one of q and sort is required: combining them is a 400,
+        and so is omitting both (searching needs a query to rank by).
       parameters:
         - name: q
           in: query
+          description: Search text. Required unless sort is set.
           schema: { type: string }
         - name: sort
           in: query

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -170,6 +170,9 @@ func cmdSearch(ctx context.Context, args []string) error {
 	if *sortBy != "" && len(pos) > 0 {
 		return fmt.Errorf("--sort lists entries; it cannot be combined with a search query")
 	}
+	if *sortBy == "" && strings.TrimSpace(strings.Join(pos, " ")) == "" {
+		return fmt.Errorf("search needs a query; use --sort to list entries without one")
+	}
 	c, err := newClient(ctx, *url)
 	if err != nil {
 		return err

--- a/cmd/ochakai/client_test.go
+++ b/cmd/ochakai/client_test.go
@@ -51,6 +51,18 @@ func TestParseRef(t *testing.T) {
 	}
 }
 
+// TestCmdSearchNeedsQueryOrSort pins the client-side check mirroring the
+// server rule: exactly one of the query and --sort is required, and both
+// checks fire before any connection is made.
+func TestCmdSearchNeedsQueryOrSort(t *testing.T) {
+	if err := cmdSearch(context.Background(), nil); err == nil || !strings.Contains(err.Error(), "needs a query") {
+		t.Errorf("no query and no --sort: got %v, want a needs-a-query error", err)
+	}
+	if err := cmdSearch(context.Background(), []string{" ", "\t"}); err == nil || !strings.Contains(err.Error(), "needs a query") {
+		t.Errorf("whitespace query: got %v, want a needs-a-query error", err)
+	}
+}
+
 func TestDecodeEntryDetectsFormat(t *testing.T) {
 	fromJSON, err := decodeEntry([]byte(`{"type":"metric","id":"revenue","title":"売上"}`))
 	if err != nil || fromJSON.ID != "revenue" {

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -114,7 +114,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"lists by demand (most search_hits first, never-used drafts oldest-first at the bottom) and " +
 			"each hit carries its usage totals — the draft review/promotion feed. With sort=\"failed\" it " +
 			"lists entries callers reported wrong (report_outcome failed), worst first — the re-verification " +
-			"feed; empty when nothing was reported wrong.",
+			"feed; empty when nothing was reported wrong. Exactly one of query / sort is required.",
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, in searchIn) (*mcp.CallToolResult, searchOut, error) {
 		f := store.Filter{Types: domain.ToTypes(in.Types), Statuses: domain.ToStatuses(in.Statuses), Tags: in.Tags}
 		if in.Sort != "" {
@@ -380,8 +380,9 @@ func parseKnowledgeURI(uri string) (id string, ok bool) {
 // document — MCP agents only see the tool schema.
 type searchIn struct {
 	// Query drives the search. Optional in the schema because sort mode
-	// rejects it — one of query / sort must be set.
-	Query    string   `json:"query,omitempty" jsonschema:"search text; omit when sort is set"`
+	// rejects it — exactly one of query / sort must be set (the service
+	// rejects an empty search, the handler rejects the combination).
+	Query    string   `json:"query,omitempty" jsonschema:"search text; required unless sort is set (omit it then)"`
 	Types    []string `json:"types,omitempty" jsonschema:"filter by type (Metric, Golden Query, Insight, Glossary Term, BigQuery Dataset, BigQuery Table, Reference, or any custom type); matched case-insensitively"`
 	Statuses []string `json:"statuses,omitempty" jsonschema:"filter by status: draft, verified, deprecated, rejected"`
 	Tags     []string `json:"tags,omitempty" jsonschema:"filter by tag"`

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -104,8 +104,9 @@ func TestLimitContractsInSchema(t *testing.T) {
 }
 
 // TestSearchSortValidation mirrors the CLI and REST rules: a search query
-// combined with a sort mode is an error (not silently ignored), and an
-// unknown sort is rejected — for verified_at, usage, and failed.
+// combined with a sort mode is an error (not silently ignored), an
+// unknown sort is rejected — for verified_at, usage, and failed — and
+// omitting both query and sort is a tool error, not a Postgres 500.
 func TestSearchSortValidation(t *testing.T) {
 	cs := connect(t)
 	cases := []struct {
@@ -117,6 +118,8 @@ func TestSearchSortValidation(t *testing.T) {
 		{"usage with query", map[string]any{"sort": "usage", "query": "revenue"}, "cannot be combined"},
 		{"failed with query", map[string]any{"sort": "failed", "query": "revenue"}, "cannot be combined"},
 		{"invalid sort", map[string]any{"sort": "created_at"}, "invalid sort"},
+		{"neither query nor sort", map[string]any{}, "needs a query"},
+		{"whitespace query", map[string]any{"query": " \t"}, "needs a query"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/restapi/restapi_test.go
+++ b/internal/restapi/restapi_test.go
@@ -42,14 +42,18 @@ func TestWriteErrorStatuses(t *testing.T) {
 }
 
 // TestBadRequestValidation exercises the parameter checks that fail before
-// any service call: malformed numbers are rejected instead of silently
-// treated as unset, and q cannot be combined with sort (matching the CLI).
+// any store access: malformed numbers are rejected instead of silently
+// treated as unset, q cannot be combined with sort (matching the CLI), and
+// a search without a query is a 400, not zero-fragment SQL handed to
+// Postgres.
 func TestBadRequestValidation(t *testing.T) {
 	h := Handler(&service.Service{})
 	cases := []struct {
 		name, url, wantSubstr string
 	}{
 		{"invalid sort", "/api/v1/knowledge?sort=created_at", "invalid sort"},
+		{"neither q nor sort", "/api/v1/knowledge", "needs a query"},
+		{"whitespace query", "/api/v1/knowledge?q=%20%09", "needs a query"},
 		{"sort with query", "/api/v1/knowledge?sort=verified_at&q=revenue", "cannot be combined"},
 		{"usage sort with query", "/api/v1/knowledge?sort=usage&q=revenue", "cannot be combined"},
 		{"failed sort with query", "/api/v1/knowledge?sort=failed&q=revenue", "cannot be combined"},

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -359,6 +359,12 @@ func (s *Service) Search(ctx context.Context, query string, f store.Filter, limi
 	// Stored text is NFC (design doc 0022); an NFD query (pasted from a
 	// macOS path) must still match it byte-wise.
 	query = domain.Normalize(query)
+	// An empty query has nothing to rank by: SearchLexical splits the
+	// query into fragments and gets none, so guard here — once, for
+	// every surface — and point the caller at the listing modes.
+	if strings.TrimSpace(query) == "" {
+		return nil, Invalidf("search needs a query; use sort=verified_at, usage, or failed to list entries without one")
+	}
 	hits, err := s.search(ctx, query, f, limit)
 	if err != nil {
 		return nil, err

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/na0fu3y/ochakai/internal/domain"
 	"github.com/na0fu3y/ochakai/internal/embed"
 	"github.com/na0fu3y/ochakai/internal/okf"
+	"github.com/na0fu3y/ochakai/internal/store"
 )
 
 func hit(id string, status domain.Status) domain.SearchHit {
@@ -92,6 +93,22 @@ func TestRRFFuseLimit(t *testing.T) {
 	}
 	if got := len(rrfFuse(2, list)); got != 2 {
 		t.Errorf("want limit 2, got %d", got)
+	}
+}
+
+// TestSearchRejectsEmptyQuery pins the guard that fires before any store
+// access: an empty or whitespace-only query is a client error
+// (InvalidInputError → 400). SearchLexical splits the query into
+// fragments and an empty query yields none, so without the guard it
+// builds zero-fragment SQL and every surface got a Postgres 500.
+func TestSearchRejectsEmptyQuery(t *testing.T) {
+	s := &Service{}
+	var inputErr *InvalidInputError
+	for _, q := range []string{"", "   ", " \t\n", "　"} {
+		_, err := s.Search(context.Background(), q, store.Filter{}, 10)
+		if !errors.As(err, &inputErr) || !strings.Contains(err.Error(), "needs a query") {
+			t.Errorf("query %q: got %v, want a needs-a-query InvalidInputError", q, err)
+		}
 	}
 }
 

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -763,7 +763,11 @@ async function runSearch() {
   const isFeed = explore.staleFeed || explore.failedFeed;
   if (explore.staleFeed) p.set('sort', 'verified_at');
   else if (explore.failedFeed) p.set('sort', 'failed');
-  else if (explore.q) p.set('q', explore.q);
+  else if (explore.q.trim()) p.set('q', explore.q);
+  // No query typed yet (or only whitespace): the landing view lists by
+  // demand instead of searching — an empty q is a 400 (searching needs
+  // a query to rank by).
+  else p.set('sort', 'usage');
   for (const t of explore.types) p.append('type', t);
   for (const s of explore.statuses) p.append('status', s);
   if (explore.tag) p.append('tag', explore.tag);


### PR DESCRIPTION
## 退行

フラグメント化リワーク(#124)で、空・空白のみのクエリが `queryFragments` から 0 個のフラグメントになり、`SearchLexical` が構文的に不正な SQL(`() / NULLIF(, 0)` など)を組み立てて Postgres エラー → 500 になっていた。v0.12.1 では空 q は `ILIKE '%%'` で全件マッチしていた。

到達経路: REST(`q` も `sort` もなし)、MCP `search_knowledge`(両方省略)、さらに **Web UI のランディング表示**(空 q で検索していたため #124 以降ずっと「Search failed」になっていた)。

## 修正

- `Service.Search` で正規化後に TrimSpace 空なら `InvalidInputError`(REST 400 / MCP ツールエラー)。sort によるリストモードへ誘導するメッセージ付き。全サーフェス共通の一箇所のガード(`Service.Context` は既存ガードあり)
- openapi.yaml と `search_knowledge` のスキーマ・説明に「q(query)と sort はちょうど一方が必須」を明記
- CLI は既存の `--sort` 併用チェックと対で、クエリ欠落を接続前に拒否
- Web UI のランディングは空 q を送る代わりに `sort=usage` で一覧する

## テスト

service(空・空白クエリ → InvalidInputError)、restapi(パラメータなし → 400)、mcpserver(query/sort 両省略 → ツールエラー)、CLI の各ユニットテストを追加。`gofmt` / `go vet` / `CGO_ENABLED=0 go build` / `go test -race ./...` 全て green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)