### PR TITLE
Lock the referrers a move rewrites

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -618,9 +618,16 @@ func (s *Store) Move(ctx context.Context, oldID, newID string, actor domain.Acto
 // derivation and so is an accurate index of who refers to oldID.
 func (s *Store) rewriteReferences(ctx context.Context, tx pgx.Tx, oldID string, moved *domain.Knowledge, actor domain.Actor) error {
 	newID := moved.ID
+	// FOR UPDATE, because each referrer is read here and written whole
+	// below: the rewrite carries body, links and attrs from this read, so
+	// an update committing in the window would be silently reverted — and
+	// recorded as an ordinary "update" revision, which hides that anything
+	// was lost. ORDER BY id gives concurrent moves one lock order, so they
+	// queue instead of deadlocking.
 	rows, err := tx.Query(ctx,
 		`SELECT `+knowledgeCols+` FROM knowledge
-		 WHERE deleted_at IS NULL AND (links @> $1 OR links @> $2 OR attrs->>'model' = $3 OR id = $4)`,
+		 WHERE deleted_at IS NULL AND (links @> $1 OR links @> $2 OR attrs->>'model' = $3 OR id = $4)
+		 ORDER BY id FOR UPDATE`,
 		fmt.Sprintf(`[{"target": %q}]`, oldID),
 		fmt.Sprintf(`[{"target": %q}]`, "ochakai://"+oldID),
 		oldID, newID)
@@ -674,10 +681,20 @@ func (s *Store) rewriteReferences(ctx context.Context, tx pgx.Tx, oldID string, 
 		} else {
 			r.UpdatedAt = now
 		}
-		if _, err := tx.Exec(ctx,
-			`UPDATE knowledge SET links=$2, attrs=$3, body=$4, updated_at=$5 WHERE id=$1`,
-			r.ID, links, attrs, r.Body, r.UpdatedAt); err != nil {
+		// deleted_at IS NULL restates what the locked read already
+		// established, so the statement does not depend on the reader
+		// having filtered: rewriting a tombstone would plant a repaired
+		// body and a revision on an entry nobody can see, to resurface
+		// whenever someone revives it.
+		tag, err := tx.Exec(ctx,
+			`UPDATE knowledge SET links=$2, attrs=$3, body=$4, updated_at=$5
+			 WHERE id=$1 AND deleted_at IS NULL`,
+			r.ID, links, attrs, r.Body, r.UpdatedAt)
+		if err != nil {
 			return err
+		}
+		if tag.RowsAffected() == 0 {
+			return fmt.Errorf("rewriting references to %s: %s changed under the move", oldID, r.ID)
 		}
 		if self {
 			// Fold the result back into the caller's entry; the caller

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -1931,3 +1931,109 @@ func TestIntegrationCreateKeepsCuratedTombstones(t *testing.T) {
 		}
 	})
 }
+
+// A move rewrites every entry that referred to the old id, and it does so
+// by reading the referrer, repairing its body in Go, and writing the whole
+// row back. Without a lock on that read, an edit committing in the window
+// is reverted by the write-back -- and recorded as an ordinary "update"
+// revision, so the history shows a change but not that one was lost.
+func TestIntegrationMoveDoesNotClobberAConcurrentEdit(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	actor := domain.Actor{Kind: "human", Name: "test"}
+
+	stamp := time.Now().UnixNano()
+	target := fmt.Sprintf("it-clobber-%d/metric", stamp)
+	moved := fmt.Sprintf("it-clobber-%d/renamed", stamp)
+	referrer := fmt.Sprintf("it-clobber-%d/insight", stamp)
+	cleanup := func() {
+		for _, table := range []string{"knowledge", "knowledge_revision"} {
+			_, _ = s.pool.Exec(ctx, `DELETE FROM `+table+` WHERE id LIKE $1`,
+				fmt.Sprintf("it-clobber-%d%%", stamp))
+		}
+	}
+	cleanup()
+	defer cleanup()
+
+	for _, k := range []*domain.Knowledge{
+		{Type: domain.TypeMetrics, ID: target, Title: "target", Status: domain.StatusDraft, CreatedBy: actor},
+		{Type: domain.TypeInsights, ID: referrer, Title: "referrer", Status: domain.StatusDraft, CreatedBy: actor,
+			Body:  "Explains [the metric](/" + target + ".md).",
+			Links: domain.LinksFromBody(referrer, "Explains [the metric](/"+target+".md).")},
+	} {
+		if err := s.Create(ctx, k, false); err != nil {
+			t.Fatalf("create %s: %v", k.ID, err)
+		}
+	}
+
+	// A human edit to the referrer, committed while the move is in flight.
+	edit, err := s.pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = edit.Rollback(ctx) }()
+	const added = "A sentence the move must not eat."
+	if _, err := edit.Exec(ctx,
+		`UPDATE knowledge SET body = body || $2, updated_at = now() WHERE id = $1`,
+		referrer, "\n\n"+added); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := s.Move(ctx, target, moved, actor)
+		done <- err
+	}()
+
+	// Let the move reach the referrer and block there.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		var waiting int
+		if err := s.pool.QueryRow(ctx,
+			`SELECT count(*) FROM pg_stat_activity
+			  WHERE wait_event_type = 'Lock' AND query LIKE '%knowledge%'`).Scan(&waiting); err != nil {
+			t.Fatal(err)
+		}
+		if waiting > 0 {
+			break
+		}
+		select {
+		case err := <-done:
+			t.Fatalf("move finished without blocking: %v", err)
+		default:
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("move never blocked on the concurrent edit")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if err := edit.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("Move: %v", err)
+	}
+
+	got, err := s.Get(ctx, referrer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got.Body, added) {
+		t.Errorf("the move reverted a concurrent edit; body = %q", got.Body)
+	}
+	// And it still did its own job: the reference follows the move.
+	if !strings.Contains(got.Body, moved) {
+		t.Errorf("reference was not rewritten to %s; body = %q", moved, got.Body)
+	}
+}


### PR DESCRIPTION
`rewriteReferences` reads every entry that referred to the old id, repairs `body`/`links`/`attrs` in Go, and writes the whole row back. The read took no lock, so an update committing in that window was reverted by the write-back: the `UPDATE` waited on the row lock, then applied a row computed from the pre-edit read. The loss was recorded as an ordinary `"update"` revision — the history showed a change, but not that one had been swallowed.

A move is exactly when this is likely: renaming a metric touches every entry that cites it, which is the set whoever is curating that metric is most likely to be editing right then.

## Fix

- `SELECT ... FOR UPDATE` on the candidate query, so a concurrent edit lands entirely before the move (and is carried into the rewrite) or entirely after it.
- `ORDER BY id` gives concurrent moves a single lock order, so they queue instead of deadlocking.
- The `UPDATE` restates `deleted_at IS NULL` and checks `RowsAffected`. With the lock held this cannot fire; it makes the statement independent of its reader having filtered, since rewriting a tombstone would plant a repaired body and a revision on an entry nobody can see, to resurface if it were ever revived.

## Test

`TestIntegrationMoveDoesNotClobberAConcurrentEdit` holds an uncommitted edit to the referrer, waits for the move to block on the row lock, commits, then checks both that the edit survived and that the reference still followed the move. Without the lock:

```
the move reverted a concurrent edit; body = "Explains [the metric](/it-clobber-.../renamed.md)."
```

Verified against a real PostgreSQL: `go test -race ./...` passes with `OCHAKAI_TEST_DATABASE_URL` set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)