### PR TITLE
Answer auth rejections in the documented error envelope

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -779,8 +779,10 @@ components:
         is acting for; the forwarded identity is recorded as the actor
         and the caller is kept as Actor.via — never dropped. A caller
         not permitted to delegate is a 403 and a malformed value a 400 —
-        an error, not a silent downgrade. Honored on every call;
-        declared on the operations that record provenance.
+        an error, not a silent downgrade, and in the same JSON envelope
+        as every other error here, so the message reaches the caller.
+        Honored on every call; declared on the operations that record
+        provenance.
       schema: { type: string, maxLength: 320 }
   responses:
     Error:

--- a/internal/httpauth/httpauth.go
+++ b/internal/httpauth/httpauth.go
@@ -18,6 +18,20 @@ import (
 
 type ctxKey struct{}
 
+// writeError answers in the same envelope the rest of the API uses —
+// {"error": "..."} as JSON — rather than http.Error's text/plain. These
+// rejections are the ones a caller most needs to read: a delegation
+// refused for an unpermitted caller says to add it to
+// OCHAKAI_DELEGATING_CALLERS, and a client that parses the documented
+// envelope (internal/apiclient does) would otherwise report a bare
+// "Forbidden" and leave the operator guessing. Written here rather than
+// borrowed from restapi, which imports this package.
+func writeError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}
+
 // Middleware resolves the actor from the Google-verified ID token that
 // Cloud Run forwards after its IAM check. It parses claims WITHOUT
 // verifying the signature: on a non-public Cloud Run service the token
@@ -33,7 +47,7 @@ func Middleware(cfg *config.Config, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		actor, status, err := ActorFromHeader(cfg, r.Header)
 		if err != nil {
-			http.Error(w, "auth: "+err.Error(), status)
+			writeError(w, status, "auth: "+err.Error())
 			return
 		}
 		next.ServeHTTP(w, r.WithContext(WithActor(r.Context(), actor)))

--- a/internal/httpauth/httpauth_test.go
+++ b/internal/httpauth/httpauth_test.go
@@ -2,6 +2,7 @@ package httpauth
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -232,5 +233,39 @@ func TestInsecureDevHonorsDelegation(t *testing.T) {
 	// A malformed header must fail here, where the developer can see it.
 	if status, _ := get(t, "tanaka@example.co.jp"); status != http.StatusBadRequest {
 		t.Errorf("malformed header status = %d, want 400", status)
+	}
+}
+
+// A rejection from the middleware is an API error like any other, and the
+// message is the useful part: an unpermitted delegator is told to add
+// itself to OCHAKAI_DELEGATING_CALLERS. Clients read the documented
+// {"error": ...} envelope (internal/apiclient does), so text/plain here
+// meant they reported a bare "Forbidden" and dropped the instruction.
+func TestMiddlewareRejectsInTheAPIErrorEnvelope(t *testing.T) {
+	cfg := &config.Config{Delegators: []string{"someone-else@example.iam.gserviceaccount.com"}}
+	h := Middleware(cfg, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("a rejected request must not reach the handler")
+	}))
+
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/knowledge", nil)
+	r.Header.Set("X-Serverless-Authorization", "Bearer "+fakeIDToken(`{"email":"stranger@example.iam.gserviceaccount.com"}`))
+	r.Header.Set(OnBehalfOfHeader, "human:tanaka@example.co.jp")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type = %q, want the JSON error envelope", ct)
+	}
+	var body struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("response is not the documented envelope: %v (%q)", err, w.Body.String())
+	}
+	if !strings.Contains(body.Error, "OCHAKAI_DELEGATING_CALLERS") {
+		t.Errorf("error drops the actionable part: %q", body.Error)
 	}
 }


### PR DESCRIPTION
`httpauth.Middleware` rejected with `http.Error` — `text/plain` — while every operation it guards documents its errors as the JSON `{"error": ...}` envelope (`components/responses/Error`). The three rejections are a 401 for a missing/undecodable token, a **403 for a caller not on the delegator allowlist**, and a **400 for a malformed `X-Ochakai-On-Behalf-Of`**.

The last two are the ones where the message is the whole value: the 403 tells an integrator to add their service account to `OCHAKAI_DELEGATING_CALLERS`. `internal/apiclient` extracts messages only from the documented envelope, so a delegating client dropped that instruction and reported a bare `Forbidden` — the failure 0027 §5.2 wanted to be loud shows up as the least informative string possible.

## Change

- `httpauth` writes `{"error": ...}` with `Content-Type: application/json`. The helper lives in `httpauth` rather than being borrowed from `restapi`, which imports this package.
- openapi's `X-Ochakai-On-Behalf-Of` description says the 403/400 arrive in the same envelope as everything else.

Status codes and messages are unchanged. `cmd/ochakai`'s proxy guards (IAP, DNS-rebinding, CSRF) keep `text/plain`: they address a person in a browser, not the API contract, and the Web UI already falls back to the raw text.

## Test

`TestMiddlewareRejectsInTheAPIErrorEnvelope` sends a delegation header from a caller that is not on the allowlist and asserts a 403, a JSON content type, a parseable envelope, and that the message still names `OCHAKAI_DELEGATING_CALLERS`.

`gofmt`, `go vet`, and `go test -race ./...` (with a real PostgreSQL) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)