### PR TITLE
Reject unreadable boolean query values instead of treating them as unset

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -113,6 +113,7 @@ paths:
           content:
             application/json:
               schema: { $ref: "#/components/schemas/Knowledge" }
+        "400": { $ref: "#/components/responses/Error" }
         "409": { $ref: "#/components/responses/Error" }
   /api/v1/browse:
     get:
@@ -333,11 +334,16 @@ paths:
       parameters:
         - name: purge
           in: query
-          description: Hard-delete an already soft-deleted entry.
-          schema: { type: string, enum: ["true"] }
+          description: >
+            Hard-delete an already soft-deleted entry. `true` or `false`;
+            anything else is a 400 rather than a soft delete, because a
+            204 for a value meant as a purge would report an id freed
+            that is not.
+          schema: { type: boolean, default: false }
         - $ref: "#/components/parameters/OnBehalfOf"
       responses:
         "204": { description: Deleted. }
+        "400": { $ref: "#/components/responses/Error" }
         "404": { $ref: "#/components/responses/Error" }
         "409": { $ref: "#/components/responses/Error" }
   /api/v1/move:
@@ -668,14 +674,16 @@ paths:
           description: >
             `false` exports the markdown only. Attachment bytes live in
             GCS, so a periodic backup can copy them from there directly
-            instead of pulling them through this endpoint.
-          schema: { type: string, enum: ["false"] }
+            instead of pulling them through this endpoint. A value that
+            is neither `true` nor `false` is a 400.
+          schema: { type: boolean, default: true }
       responses:
         "200":
           description: OKF bundle.
           content:
             application/gzip:
               schema: { type: string, format: binary }
+        "400": { $ref: "#/components/responses/Error" }
   /api/v1/reembed:
     post:
       operationId: reembedKnowledge
@@ -743,6 +751,7 @@ paths:
                       missing; unchanged from the one sent in means the
                       corpus is exhausted and what remains only fails.
                     type: string
+        "400": { $ref: "#/components/responses/Error" }
         "501": { $ref: "#/components/responses/Error" }
 components:
   headers:

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -401,8 +401,12 @@ func Handler(svc *service.Service) http.Handler {
 	// first is reversible, the second is not. Not on MCP — destroying
 	// history is a human decision (design doc 0015).
 	mux.HandleFunc("DELETE /api/v1/knowledge/{id...}", func(w http.ResponseWriter, r *http.Request) {
-		var err error
-		if r.URL.Query().Get("purge") == "true" {
+		purge, err := queryBool(r.URL.Query(), "purge", false)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		if purge {
 			err = svc.Purge(r.Context(), r.PathValue("id"), httpauth.Actor(r.Context()))
 		} else {
 			err = svc.Delete(r.Context(), r.PathValue("id"), httpauth.Actor(r.Context()))
@@ -456,6 +460,13 @@ func Handler(svc *service.Service) http.Handler {
 		// archive that disagrees with its own index — an index.md naming a
 		// file that is not there, an entry that moved appearing twice or
 		// not at all. The archive would look fine.
+		// Parsed before the snapshot: a rejected parameter should not
+		// have held a pooled connection open, however briefly.
+		withAttachments, err := queryBool(r.URL.Query(), "attachments", true)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
 		snap, err := svc.Store.BeginExport(r.Context())
 		if err != nil {
 			writeError(w, err)
@@ -469,7 +480,6 @@ func Handler(svc *service.Service) http.Handler {
 			writeError(w, err)
 			return
 		}
-		withAttachments := r.URL.Query().Get("attachments") != "false"
 		var atts []store.ExportAttachment
 		if withAttachments {
 			// Metadata only; bytes are pulled one attachment at a time below.
@@ -704,6 +714,24 @@ func queryInt(q url.Values, name string) (int, error) {
 		return 0, service.Invalidf("invalid %s %q (want an integer)", name, s)
 	}
 	return n, nil
+}
+
+// queryBool parses an optional boolean query parameter. Like queryInt it
+// refuses what it cannot read rather than falling back to def: "?purge=1"
+// answering 204 for a soft delete would tell the caller an id had been
+// freed when it had not, and the two calls of a purge are meant to be
+// deliberate (design doc 0031).
+func queryBool(q url.Values, name string, def bool) (bool, error) {
+	switch q.Get(name) {
+	case "":
+		return def, nil
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	default:
+		return false, service.Invalidf("invalid %s %q (want true or false)", name, q.Get(name))
+	}
 }
 
 func queryFloat(q url.Values, name string) (float64, error) {

--- a/internal/restapi/restapi_test.go
+++ b/internal/restapi/restapi_test.go
@@ -208,3 +208,31 @@ func TestOversizedJSONBodyIsTooLarge(t *testing.T) {
 		t.Errorf("body = %s", got)
 	}
 }
+
+// A boolean query parameter refuses what it cannot read, like the numeric
+// ones. "?purge=1" used to fall through to a soft delete and answer 204,
+// telling the caller an id had been freed that was still taken -- and the
+// two calls of a purge are meant to be deliberate (design doc 0031).
+func TestBooleanQueryParamsRejectUnreadableValues(t *testing.T) {
+	h := Handler(&service.Service{})
+	cases := []struct {
+		name, method, url, wantSubstr string
+	}{
+		{"purge=1", http.MethodDelete, "/api/v1/knowledge/metrics/revenue?purge=1", "invalid purge"},
+		{"purge=True", http.MethodDelete, "/api/v1/knowledge/metrics/revenue?purge=True", "invalid purge"},
+		{"purge=yes", http.MethodDelete, "/api/v1/knowledge/metrics/revenue?purge=yes", "invalid purge"},
+		{"attachments=0", http.MethodGet, "/api/v1/export?attachments=0", "invalid attachments"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, httptest.NewRequest(c.method, c.url, nil))
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("%s %s = %d, want 400 (body: %s)", c.method, c.url, rec.Code, rec.Body)
+			}
+			if !strings.Contains(rec.Body.String(), c.wantSubstr) {
+				t.Errorf("body %q does not mention %q", rec.Body, c.wantSubstr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`?purge=1` and `?purge=True` fell through to a **soft delete** and answered 204 — telling the caller an id had been freed when it was still taken. The two calls of a purge exist so the irreversible one is never reached by accident (0031); a typo that silently becomes the reversible call defeats the pairing from the other side. `?attachments=0` on export silently included the attachments the caller asked to leave out.

`restapi.go` already refuses what it cannot read for `limit`, `budget` and `min_score`, with the reason stated at `queryInt`: a malformed value is a client error, not an absent parameter.

## Change

- `queryBool` applies that rule to `purge` and `attachments`.
- The export handler parses before opening the snapshot, so a rejected parameter never holds a pooled connection.
- openapi described both as string enums (`["true"]` / `["false"]`) — a description of the old accident rather than a contract. They are booleans with defaults now, and the 400 is declared.
- Two more response codes existed in behavior but not in the spec: **400 on `POST /api/v1/knowledge`** (invalid type, id or status — `PUT` already declared it) and **400 on `POST /api/v1/reembed`** (non-integer `limit`).

`apiclient` and the CLI already send `"true"`/`"false"`, so no client changes and nothing that previously worked stops working.

## Test

`TestBooleanQueryParamsRejectUnreadableValues` covers `purge=1`, `purge=True`, `purge=yes` and `attachments=0`.

`gofmt`, `go vet`, and `go test -race ./...` (with a real PostgreSQL) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)