### PR TITLE
Size ef_search to the vector search's limit

### DIFF
--- a/internal/store/filter_test.go
+++ b/internal/store/filter_test.go
@@ -123,3 +123,25 @@ func TestQueryFragments(t *testing.T) {
 		t.Errorf("the cap dropped the subject named at the end: %q", got)
 	}
 }
+
+// The HNSW index scan runs before the WHERE clause, so ef_search is a
+// ceiling on what a vector search can return: at pgvector's default of 40
+// a search for 100 rows could not fill its limit even unfiltered.
+func TestEfSearchCoversTheLimit(t *testing.T) {
+	cases := []struct{ limit, want int }{
+		{0, 40},   // never below pgvector's default
+		{5, 40},   // a small search is no worse than before
+		{10, 40},  // the default still covers 4x
+		{40, 160}, // headroom for the filters applied after the scan
+		{100, 400},
+		{500, 1000}, // pgvector's ceiling
+	}
+	for _, c := range cases {
+		if got := efSearch(c.limit); got != c.want {
+			t.Errorf("efSearch(%d) = %d, want %d", c.limit, got, c.want)
+		}
+		if got := efSearch(c.limit); got < c.limit {
+			t.Errorf("efSearch(%d) = %d, below the limit it must cover", c.limit, got)
+		}
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -980,13 +980,7 @@ func (s *Store) SearchVector(ctx context.Context, vec []float32, model string, f
 		FROM knowledge k JOIN knowledge_embedding e ON k.id = e.id AND e.model = $%d
 		WHERE %s
 		ORDER BY e.embedding <=> $%d::vector LIMIT %d`, vecParam, len(args), where, vecParam, limit)
-	rows, err := s.pool.Query(ctx, q, args...)
-	if err != nil {
-		return nil, err
-	}
-	return pgx.CollectRows(rows, func(row pgx.CollectableRow) (domain.SearchHit, error) {
-		return scanHit(row)
-	})
+	return s.annSearch(ctx, limit, q, args)
 }
 
 // SearchVectorAttachments ranks entries by their closest attachment
@@ -1006,7 +1000,50 @@ func (s *Store) SearchVectorAttachments(ctx context.Context, vec []float32, mode
 			ORDER BY k.id, e.embedding <=> $%d::vector
 		) best
 		ORDER BY score DESC LIMIT %d`, vecParam, len(args), where, vecParam, limit)
-	rows, err := s.pool.Query(ctx, q, args...)
+	return s.annSearch(ctx, limit, q, args)
+}
+
+// efSearch is how many candidates the HNSW index is asked to consider for
+// a search wanting limit rows.
+//
+// The index scan runs first and the WHERE clause filters what it returns,
+// so ef_search is a ceiling on the answer, not a starting point: at
+// pgvector's default of 40, a search for 100 rows could never return more
+// than 40 even before a type or tag filter took its cut. Four times the
+// limit is the headroom for that filtering, floored at the default so a
+// small search is no worse than before and capped at pgvector's maximum.
+//
+// Set per query rather than on the connection: pooled connections are
+// shared, and a lingering session GUC would silently retune searches that
+// never asked.
+func efSearch(limit int) int {
+	const (
+		defaultEF = 40   // pgvector's own default
+		maxEF     = 1000 // pgvector's ceiling
+	)
+	ef := 4 * limit
+	if ef < defaultEF {
+		ef = defaultEF
+	}
+	if ef > maxEF {
+		ef = maxEF
+	}
+	return ef
+}
+
+// annSearch runs a vector query with ef_search sized for the limit. The
+// transaction exists only to scope SET LOCAL to this one statement; it
+// reads, so it ends in a rollback.
+func (s *Store) annSearch(ctx context.Context, limit int, q string, args []any) ([]domain.SearchHit, error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback(context.WithoutCancel(ctx)) }()
+	if _, err := tx.Exec(ctx, fmt.Sprintf("SET LOCAL hnsw.ef_search = %d", efSearch(limit))); err != nil {
+		return nil, err
+	}
+	rows, err := tx.Query(ctx, q, args...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#118 added the HNSW indexes; nothing set `hnsw.ef_search`, so both vector searches ran at pgvector's default of 40 candidates. `Service.Search` asks each ranked list for `2*limit` rows and `limit` goes up to 50 — so a search for 100 rows could return at most 40, and the WHERE clause (statuses, types, tags, model) is applied to the index scan's output, taking its cut from those 40.

Before #118 the exact scan returned the full 100. The result is quieter than a bug: no error, no wrong data, just fewer and worse candidates entering RRF fusion for exactly the searches a growing corpus needs most.

## Change

`efSearch(limit)` = `4 × limit`, floored at pgvector's default 40 and capped at its maximum 1000, applied with `SET LOCAL` inside the transaction that runs the query. The 4× is headroom for the filtering that happens after the scan; the floor keeps small searches exactly as they were.

`SET LOCAL` in a per-query transaction rather than a session `SET`: pooled connections are shared, and a lingering GUC would silently retune searches that never asked for it. PostgreSQL accepts the qualified parameter name even on a connection where pgvector's library is not yet loaded (verified against pgvector/pgvector:pg17), so this is safe on every connection in the pool.

## Test

`TestEfSearchCoversTheLimit` pins the floor, the cap, the 4× headroom, and the invariant that `efSearch(n) >= n`.

`gofmt`, `go vet`, and `go test -race ./...` (twice, with a real PostgreSQL) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)