### PR TITLE
Remove the export helpers streaming replaced

### DIFF
--- a/internal/okf/bundle_test.go
+++ b/internal/okf/bundle_test.go
@@ -1,16 +1,54 @@
 package okf
 
 import (
+	"io"
 	"io/fs"
+	"maps"
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/na0fu3y/ochakai/internal/domain"
 )
+
+// bundle renders entries into a path→content map, the inverse of
+// FromBundle. Export streams a bundle a file at a time (Indexes, then
+// Document per entry, into a TarGzWriter) and never materializes one, so
+// this lives here: the round-trip tests want the whole map at once, and
+// nothing in the server does.
+func bundle(t *testing.T, entries []domain.Knowledge) map[string][]byte {
+	t.Helper()
+	files := Indexes(entries)
+	for i := range entries {
+		doc, err := Document(&entries[i])
+		if err != nil {
+			t.Fatalf("render %s: %v", entries[i].URI(), err)
+		}
+		files[entries[i].ID+".md"] = doc
+	}
+	return files
+}
+
+// writeTarGz collects a whole bundle into one archive, in sorted path
+// order. Export adds files as it produces them; only the tests need the
+// collected form.
+func writeTarGz(t *testing.T, w io.Writer, files map[string][]byte, modTime time.Time) {
+	t.Helper()
+	paths := slices.Sorted(maps.Keys(files))
+	tgz := NewTarGzWriter(w, modTime)
+	for _, p := range paths {
+		if err := tgz.Add(p, files[p]); err != nil {
+			t.Fatalf("add %s: %v", p, err)
+		}
+	}
+	if err := tgz.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
 
 // The id's segments become nested directories, and every level gets its
 // own index.md. The layout is the user's (design doc 0016): a domain
@@ -25,10 +63,7 @@ func TestBundleNestedDirectories(t *testing.T) {
 		{Type: "runbook", ID: "ops/restore", Title: "リストア手順",
 			CreatedBy: domain.Actor{Kind: "human", Name: "na0"}, Status: domain.StatusDraft, UpdatedAt: now},
 	}
-	files, err := Bundle(entries)
-	if err != nil {
-		t.Fatal(err)
-	}
+	files := bundle(t, entries)
 	for _, path := range []string{
 		"queries/sales/monthly-revenue.md", "queries/sales/refunds/by-region.md", "ops/restore.md",
 		"index.md", "queries/index.md", "queries/sales/index.md", "queries/sales/refunds/index.md", "ops/index.md",
@@ -67,10 +102,7 @@ func TestBundleRoundTrip(t *testing.T) {
 			Attrs:       map[string]any{"sql": "SELECT 1"},
 			Body:        "本文。", UpdatedAt: now},
 	}
-	files, err := Bundle(want)
-	if err != nil {
-		t.Fatal(err)
-	}
+	files := bundle(t, want)
 	got, _, skipped := FromBundle(files)
 	if len(skipped) != 0 {
 		t.Fatalf("skipped %v", skipped)
@@ -110,10 +142,7 @@ func TestBundleTitleOptional(t *testing.T) {
 	if len(entries) != 1 || entries[0].ID != "insights/サンプル" || entries[0].Title != "" {
 		t.Fatalf("entries = %+v, want one titleless insights/サンプル", entries)
 	}
-	out, err := Bundle(entries)
-	if err != nil {
-		t.Fatal(err)
-	}
+	out := bundle(t, entries)
 	doc := string(out["insights/サンプル.md"])
 	if strings.Contains(doc, "title:") {
 		t.Errorf("re-export must omit the empty title:\n%s", doc)
@@ -187,10 +216,7 @@ func TestFromBundleForeign(t *testing.T) {
 	// Import and export are identity on the type key: what came in as
 	// "Table" goes back out as "Table", at the original path, with no
 	// preservation attr in between.
-	out, err := Bundle(entries)
-	if err != nil {
-		t.Fatal(err)
-	}
+	out := bundle(t, entries)
 	if doc := string(out["tables/users.md"]); !strings.Contains(doc, "type: Table\n") {
 		t.Errorf("re-export did not reproduce the authored type:\n%s", doc)
 	}
@@ -245,10 +271,7 @@ func TestFromBundleFixture(t *testing.T) {
 		t.Errorf("body mangled:\n%s", aov.Body)
 	}
 
-	out, err := Bundle(entries)
-	if err != nil {
-		t.Fatal(err)
-	}
+	out := bundle(t, entries)
 	doc := string(out["references/metrics/avg_order_value.md"])
 	for _, want := range []string{
 		"type: Reference",

--- a/internal/okf/okf.go
+++ b/internal/okf/okf.go
@@ -61,22 +61,6 @@ var reservedKeys = map[string]bool{
 	"verified_at": true, "rejected_by": true, "rejected_at": true,
 }
 
-// Bundle renders every entry into a path→content map. The path is
-// "<id>.md" — the OKF concept ID is ochakai's id, and its segments are
-// the directories. Every directory level gets an index.md for
-// progressive disclosure.
-func Bundle(entries []domain.Knowledge) (map[string][]byte, error) {
-	files := Indexes(entries)
-	for i := range entries {
-		doc, err := Document(&entries[i])
-		if err != nil {
-			return nil, fmt.Errorf("render %s: %w", entries[i].URI(), err)
-		}
-		files[entries[i].ID+".md"] = doc
-	}
-	return files, nil
-}
-
 // Indexes renders a bundle's directory index.md files and nothing else,
 // sorting entries by id on the way (Bundle's ordering). Split out so a
 // streaming exporter can render one concept document at a time — the
@@ -228,24 +212,6 @@ func Document(k *domain.Knowledge) ([]byte, error) {
 	return []byte(b.String()), nil
 }
 
-// WriteTarGz streams the bundle as a gzipped tarball (the OKF-sanctioned
-// archive distribution), with deterministic entry order.
-func WriteTarGz(w io.Writer, files map[string][]byte, modTime time.Time) error {
-	paths := make([]string, 0, len(files))
-	for p := range files {
-		paths = append(paths, p)
-	}
-	sort.Strings(paths)
-
-	tgz := NewTarGzWriter(w, modTime)
-	for _, p := range paths {
-		if err := tgz.Add(p, files[p]); err != nil {
-			return err
-		}
-	}
-	return tgz.Close()
-}
-
 // TarGzWriter writes a bundle one file at a time. A caller that can
 // produce its files lazily — the export endpoint, pulling attachment
 // bytes from the blob store as it goes — then never holds more than one
@@ -262,8 +228,8 @@ func NewTarGzWriter(w io.Writer, modTime time.Time) *TarGzWriter {
 	return &TarGzWriter{gz: gz, tw: tar.NewWriter(gz), modTime: modTime.UTC()}
 }
 
-// Add appends one file. Callers that care about ordering add in order:
-// unlike WriteTarGz, nothing is sorted here because nothing is collected.
+// Add appends one file, in the order the caller adds them: nothing is
+// sorted here because nothing is collected.
 func (t *TarGzWriter) Add(path string, data []byte) error {
 	if err := t.tw.WriteHeader(&tar.Header{
 		Name:    path,

--- a/internal/okf/okf_test.go
+++ b/internal/okf/okf_test.go
@@ -124,10 +124,7 @@ func TestDocumentResourceForTable(t *testing.T) {
 }
 
 func TestBundleLayoutAndIndexes(t *testing.T) {
-	files, err := Bundle(sample())
-	if err != nil {
-		t.Fatal(err)
-	}
+	files := bundle(t, sample())
 	for _, path := range []string{"insights/revenue-seasonality.md", "tables/orders.md", "index.md", "insights/index.md", "tables/index.md"} {
 		if _, ok := files[path]; !ok {
 			t.Errorf("bundle missing %s (have %d files)", path, len(files))
@@ -188,14 +185,9 @@ func TestDocumentFlattensAttrs(t *testing.T) {
 }
 
 func TestWriteTarGzRoundTrip(t *testing.T) {
-	files, err := Bundle(sample())
-	if err != nil {
-		t.Fatal(err)
-	}
+	files := bundle(t, sample())
 	var buf bytes.Buffer
-	if err := WriteTarGz(&buf, files, time.Unix(0, 0)); err != nil {
-		t.Fatal(err)
-	}
+	writeTarGz(t, &buf, files, time.Unix(0, 0))
 	gz, err := gzip.NewReader(&buf)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/restapi/restapi_integration_test.go
+++ b/internal/restapi/restapi_integration_test.go
@@ -25,7 +25,7 @@ import (
 
 // lockLiveAttachments serializes, across the test packages sharing the
 // test database, the tests that hold live attachments or scan them all
-// (OKF export, ListAllAttachments): bytes resolve against each test's
+// (OKF export, ExportSnapshot.AttachmentMeta): bytes resolve against each
 // own in-memory blob fake, so a foreign live attachment breaks a
 // whole-KB scan. Key shared with the store and service test packages.
 func lockLiveAttachments(t *testing.T, dbURL string) {
@@ -360,7 +360,7 @@ func TestRESTIntegrationAttachments(t *testing.T) {
 
 	// Soft-delete the entry so its attachment row does not stay live in
 	// the shared test database: other packages' tests scan all live
-	// attachments (ListAllAttachments) and resolve bytes from their own
+	// attachments (the export snapshot) and resolve bytes from their own
 	// blob stores, while this test's bytes live only in this process.
 	req, _ = http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/knowledge/"+typ+"/reading", nil)
 	resp, err = http.DefaultClient.Do(req)

--- a/internal/service/attachment_integration_test.go
+++ b/internal/service/attachment_integration_test.go
@@ -19,7 +19,7 @@ import (
 
 // lockLiveAttachments serializes, across the test packages sharing the
 // test database, the tests that hold live attachments or scan them all
-// (OKF export, ListAllAttachments): bytes resolve against each test's
+// (OKF export, ExportSnapshot.AttachmentMeta): bytes resolve against each
 // own in-memory blob fake, so a foreign live attachment breaks a
 // whole-KB scan. Key shared with the store and restapi test packages.
 func lockLiveAttachments(t *testing.T, dbURL string) {

--- a/internal/store/attachment.go
+++ b/internal/store/attachment.go
@@ -240,38 +240,6 @@ func (s *Store) AttachmentBytes(ctx context.Context, sha256 string) ([]byte, err
 	return s.blobs.Get(ctx, sha256)
 }
 
-// ListAllAttachments returns every live entry's attachments with bytes,
-// ordered by id then name. Holds every attachment in memory at once —
-// prefer ListAllAttachmentMeta plus AttachmentBytes.
-func (s *Store) ListAllAttachments(ctx context.Context) ([]ExportAttachment, error) {
-	rows, err := s.pool.Query(ctx, `SELECT a.knowledge_id, `+attachmentCols+`
-		FROM attachment a
-		JOIN blob b ON b.sha256 = a.sha256
-		JOIN knowledge k ON k.id = a.knowledge_id AND k.deleted_at IS NULL
-		ORDER BY a.knowledge_id, a.name`)
-	if err != nil {
-		return nil, err
-	}
-	atts, err := pgx.CollectRows(rows, func(row pgx.CollectableRow) (ExportAttachment, error) {
-		var e ExportAttachment
-		err := row.Scan(&e.ID, &e.Att.Name, &e.Att.MediaType, &e.Att.Size, &e.Att.SHA256, &e.Att.OKFPath,
-			&e.Att.CreatedBy.Kind, &e.Att.CreatedBy.Name, &e.Att.CreatedAt)
-		return e, err
-	})
-	if err != nil {
-		return nil, err
-	}
-	if len(atts) > 0 && s.blobs == nil {
-		return nil, errNoBlobStore
-	}
-	for i := range atts {
-		if atts[i].Data, err = s.blobs.Get(ctx, atts[i].Att.SHA256); err != nil {
-			return nil, err
-		}
-	}
-	return atts, nil
-}
-
 // touchAndRevise bumps the entry's updated_at and records a revision
 // whose snapshot includes the attachment list after the change —
 // attach/detach are changes to the entry, and every change is kept.

--- a/internal/store/attachment_search_integration_test.go
+++ b/internal/store/attachment_search_integration_test.go
@@ -12,7 +12,7 @@ import (
 
 // lockLiveAttachments serializes, across the test packages sharing the
 // test database, the tests that hold live attachments or scan them all
-// (OKF export, ListAllAttachments): bytes resolve against each test's
+// (OKF export, ExportSnapshot.AttachmentMeta): bytes resolve against each
 // own in-memory blob fake, so a foreign live attachment breaks a
 // whole-KB scan. Key shared with the service and restapi test packages.
 func lockLiveAttachments(t *testing.T, dbURL string) {
@@ -75,7 +75,7 @@ func TestIntegrationAttachmentSearch(t *testing.T) {
 		}
 	}
 	// Leave no live attachments behind: TestIntegrationBlobStoreOnly's
-	// ListAllAttachments resolves every live attachment against its own
+	// The export scan resolves every live attachment against its own
 	// blob fake and would trip over this test's leftovers.
 	defer func() {
 		_ = s.SoftDelete(ctx, a.ID, actor)

--- a/internal/store/blob_integration_test.go
+++ b/internal/store/blob_integration_test.go
@@ -76,19 +76,33 @@ func TestIntegrationBlobStoreOnly(t *testing.T) {
 		t.Errorf("attachment did not round-trip: %v", err)
 	}
 
-	// The export listing resolves bytes from the blob store.
-	all, err := s.ListAllAttachments(ctx)
+	// The export path finds the attachment in its snapshot and resolves
+	// the bytes from the blob store, one at a time.
+	snap, err := s.BeginExport(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	metas, err := snap.AttachmentMeta(ctx)
+	snap.Close(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
 	found := false
-	for _, e := range all {
-		if e.ID == k.ID && e.Att.Name == "chart.png" && string(e.Data) == string(png) {
-			found = true
+	for _, m := range metas {
+		if m.ID != k.ID || m.Att.Name != "chart.png" {
+			continue
 		}
+		data, err := s.AttachmentBytes(ctx, m.Att.SHA256)
+		if err != nil {
+			t.Fatalf("AttachmentBytes: %v", err)
+		}
+		if string(data) != string(png) {
+			t.Errorf("export read %q, want %q", data, png)
+		}
+		found = true
 	}
 	if !found {
-		t.Error("ListAllAttachments did not resolve the blob")
+		t.Error("the export snapshot did not list the attachment")
 	}
 
 	// Without a blob store, writes and reads refuse with the config hint.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1160,17 +1160,6 @@ func scanUsageHit(row pgx.CollectableRow) (domain.SearchHit, error) {
 	return h, nil
 }
 
-// ListAll returns every non-deleted entry, ordered by id. Used by the
-// OKF exporter.
-func (s *Store) ListAll(ctx context.Context) ([]domain.Knowledge, error) {
-	rows, err := s.pool.Query(ctx,
-		`SELECT `+knowledgeCols+` FROM knowledge WHERE deleted_at IS NULL ORDER BY id`)
-	if err != nil {
-		return nil, err
-	}
-	return pgx.CollectRows(rows, scanKnowledge)
-}
-
 // ListUnembedded returns the ids of live entries with no vector for the
 // named model, oldest first, up to limit. That covers both halves of the
 // same gap: entries written before semantic search was configured (there


### PR DESCRIPTION
The streaming export (#117/#129/#139) replaced the collect-it-all path but left its parts behind. Four functions have no non-test caller, confirmed with `golang.org/x/tools/cmd/deadcode`; all four were live at v0.12.1.

- **`Store.ListAll`** — no caller at all, and its comment still says "Used by the OKF exporter". The exporter reads `ExportSnapshot.IndexRows`/`ListByIDs` now.
- **`Store.ListAllAttachments`** — replaced by `ExportSnapshot.AttachmentMeta` plus `AttachmentBytes`, whose SQL it duplicated almost verbatim, so it was also a place for the two to drift apart. Its comment recommended `ListAllAttachmentMeta`, which does not exist.
- **`okf.Bundle` / `okf.WriteTarGz`** — the export path composes `Indexes` + `Document` into a `TarGzWriter` directly, one file at a time, which is the point of streaming: never holding the whole knowledge base plus every attachment in memory.

`Bundle` and `WriteTarGz` were genuinely useful to the round-trip tests, which want a whole bundle at once — so they move into `bundle_test.go` as test helpers rather than being rewritten away. Nothing is lost from the tests; the server just stops shipping a collected-bundle path it does not use.

`TestIntegrationBlobStoreOnly` now checks what the export actually does: find the attachment in a snapshot, then resolve its bytes by digest. Three stale comments naming `ListAllAttachments` point at the snapshot instead.

`gofmt`, `go vet`, `go test -race ./...` (against a fresh PostgreSQL) and the `CGO_ENABLED=0` build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)