### PR TITLE
If-Match を公開契約と CLI に載せ、ワイヤ契約の抜けを埋める

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -10,7 +10,7 @@ info:
     human-facing browse/revisions/backlinks reads, and attachment writes —
     so users can build their own web UIs. ochakai executes no SQL and uses
     no LLM.
-  version: 0.1.0
+  version: 0.13.0
   license:
     name: MIT
 servers:
@@ -18,7 +18,11 @@ servers:
 # Authentication is Cloud Run IAM (Google identity), handled by the
 # infrastructure before requests reach ochakai — there is no
 # application-level auth scheme. ochakai reads the forwarded identity
-# only to record provenance (design docs 0002/0003).
+# only to record provenance (design docs 0002/0003). An application on
+# the delegator allowlist may forward the end user it acts for with
+# X-Ochakai-On-Behalf-Of (design doc 0027) — the header is honored on
+# every call; it is declared below (components/parameters/OnBehalfOf)
+# on the operations that record provenance.
 paths:
   /api/v1/knowledge:
     get:
@@ -94,6 +98,8 @@ paths:
         authorization). A live entry with the same id is a 409 —
         including rejected ones — but creating over a soft-deleted entry
         revives it (its prior history stays in the revisions).
+      parameters:
+        - $ref: "#/components/parameters/OnBehalfOf"
       requestBody:
         required: true
         content:
@@ -250,6 +256,8 @@ paths:
       responses:
         "200":
           description: The entry.
+          headers:
+            ETag: { $ref: "#/components/headers/ETag" }
           content:
             application/json:
               schema: { $ref: "#/components/schemas/Knowledge" }
@@ -259,7 +267,12 @@ paths:
       summary: Update a knowledge entry (full replacement; revisions retained)
       description: >
         The path is the address; the body carries the metadata — type
-        included, always (design doc 0016).
+        included, always (design doc 0016). With If-Match, the update is
+        conditional on the entry's version — see the parameter; without
+        it, last write wins.
+      parameters:
+        - $ref: "#/components/parameters/IfMatch"
+        - $ref: "#/components/parameters/OnBehalfOf"
       requestBody:
         required: true
         content:
@@ -269,6 +282,7 @@ paths:
         "200":
           description: Updated, or unchanged (see the Ochakai-Unchanged header).
           headers:
+            ETag: { $ref: "#/components/headers/ETag" }
             Ochakai-Unchanged:
               description: >
                 Set to "true" when the payload matched the stored content
@@ -278,7 +292,28 @@ paths:
           content:
             application/json:
               schema: { $ref: "#/components/schemas/Knowledge" }
+        "400":
+          description: >
+            Invalid entry, or a malformed If-Match value (one that is
+            neither "*" nor an RFC3339Nano version, quoted or bare).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error: { type: string }
         "404": { $ref: "#/components/responses/Error" }
+        "412":
+          description: >
+            The If-Match precondition failed: the entry changed since it
+            was read. Nothing was written — re-read the entry, redo the
+            edit, and retry with the new version.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error: { type: string }
     delete:
       operationId: deleteKnowledge
       summary: Soft-delete a knowledge entry (history retained)
@@ -298,6 +333,7 @@ paths:
           in: query
           description: Hard-delete an already soft-deleted entry.
           schema: { type: string, enum: ["true"] }
+        - $ref: "#/components/parameters/OnBehalfOf"
       responses:
         "204": { description: Deleted. }
         "404": { $ref: "#/components/responses/Error" }
@@ -317,6 +353,8 @@ paths:
         DELETE ...?purge=true. Lives at its own top-level path for the
         same reason /usage and /revisions do — a suffix after the
         hierarchical id could be confused with an ID segment.
+      parameters:
+        - $ref: "#/components/parameters/OnBehalfOf"
       requestBody:
         required: true
         content:
@@ -362,6 +400,8 @@ paths:
         ruling the write-back loop turns on. Lives at its own top-level
         path for the same reason /usage does — a suffix after the
         hierarchical id could be confused with an ID segment.
+      parameters:
+        - $ref: "#/components/parameters/OnBehalfOf"
       responses:
         "200":
           description: The verified entry.
@@ -369,9 +409,7 @@ paths:
             application/json:
               schema: { $ref: "#/components/schemas/Knowledge" }
           headers:
