### PR TITLE
Make a purge lose to a concurrent revival

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -475,9 +475,15 @@ func (s *Store) SoftDelete(ctx context.Context, id string, actor domain.Actor) e
 // that someone destroyed it is not.
 func (s *Store) Purge(ctx context.Context, id string, actor domain.Actor) error {
 	return s.withTx(ctx, func(tx pgx.Tx) error {
+		// FOR UPDATE, because the check and the delete must see the same
+		// row: Create revives a tombstone in place, so without the lock a
+		// revival committing in between would leave this transaction
+		// deleting a live entry — the one thing two-step destruction
+		// exists to prevent. The lock also serializes two purges of the
+		// same id, which would otherwise both log an audit row.
 		var deleted bool
 		err := tx.QueryRow(ctx,
-			`SELECT deleted_at IS NOT NULL FROM knowledge WHERE id=$1`, id).Scan(&deleted)
+			`SELECT deleted_at IS NOT NULL FROM knowledge WHERE id=$1 FOR UPDATE`, id).Scan(&deleted)
 		if errors.Is(err, pgx.ErrNoRows) {
 			return ErrNotFound
 		}
@@ -501,11 +507,21 @@ func (s *Store) Purge(ctx context.Context, id string, actor domain.Actor) error 
 			`DELETE FROM knowledge_usage WHERE knowledge_id=$1`,
 			`DELETE FROM knowledge_event WHERE knowledge_id=$1`,
 			`DELETE FROM knowledge_revision WHERE id=$1`,
-			`DELETE FROM knowledge WHERE id=$1`,
 		} {
 			if _, err := tx.Exec(ctx, q, id); err != nil {
 				return err
 			}
+		}
+		// The tombstone condition is repeated here so the destructive
+		// statement carries the precondition itself, not just the lock
+		// taken above: a purge that would hit a live row aborts the
+		// transaction instead of erasing it.
+		tag, err := tx.Exec(ctx, `DELETE FROM knowledge WHERE id=$1 AND deleted_at IS NOT NULL`, id)
+		if err != nil {
+			return err
+		}
+		if tag.RowsAffected() == 0 {
+			return ErrNotDeleted
 		}
 		// Embedding tables exist only once semantic search has been enabled.
 		for _, q := range []string{

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -1243,6 +1243,107 @@ func TestIntegrationPurgeFreesIDForMove(t *testing.T) {
 	_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_revision WHERE id = $1`, dst)
 }
 
+// A purge and a revival can be in flight at the same time: Create brings a
+// tombstone back in place, and the entry it produces is live knowledge
+// somebody is now using. The purge must lose that race — it was authorized
+// against a tombstone, and hard-deleting the revived entry would destroy in
+// one call history that was in use a moment ago, which is exactly what the
+// two-step delete-then-purge exists to prevent.
+func TestIntegrationPurgeLosesToRevival(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	actor := domain.Actor{Kind: "human", Name: "test"}
+
+	const id = "it-purge-race"
+	cleanup := func() {
+		_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge WHERE id = $1`, id)
+		_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_revision WHERE id = $1`, id)
+		_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_purge WHERE id = $1`, id)
+	}
+	cleanup()
+	defer cleanup()
+
+	if err := s.Create(ctx, &domain.Knowledge{
+		Type: domain.TypeTerms, ID: id, Title: id,
+		Status: domain.StatusDraft, CreatedBy: actor,
+	}, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SoftDelete(ctx, id, actor); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stand in for a concurrent Create: it revives the tombstone in place
+	// and holds the row until it commits.
+	revive, err := s.pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = revive.Rollback(ctx) }()
+	if _, err := revive.Exec(ctx,
+		`UPDATE knowledge SET deleted_at = NULL, updated_at = now() WHERE id = $1`, id); err != nil {
+		t.Fatal(err)
+	}
+
+	purged := make(chan error, 1)
+	go func() { purged <- s.Purge(ctx, id, actor) }()
+
+	// Wait for the purge to block on the revival's row lock. Without the
+	// wait the purge might not have reached the row yet, and committing
+	// first would test a serial order rather than the interleaving.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		var waiting int
+		if err := s.pool.QueryRow(ctx,
+			`SELECT count(*) FROM pg_stat_activity
+			  WHERE wait_event_type = 'Lock' AND query LIKE '%knowledge%'`).Scan(&waiting); err != nil {
+			t.Fatal(err)
+		}
+		if waiting > 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("purge never blocked on the revival's lock")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if err := revive.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-purged; !errors.Is(err, ErrNotDeleted) {
+		t.Errorf("purge racing a revival: got %v, want ErrNotDeleted", err)
+	}
+
+	k, err := s.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("the revived entry is gone: %v", err)
+	}
+	if k.ID != id {
+		t.Errorf("got entry %q, want %q", k.ID, id)
+	}
+	// An audit row would claim a destruction that must not have happened.
+	var audits int
+	if err := s.pool.QueryRow(ctx,
+		`SELECT count(*) FROM knowledge_purge WHERE id = $1`, id).Scan(&audits); err != nil {
+		t.Fatal(err)
+	}
+	if audits != 0 {
+		t.Errorf("refused purge left %d audit rows", audits)
+	}
+}
+
 // Close is the last thing a SIGTERM'd process does with the usage buffer:
 // stop the flush loop, drain what is still in it. Events recorded in the
 // seconds before shutdown — a whole request's worth on a Cloud Run


### PR DESCRIPTION
`Store.Purge` checked `deleted_at IS NOT NULL` with a plain read and then deleted the row without repeating the condition. Under READ COMMITTED the check does not block on an uncommitted revival, and the `DELETE` re-evaluates `id=$1` once the lock is released — so a `Create` reviving the tombstone in the window left the purge hard-deleting a **live** entry along with its revisions, usage, events and embeddings, and logging an audit row that described the revived entry as the tombstone it purged.

That is precisely what the two-step delete-then-purge exists to prevent (0031): the purge was authorized against a tombstone nobody was using, and it destroyed knowledge somebody had just brought back. It is the same race #155 closed on the `Create` side, left open on the `Purge` side.

## Fix

- `SELECT ... FOR UPDATE` on the check, so the check and the delete see the same row. A revival now lands entirely before the purge (which refuses with `ErrNotDeleted`) or entirely after it.
- The `DELETE` carries `AND deleted_at IS NOT NULL` with a `RowsAffected` guard. The lock is the fix; the condition makes the destructive statement state its own precondition, so a future regression rolls the transaction back instead of erasing history.
- The lock also serializes two concurrent purges of the same id, which previously both passed the check and both wrote an audit row.

## Test

`TestIntegrationPurgeLosesToRevival` drives the interleaving deterministically: it holds an uncommitted revival, waits for the purge to block on the row lock, then commits. Without the fix it fails with the entry destroyed and the purge reporting success:

```
purge racing a revival: got <nil>, want ErrNotDeleted
the revived entry is gone: knowledge not found
```

Verified against a real PostgreSQL: `go test -race ./...` passes with `OCHAKAI_TEST_DATABASE_URL` set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)