### PR TITLE
reembed: 添付ベクトルもカバーし、恒久失敗するエントリの先へ進めるようにする

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -643,17 +643,33 @@ paths:
         more (design doc 0020). This fills the gap.
 
 
-        Bounded per call — repeat while `missing` is above zero; the CLI
-        (`ochakai reembed`) does that for you. One entry is one call to
+        Attachment vectors are covered too: only `attach` writes them, so
+        a corpus loaded before semantic search — or one whose embedding
+        tables were dropped to change dimensions — has files that are
+        findable by name alone until this runs. Entries go first and
+        attachments fill the rest of the pass.
+
+
+        Bounded per call — repeat while `missing` is above zero, passing
+        the previous response's `cursor` back each time; the CLI
+        (`ochakai reembed`) does that for you. One item is one call to
         the embedding provider and the calls are sequential, so the
         default pass is sized to finish well inside a request timeout
         (Cloud Run's default is 300s); raise `limit` only if you know
-        yours. A provider failure on one entry is counted, not fatal. 501
+        yours. A provider failure on one item is counted, not fatal. 501
         when semantic search is not configured.
       parameters:
         - name: limit
           in: query
           schema: { type: integer, default: 200, maximum: 5000 }
+        - name: cursor
+          in: query
+          description: >
+            Resume position from a previous response. Omit to start from
+            the beginning. Without it, a pass whose every item the
+            provider refuses returns the same window forever and the rest
+            of the corpus is never attempted.
+          schema: { type: string }
       responses:
         "200":
           description: What the pass did.
@@ -662,11 +678,25 @@ paths:
               schema:
                 type: object
                 properties:
-                  embedded: { type: integer }
+                  embedded:
+                    description: Knowledge entries embedded by this pass.
+                    type: integer
+                  attachments:
+                    description: Attachments embedded by this pass.
+                    type: integer
                   failed: { type: integer }
                   missing:
-                    description: Still unembedded when the limit was reached.
+                    description: >
+                      Entries and attachments still unembedded once the
+                      pass was over — counted after the fact, so items
+                      this pass failed on are included.
                     type: integer
+                  cursor:
+                    description: >
+                      Where the next pass resumes. Absent once nothing is
+                      missing; unchanged from the one sent in means the
+                      corpus is exhausted and what remains only fails.
+                    type: string
         "501": { $ref: "#/components/responses/Error" }
 components:
   responses:

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -840,36 +840,42 @@ func cmdReembed(ctx context.Context, args []string) error {
 	// request timeout — which makes "run it until it is done" the client's
 	// job. Looping here also means an operator types one command instead
 	// of watching a number and deciding when to stop.
-	var embedded, failed int
+	var embedded, attachments, failed int
+	cursor := ""
 	for pass := 1; ; pass++ {
-		res, err := c.Reembed(ctx, *limit)
+		res, err := c.Reembed(ctx, cursor, *limit)
 		if err != nil {
 			return err
 		}
 		embedded += res.Embedded
+		attachments += res.Attachments
 		failed += res.Failed
 		if *asJSON {
 			if err := printJSON(res); err != nil {
 				return err
 			}
 		} else {
-			fmt.Printf("pass %d: embedded %d, failed %d, still missing %d\n",
-				pass, res.Embedded, res.Failed, res.Missing)
+			fmt.Printf("pass %d: embedded %d entries, %d attachments, failed %d, still missing %d\n",
+				pass, res.Embedded, res.Attachments, res.Failed, res.Missing)
 		}
 		if *once || res.Missing == 0 {
 			break
 		}
-		if res.Embedded == 0 {
-			// Every entry left is one the provider refuses. Another pass
-			// would fetch the same ids and fail the same way.
+		// The cursor, not the progress count, decides when to stop: a
+		// pass whose every item the provider refuses still advances, and
+		// the corpus beyond that window deserves its turn. An exhausted
+		// cursor with work still missing means those failures are all
+		// that is left.
+		if res.Cursor == "" || res.Cursor == cursor {
 			fmt.Fprintf(os.Stderr,
-				"stopping: %d entries still missing and no progress this pass; see the server log for why\n",
+				"stopping: %d items still missing and the corpus is exhausted; see the server log for why they failed\n",
 				res.Missing)
 			return errReported
 		}
+		cursor = res.Cursor
 	}
 	if !*asJSON {
-		fmt.Printf("done: embedded %d, failed %d\n", embedded, failed)
+		fmt.Printf("done: embedded %d entries, %d attachments, failed %d\n", embedded, attachments, failed)
 	}
 	return nil
 }

--- a/internal/apiclient/apiclient.go
+++ b/internal/apiclient/apiclient.go
@@ -381,19 +381,30 @@ func (c *Client) Export(ctx context.Context, attachments bool) (io.ReadCloser, e
 
 // ReembedResult mirrors the /api/v1/reembed response.
 type ReembedResult struct {
-	Embedded int `json:"embedded"`
-	Failed   int `json:"failed"`
-	Missing  int `json:"missing"`
+	Embedded    int    `json:"embedded"`
+	Attachments int    `json:"attachments"`
+	Failed      int    `json:"failed"`
+	Missing     int    `json:"missing"`
+	Cursor      string `json:"cursor,omitempty"`
 }
 
-// Reembed fills in vectors for entries that have none for the configured
-// model (POST /api/v1/reembed). limit 0 uses the server default. One
-// pass is bounded: Missing reports what is still left, and the caller
-// repeats (see cmdReembed) rather than asking for a pass that cannot
-// finish inside a request timeout.
-func (c *Client) Reembed(ctx context.Context, limit int) (*ReembedResult, error) {
+// Reembed fills in vectors for entries and attachments that have none
+// for the configured model (POST /api/v1/reembed). limit 0 uses the
+// server default. One pass is bounded: Missing reports what is still
+// left and Cursor where to resume, and the caller repeats (see
+// cmdReembed) rather than asking for a pass that cannot finish inside a
+// request timeout. Pass the previous Cursor back to advance; passing ""
+// starts from the beginning.
+func (c *Client) Reembed(ctx context.Context, cursor string, limit int) (*ReembedResult, error) {
+	q := limitQuery(limit)
+	if cursor != "" {
+		if q == nil {
+			q = url.Values{}
+		}
+		q.Set("cursor", cursor)
+	}
 	var out ReembedResult
-	if err := c.doJSON(ctx, http.MethodPost, "/api/v1/reembed", limitQuery(limit), nil, &out); err != nil {
+	if err := c.doJSON(ctx, http.MethodPost, "/api/v1/reembed", q, nil, &out); err != nil {
 		return nil, err
 	}
 	return &out, nil

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -567,17 +567,19 @@ func Handler(svc *service.Service) http.Handler {
 		}
 	})
 
-	// POST /api/v1/reembed?limit=N — fill in vectors for entries that have
-	// none for the configured model. Not an MCP tool: an operator task
-	// with an unbounded runtime and no place in an agent's turn (design
-	// doc 0015).
+	// POST /api/v1/reembed?limit=N&cursor=... — fill in vectors for
+	// entries and attachments that have none for the configured model.
+	// The response's cursor feeds the next call: a pass whose entries all
+	// fail would otherwise hand back the same window forever. Not an MCP
+	// tool: an operator task with an unbounded runtime and no place in an
+	// agent's turn (design doc 0015).
 	mux.HandleFunc("POST /api/v1/reembed", func(w http.ResponseWriter, r *http.Request) {
 		limit, err := queryInt(r.URL.Query(), "limit")
 		if err != nil {
 			writeError(w, err)
 			return
 		}
-		res, err := svc.Reembed(r.Context(), limit)
+		res, err := svc.Reembed(r.Context(), r.URL.Query().Get("cursor"), limit)
 		if err != nil {
 			writeError(w, err)
 			return

--- a/internal/service/attachment_integration_test.go
+++ b/internal/service/attachment_integration_test.go
@@ -188,7 +188,7 @@ func TestAttachmentSearchIntegration(t *testing.T) {
 	// Had the png slipped past the media gate, its stub vector would be
 	// the fallback {0,0,0,1} and the entry would score ~1 here; with only
 	// expected.txt embedded, the entry's best attachment is orthogonal.
-	vhits, err := s.SearchVectorAttachments(ctx, []float32{0, 0, 0, 1}, store.Filter{}, 50)
+	vhits, err := s.SearchVectorAttachments(ctx, []float32{0, 0, 0, 1}, "stub", store.Filter{}, 50)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -207,7 +207,7 @@ func TestAttachmentSearchIntegration(t *testing.T) {
 	if _, err := fsvc.Attach(ctx, id, "chart.png", "", png, actor); err != nil {
 		t.Fatalf("re-attach png with file embedder: %v", err)
 	}
-	vhits, err = s.SearchVectorAttachments(ctx, []float32{0, 0, 1, 0}, store.Filter{}, 50)
+	vhits, err = s.SearchVectorAttachments(ctx, []float32{0, 0, 1, 0}, "stub", store.Filter{}, 50)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -220,4 +220,101 @@ func TestAttachmentSearchIntegration(t *testing.T) {
 	if !found {
 		t.Errorf("image attachment not searchable with a file-capable embedder: %+v", vhits)
 	}
+}
+
+// Reembed covers attachment vectors, not just entry vectors (design doc
+// 0020). Only attach writes them, so the documented recovery from a
+// dimension change — drop both embedding tables, restart, reembed —
+// used to leave every file findable by name alone, forever. Also pins
+// the cursor: a pass must not keep handing back the same window.
+func TestReembedCoversAttachmentsIntegration(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	lockLiveAttachments(t, dbURL)
+	ctx := context.Background()
+	s, err := store.New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Cleanup, not defer: the entry below is removed from a t.Cleanup,
+	// which runs after the test function returns — a deferred Close would
+	// already have shut the pool, leaving a live entry whose attachment
+	// bytes exist only in this test's in-memory blob store. Registered
+	// first, so LIFO runs it last.
+	t.Cleanup(func() { s.Close() })
+	s.UseBlobStore(memBlobStore{})
+	if err := s.Migrate(ctx, 4); err != nil {
+		t.Fatal(err)
+	}
+	model := fmt.Sprintf("reembed-att-%d", time.Now().UnixNano())
+	svc := &Service{Store: s, Embedder: stubEmbedder{}, Log: slog.New(slog.DiscardHandler)}
+	actor := domain.Actor{Kind: "human", Name: "test"}
+
+	typ := domain.Type(fmt.Sprintf("svcre%d", time.Now().UnixNano()))
+	id := string(typ) + "/host"
+	if _, err := svc.Create(ctx, &domain.Knowledge{Type: typ, ID: id, Title: "host"}, actor); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = svc.Delete(ctx, id, actor) })
+	for _, name := range []string{"a.txt", "b.txt"} {
+		if _, err := svc.Attach(ctx, id, name, "", []byte("some text for "+name), actor); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Simulate the recovery procedure: the vectors written by attach are
+	// under the stub's model, so switching the model leaves both
+	// attachments unembedded for the model now in use.
+	svc.Embedder = &fixedEmbedder{model: model, dim: 4}
+
+	pending, err := s.ListUnembeddedAttachments(ctx, model, "", "", 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := countOwned(pending, id); got != 2 {
+		t.Fatalf("unembedded attachments for %s = %d, want 2", id, got)
+	}
+
+	// Run the corpus down the way the CLI does. Entries go first, so the
+	// attachments are reached only once the cursor has walked past every
+	// entry — which is also the assertion that the cursor advances: a
+	// pass that kept returning the same window would never get here.
+	cursor := ""
+	for pass := 1; ; pass++ {
+		if pass > 100 {
+			t.Fatalf("reembed did not converge in %d passes (cursor %q)", pass-1, cursor)
+		}
+		res, err := svc.Reembed(ctx, cursor, 500)
+		if err != nil {
+			t.Fatalf("pass %d: %v", pass, err)
+		}
+		if res.Missing == 0 {
+			break
+		}
+		if res.Cursor == "" || res.Cursor == cursor {
+			t.Fatalf("pass %d left %d missing but did not advance the cursor (%q)",
+				pass, res.Missing, cursor)
+		}
+		cursor = res.Cursor
+	}
+
+	// Both attachments now have a vector under the current model.
+	if pending, err = s.ListUnembeddedAttachments(ctx, model, "", "", 100); err != nil {
+		t.Fatal(err)
+	}
+	if got := countOwned(pending, id); got != 0 {
+		t.Errorf("after reembed, %d of %s's attachments still lack a vector", got, id)
+	}
+}
+
+func countOwned(pending []store.UnembeddedAttachment, id string) int {
+	n := 0
+	for _, p := range pending {
+		if p.KnowledgeID == id {
+			n++
+		}
+	}
+	return n
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -395,14 +395,14 @@ func (s *Service) search(ctx context.Context, query string, f store.Filter, limi
 		}
 		return lexical, nil
 	}
-	vector, err := s.Store.SearchVector(ctx, vecs[0], f, limit*2)
+	vector, err := s.Store.SearchVector(ctx, vecs[0], s.Embedder.Model(), f, limit*2)
 	if err != nil {
 		return nil, err
 	}
 	// Entries whose attachments match are the third list (design doc
 	// 0020): an entry matching in both body and attachment gains rank
 	// from both, so evidence-backed entries surface first.
-	attachments, err := s.Store.SearchVectorAttachments(ctx, vecs[0], f, limit*2)
+	attachments, err := s.Store.SearchVectorAttachments(ctx, vecs[0], s.Embedder.Model(), f, limit*2)
 	if err != nil {
 		return nil, err
 	}
@@ -839,13 +839,17 @@ func (s *Service) embedBytes() int {
 }
 
 // ReembedResult reports what a Reembed pass did. Missing is how many
-// entries still have no vector once the pass is over — the number that
-// decides whether the operator runs it again, so it counts what is
-// actually left rather than what this pass did not get to.
+// entries and attachments still have no vector once the pass is over —
+// the number that decides whether the operator runs it again, so it
+// counts what is actually left rather than what this pass did not get
+// to. Cursor is where the next pass resumes; empty means the corpus is
+// exhausted.
 type ReembedResult struct {
-	Embedded int `json:"embedded"`
-	Failed   int `json:"failed"`
-	Missing  int `json:"missing"`
+	Embedded    int    `json:"embedded"`
+	Attachments int    `json:"attachments"`
+	Failed      int    `json:"failed"`
+	Missing     int    `json:"missing"`
+	Cursor      string `json:"cursor,omitempty"`
 }
 
 // A reembed pass is one HTTP request, and one entry is one call to the
@@ -872,14 +876,15 @@ const (
 //
 // Failures are counted, not fatal: one entry the provider chokes on must
 // not strand the rest of the corpus.
-func (s *Service) Reembed(ctx context.Context, limit int) (*ReembedResult, error) {
+func (s *Service) Reembed(ctx context.Context, cursor string, limit int) (*ReembedResult, error) {
 	if s.Embedder == nil {
 		return nil, Unsupportedf("semantic search is not configured: set OCHAKAI_VERTEX_PROJECT")
 	}
 	if limit <= 0 || limit > maxReembedPass {
 		limit = defaultReembedPass
 	}
-	ids, err := s.Store.ListUnembedded(ctx, s.Embedder.Model(), limit)
+	entryCursor, attachCursor := splitReembedCursor(cursor)
+	ids, err := s.Store.ListUnembedded(ctx, s.Embedder.Model(), entryCursor, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -904,6 +909,20 @@ func (s *Service) Reembed(ctx context.Context, limit int) (*ReembedResult, error
 		}
 		res.Embedded++
 	}
+	if len(ids) > 0 {
+		entryCursor = ids[len(ids)-1]
+	}
+	// Attachments carry vectors of their own (design doc 0020) and only
+	// attach writes them, so dropping the embedding tables to change
+	// dimensions leaves every file findable by name alone. Entries come
+	// first and attachments fill the rest of the pass, so a corpus with
+	// both makes progress on both.
+	if rest := limit - len(ids); rest > 0 {
+		attachCursor, err = s.reembedAttachments(ctx, res, attachCursor, rest)
+		if err != nil {
+			return nil, err
+		}
+	}
 	// Counted after the pass, so it is what is left — not what was left
 	// minus what we did, which double-counts the work and reports a
 	// bounded pass as a finished one. Entries this pass failed on are
@@ -915,8 +934,73 @@ func (s *Service) Reembed(ctx context.Context, limit int) (*ReembedResult, error
 		s.Log.Warn("reembed: counting what is left failed", "error", err)
 		return res, nil
 	}
-	res.Missing = missing
+	attMissing, err := s.Store.CountUnembeddedAttachments(ctx, s.Embedder.Model())
+	if err != nil {
+		s.Log.Warn("reembed: counting attachments left failed", "error", err)
+	}
+	res.Missing = missing + attMissing
+	if res.Missing > 0 {
+		res.Cursor = joinReembedCursor(entryCursor, attachCursor)
+	}
 	return res, nil
+}
+
+// reembedAttachments re-embeds up to limit attachments, returning the
+// cursor to resume from. Failures are counted like entry failures: a
+// file the provider rejects must not strand the rest.
+func (s *Service) reembedAttachments(ctx context.Context, res *ReembedResult, cursor string, limit int) (string, error) {
+	afterID, afterName := splitReembedCursor(cursor)
+	pending, err := s.Store.ListUnembeddedAttachments(ctx, s.Embedder.Model(), afterID, afterName, limit)
+	if err != nil {
+		return cursor, err
+	}
+	for _, a := range pending {
+		att, data, err := s.Store.GetAttachment(ctx, a.KnowledgeID, a.Name)
+		if err != nil {
+			res.Failed++
+			s.Log.Warn("reembed: attachment disappeared", "id", a.KnowledgeID, "name", a.Name, "error", err)
+			continue
+		}
+		// The same path attach uses, so the vectors match what a fresh
+		// attach would have produced; it logs and swallows its own
+		// failures, which is why the count below is of rows written.
+		before := s.attachmentVectorCount(ctx, a.KnowledgeID, a.Name)
+		s.updateAttachmentEmbedding(ctx, a.KnowledgeID, att, data)
+		if s.attachmentVectorCount(ctx, a.KnowledgeID, a.Name) > before {
+			res.Attachments++
+		} else {
+			res.Failed++
+		}
+		afterID, afterName = a.KnowledgeID, a.Name
+	}
+	return joinReembedCursor(afterID, afterName), nil
+}
+
+// attachmentVectorCount reports whether a current-model vector exists,
+// so a pass can tell an embedding that landed from one the provider (or
+// the model's file support) declined.
+func (s *Service) attachmentVectorCount(ctx context.Context, id, name string) int {
+	n, err := s.Store.CountAttachmentEmbedding(ctx, id, name, s.Embedder.Model())
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+// The reembed cursor carries two positions — entries and attachments —
+// in one opaque string, so the wire stays a single token the CLI can
+// hand back unchanged. "\x00" cannot occur in an id (design doc 0017)
+// or an attachment name.
+func joinReembedCursor(a, b string) string {
+	if a == "" && b == "" {
+		return ""
+	}
+	return a + "\x00" + b
+}
+
+func splitReembedCursor(c string) (string, string) {
+	a, b, _ := strings.Cut(c, "\x00")
+	return a, b
 }
 
 // embedDocument embeds text, halving it and retrying while the model says

--- a/internal/service/service_integration_test.go
+++ b/internal/service/service_integration_test.go
@@ -371,7 +371,7 @@ func TestReembedIntegration(t *testing.T) {
 	// not a nil dereference.
 	embedder := svc.Embedder
 	svc.Embedder = nil
-	_, err := svc.Reembed(ctx, 10)
+	_, err := svc.Reembed(ctx, "", 10)
 	var unsupported *UnsupportedError
 	if !errors.As(err, &unsupported) {
 		t.Errorf("without an embedder: got %v, want an UnsupportedError naming the setting", err)
@@ -390,7 +390,7 @@ func TestReembedIntegration(t *testing.T) {
 	// up whatever else happens to be unembedded.
 	unembedded := func(t *testing.T, model string) bool {
 		t.Helper()
-		ids, err := svc.Store.ListUnembedded(ctx, model, 5000)
+		ids, err := svc.Store.ListUnembedded(ctx, model, "", 5000)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -408,7 +408,7 @@ func TestReembedIntegration(t *testing.T) {
 		t.Fatal("a model change must leave the old vector behind")
 	}
 
-	res, err := svc.Reembed(ctx, 5000)
+	res, err := svc.Reembed(ctx, "", 5000)
 	if err != nil {
 		t.Fatalf("Reembed after a model change: %v", err)
 	}
@@ -423,7 +423,7 @@ func TestReembedIntegration(t *testing.T) {
 	}
 
 	// And it is idempotent: a second pass finds this entry already done.
-	done, err := svc.Reembed(ctx, 5000)
+	done, err := svc.Reembed(ctx, "", 5000)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -473,7 +473,7 @@ func TestReembedReportsWhatIsLeft(t *testing.T) {
 	}
 
 	// A pass smaller than the corpus must say what it did not reach.
-	res, err := svc.Reembed(ctx, 2)
+	res, err := svc.Reembed(ctx, "", 2)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/store/attachment_search_integration_test.go
+++ b/internal/store/attachment_search_integration_test.go
@@ -118,7 +118,7 @@ func TestIntegrationAttachmentSearch(t *testing.T) {
 			t.Fatalf("UpsertAttachmentEmbedding(%s/%s): %v", e.id, e.name, err)
 		}
 	}
-	vhits, err := s.SearchVectorAttachments(ctx, []float32{0.9, 0.1, 0.1, 0}, Filter{}, 5)
+	vhits, err := s.SearchVectorAttachments(ctx, []float32{0.9, 0.1, 0.1, 0}, "test-model", Filter{}, 5)
 	if err != nil {
 		t.Fatalf("SearchVectorAttachments: %v", err)
 	}
@@ -169,7 +169,7 @@ func TestIntegrationAttachmentSearch(t *testing.T) {
 	if n := countEmbeddings(b.ID, "other.txt"); n != 1 {
 		t.Errorf("soft delete removed attachment embeddings: got %d rows, want 1", n)
 	}
-	vhits, err = s.SearchVectorAttachments(ctx, []float32{0, 0, 1, 0}, Filter{}, 5)
+	vhits, err = s.SearchVectorAttachments(ctx, []float32{0, 0, 1, 0}, "test-model", Filter{}, 5)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -907,15 +907,22 @@ func (s *Store) SearchLexical(ctx context.Context, query string, f Filter, limit
 }
 
 // SearchVector ranks by cosine distance against stored embeddings.
-func (s *Store) SearchVector(ctx context.Context, vec []float32, f Filter, limit int) ([]domain.SearchHit, error) {
+func (s *Store) SearchVector(ctx context.Context, vec []float32, model string, f Filter, limit int) ([]domain.SearchHit, error) {
 	// Columns must be qualified: knowledge_embedding shares id/updated_at.
 	where, args := f.buildWhere("k.")
 	args = append(args, encodeVector(vec))
+	vecParam := len(args)
+	// Only this model's vectors: a vector written by another model lives
+	// in a different space, so comparing it to this query's vector yields
+	// a number that means nothing. Reembed refills the gap (design doc
+	// 0020); until it runs the entry is lexical-only, which is a visible
+	// absence rather than a plausible wrong ranking.
+	args = append(args, model)
 	q := fmt.Sprintf(`
 		SELECT `+qualifyCols("k")+`, 1 - (e.embedding <=> $%d::vector) AS score
-		FROM knowledge k JOIN knowledge_embedding e ON k.id = e.id
+		FROM knowledge k JOIN knowledge_embedding e ON k.id = e.id AND e.model = $%d
 		WHERE %s
-		ORDER BY e.embedding <=> $%d::vector LIMIT %d`, len(args), where, len(args), limit)
+		ORDER BY e.embedding <=> $%d::vector LIMIT %d`, vecParam, len(args), where, vecParam, limit)
 	rows, err := s.pool.Query(ctx, q, args...)
 	if err != nil {
 		return nil, err
@@ -929,17 +936,19 @@ func (s *Store) SearchVector(ctx context.Context, vec []float32, f Filter, limit
 // embedding (design doc 0020). Each entry appears once, carrying its
 // best attachment's score — attachments never stand alone, so the hit
 // is the owning entry.
-func (s *Store) SearchVectorAttachments(ctx context.Context, vec []float32, f Filter, limit int) ([]domain.SearchHit, error) {
+func (s *Store) SearchVectorAttachments(ctx context.Context, vec []float32, model string, f Filter, limit int) ([]domain.SearchHit, error) {
 	where, args := f.buildWhere("k.")
 	args = append(args, encodeVector(vec))
+	vecParam := len(args)
+	args = append(args, model) // this model's vectors only, as in SearchVector
 	q := fmt.Sprintf(`
 		SELECT `+knowledgeCols+`, score FROM (
 			SELECT DISTINCT ON (k.id) k.*, 1 - (e.embedding <=> $%d::vector) AS score
-			FROM knowledge k JOIN attachment_embedding e ON k.id = e.knowledge_id
+			FROM knowledge k JOIN attachment_embedding e ON k.id = e.knowledge_id AND e.model = $%d
 			WHERE %s
 			ORDER BY k.id, e.embedding <=> $%d::vector
 		) best
-		ORDER BY score DESC LIMIT %d`, len(args), where, len(args), limit)
+		ORDER BY score DESC LIMIT %d`, vecParam, len(args), where, vecParam, limit)
 	rows, err := s.pool.Query(ctx, q, args...)
 	if err != nil {
 		return nil, err
@@ -1111,16 +1120,73 @@ func (s *Store) ListAll(ctx context.Context) ([]domain.Knowledge, error) {
 // is no row), and entries whose vector belongs to a model that has since
 // been changed (design doc 0020 — the old vectors sit in a space nobody
 // queries any more).
-func (s *Store) ListUnembedded(ctx context.Context, model string, limit int) ([]string, error) {
+//
+// after is a keyset cursor: pass the last id of the previous page to get
+// the next one. Without it a pass whose entries all fail keeps handing
+// back the same window, and the caller — which stops when a pass embeds
+// nothing — never reaches the rest of the corpus.
+func (s *Store) ListUnembedded(ctx context.Context, model, after string, limit int) ([]string, error) {
 	rows, err := s.pool.Query(ctx,
 		`SELECT k.id FROM knowledge k
 		 LEFT JOIN knowledge_embedding e ON e.id = k.id AND e.model = $1
-		 WHERE k.deleted_at IS NULL AND e.id IS NULL
-		 ORDER BY k.created_at LIMIT $2`, model, limit)
+		 WHERE k.deleted_at IS NULL AND e.id IS NULL AND ($2 = '' OR k.id > $2)
+		 ORDER BY k.id LIMIT $3`, model, after, limit)
 	if err != nil {
 		return nil, err
 	}
 	return pgx.CollectRows(rows, pgx.RowTo[string])
+}
+
+// UnembeddedAttachment names one attachment awaiting a vector.
+type UnembeddedAttachment struct {
+	KnowledgeID string
+	Name        string
+}
+
+// ListUnembeddedAttachments is ListUnembedded for attachment vectors
+// (design doc 0020). Attach writes them, so a corpus loaded before
+// semantic search — or one whose embedding tables were dropped to change
+// dimensions — has none, and the files are findable by name only. The
+// cursor is the (knowledge_id, name) pair, for the same reason.
+func (s *Store) ListUnembeddedAttachments(ctx context.Context, model, afterID, afterName string, limit int) ([]UnembeddedAttachment, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT a.knowledge_id, a.name FROM attachment a
+		 JOIN knowledge k ON k.id = a.knowledge_id AND k.deleted_at IS NULL
+		 LEFT JOIN attachment_embedding e
+		   ON e.knowledge_id = a.knowledge_id AND e.name = a.name AND e.model = $1
+		 WHERE e.knowledge_id IS NULL
+		   AND ($2 = '' OR (a.knowledge_id, a.name) > ($2, $3))
+		 ORDER BY a.knowledge_id, a.name LIMIT $4`, model, afterID, afterName, limit)
+	if err != nil {
+		if isUndefinedTable(err) {
+			return nil, nil // embedding tables appear with semantic search
+		}
+		return nil, err
+	}
+	out, err := pgx.CollectRows(rows, func(row pgx.CollectableRow) (UnembeddedAttachment, error) {
+		var a UnembeddedAttachment
+		return a, row.Scan(&a.KnowledgeID, &a.Name)
+	})
+	if err != nil && isUndefinedTable(err) {
+		return nil, nil
+	}
+	return out, err
+}
+
+// CountUnembeddedAttachments counts what ListUnembeddedAttachments would
+// eventually return.
+func (s *Store) CountUnembeddedAttachments(ctx context.Context, model string) (int, error) {
+	var n int
+	err := s.pool.QueryRow(ctx,
+		`SELECT count(*) FROM attachment a
+		 JOIN knowledge k ON k.id = a.knowledge_id AND k.deleted_at IS NULL
+		 LEFT JOIN attachment_embedding e
+		   ON e.knowledge_id = a.knowledge_id AND e.name = a.name AND e.model = $1
+		 WHERE e.knowledge_id IS NULL`, model).Scan(&n)
+	if err != nil && isUndefinedTable(err) {
+		return 0, nil
+	}
+	return n, err
 }
 
 // CountUnembedded counts the live entries with no vector for the named
@@ -1236,4 +1302,19 @@ func encodeVector(vec []float32) string {
 
 func isUndefinedTable(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "42P01")
+}
+
+// CountAttachmentEmbedding reports whether one attachment has a vector
+// for the named model (0 or 1). Reembed uses it to tell an embedding
+// that landed from one the provider declined — the attach path logs its
+// own failures rather than returning them.
+func (s *Store) CountAttachmentEmbedding(ctx context.Context, id, name, model string) (int, error) {
+	var n int
+	err := s.pool.QueryRow(ctx,
+		`SELECT count(*) FROM attachment_embedding
+		 WHERE knowledge_id = $1 AND name = $2 AND model = $3`, id, name, model).Scan(&n)
+	if err != nil && isUndefinedTable(err) {
+		return 0, nil
+	}
+	return n, err
 }

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -85,7 +85,7 @@ func TestIntegration(t *testing.T) {
 
 	// The joined vector query must not have ambiguous column references
 	// (knowledge_embedding shares type/id/updated_at with knowledge).
-	vec, err := s.SearchVector(ctx, []float32{1, 0, 0, 0}, Filter{
+	vec, err := s.SearchVector(ctx, []float32{1, 0, 0, 0}, "test-model", Filter{
 		Types: []domain.Type{domain.TypeMetrics}, Statuses: []domain.Status{domain.StatusVerified},
 	}, 20)
 	if err != nil {


### PR DESCRIPTION
## 1. 添付ベクトルが reembed の対象外だった

次元変更ガード(#140)は「両方の埋め込みテーブルを DROP → 再起動 → `ochakai reembed`」を復旧手順として案内する。しかし `Reembed` はナレッジエントリしか列挙しておらず、**添付ベクトルは二度と戻らなかった** — 各ファイルは再添付するまで永久にファイル名でしか見つからず、しかもそれを知らせるものが何もない(design 0020 が定めた添付のベクトル検索が黙って死ぬ)。

添付を各パスの残り枠で処理するようにした。埋め込みは attach と同じ経路を通るので、生成されるベクトルは新規添付時と同じもの。ガードの復旧手順がようやく真実になる。

## 2. ベクトル検索がモデルを見ていなかった

`SearchVector` / `SearchVectorAttachments` の JOIN に model 条件が無かった。**次元を変えずにモデルだけ差し替える**とガードは通過し、エントリは reembed で自己修復するが、それまでの間(添付に至っては永久に)**旧モデルのベクトルが新モデルのクエリベクトルと比較され続ける**。別の空間どうしの比較なので、スコアは無意味だがもっともらしい数字になる。

両検索を現行モデルのベクトルに限定した。ベクトルが無いエントリは lexical のみになる — 「見えない欠落」ではなく「もっともらしい誤ったランキング」を避ける方を選ぶ。

## 3. 恒久失敗するエントリがページングを塞いでいた

`ListUnembedded` は `ORDER BY ... LIMIT` だけでカーソルを持たず、CLI は「embedded==0 で停止」する。最古の limit 件がプロバイダに恒久的に拒否される場合、毎パス同じ窓を取って全滅 → 停止し、**その先の数千件は一度も試行されない**。

パスがキーセットカーソルを持ち、CLI は「進捗が無かったとき」ではなく「カーソルが尽きたとき」に停止する。カーソルは REST(`?cursor=`)とレスポンスに載せ、openapi に文書化した。

## 変更点

- store: `ListUnembedded` にカーソル、`ListUnembeddedAttachments` / `CountUnembeddedAttachments` / `CountAttachmentEmbedding` を追加、両ベクトル検索に model 条件
- service: `Reembed(ctx, cursor, limit)`、添付の再埋め込み、`ReembedResult` に `attachments` と `cursor`
- REST / apiclient / CLI / openapi を同じ形に(reembed は 0015 のとおり REST + CLI のみ)

## テスト

`TestReembedCoversAttachmentsIntegration` を追加(実 DB)。添付 2 件を持つエントリでモデルを差し替え、コーパスを走り切らせて両方にベクトルが付くことと、カーソルが毎パス前進することを検証する。`gofmt` / `go vet` / `CGO_ENABLED=0 go build` / `go test -race ./...`(pgvector 実 DB 込み)green。

> 補足: 実 DB で全パッケージを同時実行すると、`internal/store` の blob テストが live な添付を残したまま終わるため `internal/restapi` の export テストが 500 で落ちる。**本 PR とは無関係の既存問題**(未変更の main でも再現)なので触っていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)