### PR TITLE
移動対象自身の書き換えを move リビジョンに畳み込む (design 0024 §3.5)

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -552,10 +552,10 @@ func (s *Store) Move(ctx context.Context, oldID, newID string, actor domain.Acto
 				return err
 			}
 		}
-		if err := s.rewriteReferences(ctx, tx, oldID, newID, actor); err != nil {
+		k.ID = newID
+		if err := s.rewriteReferences(ctx, tx, oldID, k, actor); err != nil {
 			return err
 		}
-		k.ID = newID
 		return s.addRevision(ctx, tx, k, "move", actor)
 	})
 	if err != nil {
@@ -567,7 +567,12 @@ func (s *Store) Move(ctx context.Context, oldID, newID string, actor domain.Acto
 // rewriteReferences updates live entries that reference oldID — the
 // markdown links in their body, and attrs.model (design doc 0019) — each
 // rewrite recorded as an "update" revision. Runs after the rename itself,
-// so a self-referencing entry (already at newID) is covered too.
+// so the moved entry (already renamed, passed as moved with the move's
+// timestamp stamped) is covered too — but its own rewrite is part of the
+// move, not a separate change: the row keeps the move's updated_at, no
+// "update" revision is added, and the rewritten body, links, and attrs
+// are folded back into moved so the caller's "move" revision and return
+// value carry the final state.
 //
 // The body is what gets rewritten: links are derived from it (design doc
 // 0024), so repairing the links column alone would leave the author's
@@ -576,7 +581,8 @@ func (s *Store) Move(ctx context.Context, oldID, newID string, actor domain.Acto
 //
 // Candidates come from the links column, which still holds the pre-move
 // derivation and so is an accurate index of who refers to oldID.
-func (s *Store) rewriteReferences(ctx context.Context, tx pgx.Tx, oldID, newID string, actor domain.Actor) error {
+func (s *Store) rewriteReferences(ctx context.Context, tx pgx.Tx, oldID string, moved *domain.Knowledge, actor domain.Actor) error {
+	newID := moved.ID
 	rows, err := tx.Query(ctx,
 		`SELECT `+knowledgeCols+` FROM knowledge
 		 WHERE deleted_at IS NULL AND (links @> $1 OR links @> $2 OR attrs->>'model' = $3 OR id = $4)`,
@@ -594,11 +600,12 @@ func (s *Store) rewriteReferences(ctx context.Context, tx pgx.Tx, oldID, newID s
 	movedDirs := path.Dir(oldID) != path.Dir(newID)
 	for i := range referrers {
 		r := &referrers[i]
+		self := r.ID == newID
 		// The moved entry resolves its own relative links against its old
 		// directory, so it is rewritten as if it still lived at oldID.
 		from := r.ID
 		body := r.Body
-		if r.ID == newID {
+		if self {
 			from = oldID
 			// Its own outbound relative links point at the old directory,
 			// and links are derived from the body against the entry's
@@ -624,11 +631,26 @@ func (s *Store) rewriteReferences(ctx context.Context, tx pgx.Tx, oldID, newID s
 		if err != nil {
 			return err
 		}
-		r.UpdatedAt = now
+		// The moved entry's own rewrite is the move, not a change on top
+		// of it: keep the move's timestamp so the row, the "move"
+		// revision, and the returned entry agree on one instant.
+		if self {
+			r.UpdatedAt = moved.UpdatedAt
+		} else {
+			r.UpdatedAt = now
+		}
 		if _, err := tx.Exec(ctx,
 			`UPDATE knowledge SET links=$2, attrs=$3, body=$4, updated_at=$5 WHERE id=$1`,
 			r.ID, links, attrs, r.Body, r.UpdatedAt); err != nil {
 			return err
+		}
+		if self {
+			// Fold the result back into the caller's entry; the caller
+			// records the single "move" revision with this final state.
+			moved.Body = r.Body
+			moved.Links = r.Links
+			moved.Attrs = r.Attrs
+			continue
 		}
 		if err := s.addRevision(ctx, tx, r, "update", actor); err != nil {
 			return err

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -1670,6 +1670,123 @@ func TestIntegrationMoveKeepsOutboundRelativeLinks(t *testing.T) {
 	}
 }
 
+// A move that rewrites the moved entry's own body — relative links
+// absolutized because the directory changed (design doc 0024 §3.5) — is
+// still one logical operation. The value Move returns, the stored row,
+// and the entry's terminal "move" revision must all carry the same final
+// body, links, attrs, and timestamp; the moved entry gets no separate
+// "update" revision (only its referrers do). This is the regression test
+// for Move returning the pre-rewrite body with a stale updated_at.
+func TestIntegrationMoveSelfRewriteIsOneRevision(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	for _, table := range []string{"knowledge", "knowledge_revision"} {
+		if _, err := s.pool.Exec(ctx, `DELETE FROM `+table+` WHERE id LIKE 'it-selfmove%'`); err != nil {
+			t.Fatal(err)
+		}
+	}
+	defer func() {
+		for _, table := range []string{"knowledge", "knowledge_revision"} {
+			_, _ = s.pool.Exec(ctx, `DELETE FROM `+table+` WHERE id LIKE 'it-selfmove%'`)
+		}
+	}()
+
+	actor := domain.Actor{Kind: "human", Name: "test"}
+	const neighbour = "it-selfmove-src/gross"
+	const mover = "it-selfmove-src/revenue"
+	const referrer = "it-selfmove-src/note"
+	const dest = "it-selfmove-dst/revenue"
+	for _, k := range []*domain.Knowledge{
+		{Type: domain.TypeMetrics, ID: neighbour, Title: "gross", Status: domain.StatusDraft, CreatedBy: actor},
+		{Type: domain.TypeMetrics, ID: mover, Title: "revenue", Status: domain.StatusDraft, CreatedBy: actor,
+			Body:  "Net of [gross](./gross.md).",
+			Links: []domain.Link{{Target: neighbour, Text: "gross"}}},
+		{Type: domain.TypeInsights, ID: referrer, Title: "note", Status: domain.StatusDraft, CreatedBy: actor,
+			Body:  "See [revenue](./revenue.md).",
+			Links: []domain.Link{{Target: mover, Text: "revenue"}}},
+	} {
+		if err := s.Create(ctx, k); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	returned, err := s.Move(ctx, mover, dest, actor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stored, err := s.Get(ctx, dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// (1) The return value is the stored row: the rewrite that the move
+	// performed on the entry's own body is visible in what Move hands back.
+	if !strings.Contains(stored.Body, "/"+neighbour+".md") {
+		t.Fatalf("the move did not absolutize the entry's own relative link: %q", stored.Body)
+	}
+	if returned.Body != stored.Body {
+		t.Errorf("Move returned body %q, stored body is %q", returned.Body, stored.Body)
+	}
+	if !returned.UpdatedAt.Equal(stored.UpdatedAt) {
+		t.Errorf("Move returned updated_at %v, stored row has %v — the returned value cannot serve as If-Match", returned.UpdatedAt, stored.UpdatedAt)
+	}
+	if len(returned.Links) != 1 || returned.Links[0].Target != neighbour {
+		t.Errorf("Move returned links %+v, want the re-derived link to %s", returned.Links, neighbour)
+	}
+
+	// (2) One operation, one revision: history is create then move, the
+	// move snapshot is the stored row, and nothing trails it.
+	revs, err := s.ListRevisions(ctx, dest, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(revs) != 2 || revs[0].Change != "move" || revs[1].Change != "create" {
+		changes := make([]string, len(revs))
+		for i, r := range revs {
+			changes[i] = r.Change
+		}
+		t.Fatalf("revisions (newest first) = %v, want [move create] — the moved entry must not get its own trailing \"update\"", changes)
+	}
+	if revs[0].Snapshot.Body != stored.Body {
+		t.Errorf("move revision snapshot body %q contradicts the stored row %q", revs[0].Snapshot.Body, stored.Body)
+	}
+	if !revs[0].Snapshot.UpdatedAt.Equal(stored.UpdatedAt) {
+		t.Errorf("move revision snapshot updated_at %v, stored row has %v", revs[0].Snapshot.UpdatedAt, stored.UpdatedAt)
+	}
+	if revs[0].Snapshot.UpdatedAt.Before(revs[1].Snapshot.UpdatedAt) {
+		t.Errorf("revision timestamps run backwards: rev %d has %v, rev %d has %v",
+			revs[1].Rev, revs[1].Snapshot.UpdatedAt, revs[0].Rev, revs[0].Snapshot.UpdatedAt)
+	}
+	if revs[0].ChangedAt.Before(revs[1].ChangedAt) {
+		t.Errorf("revision changed_at runs backwards: rev %d at %v, rev %d at %v",
+			revs[1].Rev, revs[1].ChangedAt, revs[0].Rev, revs[0].ChangedAt)
+	}
+
+	// (3) Referrers keep their own "update" revision — their rewrite is a
+	// change to them, distinct from the move.
+	refRevs, err := s.ListRevisions(ctx, referrer, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refRevs) != 2 || refRevs[0].Change != "update" {
+		t.Fatalf("referrer revisions = %+v, want an \"update\" on top of \"create\"", refRevs)
+	}
+	if !strings.Contains(refRevs[0].Snapshot.Body, "/"+dest+".md") {
+		t.Errorf("referrer's update snapshot still points at the old id: %q", refRevs[0].Snapshot.Body)
+	}
+}
+
 // An export is streamed, so its reads happen at different moments. The
 // snapshot is what keeps the archive a picture of one instant: an entry
 // deleted after the id list was taken still has to be in the bundle the


### PR DESCRIPTION
## 問題

`Store.Move` はトランザクション外でエントリを読み、行をリネームした後、`rewriteReferences` が移動対象自身を「他の参照元と同じ扱い」で書き換えていた。ディレクトリが変わる移動では自身の相対リンクが絶対化され(design 0024 §3.5、PR #138)、新しいタイムスタンプと独立した "update" リビジョンが記録される一方、Move は書き換え**前**の値で "move" リビジョンを記録し、それを返していた。

その結果:

- REST `/move` のレスポンス本文は旧相対リンクのまま、DB は絶対リンク
- レスポンスの `updated_at` が保存行と一致せず、次の PUT の If-Match に使うと必ず 412
- リビジョン履歴が「update(新しい本文)→ move(古い本文)」となり、タイムスタンプ順が崩れ、最新スナップショットが実際の行と矛盾する

## 修正

1 つの論理操作は 1 リビジョン・1 タイムスタンプに。`rewriteReferences` に移動後のエントリ自体を渡し、自身の行については move のタイムスタンプを使い、独立した "update" リビジョンを追加せず、書き換え後の body・再導出した links・修復した attrs を呼び出し元へ反映する。これで終端の "move" リビジョンと Move の返り値が保存行と一致する。他の参照元は従来どおり各自の "update" リビジョンを持つ(0024 の規定どおり)。自身の本文に修復が不要な場合の挙動は不変。

## テスト

環境変数ゲート付き統合テスト `TestIntegrationMoveSelfRewriteIsOneRevision` を追加。**修正前のコードでは上記 3 症状すべてで失敗する**ことを確認済み。pgvector/pg17 の実 DB に対して全統合テストを含む `go test -race ./...` が green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)