-            ETag:
-              schema: { type: string }
-              description: The entry's version, usable as If-Match on a later update.
+            ETag: { $ref: "#/components/headers/ETag" }
         "404": { $ref: "#/components/responses/Error" }
   /api/v1/usage/{id}:
     parameters:
@@ -405,6 +443,8 @@ paths:
         failed counts against verified entries flag them for
         re-verification. The caller's identity is recorded with each
         report; the optional note travels with the raw event.
+      parameters:
+        - $ref: "#/components/parameters/OnBehalfOf"
       requestBody:
         required: true
         content:
@@ -440,7 +480,8 @@ paths:
       operationId: listKnowledgeRevisions
       summary: Change history for one knowledge entry
       description: >
-        Every create/update/delete/attach/detach, newest first, each with
+        Every change — create, update, verify, delete, move, attach,
+        detach — newest first, each with
         who made it, when, and the full snapshot as of that change — the
         read surface behind "every change kept as a revision". Works for
         soft-deleted entries too: the audit trail is most interesting
@@ -529,6 +570,7 @@ paths:
         server to have GCS configured (OCHAKAI_GCS_BUCKET); without it
         the request fails with 501.
       parameters:
+        - $ref: "#/components/parameters/OnBehalfOf"
         - name: okf_path
           in: query
           required: false
@@ -578,6 +620,8 @@ paths:
       description: >
         Removes the attachment (kept as a revision; the content-addressed
         bytes remain referenced by history).
+      parameters:
+        - $ref: "#/components/parameters/OnBehalfOf"
       responses:
         "204": { description: Detached. }
         "404": { $ref: "#/components/responses/Error" }
@@ -669,6 +713,43 @@ paths:
                     type: integer
         "501": { $ref: "#/components/responses/Error" }
 components:
