### PR TITLE
Record the amendments 0032 and 0028 made to older docs

### DIFF
--- a/docs/design/0002-authn-authz.md
+++ b/docs/design/0002-authn-authz.md
@@ -1,6 +1,6 @@
 # ochakai 設計ドキュメント 0002: 認証・認可
 
-Status: Accepted(2026-07-15)
+Status: Accepted(2026-07-15)。§4 の「IAP JWT 検証」は [0032](0032-webui-iap-identity.md) が実装済み(§3 の表の「webui 側は未実装」もその時点の記述)
 Date: 2026-07-15
 
 ## 1. 原則

--- a/docs/design/0006-web-ui-serving.md
+++ b/docs/design/0006-web-ui-serving.md
@@ -1,6 +1,6 @@
 # ochakai 設計ドキュメント 0006: Web UI の二つの配信経路
 
-Status: Accepted(2026-07-17)、改訂(2026-07-19: examples/webui を `ochakai serve-ui` に昇格)
+Status: Accepted(2026-07-17)、改訂(2026-07-19: examples/webui を `ochakai serve-ui` に昇格)。§6 の「IAP を前置しても記録されるのはサービスの SA」は [0032](0032-webui-iap-identity.md) が覆した(`OCHAKAI_IAP_AUDIENCE` 設定時はブラウザ利用者を記録する)
 Date: 2026-07-17
 
 ## 1. 目的

--- a/docs/design/0016-knowledge-catalog-alignment.md
+++ b/docs/design/0016-knowledge-catalog-alignment.md
@@ -1,6 +1,6 @@
 # ochakai 設計ドキュメント 0016: knowledge-catalog リファレンスバンドルへの準拠
 
-Status: Accepted(2026-07-19 の議論で決定)。推奨タイプの複数形スラグは [0023](0023-okf-type-vocabulary.md) が OKF 表示名そのものに置き換え(カタログ準拠の残り — `resource` の封筒フィールド化など — は有効)
+Status: Accepted(2026-07-19 の議論で決定)。推奨タイプの複数形スラグは [0023](0023-okf-type-vocabulary.md) が OKF 表示名そのものに置き換え(カタログ準拠の残り — `resource` の封筒フィールド化など — は有効)。§2.5 のうち compile の `dialect` に関する部分は [0028](0028-retire-compile-sql.md) の compile 撤去により対象が消滅(BigQuery 修飾の表示名は有効)
 Date: 2026-07-19
 
 ## 1. 目的

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -24,7 +24,8 @@ PR の中に残る。
 
 ## 認証・認可と provenance
 
-- [0002 認証・認可](0002-authn-authz.md) — **Accepted**。認可機構を
+- [0002 認証・認可](0002-authn-authz.md) — **Accepted**(§4 の
+  「IAP JWT 検証」は 0032 が実装済み)。認可機構を
   持たない —「到達できた者は読み書きできる」。ヘッダから読むのは
   provenance だけで、信頼の判断は参照側が provenance を見て行う。
 - [0027 呼び出し元によるエンドユーザー identity の委譲](0027-delegated-provenance.md)
@@ -41,7 +42,8 @@ PR の中に残る。
   **Accepted**(一部を 0016 / 0017 が改訂)。OKF バンドルとの双方向互換 —
   任意ネストのパス、自由文字列タイプ、バンドルインポート、サーバー所有キー。
 - [0016 knowledge-catalog リファレンスバンドルへの準拠](0016-knowledge-catalog-alignment.md)
-  — **Accepted**(型の語彙は 0023 が置き換え)。リファレンスバンドルへの
+  — **Accepted**(型の語彙は 0023 が置き換え、§2.5 の compile `dialect`
+  は 0028 で対象消滅)。リファレンスバンドルへの
   準拠(`resource` の封筒フィールド化ほか)。
 - [0017 パスが住所、タイプは属性](0017-path-addressing.md) —
   **Accepted**(ID 文字種は 0019 §2、型の語彙は 0023 が改訂)。
@@ -75,7 +77,8 @@ PR の中に残る。
 ## ブラウズと Web UI
 
 - [0006 Web UI の二つの配信経路](0006-web-ui-serving.md) — **Accepted**
-  (2026-07-19 改訂)。自己完結 1 ファイルの UI を、認証モデルの異なる
+  (2026-07-19 改訂、§6 の非目標のうち per-user provenance は 0032 が
+  覆した)。自己完結 1 ファイルの UI を、認証モデルの異なる
   二経路(`ochakai ui` / `ochakai serve-ui`)で配信する。
 - [0014 フォルダブラウズ](0014-folder-browse.md) — **Accepted**
   (API パラメタは 0017 §4.7、UI は常設サイドバーへ改訂)。prefix に


### PR DESCRIPTION
#144 codified the rule that a new design doc updates the `Status:` header of every older doc it supersedes or amends, so that reading an area's docs by their Status notes tells you the current state. Three amendments from this release cycle were never recorded, and two of them make an older doc read as false:

- **0002 §4** still lists IAP JWT verification under "将来の選択肢(作らない、必要になったら)", and the §3 table says "webui 側は未実装". 0032 implemented exactly that (`cmd/ochakai/iap.go`, `serveui.go`). 0032's PR updated 0027's Status but not 0002's — so a reader following the auth area concludes per-user Web UI provenance does not exist.
- **0006 §6** says "IAP を前置した `serve-ui` でも、記録される識別はサービスの SA であってブラウザ利用者ではない". False once `OCHAKAI_IAP_AUDIENCE` is set.
- **0016 §2.5** is about compile's `dialect` option, which 0028 removed. #142 added the equivalent note to 0019 §4 ("対象消滅") but not here — same decision, same fate, different treatment. The BigQuery-qualified display names in that section are still live, so the note is partial, like 0019's.

Status headers and the index entries updated; no decision changes.

## One thing to decide separately

0006 and 0016 now each carry two stacked partial notes. CONTRIBUTING's amendment-chain rule says that is the point at which the next change in the area should be a full replacement doc, with the older ones marked Superseded, rather than a third note. Nothing to do now — recording what already happened is the index's contract — but worth knowing before the next Web UI or catalog change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)