### PR TITLE
Log the usage flushes that fail

### DIFF
--- a/cmd/ochakai/main.go
+++ b/cmd/ochakai/main.go
@@ -129,6 +129,7 @@ func setup(ctx context.Context, log *slog.Logger) (*service.Service, *config.Con
 	if err != nil {
 		return nil, nil, err
 	}
+	st.UseLogger(log)
 	embedDim := 0
 	var embedder embed.Embedder
 	if cfg.Embedding != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"path"
 	"strings"
 	"sync"
@@ -57,6 +58,10 @@ type Store struct {
 	blobs blob.Store
 	// lastEventPrune throttles knowledge_event pruning (unix seconds).
 	lastEventPrune atomic.Int64
+	// log carries what only the store can see. The background flush loop
+	// has no caller to return an error to, so without this a database
+	// that rejects writes loses usage in silence.
+	log *slog.Logger
 
 	// Usage events buffer in memory and flush on a timer so recording
 	// never touches the read path (design doc 0029). usageBuf is
@@ -66,6 +71,15 @@ type Store struct {
 	usageBuf  []usageEvent
 	flushStop chan struct{}
 	flushWG   sync.WaitGroup
+}
+
+// UseLogger routes the store's own diagnostics to l — the flush loop's
+// failures, which no request is waiting on. Call before serving; the
+// default is slog.Default().
+func (s *Store) UseLogger(l *slog.Logger) {
+	if l != nil {
+		s.log = l
+	}
 }
 
 // UseBlobStore routes attachment bytes to b (design doc 0013). Call
@@ -102,7 +116,7 @@ func New(ctx context.Context, databaseURL string, iamAuth bool) (*Store, error) 
 		pool.Close()
 		return nil, fmt.Errorf("connect to PostgreSQL: %w", err)
 	}
-	s := &Store{pool: pool, flushStop: make(chan struct{})}
+	s := &Store{pool: pool, flushStop: make(chan struct{}), log: slog.Default()}
 	s.flushWG.Add(1)
 	go s.usageFlushLoop()
 	return s, nil

--- a/internal/store/usage.go
+++ b/internal/store/usage.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/na0fu3y/ochakai/internal/domain"
@@ -62,16 +63,26 @@ func (e errUsageBuffer) Error() string { return string(e) }
 
 // usageFlushLoop drains the usage buffer on a timer until Close, then once
 // more so a clean shutdown loses nothing already buffered.
+//
+// Nobody is waiting on these writes, so the loop is the last place the
+// error can be seen. It logs: design doc 0029 §3.1 accepts losing a
+// failed batch, on the condition that the loss is visible rather than
+// silent, and the loop is the only caller in a position to make it so.
 func (s *Store) usageFlushLoop() {
 	defer s.flushWG.Done()
 	t := time.NewTicker(usageFlushInterval)
 	defer t.Stop()
+	flush := func() {
+		if err := s.FlushUsage(context.Background()); err != nil {
+			s.log.Warn("usage flush failed", "error", err)
+		}
+	}
 	for {
 		select {
 		case <-t.C:
-			s.FlushUsage(context.Background())
+			flush()
 		case <-s.flushStop:
-			s.FlushUsage(context.Background())
+			flush()
 			return
 		}
 	}
@@ -79,9 +90,13 @@ func (s *Store) usageFlushLoop() {
 
 // FlushUsage writes all buffered usage events: one knowledge_event row per
 // occurrence, and the running totals in knowledge_usage bumped in the same
-// statement. Exported so shutdown and tests can force a flush. On a
-// database error the drained batch is lost (best-effort); the error is
-// returned for visibility.
+// statement. Exported so shutdown and tests can force a flush.
+//
+// On a database error the drained batch is lost and there is no retry
+// queue: usage is best-effort, and design doc 0029 §3.1 chose that
+// deliberately over spending memory on a stalled database. What the
+// decision also asked for is that the loss be visible — the error says
+// how many events went with it, and the flush loop logs it.
 func (s *Store) FlushUsage(ctx context.Context) error {
 	s.usageMu.Lock()
 	if len(s.usageBuf) == 0 {
@@ -115,7 +130,7 @@ func (s *Store) FlushUsage(ctx context.Context) error {
 			last_at = GREATEST(knowledge_usage.last_at, EXCLUDED.last_at)`,
 		ids, events, kinds, names, ats)
 	if err != nil {
-		return err
+		return fmt.Errorf("writing %d buffered usage events: %w", len(batch), err)
 	}
 	s.maybePruneEvents(ctx)
 	return nil

--- a/internal/store/usage_test.go
+++ b/internal/store/usage_test.go
@@ -1,0 +1,55 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func usageEvents(prefix string, n int) []usageEvent {
+	out := make([]usageEvent, n)
+	now := time.Now()
+	for i := range out {
+		out[i] = usageEvent{
+			id: fmt.Sprintf("%s-%d", prefix, i), event: "fetched",
+			actorKind: "human", actorName: "test", at: now,
+		}
+	}
+	return out
+}
+
+// A flush that fails must say how much it lost. Design doc 0029 §3.1
+// accepts losing the batch — there is no retry queue, deliberately —
+// on the condition that the loss is visible rather than silent, and
+// nobody but the flush loop is in a position to see it.
+func TestIntegrationFlushErrorNamesTheEventsItLost(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	// Take the database away from a store that still has events buffered:
+	// the shape of a flush arriving while Cloud SQL is unreachable.
+	s.pool.Close()
+	s.usageBuf = usageEvents("it-flush-lost", 3)
+
+	err = s.FlushUsage(ctx)
+	if err == nil {
+		t.Fatal("flush against a closed pool: want an error")
+	}
+	if !strings.Contains(err.Error(), "3 buffered usage events") {
+		t.Errorf("error does not say what was lost: %v", err)
+	}
+	if len(s.usageBuf) != 0 {
+		t.Errorf("buffer holds %d events; a drained batch is not retried (0029 §3.1)", len(s.usageBuf))
+	}
+}


### PR DESCRIPTION
Design doc 0029 §3.1 chose to lose a failed usage batch — no retry queue, usage is best-effort — *on the condition that the loss be visible*: "エラーは可視化のために返す". The code returned the error to a caller that discarded it. `usageFlushLoop` called `FlushUsage(context.Background())` twice and ignored both results, and `FlushUsage` drains the buffer before it writes.

So a database that rejects writes dropped up to 20,000 events per tick with **no log line anywhere**. Usage totals drive the draft-promotion and re-verification feeds; the failure they would show up as is "the feeds look quiet", which reads like nothing happened.

## Change

- `Store` gets a logger (`UseLogger`, defaulting to `slog.Default()`, wired from `setup` in `cmd/ochakai`), because the flush loop has no caller to return an error to.
- The loop logs the failure.
- `FlushUsage`'s error says how many events went with it, so the log line quantifies the loss instead of just naming it.

No behavior change to the decision itself: the batch is still dropped, there is still no retry queue, and the buffer cap is untouched.

## Test

`TestIntegrationFlushErrorNamesTheEventsItLost` takes the pool away from a store with events buffered and asserts the error names the count and that the batch is not retried.

`gofmt`, `go vet`, and `go test -race ./...` (with a real PostgreSQL) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)