+  headers:
+    ETag:
+      description: >
+        The entry's version — its updated_at in RFC3339Nano, quoted. A
+        client echoes it in If-Match on a later update to write only if
+        nothing changed meanwhile (design doc 0030).
+      schema: { type: string }
+  parameters:
+    IfMatch:
+      name: If-Match
+      in: header
+      required: false
+      description: >
+        Optimistic-concurrency precondition (design doc 0030): the
+        entry's version — its updated_at in RFC3339Nano, as a prior read
+        returned it in the ETag response header (quotes optional; the
+        JSON body's updated_at field is the same value). The write
+        happens only if the entry still has this version; an entry
+        changed since it was read is a 412 and nothing is written.
+        Absent or "*" means no precondition — last write wins. A value
+        that is neither is a 400.
+      schema: { type: string }
+    OnBehalfOf:
+      name: X-Ochakai-On-Behalf-Of
+      in: header
+      required: false
+      description: >
+        Delegated end-user identity (design doc 0027): "kind:identity",
+        kind human or agent, no whitespace in the identity, at most 320
+        bytes — e.g. "human:tanaka@example.co.jp". An application on the
+        delegator allowlist (OCHAKAI_DELEGATING_CALLERS) forwards who it
+        is acting for; the forwarded identity is recorded as the actor
+        and the caller is kept as Actor.via — never dropped. A caller
+        not permitted to delegate is a 403 and a malformed value a 400 —
+        an error, not a silent downgrade. Honored on every call;
+        declared on the operations that record provenance.
+      schema: { type: string, maxLength: 320 }
   responses:
     Error:
       description: Error.
@@ -866,7 +947,7 @@ components:
         how, when, and the full snapshot as of that change.
       properties:
         rev: { type: integer, description: 1-based, monotonically increasing per entry. }
-        change: { type: string, enum: [create, update, delete, move, attach, detach] }
+        change: { type: string, enum: [create, update, verify, delete, move, attach, detach] }
         changed_by: { $ref: "#/components/schemas/Actor" }
         changed_at: { type: string, format: date-time }
         snapshot: { $ref: "#/components/schemas/Knowledge" }

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -681,9 +681,10 @@ func cmdCreate(ctx context.Context, args []string) error {
 
 func cmdUpdate(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
-		"Usage: ochakai update [flags] <id>\n\nReplace a knowledge entry from -f or stdin (OKF document or JSON;\nthe id comes from the argument, the type from the input). Every\nchange is kept as a revision server-side.",
-		"  ochakai get metrics/revenue | $EDITOR /dev/stdin | ochakai update metrics/revenue\n  ochakai update metrics/revenue -f revenue.md\n")
+		"Usage: ochakai update [flags] <id>\n\nReplace a knowledge entry from -f or stdin (OKF document or JSON;\nthe id comes from the argument, the type from the input). Every\nchange is kept as a revision server-side. With --if-match the update\nis conditional: it lands only if the entry still has the version you\nread, and fails instead of overwriting someone else's edit.",
+		"  ochakai get metrics/revenue | $EDITOR /dev/stdin | ochakai update metrics/revenue\n  ochakai update metrics/revenue -f revenue.md\n  ochakai update metrics/revenue -f revenue.md --if-match \"$(ochakai get metrics/revenue --json | jq -r .updated_at)\"\n")
 	file := fs.String("f", "", "input file (default: stdin)")
+	ifMatch := fs.String("if-match", "", "update only if the entry still has this `version` — its updated_at (`ochakai get <id> --json` prints it as .updated_at; a REST GET returns it as the ETag header); a stale version fails with a conflict instead of overwriting")
 	asJSON := fs.Bool("json", false, "print the updated entry as JSON")
 	pos, err := parseArgs(fs, args)
 	if err != nil {
@@ -706,8 +707,12 @@ func cmdUpdate(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	updated, changed, err := c.Update(ctx, k)
+	updated, changed, err := c.Update(ctx, k, *ifMatch)
 	if err != nil {
+		var apiErr *apiclient.APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusPreconditionFailed {
+			return fmt.Errorf("conflict: ochakai://%s changed since the version in --if-match — `ochakai get %s` again, redo the edit, and retry with the new updated_at", id, id)
+		}
 		return err
 	}
 	if *asJSON {
@@ -998,7 +1003,9 @@ func cmdImport(ctx context.Context, args []string) error {
 		} else if !isConflict(err) {
 			return fmt.Errorf("%s: %w", k.URI(), err)
 		}
-		_, changed, err := c.Update(ctx, k)
+		// No If-Match: import deliberately replaces whatever is stored
+		// (the bundle is the source of truth for this loop).
+		_, changed, err := c.Update(ctx, k, "")
 		if err != nil {
 			if isInvalid(err) {
 				skipEntry(k, err)

--- a/cmd/ochakai/client_test.go
+++ b/cmd/ochakai/client_test.go
@@ -248,3 +248,36 @@ func TestImportReportsUnchanged(t *testing.T) {
 		}
 	}
 }
+
+// `ochakai update --if-match` sends the version as the If-Match header,
+// and a 412 comes back as an actionable conflict message (re-read, redo,
+// retry) rather than the raw server error.
+func TestUpdateIfMatchSendsHeaderAndExplainsConflict(t *testing.T) {
+	var gotIfMatch string
+	mux := http.NewServeMux()
+	mux.HandleFunc("PUT /api/v1/knowledge/{id...}", func(w http.ResponseWriter, r *http.Request) {
+		gotIfMatch = r.Header.Get("If-Match")
+		w.WriteHeader(http.StatusPreconditionFailed)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "knowledge changed since it was read"})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	doc := filepath.Join(t.TempDir(), "revenue.md")
+	if err := os.WriteFile(doc, []byte("---\ntype: metric\ntitle: 売上\n---\n\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := cmdUpdate(context.Background(), []string{"metrics/revenue",
+		"-f", doc, "--if-match", "2026-07-01T00:00:00.123456789Z", "--url", srv.URL})
+	if gotIfMatch != `"2026-07-01T00:00:00.123456789Z"` {
+		t.Errorf("If-Match on the wire = %q", gotIfMatch)
+	}
+	if err == nil {
+		t.Fatal("stale --if-match succeeded, want a conflict error")
+	}
+	for _, want := range []string{"conflict", "ochakai get metrics/revenue"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("conflict error misses %q: %v", want, err)
+		}
+	}
+}

--- a/cmd/ochakai/completion.go
+++ b/cmd/ochakai/completion.go
@@ -105,8 +105,11 @@ _ochakai() {
     report)
       _arguments '--note[context recorded with the report]:note:' '--json[print JSON]' '--url[server URL]:url:' '2:outcome:(worked failed)'
       ;;
-    create|update)
+    create)
       _arguments '-f[input file]:file:_files' '--json[print the entry as JSON]' '--url[server URL]:url:'
+      ;;
+    update)
+      _arguments '-f[input file]:file:_files' '--if-match[update only if the entry still has this version (updated_at)]:version:' '--json[print the entry as JSON]' '--url[server URL]:url:'
       ;;
     verify|delete|purge|detach|move)
       _arguments '--url[server URL]:url:'
