### PR TITLE
test: stop the blob integration test from leaving a live attachment behind

### DIFF
--- a/internal/store/blob_integration_test.go
+++ b/internal/store/blob_integration_test.go
@@ -47,6 +47,10 @@ func TestIntegrationBlobStoreOnly(t *testing.T) {
 	if err := s.Create(ctx, k); err != nil {
 		t.Fatal(err)
 	}
+	// Leave no live attachment behind: the bytes below exist only in this
+	// test's blob fake, and other packages' export scans resolve every
+	// live attachment against their own. Runs before the deferred Close.
+	defer func() { _ = s.SoftDelete(ctx, k.ID, actor) }()
 
 	// Migration 0009 dropped the bytea column.
 	var hasBytes bool

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -1073,6 +1073,7 @@ func TestIntegrationSearchTextFollowsAttachmentsAndMoves(t *testing.T) {
 	if dbURL == "" {
 		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
 	}
+	lockLiveAttachments(t, dbURL) // seeds.txt rides a fake blob store other packages' export scans can't read
 	ctx := context.Background()
 	s, err := New(ctx, dbURL, false)
 	if err != nil {


### PR DESCRIPTION
## What

`TestIntegrationBlobStoreOnly` (`internal/store/blob_integration_test.go`) creates `it-ext-reading` with a live attachment `chart.png` whose bytes exist only in that test's in-memory blob fake. It cleaned up leftovers at the *start* of the test but never at the end. Now it soft-deletes the entry when it finishes.

`TestIntegrationSearchTextFollowsAttachmentsAndMoves` had the same exposure in a narrower form — it holds a live `seeds.txt` on a fake blob store for the middle of the test — but never took `lockLiveAttachments`. It does now.

## Why

`ListAllAttachments` joins `knowledge ... AND k.deleted_at IS NULL` and resolves every live attachment's bytes against the store's own blob backend. A live attachment left behind by another package's test therefore breaks any whole-KB scan: `internal/restapi`'s `TestRESTIntegration` fails its export step with a 500.

The `lockLiveAttachments` advisory lock only serializes tests that *hold or scan* live attachments while they run. Once `TestIntegrationBlobStoreOnly` released it, `it-ext-reading` stayed live and unprotected — through the browse and migrate integration tests — until `TestIntegration`'s start-of-run `DELETE ... WHERE id LIKE 'it-%'` incidentally swept it. A concurrent export landing in that several-second window fails.

## Note for reviewers

The entry does not survive the store package: `TestIntegration`'s `'it-%'` sweep cleans it up, which is why this presents as a flake rather than a hard failure, and why a full `go test -race ./...` can pass on unmodified main. The defect is the window, not a permanent leftover.

The cleanup is a `defer` registered *after* `defer s.Close()`, so LIFO runs it while the pool is still open — a `t.Cleanup` would run after the deferred `Close`. This matches the idiom already used in `attachment_search_integration_test.go` and `internal/service/attachment_integration_test.go`. `SoftDelete` suffices because the scan filters on `deleted_at IS NULL`, and the test's start-of-run delete still clears the tombstone on reruns.

Surveyed the other integration tests that create live attachments — `TestIntegrationMove` detaches at the end, `TestIntegrationAttachments` soft-deletes as its last assertion, and the attachment-search, service and restapi tests already clean up. No other test attaches against a real database.

## Verification

Against a fresh `pgvector/pgvector:pg17` on port 55433:

- Deterministic repro on unmodified main: `-run TestIntegrationBlobStoreOnly ./internal/store/` left `it-ext-reading | chart.png` live, and `-run TestRESTIntegration ./internal/restapi/` then failed with `export: status = 500`. After this change the same two steps leave 0 live attachments and the REST test passes.
- `gofmt -l .` and `go vet ./...` clean.
- `go test -race -count=1 ./...` three consecutive runs: all 12 packages ok, 0 live attachments left in the database after each.

Test-only change; no design doc needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)