### PR TITLE
create 復活のレースを塞ぎ、細かな不整合を 5 件直す

### DIFF
--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -269,7 +269,7 @@ func cmdContext(ctx context.Context, args []string) error {
 	fs.Var(&statuses, "status", "filter by status: "+statusList()+" (repeatable)")
 	fs.Var(&tags, "tag", "filter by tag (repeatable)")
 	limit := fs.Int("limit", 0, "max full entries (server default 5, max 20)")
-	budget := fs.Int("budget", 0, "stop rendering entries after ~this many bytes (0 = no cap)")
+	budget := fs.Int("budget", 0, "cap the response at ~this many bytes (0 = no cap); the rendered output stops printing entries, --json asks the server to cap and list what did not fit under \"outline\"")
 	minScore := fs.Float64("min-score", 0, "drop hits scoring below this; scores depend on the server's search mode (trigram vs hybrid), so calibrate before use (0 = off)")
 	asJSON := fs.Bool("json", false, "print the raw JSON response")
 	pos, err := parseArgs(fs, args)
@@ -284,7 +284,15 @@ func cmdContext(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	res, err := c.Context(ctx, strings.Join(pos, " "), types, statuses, tags, *limit, *minScore)
+	// The budget goes to the server only for --json: the rendered path
+	// asks for everything and caps while printing, where it can name what
+	// it dropped. JSON has no such layer, so an unsent budget was silently
+	// doing nothing.
+	serverBudget := 0
+	if *asJSON {
+		serverBudget = *budget
+	}
+	res, err := c.Context(ctx, strings.Join(pos, " "), types, statuses, tags, *limit, *minScore, serverBudget)
 	if err != nil {
 		return err
 	}

--- a/internal/apiclient/apiclient.go
+++ b/internal/apiclient/apiclient.go
@@ -141,8 +141,8 @@ func (c *Client) Search(ctx context.Context, p SearchParams) ([]domain.SearchHit
 
 // ContextResult mirrors the /api/v1/context response: ranked hits plus
 // the full entries behind the top ones, expanded one hop through links.
-// Outline lists entries the server's budget dropped; it stays empty for
-// the CLI, which asks for everything and caps at render time instead.
+// Outline lists entries the server's budget dropped; it stays empty
+// unless the caller passes a budget.
 type ContextResult struct {
 	Hits      []domain.SearchHit      `json:"hits"`
 	Entries   []domain.Knowledge      `json:"entries"`
@@ -150,7 +150,12 @@ type ContextResult struct {
 	Truncated int                     `json:"truncated,omitempty"`
 }
 
-func (c *Client) Context(ctx context.Context, query string, types, statuses, tags []string, limit int, minScore float64) (*ContextResult, error) {
+// budget, when positive, caps the response bytes server-side: entries
+// that do not fit come back as Outline instead of being dropped
+// silently. 0 asks for everything, which is what the rendered CLI
+// output wants — it caps at render time, where it can say what it left
+// out.
+func (c *Client) Context(ctx context.Context, query string, types, statuses, tags []string, limit int, minScore float64, budget int) (*ContextResult, error) {
 	q := url.Values{}
 	q.Set("q", query)
 	if minScore > 0 {
@@ -167,6 +172,9 @@ func (c *Client) Context(ctx context.Context, query string, types, statuses, tag
 	}
 	if limit > 0 {
 		q.Set("limit", strconv.Itoa(limit))
+	}
+	if budget > 0 {
+		q.Set("budget", strconv.Itoa(budget))
 	}
 	var out ContextResult
 	if err := c.doJSON(ctx, http.MethodGet, "/api/v1/context", q, nil, &out); err != nil {

--- a/internal/apiclient/apiclient_test.go
+++ b/internal/apiclient/apiclient_test.go
@@ -294,7 +294,7 @@ func TestContextBuildsQueryAndDecodesPack(t *testing.T) {
 		})
 	})
 	res, err := c.Context(context.Background(), "why did revenue drop",
-		[]string{"metrics"}, []string{"verified"}, []string{"core"}, 7, 0.5)
+		[]string{"metrics"}, []string{"verified"}, []string{"core"}, 7, 0.5, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -429,5 +429,30 @@ func TestUpdateSendsIfMatchAndMapsConflict(t *testing.T) {
 	}
 	if apiErr.Message != "knowledge changed since it was read" {
 		t.Errorf("Message = %q", apiErr.Message)
+	}
+}
+
+// A positive budget reaches the server, so --json gets the server's
+// budget semantics (entries that do not fit come back as outline). 0
+// sends nothing: the rendered CLI path asks for everything and caps
+// while printing.
+func TestContextSendsBudgetOnlyWhenSet(t *testing.T) {
+	var got []string
+	c := newTestPair(t, func(w http.ResponseWriter, r *http.Request) {
+		v := r.URL.Query().Get("budget")
+		if v == "" {
+			v = "(absent)"
+		}
+		got = append(got, v)
+		_ = json.NewEncoder(w).Encode(ContextResult{})
+	})
+	for _, budget := range []int{0, 4000} {
+		if _, err := c.Context(context.Background(), "q", nil, nil, nil, 0, 0, budget); err != nil {
+			t.Fatal(err)
+		}
+	}
+	want := []string{"(absent)", "4000"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("budget on the wire = %q, want %q", got, want)
 	}
 }

--- a/internal/domain/knowledge.go
+++ b/internal/domain/knowledge.go
@@ -119,6 +119,22 @@ const (
 // every user-facing enumeration (CLI help, completions, docs guards).
 var Statuses = []Status{StatusDraft, StatusVerified, StatusDeprecated, StatusRejected}
 
+// CuratedStatuses are the states a human has ruled on. Surfaces with no
+// If-Match channel must not replace one in place (design doc 0015 §3.1),
+// and the rule is enforced both in the service guards and in the store's
+// create transaction — so this list is the one place it is spelled.
+var CuratedStatuses = []Status{StatusVerified, StatusDeprecated, StatusRejected}
+
+// Curated reports whether a human has ruled on this status.
+func (s Status) Curated() bool {
+	for _, v := range CuratedStatuses {
+		if s == v {
+			return true
+		}
+	}
+	return false
+}
+
 func ValidStatus(s Status) bool {
 	for _, v := range Statuses {
 		if s == v {

--- a/internal/httpauth/httpauth.go
+++ b/internal/httpauth/httpauth.go
@@ -56,7 +56,7 @@ func ActorFromHeader(cfg *config.Config, h http.Header) (domain.Actor, int, erro
 		// production, hidden until the first deployment.
 		return delegate(
 			domain.Actor{Kind: domain.ActorHuman, Name: "anonymous"},
-			h.Get(OnBehalfOfHeader), []string{"*"})
+			h.Values(OnBehalfOfHeader), []string{"*"})
 	}
 	// When both headers are present, Cloud Run validates only
 	// X-Serverless-Authorization — so it must take precedence here,
@@ -69,7 +69,7 @@ func ActorFromHeader(cfg *config.Config, h http.Header) (domain.Actor, int, erro
 	if err != nil {
 		return domain.Actor{}, http.StatusUnauthorized, err
 	}
-	return delegate(actor, h.Get(OnBehalfOfHeader), cfg.Delegators)
+	return delegate(actor, h.Values(OnBehalfOfHeader), cfg.Delegators)
 }
 
 // OnBehalfOfHeader carries the end-user identity a trusted caller is
@@ -90,8 +90,18 @@ const maxOnBehalfOf = 320 // the maximum length of an email address
 // A header from a caller that is not permitted to delegate is an error,
 // not a silent downgrade: an application that believes it is writing as
 // tanaka must not discover months later that every entry says otherwise.
-func delegate(caller domain.Actor, header string, delegators []string) (domain.Actor, int, error) {
-	header = strings.TrimSpace(header)
+func delegate(caller domain.Actor, headers []string, delegators []string) (domain.Actor, int, error) {
+	if len(headers) > 1 {
+		// Taking the first and ignoring the rest would pick an identity
+		// the sender did not necessarily mean; §5.2's rule against silent
+		// degradation applies to ambiguity as much as to rejection.
+		return caller, http.StatusBadRequest, fmt.Errorf(
+			"%s: sent %d times; send it once", OnBehalfOfHeader, len(headers))
+	}
+	header := ""
+	if len(headers) == 1 {
+		header = strings.TrimSpace(headers[0])
+	}
 	if header == "" {
 		return caller, 0, nil
 	}

--- a/internal/httpauth/httpauth_test.go
+++ b/internal/httpauth/httpauth_test.go
@@ -119,14 +119,27 @@ func TestDelegate(t *testing.T) {
 	allowed := []string{sa.Name}
 
 	t.Run("no header acts as the caller", func(t *testing.T) {
-		got, status, err := delegate(sa, "", allowed)
-		if err != nil || status != 0 || got != sa {
-			t.Errorf("got (%v, %d, %v), want the caller unchanged", got, status, err)
+		for _, headers := range [][]string{nil, {""}} {
+			got, status, err := delegate(sa, headers, allowed)
+			if err != nil || status != 0 || got != sa {
+				t.Errorf("delegate(%q) = (%v, %d, %v), want the caller unchanged", headers, got, status, err)
+			}
+		}
+	})
+
+	// Two identities in one request is ambiguous, and picking the first
+	// would attribute the write to whichever the sender happened to put
+	// there first — silent degradation, which 0027 §5.2 refuses.
+	t.Run("a repeated header is refused, not resolved", func(t *testing.T) {
+		got, status, err := delegate(sa,
+			[]string{"human:tanaka@example.co.jp", "human:suzuki@example.co.jp"}, allowed)
+		if err == nil || status != http.StatusBadRequest {
+			t.Errorf("got (%v, %d, %v), want a 400", got, status, err)
 		}
 	})
 
 	t.Run("permitted caller delegates", func(t *testing.T) {
-		got, _, err := delegate(sa, "human:tanaka@example.co.jp", allowed)
+		got, _, err := delegate(sa, []string{"human:tanaka@example.co.jp"}, allowed)
 		if err != nil {
 			t.Fatalf("delegate: %v", err)
 		}
@@ -142,7 +155,7 @@ func TestDelegate(t *testing.T) {
 	// Silently ignoring the header would be worse than refusing it: the
 	// application goes on believing it writes as its users.
 	t.Run("unlisted caller is refused, not downgraded", func(t *testing.T) {
-		got, status, err := delegate(human, "human:tanaka@example.co.jp", allowed)
+		got, status, err := delegate(human, []string{"human:tanaka@example.co.jp"}, allowed)
 		if err == nil {
 			t.Fatalf("delegation by an unlisted caller succeeded as %+v", got)
 		}
@@ -152,14 +165,14 @@ func TestDelegate(t *testing.T) {
 	})
 
 	t.Run("wildcard trusts every authenticated caller", func(t *testing.T) {
-		got, _, err := delegate(human, "human:tanaka@example.co.jp", []string{"*"})
+		got, _, err := delegate(human, []string{"human:tanaka@example.co.jp"}, []string{"*"})
 		if err != nil || got.Name != "tanaka@example.co.jp" || got.Via != human.String() {
 			t.Errorf("got (%+v, %v), want the delegation accepted", got, err)
 		}
 	})
 
 	t.Run("delegation is off by default", func(t *testing.T) {
-		if _, status, err := delegate(sa, "human:tanaka@example.co.jp", nil); err == nil || status != http.StatusForbidden {
+		if _, status, err := delegate(sa, []string{"human:tanaka@example.co.jp"}, nil); err == nil || status != http.StatusForbidden {
 			t.Errorf("empty allowlist must refuse: status %d, err %v", status, err)
 		}
 	})
@@ -172,7 +185,7 @@ func TestDelegate(t *testing.T) {
 		"human:" + strings.Repeat("x", 400),
 	} {
 		t.Run("rejects "+bad[:min(len(bad), 20)], func(t *testing.T) {
-			_, status, err := delegate(sa, bad, allowed)
+			_, status, err := delegate(sa, []string{bad}, allowed)
 			if err == nil {
 				t.Errorf("accepted malformed header %q", bad)
 			} else if status != http.StatusBadRequest {

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -237,14 +237,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 		if err != nil {
 			return nil, knowledgeOut{}, err
 		}
-		// Creating on a soft-deleted id revives that row in place, status
-		// and status_note included — the other way to overwrite a ruling
-		// from a surface with no If-Match channel, and the one the update
-		// and delete guards cannot see (design doc 0015 §3.1).
-		if err := svc.RefuseIfRevivingCurated(ctx, in.ID); err != nil {
-			return nil, knowledgeOut{}, err
-		}
-		k, err := svc.Create(ctx, in.toKnowledge(), actor)
+		k, err := svc.CreateKeepingCurated(ctx, in.toKnowledge(), actor)
 		if err != nil {
 			return nil, knowledgeOut{}, err
 		}

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -519,8 +519,10 @@ func Handler(svc *service.Service) http.Handler {
 				return
 			}
 		}
-		// Entries in batches: one batch in memory at a time, and no pool
-		// connection held for the length of the download.
+		// Entries in batches: one batch in memory at a time. The snapshot
+		// does hold a pooled connection for the length of the download —
+		// the trade a point-in-time backup makes (see ExportSnapshot);
+		// batching bounds the memory, not the connection.
 		for start := 0; start < len(ids); start += exportBatch {
 			end := min(start+exportBatch, len(ids))
 			batch, err := snap.ListByIDs(r.Context(), ids[start:end])
@@ -631,6 +633,15 @@ func readBody(w http.ResponseWriter, r *http.Request, limit int64, tooLarge stri
 func readJSON(w http.ResponseWriter, r *http.Request, v any) bool {
 	dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4<<20))
 	if err := dec.Decode(v); err != nil {
+		// An oversized body is not malformed JSON, and calling it that
+		// sends the caller looking for a syntax error in a payload that
+		// is simply too big — readBody already answers 413 here.
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeJSON(w, http.StatusRequestEntityTooLarge,
+				map[string]string{"error": fmt.Sprintf("request body exceeds %d bytes", maxErr.Limit)})
+			return false
+		}
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
 		return false
 	}

--- a/internal/restapi/restapi_test.go
+++ b/internal/restapi/restapi_test.go
@@ -189,3 +189,22 @@ func TestETagRoundTrip(t *testing.T) {
 		t.Error("malformed If-Match must be an error")
 	}
 }
+
+// An oversized JSON body is a 413, matching what the attachment path
+// (readBody) already answers. Calling it "invalid JSON" sent the caller
+// hunting for a syntax error in a payload that merely did not fit.
+func TestOversizedJSONBodyIsTooLarge(t *testing.T) {
+	h := Handler(&service.Service{})
+	body := `{"type":"metrics","id":"metrics/x","body":"` + strings.Repeat("a", 5<<20) + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/knowledge", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusRequestEntityTooLarge)
+	}
+	if got := w.Body.String(); !strings.Contains(got, "exceeds") {
+		t.Errorf("body = %s", got)
+	}
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -69,6 +69,33 @@ func (s *Service) Get(ctx context.Context, id string) (*domain.Knowledge, error)
 }
 
 func (s *Service) Create(ctx context.Context, k *domain.Knowledge, actor domain.Actor) (*domain.Knowledge, error) {
+	return s.create(ctx, k, actor, false)
+}
+
+// CreateKeepingCurated is Create for surfaces that must not replace a
+// human ruling (MCP, design doc 0015 §3.1). Creating on a soft-deleted id
+// revives that row in place, status and status_note included, which is
+// the one way past the update and delete guards — they read a live row
+// and a tombstone is not one. The check runs first so the refusal can
+// explain itself, and the store repeats it inside the create transaction
+// so a curation landing in between loses the race rather than being
+// erased by it.
+func (s *Service) CreateKeepingCurated(ctx context.Context, k *domain.Knowledge, actor domain.Actor) (*domain.Knowledge, error) {
+	if err := s.RefuseIfRevivingCurated(ctx, k.ID); err != nil {
+		return nil, err
+	}
+	created, err := s.create(ctx, k, actor, true)
+	if errors.Is(err, store.ErrCuratedTombstone) {
+		// The window closed on us: re-read for the same advice the
+		// pre-check would have given.
+		if err := s.RefuseIfRevivingCurated(ctx, k.ID); err != nil {
+			return nil, err
+		}
+	}
+	return created, err
+}
+
+func (s *Service) create(ctx context.Context, k *domain.Knowledge, actor domain.Actor, keepCuratedTombstones bool) (*domain.Knowledge, error) {
 	normalizeKeys(k)
 	if err := validate(k); err != nil {
 		return nil, err
@@ -79,7 +106,7 @@ func (s *Service) Create(ctx context.Context, k *domain.Knowledge, actor domain.
 	}
 	s.applyVerification(k, nil, actor)
 	k.CreatedBy = actor
-	if err := s.Store.Create(ctx, k); err != nil {
+	if err := s.Store.Create(ctx, k, keepCuratedTombstones); err != nil {
 		return nil, err
 	}
 	s.updateEmbedding(ctx, k)

--- a/internal/store/attachment.go
+++ b/internal/store/attachment.go
@@ -276,7 +276,11 @@ func (s *Store) ListAllAttachments(ctx context.Context) ([]ExportAttachment, err
 // whose snapshot includes the attachment list after the change —
 // attach/detach are changes to the entry, and every change is kept.
 func (s *Store) touchAndRevise(ctx context.Context, tx pgx.Tx, k *domain.Knowledge, change string, actor domain.Actor) error {
-	k.UpdatedAt = time.Now().UTC()
+	// nowStored, like every other write path: time.Now()'s nanoseconds do
+	// not survive the round trip through timestamptz, so the revision
+	// snapshot would carry a version the stored row never had (design
+	// doc 0030).
+	k.UpdatedAt = nowStored()
 	if _, err := tx.Exec(ctx,
 		`UPDATE knowledge SET updated_at=$2 WHERE id=$1`, k.ID, k.UpdatedAt); err != nil {
 		return err

--- a/internal/store/attachment_search_integration_test.go
+++ b/internal/store/attachment_search_integration_test.go
@@ -70,7 +70,7 @@ func TestIntegrationAttachmentSearch(t *testing.T) {
 		Status: domain.StatusDraft, CreatedBy: actor,
 	}
 	for _, k := range []*domain.Knowledge{a, b} {
-		if err := s.Create(ctx, k); err != nil {
+		if err := s.Create(ctx, k, false); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/store/blob_integration_test.go
+++ b/internal/store/blob_integration_test.go
@@ -44,7 +44,7 @@ func TestIntegrationBlobStoreOnly(t *testing.T) {
 		Type: domain.TypeInsights, ID: "it-ext-reading", Title: "GCS一本化テスト",
 		Status: domain.StatusDraft, CreatedBy: actor,
 	}
-	if err := s.Create(ctx, k); err != nil {
+	if err := s.Create(ctx, k, false); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/store/browse_integration_test.go
+++ b/internal/store/browse_integration_test.go
@@ -38,7 +38,7 @@ func TestIntegrationBrowse(t *testing.T) {
 	actor := domain.Actor{Kind: "human", Name: "test"}
 	mk := func(typ domain.Type, id string, status domain.Status) {
 		k := &domain.Knowledge{Type: typ, ID: id, Title: "t:" + id, Description: "d:" + id, Status: status, CreatedBy: actor}
-		if err := s.Create(ctx, k); err != nil {
+		if err := s.Create(ctx, k, false); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -29,6 +29,12 @@ var ErrAlreadyExists = errors.New("knowledge already exists")
 // (design doc 0030). The entry exists — a missing entry is ErrNotFound.
 var ErrConflict = errors.New("knowledge changed since it was read")
 
+// ErrCuratedTombstone is returned by Create when the id holds a
+// soft-deleted entry a human ruled on and the caller asked for curated
+// tombstones to be kept (design doc 0015 §3.1). Distinct from
+// ErrAlreadyExists: the blocking row is invisible to a plain read.
+var ErrCuratedTombstone = errors.New("knowledge id holds a curated tombstone")
+
 // ErrNotDeleted is returned by Purge for an entry that is still live.
 // Purging is the second step of a two-step destruction: delete first, so
 // no single call can erase history that was in use a moment ago.
@@ -238,9 +244,18 @@ func (s *Store) ListLinkingTo(ctx context.Context, id string, limit int) ([]doma
 // otherwise be dead forever (the row still owns the primary key while
 // Update refuses deleted rows), and its history stays in the revisions
 // either way.
-func (s *Store) Create(ctx context.Context, k *domain.Knowledge) error {
+func (s *Store) Create(ctx context.Context, k *domain.Knowledge, keepCuratedTombstones bool) error {
 	now := nowStored()
 	k.CreatedAt, k.UpdatedAt = now, now
+	// Reviving a tombstone overwrites its status in place. When the caller
+	// must not replace a human ruling (design doc 0015 §3.1), the revival
+	// carries the same restriction as the UPDATE itself, so a curation
+	// landing between a service-level check and this write loses the race
+	// instead of being erased by it.
+	revive := ""
+	if keepCuratedTombstones {
+		revive = ` AND knowledge.status <> ALL($25::text[])`
+	}
 	return s.withTx(ctx, func(tx pgx.Tx) error {
 		links, attrs, err := marshalJSONFields(k)
 		if err != nil {
@@ -248,6 +263,20 @@ func (s *Store) Create(ctx context.Context, k *domain.Knowledge) error {
 		}
 		verifiedKind, verifiedName, verifiedVia := actorPtrs(k.VerifiedBy)
 		rejectedKind, rejectedName, rejectedVia := actorPtrs(k.RejectedBy)
+		args := []any{
+			k.Type, k.ID, k.Title, k.Description, k.Resource, k.Tags, k.Status, k.StatusNote,
+			k.CreatedBy.Kind, k.CreatedBy.Name, k.CreatedBy.Via,
+			verifiedKind, verifiedName, verifiedVia, k.VerifiedAt,
+			rejectedKind, rejectedName, rejectedVia, k.RejectedAt,
+			links, attrs, k.Body, k.CreatedAt, k.UpdatedAt,
+		}
+		if keepCuratedTombstones {
+			curated := make([]string, len(domain.CuratedStatuses))
+			for i, st := range domain.CuratedStatuses {
+				curated[i] = string(st)
+			}
+			args = append(args, curated)
+		}
 		tag, err := tx.Exec(ctx, `INSERT INTO knowledge (`+knowledgeCols+`)
 			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24)
 			ON CONFLICT (id) DO UPDATE SET
@@ -263,16 +292,22 @@ func (s *Store) Create(ctx context.Context, k *domain.Knowledge) error {
 				links=EXCLUDED.links, attrs=EXCLUDED.attrs, body=EXCLUDED.body,
 				created_at=EXCLUDED.created_at, updated_at=EXCLUDED.updated_at,
 				deleted_at=NULL
-			WHERE knowledge.deleted_at IS NOT NULL`,
-			k.Type, k.ID, k.Title, k.Description, k.Resource, k.Tags, k.Status, k.StatusNote,
-			k.CreatedBy.Kind, k.CreatedBy.Name, k.CreatedBy.Via,
-			verifiedKind, verifiedName, verifiedVia, k.VerifiedAt,
-			rejectedKind, rejectedName, rejectedVia, k.RejectedAt,
-			links, attrs, k.Body, k.CreatedAt, k.UpdatedAt)
+			WHERE knowledge.deleted_at IS NOT NULL`+revive,
+			args...)
 		if err != nil {
 			return err
 		}
 		if tag.RowsAffected() == 0 {
+			if keepCuratedTombstones {
+				// Either a live entry or a curated tombstone blocked the
+				// write; only the second is this guard's business, and the
+				// caller needs to tell them apart to explain itself.
+				if t, err := s.GetTombstone(ctx, k.ID); err == nil && t.Status.Curated() {
+					return ErrCuratedTombstone
+				} else if err != nil && !errors.Is(err, ErrNotFound) {
+					return err
+				}
+			}
 			return ErrAlreadyExists
 		}
 		return s.addRevision(ctx, tx, k, "create", k.CreatedBy)

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -68,7 +68,7 @@ func TestIntegration(t *testing.T) {
 		Description: "統合テスト用", Status: domain.StatusVerified,
 		CreatedBy: domain.Actor{Kind: "human", Name: "test"},
 	}
-	if err := s.Create(ctx, k); err != nil {
+	if err := s.Create(ctx, k, false); err != nil {
 		t.Fatal(err)
 	}
 	if err := s.UpsertEmbedding(ctx, k.ID, "test-model", []float32{1, 0, 0, 0}); err != nil {
@@ -105,7 +105,7 @@ func TestIntegration(t *testing.T) {
 		CreatedBy:  domain.Actor{Kind: "agent", Name: "claude-code"},
 		RejectedBy: &domain.Actor{Kind: "human", Name: "test"}, RejectedAt: &rejectedAt,
 	}
-	if err := s.Create(ctx, rej); err != nil {
+	if err := s.Create(ctx, rej, false); err != nil {
 		t.Fatal(err)
 	}
 	got, err := s.Get(ctx, rej.ID)
@@ -143,7 +143,7 @@ func TestIntegration(t *testing.T) {
 		Description: "統合テスト用", Status: domain.StatusVerified,
 		CreatedBy: domain.Actor{Kind: "human", Name: "test"},
 	}
-	if err := s.Create(ctx, free); err != nil {
+	if err := s.Create(ctx, free, false); err != nil {
 		t.Fatal(err)
 	}
 	for _, tc := range []struct {
@@ -231,7 +231,7 @@ func TestIntegration(t *testing.T) {
 		CreatedBy:  domain.Actor{Kind: "human", Name: "test"},
 		VerifiedBy: &domain.Actor{Kind: "human", Name: "test"}, VerifiedAt: &oldAt,
 	}
-	if err := s.Create(ctx, older); err != nil {
+	if err := s.Create(ctx, older, false); err != nil {
 		t.Fatal(err)
 	}
 	list, err := s.ListByVerifiedAt(ctx, Filter{Statuses: []domain.Status{domain.StatusVerified}}, 100)
@@ -261,7 +261,7 @@ func TestIntegration(t *testing.T) {
 		Status: domain.StatusDraft, CreatedBy: domain.Actor{Kind: "agent", Name: "claude-code"},
 	}
 	for _, d := range []*domain.Knowledge{hot, cold} {
-		if err := s.Create(ctx, d); err != nil {
+		if err := s.Create(ctx, d, false); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -321,7 +321,7 @@ func TestIntegration(t *testing.T) {
 			k.VerifiedBy = &domain.Actor{Kind: "human", Name: "test"}
 			k.VerifiedAt = &verifiedAt
 		}
-		if err := s.Create(ctx, k); err != nil {
+		if err := s.Create(ctx, k, false); err != nil {
 			t.Fatal(err)
 		}
 		return k
@@ -410,7 +410,7 @@ func TestIntegrationToleratesMissingEmbeddingTable(t *testing.T) {
 		Status: domain.StatusDraft, CreatedBy: domain.Actor{Kind: "human", Name: "test"},
 	}
 	_ = s.SoftDelete(ctx, k.ID, k.CreatedBy) // clean rerun
-	if err := s.Create(ctx, k); err != nil {
+	if err := s.Create(ctx, k, false); err != nil {
 		t.Fatal(err)
 	}
 	if err := s.SoftDelete(ctx, k.ID, k.CreatedBy); err != nil {
@@ -455,7 +455,7 @@ func TestIntegrationListLinkingTo(t *testing.T) {
 			Links: []domain.Link{{Target: "it-link-metric", Text: "explains"}}},
 	}
 	for _, k := range entries {
-		if err := s.Create(ctx, k); err != nil {
+		if err := s.Create(ctx, k, false); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -506,7 +506,7 @@ func TestIntegrationSearchLexicalWildcardEscape(t *testing.T) {
 	pct := &domain.Knowledge{Type: domain.TypeMetrics, ID: "it-wild-pct", Title: "解約率は5%以内",
 		Description: "パーセント記号を含む", Status: domain.StatusDraft, CreatedBy: actor}
 	for _, k := range []*domain.Knowledge{plain, pct} {
-		if err := s.Create(ctx, k); err != nil {
+		if err := s.Create(ctx, k, false); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -562,7 +562,7 @@ func TestIntegrationUsageBuffering(t *testing.T) {
 	actor := domain.Actor{Kind: "agent", Name: "claude-code"}
 	k := &domain.Knowledge{Type: domain.TypeMetrics, ID: "it-buf-metric", Title: "計測",
 		Status: domain.StatusDraft, CreatedBy: actor}
-	if err := s.Create(ctx, k); err != nil {
+	if err := s.Create(ctx, k, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -635,7 +635,7 @@ func TestIntegrationMove(t *testing.T) {
 		{Type: domain.TypeInsights, ID: "it-move-taken", Title: "occupies destination", Status: domain.StatusDraft, CreatedBy: actor},
 	}
 	for _, k := range entries {
-		if err := s.Create(ctx, k); err != nil {
+		if err := s.Create(ctx, k, false); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -774,7 +774,7 @@ func TestIntegrationCreateRevivesSoftDeleted(t *testing.T) {
 		Type: domain.TypeTerms, ID: "it-revive-me", Title: "first life",
 		Status: domain.StatusDraft, CreatedBy: actor,
 	}
-	if err := s.Create(ctx, first); err != nil {
+	if err := s.Create(ctx, first, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -783,7 +783,7 @@ func TestIntegrationCreateRevivesSoftDeleted(t *testing.T) {
 		Type: domain.TypeTerms, ID: "it-revive-me", Title: "imposter",
 		Status: domain.StatusDraft, CreatedBy: actor,
 	}
-	if err := s.Create(ctx, dup); err != ErrAlreadyExists {
+	if err := s.Create(ctx, dup, false); err != ErrAlreadyExists {
 		t.Fatalf("create over a live entry = %v, want ErrAlreadyExists", err)
 	}
 
@@ -796,7 +796,7 @@ func TestIntegrationCreateRevivesSoftDeleted(t *testing.T) {
 		Type: domain.TypeTerms, ID: "it-revive-me", Title: "second life",
 		Status: domain.StatusDraft, CreatedBy: domain.Actor{Kind: "agent", Name: "claude-code"},
 	}
-	if err := s.Create(ctx, second); err != nil {
+	if err := s.Create(ctx, second, false); err != nil {
 		t.Fatalf("create over a soft-deleted entry: %v", err)
 	}
 	got, err := s.Get(ctx, second.ID)
@@ -838,14 +838,14 @@ func TestIntegrationCreateRevivesSoftDeleted(t *testing.T) {
 		Status: domain.StatusRejected, StatusNote: "duplicate",
 		CreatedBy: actor, RejectedBy: &actor,
 	}
-	if err := s.Create(ctx, rejected); err != nil {
+	if err := s.Create(ctx, rejected, false); err != nil {
 		t.Fatal(err)
 	}
 	again := &domain.Knowledge{
 		Type: domain.TypeTerms, ID: "it-revive-no", Title: "try again",
 		Status: domain.StatusDraft, CreatedBy: actor,
 	}
-	if err := s.Create(ctx, again); err != ErrAlreadyExists {
+	if err := s.Create(ctx, again, false); err != ErrAlreadyExists {
 		t.Fatalf("create over a rejected entry = %v, want ErrAlreadyExists", err)
 	}
 }
@@ -884,7 +884,7 @@ func TestIntegrationAttachments(t *testing.T) {
 		Type: domain.TypeInsights, ID: "it-att-reading", Title: "売上の読み方",
 		Status: domain.StatusDraft, CreatedBy: actor,
 	}
-	if err := s.Create(ctx, k); err != nil {
+	if err := s.Create(ctx, k, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -991,7 +991,7 @@ func TestIntegrationListRevisions(t *testing.T) {
 		Type: domain.TypeTerms, ID: "it-revs-1", Title: "v1",
 		Status: domain.StatusDraft, CreatedBy: actor,
 	}
-	if err := s.Create(ctx, k); err != nil {
+	if err := s.Create(ctx, k, false); err != nil {
 		t.Fatal(err)
 	}
 	k.Title = "v2"
@@ -1102,7 +1102,7 @@ func TestIntegrationSearchTextFollowsAttachmentsAndMoves(t *testing.T) {
 		Type: domain.TypeTerms, ID: id, Title: "haystack", Tags: []string{"ledger"},
 		Status: domain.StatusDraft, CreatedBy: actor, Body: "prose",
 	}
-	if err := s.Create(ctx, k); err != nil {
+	if err := s.Create(ctx, k, false); err != nil {
 		t.Fatal(err)
 	}
 	for _, want := range []string{id, "haystack", "ledger", "prose"} {
@@ -1168,7 +1168,7 @@ func TestIntegrationPurgeFreesIDForMove(t *testing.T) {
 		if err := s.Create(ctx, &domain.Knowledge{
 			Type: domain.TypeTerms, ID: id, Title: id,
 			Status: domain.StatusDraft, CreatedBy: actor,
-		}); err != nil {
+		}, false); err != nil {
 			t.Fatalf("create %s: %v", id, err)
 		}
 	}
@@ -1268,7 +1268,7 @@ func TestIntegrationCloseFlushesBufferedUsage(t *testing.T) {
 	actor := domain.Actor{Kind: "human", Name: "test"}
 	if err := s.Create(ctx, &domain.Knowledge{
 		Type: domain.TypeTerms, ID: id, Title: "flush", Status: domain.StatusDraft, CreatedBy: actor,
-	}); err != nil {
+	}, false); err != nil {
 		s.Close()
 		t.Fatal(err)
 	}
@@ -1327,7 +1327,7 @@ func TestIntegrationDelegatedProvenance(t *testing.T) {
 	if err := s.Create(ctx, &domain.Knowledge{
 		Type: domain.TypeInsights, ID: id, Title: "delegated",
 		Status: domain.StatusDraft, CreatedBy: delegated,
-	}); err != nil {
+	}, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1425,7 +1425,7 @@ func TestIntegrationLexicalSearchAnswersQuestions(t *testing.T) {
 		if err := s.Create(ctx, &domain.Knowledge{
 			Type: domain.TypeInsights, ID: id, Title: title,
 			Status: domain.StatusDraft, CreatedBy: actor, Body: body,
-		}); err != nil {
+		}, false); err != nil {
 			t.Fatalf("create %s: %v", id, err)
 		}
 	}
@@ -1525,7 +1525,7 @@ func TestIntegrationVerifyClearsTheReviewFeed(t *testing.T) {
 	agent := domain.Actor{Kind: domain.ActorAgent, Name: "claude-code"}
 	k := &domain.Knowledge{Type: domain.TypeQueries, ID: id, Title: "月次売上",
 		Status: domain.StatusDraft, CreatedBy: agent}
-	if err := s.Create(ctx, k); err != nil {
+	if err := s.Create(ctx, k, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1634,7 +1634,7 @@ func TestIntegrationMoveKeepsOutboundRelativeLinks(t *testing.T) {
 			Body:  "Net of [gross](./gross.md).",
 			Links: []domain.Link{{Target: neighbour, Text: "gross"}}},
 	} {
-		if err := s.Create(ctx, k); err != nil {
+		if err := s.Create(ctx, k, false); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -1716,7 +1716,7 @@ func TestIntegrationMoveSelfRewriteIsOneRevision(t *testing.T) {
 			Body:  "See [revenue](./revenue.md).",
 			Links: []domain.Link{{Target: mover, Text: "revenue"}}},
 	} {
-		if err := s.Create(ctx, k); err != nil {
+		if err := s.Create(ctx, k, false); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -1813,7 +1813,7 @@ func TestIntegrationExportSnapshotIsConsistent(t *testing.T) {
 	}
 	actor := domain.Actor{Kind: "human", Name: "test"}
 	if err := s.Create(ctx, &domain.Knowledge{Type: domain.TypeInsights, ID: doomed,
-		Title: "deleted mid-export", Status: domain.StatusDraft, CreatedBy: actor}); err != nil {
+		Title: "deleted mid-export", Status: domain.StatusDraft, CreatedBy: actor}, false); err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
@@ -1851,4 +1851,82 @@ func TestIntegrationExportSnapshotIsConsistent(t *testing.T) {
 	if _, err := s.Get(ctx, doomed); !errors.Is(err, ErrNotFound) {
 		t.Errorf("Get after delete = %v, want ErrNotFound", err)
 	}
+}
+
+// The curated-tombstone guard lives in the create transaction, not only
+// in the service pre-check (design doc 0015 §3.1): a ruling that lands
+// after the check must beat the create, not be erased by it. Reviving a
+// draft tombstone stays allowed either way, and the unguarded call — the
+// human surfaces — still revives anything.
+func TestIntegrationCreateKeepsCuratedTombstones(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := t.Context()
+	s, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	actor := domain.Actor{Kind: domain.ActorHuman, Name: "test"}
+
+	tombstone := func(t *testing.T, id string, status domain.Status) {
+		t.Helper()
+		k := &domain.Knowledge{Type: domain.TypeTerms, ID: id, Title: id,
+			Status: status, StatusNote: "why", CreatedBy: actor}
+		if err := s.Create(ctx, k, false); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.SoftDelete(ctx, id, actor); err != nil {
+			t.Fatal(err)
+		}
+	}
+	revive := func(id string) *domain.Knowledge {
+		return &domain.Knowledge{Type: domain.TypeTerms, ID: id, Title: "revived",
+			Status: domain.StatusDraft, CreatedBy: actor}
+	}
+
+	for _, status := range domain.CuratedStatuses {
+		t.Run("guarded create refuses a "+string(status)+" tombstone", func(t *testing.T) {
+			id := fmt.Sprintf("it-tomb-%s-%d", status, time.Now().UnixNano())
+			tombstone(t, id, status)
+			if err := s.Create(ctx, revive(id), true); !errors.Is(err, ErrCuratedTombstone) {
+				t.Fatalf("create = %v, want ErrCuratedTombstone", err)
+			}
+			// The ruling is intact: nothing was revived under it.
+			old, err := s.GetTombstone(ctx, id)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if old.Status != status || old.StatusNote != "why" {
+				t.Errorf("tombstone = %s/%q, want %s/\"why\"", old.Status, old.StatusNote, status)
+			}
+			// The human surfaces still revive it.
+			if err := s.Create(ctx, revive(id), false); err != nil {
+				t.Errorf("unguarded create must still revive: %v", err)
+			}
+		})
+	}
+
+	t.Run("guarded create still revives a draft tombstone", func(t *testing.T) {
+		id := fmt.Sprintf("it-tomb-draft-%d", time.Now().UnixNano())
+		tombstone(t, id, domain.StatusDraft)
+		if err := s.Create(ctx, revive(id), true); err != nil {
+			t.Fatalf("draft tombstone must stay revivable: %v", err)
+		}
+	})
+
+	t.Run("guarded create over a live entry is still ErrAlreadyExists", func(t *testing.T) {
+		id := fmt.Sprintf("it-tomb-live-%d", time.Now().UnixNano())
+		if err := s.Create(ctx, revive(id), false); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.Create(ctx, revive(id), true); !errors.Is(err, ErrAlreadyExists) {
+			t.Errorf("create over a live entry = %v, want ErrAlreadyExists", err)
+		}
+	})
 }


### PR DESCRIPTION
> 設計ドキュメント 0030 をコメントで参照している(#153 で追加)。

## 1. MCP の墓標復活ガードに TOCTOU 窓があった(#136)

`RefuseIfRevivingCurated` でチェックしてから `Create` を呼ぶ二段構えだったため、その間に別クライアントが verified / rejected エントリをソフト削除すると、**裁定付きの墓標が draft として復活**できた。update 経路は読んだ版を If-Match として渡すことで構造的に閉じてあるのに、create 経路だけストア側のガードが無かった。

ストアの create トランザクション内に同じ制限を持たせた(`ON CONFLICT ... WHERE` に条件を追加)。窓の中でキュレーションが着地した場合、create は**それを消すのではなく負ける**。curated な状態の定義は `domain.CuratedStatuses` 一箇所に集約し、SQL と Go で二重に綴らないようにしている。人間の面(REST / CLI / Web UI)は従来どおり何でも復活できる(0015 §3.1)。

MCP 側は `svc.CreateKeepingCurated` の 1 コールになり、事前チェック(良いエラーメッセージのため)とトランザクション内判定(正しさのため)の役割分担がサービス層に収まった。

## 2〜6. 細かな不整合

- **4MiB 超の JSON ボディが「invalid JSON」で 400** になっていた。同じ状況を添付側の `readBody` は 413 で返す。呼び出し元は、単に大きすぎるだけのペイロードの中に構文エラーを探すことになる → 413 に統一
- **`touchAndRevise` だけ `time.Now()`** を使っており、ナノ秒が timestamptz を往復しないため、attach / detach のリビジョンスナップショットが**保存行に存在しない版**を持っていた → `nowStored()` に統一(0030 の往復不変条件)
- **export ハンドラのコメントが実装と逆**だった(「ダウンロード中プール接続を保持しない」— 実際は保持する。export.go 側が正しくトレードオフとして明記している)
- **`X-Ochakai-On-Behalf-Of` が複数あると先頭だけ採用**して残りを黙って無視していた。送信側が意図していない identity を選びうるので、0027 §5.2 の「静かな降格を許さない」に従い 400 にする
- **`context --json --budget N` が budget を黙って無視**していた。フラグはレンダリング側の切り詰めだけを行い、JSON 出力はその層を通らないため。JSON モードではサーバーに渡し、入りきらないエントリが `outline` として返る本来の意味論が効くようにした(レンダリング時の挙動は不変)

## テスト

curated 墓標ガード(3 状態 × 拒否 + 裁定が無傷であること + 非ガード create は従来どおり + draft 墓標は復活可 + live は ErrAlreadyExists)を統合テストで、413・ヘッダ重複・budget のワイヤ送出をユニットテストで追加。`gofmt` / `go vet` / `CGO_ENABLED=0 go build` / `go test -race ./...`(pgvector 実 DB 込み)green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)