@@ -180,7 +183,8 @@ _ochakai() {
         return
       fi
       opts="--note --json --url" ;;
-    create|update) opts="-f --json --url" ;;
+    create)        opts="-f --json --url" ;;
+    update)        opts="-f --if-match --json --url" ;;
     verify|delete|purge|detach|move) opts="--url" ;;
     attach)        opts="--name --json --url" ;;
     reembed)       opts="--url --limit --once --json" ;;
@@ -238,11 +242,11 @@ complete -c ochakai -n __fish_use_subcommand -a serve -d 'start the MCP + REST s
 complete -c ochakai -n __fish_use_subcommand -a serve-ui -d 'serve the team web UI as a deployed service'
 complete -c ochakai -n __fish_use_subcommand -a version -d 'print the version'
 
-complete -c ochakai -n '__fish_seen_subcommand_from search browse context get create update verify delete purge move attach detach usage report revisions backlinks export import whoami ui' -l url -x -d 'server URL'
+complete -c ochakai -n '__fish_seen_subcommand_from search browse context get create update verify delete purge reembed move attach detach usage report revisions backlinks export import whoami ui' -l url -x -d 'server URL'
 complete -c ochakai -n '__fish_seen_subcommand_from ui' -l port -x -d 'port on 127.0.0.1'
 complete -c ochakai -n '__fish_seen_subcommand_from import' -l dry-run -d 'parse and list, write nothing'
 complete -c ochakai -n '__fish_seen_subcommand_from import' -F
-complete -c ochakai -n '__fish_seen_subcommand_from search browse context get create update attach usage report revisions backlinks whoami' -l json -d 'print raw JSON'
+complete -c ochakai -n '__fish_seen_subcommand_from search browse context get create update reembed attach usage report revisions backlinks whoami' -l json -d 'print raw JSON'
 complete -c ochakai -n '__fish_seen_subcommand_from report' -l note -x -d 'context recorded with the report'
 complete -c ochakai -n '__fish_seen_subcommand_from report' -a 'worked failed'
 complete -c ochakai -n '__fish_seen_subcommand_from get' -l download -r -a '(__fish_complete_directories)' -d 'save attachments into this directory'
@@ -258,6 +262,7 @@ complete -c ochakai -n '__fish_seen_subcommand_from reembed' -l once -d 'a singl
 complete -c ochakai -n '__fish_seen_subcommand_from context' -l budget -x -d 'stop rendering after ~bytes'
 complete -c ochakai -n '__fish_seen_subcommand_from context' -l min-score -x -d 'drop hits below this score'
 complete -c ochakai -n '__fish_seen_subcommand_from create update' -s f -r -F -d 'input file'
+complete -c ochakai -n '__fish_seen_subcommand_from update' -l if-match -x -d 'update only if the entry still has this version (updated_at)'
 complete -c ochakai -n '__fish_seen_subcommand_from use' -l name -x -d 'name to save the URL under'
 complete -c ochakai -n '__fish_seen_subcommand_from use' -a '(ochakai use 2>/dev/null | cut -c3- | cut -f1)'
 complete -c ochakai -n '__fish_seen_subcommand_from completion' -a 'zsh bash fish'

--- a/cmd/ochakai/completion_test.go
+++ b/cmd/ochakai/completion_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"regexp"
+	"slices"
 	"strings"
 	"testing"
 
@@ -53,6 +55,113 @@ func TestCompletionScriptsStayInSync(t *testing.T) {
 		for _, gone := range []string{"--keep-root", "--dialect", "import-ossie"} {
 			if strings.Contains(script, gone) {
 				t.Errorf("%s script still offers removed flag/command %q", shell, gone)
+			}
+		}
+	}
+}
+
+// The canonical long-flag surface of every client command — the single
+// spec all three hand-written scripts are checked against, both ways
+// (a flag missing from one shell, and a flag a shell offers that the
+// command does not have). Short flags (-f) are outside the check.
+var completionLongFlags = map[string][]string{
+	"search":    {"type", "status", "tag", "sort", "limit", "json", "url"},
+	"browse":    {"json", "url"},
+	"context":   {"type", "status", "tag", "limit", "budget", "min-score", "json", "url"},
+	"get":       {"json", "download", "url"},
+	"create":    {"json", "url"},
+	"update":    {"if-match", "json", "url"},
+	"verify":    {"url"},
+	"delete":    {"url"},
+	"purge":     {"url"},
+	"reembed":   {"limit", "once", "json", "url"},
+	"move":      {"url"},
+	"attach":    {"name", "json", "url"},
+	"detach":    {"url"},
+	"usage":     {"json", "url"},
+	"report":    {"note", "json", "url"},
+	"revisions": {"limit", "json", "url"},
+	"backlinks": {"limit", "json", "url"},
+	"export":    {"no-attachments", "url"},
+	"import":    {"dry-run", "url"},
+	"use":       {"name"},
+	"whoami":    {"json", "url"},
+	"ui":        {"port", "url"},
+}
+
+// caseArms parses the "label) ... ;;" arms of a shell case statement,
+// mapping every |-alternative of each label to the arm's text.
+func caseArms(script string) map[string]string {
+	arms := map[string]string{}
+	label := regexp.MustCompile(`(?m)^\s*([a-z|_-]+)\)`)
+	for _, loc := range label.FindAllStringSubmatchIndex(script, -1) {
+		body := script[loc[1]:]
+		if end := strings.Index(body, ";;"); end >= 0 {
+			body = body[:end]
+		}
+		for _, name := range strings.Split(script[loc[2]:loc[3]], "|") {
+			arms[name] += body
+		}
+	}
+	return arms
+}
+
+// armFlags extracts the long flags each command's case arm offers.
+func armFlags(arms map[string]string, flagPattern string) map[string]map[string]bool {
+	re := regexp.MustCompile(flagPattern)
+	flags := map[string]map[string]bool{}
+	for cmd, body := range arms {
+		flags[cmd] = map[string]bool{}
+		for _, m := range re.FindAllStringSubmatch(body, -1) {
+			flags[cmd][m[1]] = true
+		}
+	}
+	return flags
+}
+
+// fishFlags maps each command to the long flags declared for it: every
+// `complete ... -n '__fish_seen_subcommand_from a b c' ... -l flag` line
+// attributes the flag to each listed command.
+func fishFlags(script string) map[string]map[string]bool {
+	cond := regexp.MustCompile(`__fish_seen_subcommand_from ([a-z -]+)'`)
+	long := regexp.MustCompile(`-l ([a-z-]+)`)
+	flags := map[string]map[string]bool{}
+	for _, line := range strings.Split(script, "\n") {
+		c, l := cond.FindStringSubmatch(line), long.FindStringSubmatch(line)
+		if c == nil || l == nil {
+			continue
+		}
+		for _, cmd := range strings.Fields(c[1]) {
+			if flags[cmd] == nil {
+				flags[cmd] = map[string]bool{}
+			}
+			flags[cmd][l[1]] = true
+		}
+	}
+	return flags
+}
+
+// Guard: each shell script offers exactly the long flags each command
+// has — per command, both directions — so a flag added to one script
+// (or to the command itself) cannot silently miss the other shells.
+func TestCompletionFlagsStayInSyncAcrossShells(t *testing.T) {
+	byShell := map[string]map[string]map[string]bool{
+		// zsh spells a flag "--name[help]", bash lists them in opts="...".
+		"zsh":  armFlags(caseArms(zshCompletion), `--([a-z-]+)\[`),
+		"bash": armFlags(caseArms(bashCompletion), `--([a-z-]+)`),
+		"fish": fishFlags(fishCompletion),
+	}
+	for shell, byCmd := range byShell {
+		for cmd, want := range completionLongFlags {
+			for _, f := range want {
+				if !byCmd[cmd][f] {
+					t.Errorf("%s script misses --%s for %q", shell, f, cmd)
+				}
+			}
+			for f := range byCmd[cmd] {
+				if !slices.Contains(want, f) {
+					t.Errorf("%s script offers --%s for %q, which that command does not have", shell, f, cmd)
+				}
 			}
 		}
 	}

--- a/internal/apiclient/apiclient.go
+++ b/internal/apiclient/apiclient.go
@@ -242,8 +242,22 @@ func (c *Client) Create(ctx context.Context, k *domain.Knowledge) (*domain.Knowl
 // wrote nothing because the payload matched the stored content (the
 // Ochakai-Unchanged response header); servers predating the header
 // always report changed=true.
-func (c *Client) Update(ctx context.Context, k *domain.Knowledge) (updated *domain.Knowledge, changed bool, err error) {
-	resp, err := c.do(ctx, http.MethodPut, entryPath(k.ID), nil, k)
+//
+// A non-empty ifMatch is sent as the If-Match precondition: the entry's
+// version — its updated_at in RFC3339Nano, as a prior read returned it
+// (the ETag header, or the JSON body's updated_at field). The update
+// then lands only if the entry still has that version; a stale one is a
+// 412 APIError and nothing is written. "" means last write wins.
+func (c *Client) Update(ctx context.Context, k *domain.Knowledge, ifMatch string) (updated *domain.Knowledge, changed bool, err error) {
+	buf, err := json.Marshal(k)
+	if err != nil {
+		return nil, false, err
+	}
+	var hdr http.Header
+	if ifMatch != "" {
+		hdr = http.Header{"If-Match": {etagValue(ifMatch)}}
+	}
+	resp, err := c.doRaw(ctx, http.MethodPut, entryPath(k.ID), nil, "application/json", hdr, bytes.NewReader(buf))
 	if err != nil {
 		return nil, false, err
 	}
@@ -253,6 +267,15 @@ func (c *Client) Update(ctx context.Context, k *domain.Knowledge) (updated *doma
 		return nil, false, err
 	}
 	return &out, resp.Header.Get("Ochakai-Unchanged") != "true", nil
+}
+
+// etagValue renders a version as an If-Match value: quoted, the way HTTP
+// spells an ETag, unless the caller already passed one (or "*").
+func etagValue(v string) string {
+	if v == "*" || strings.HasPrefix(v, `"`) {
+		return v
+	}
+	return `"` + v + `"`
 }
 
 func (c *Client) Delete(ctx context.Context, id string) error {
@@ -304,7 +327,7 @@ func (c *Client) Attach(ctx context.Context, id, name, okfPath string, data []by
 		q = url.Values{"okf_path": {okfPath}}
 	}
 	resp, err := c.doRaw(ctx, http.MethodPut, attachmentPath(id, name), q,
-		"application/octet-stream", bytes.NewReader(data))
+		"application/octet-stream", nil, bytes.NewReader(data))
 	if err != nil {
 		return nil, err
 	}
@@ -426,12 +449,13 @@ func (c *Client) do(ctx context.Context, method, path string, query url.Values, 
 		rd = bytes.NewReader(buf)
 		contentType = "application/json"
 	}
-	return c.doRaw(ctx, method, path, query, contentType, rd)
+	return c.doRaw(ctx, method, path, query, contentType, nil, rd)
 }
 
 // doRaw is do without the JSON encoding: the body is sent verbatim
-// (nil rd and empty contentType for body-less requests).
-func (c *Client) doRaw(ctx context.Context, method, path string, query url.Values, contentType string, rd io.Reader) (*http.Response, error) {
+// (nil rd and empty contentType for body-less requests); extra headers,
+// if any, are copied onto the request.
+func (c *Client) doRaw(ctx context.Context, method, path string, query url.Values, contentType string, extra http.Header, rd io.Reader) (*http.Response, error) {
 	u := c.base + path
 	if len(query) > 0 {
 		u += "?" + query.Encode()
@@ -442,6 +466,9 @@ func (c *Client) doRaw(ctx context.Context, method, path string, query url.Value
 	}
 	if contentType != "" {
 		req.Header.Set("Content-Type", contentType)
+	}
+	for name, values := range extra {
+		req.Header[name] = values
 	}
 	if c.tokens != nil {
 		tok, err := c.tokens.Token()

--- a/internal/apiclient/apiclient_test.go
+++ b/internal/apiclient/apiclient_test.go
@@ -3,10 +3,12 @@ package apiclient
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"reflect"
 	"testing"
 
 	"github.com/na0fu3y/ochakai/internal/domain"
@@ -384,5 +386,48 @@ func TestReportOutcomePostsAndDecodesTotals(t *testing.T) {
 	}
 	if u.Worked != 3 || u.Failed != 1 {
 		t.Errorf("usage = %+v", u)
+	}
+}
+
+// Update's ifMatch becomes the If-Match precondition on the wire: absent
+// when "", quoted into a valid ETag when the caller passes the bare
+// version (the updated_at a read returned), verbatim when already an
+// ETag. A stale version surfaces as a 412 APIError.
+func TestUpdateSendsIfMatchAndMapsConflict(t *testing.T) {
+	var got []string
+	c := newTestPair(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/api/v1/knowledge/metrics/revenue" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		v, sent := r.Header["If-Match"]
+		if !sent {
+			v = []string{"(absent)"}
+		}
+		got = append(got, v[0])
+		if v[0] == `"2026-07-01T00:00:00.000000001Z"` {
+			w.WriteHeader(http.StatusPreconditionFailed)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "knowledge changed since it was read"})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(domain.Knowledge{Type: domain.TypeMetrics, ID: "metrics/revenue"})
+	})
+	k := &domain.Knowledge{Type: domain.TypeMetrics, ID: "metrics/revenue", Title: "売上"}
+	for _, ifMatch := range []string{"", "2026-06-30T00:00:00Z", `"2026-06-30T00:00:00Z"`} {
+		if _, _, err := c.Update(context.Background(), k, ifMatch); err != nil {
+			t.Fatalf("Update(ifMatch=%q): %v", ifMatch, err)
+		}
+	}
+	want := []string{"(absent)", `"2026-06-30T00:00:00Z"`, `"2026-06-30T00:00:00Z"`}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("If-Match on the wire = %q, want %q", got, want)
+	}
+
+	_, _, err := c.Update(context.Background(), k, "2026-07-01T00:00:00.000000001Z")
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusPreconditionFailed {
+		t.Fatalf("stale version: err = %v, want a 412 *APIError", err)
+	}
+	if apiErr.Message != "knowledge changed since it was read" {
+		t.Errorf("Message = %q", apiErr.Message)
 	}
 }


### PR DESCRIPTION
> **依存**: 設計ドキュメント 0030 を参照している。#153 の後にマージしてください。

## 問題

If-Match による楽観ロック(#108)はサーバー側だけランドし、公開契約にもクライアントにも届いていなかった。CLAUDE.md の「openapi.yaml / restapi / mcpserver / apiclient を同期させる」に反した状態。

- openapi は **If-Match パラメータも 412 も ETag レスポンスヘッダも**書いていない。にもかかわらず verify の説明文だけが「usable as If-Match on a later update」と、**スペック上どこにも定義されていないパラメータ**を参照していた
- `Revision.change` の enum が verify リビジョン(#135)より前のままで、**サーバーが自分のスキーマ外の値を返す**状態だった
- `X-Ochakai-On-Behalf-Of`(#122)は `Actor.via` の説明文の中にしか存在せず、埋め込みホストが読む公開契約から仕様を引けなかった
- `info.version` が `0.1.0` のまま
- CLI / apiclient から If-Match を使う手段が無く、0015 §2 の「CLI は REST の全操作をカバーする」に対する省略の文書化も無かった

## 修正

**契約**: `If-Match` と `X-Ochakai-On-Behalf-Of` を共有パラメータとして、`ETag` を共有レスポンスヘッダとして宣言し、PUT に 400 / 412 を追加。enum に `verify` を追加。`info.version` を 0.13.0 に。

**CLI / apiclient**: `apiclient.Update` が version を取り、`ochakai update --if-match <version>` で送る(素の `updated_at` は正しい ETag に引用符で包む)。412 は生のサーバーエラーではなく「読み直して編集をやり直し、新しい updated_at で再試行せよ」という実行可能なメッセージにする。`ochakai import` は明示的に precondition 無し(バンドルが真実の側)。

**補完**: 3 シェルすべてに `--if-match` を追加。ついでに fish だけ `reembed` の `--url` / `--json` が抜けていたのを修正。**全コマンドの長フラグを 3 シェル × 双方向で突き合わせるテスト**を追加した — この抜けが見過ごされていたのは、既存テストがコマンド名しか見ていなかったため。仕様表は全 22 コマンドの `-h` 出力と一致することを確認済み。

## テスト

apiclient(If-Match の送出 3 パターン + 412 の APIError マッピング)、CLI(ヘッダがワイヤに出ること + 衝突メッセージ)、補完の双方向同期。`gofmt` / `go vet` / `CGO_ENABLED=0 go build` / `go test -race ./...`(pgvector 実 DB 込み)green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)