### PR TITLE
Fix references that outlived what they described

### DIFF
--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -270,7 +270,7 @@ func cmdContext(ctx context.Context, args []string) error {
 	fs.Var(&tags, "tag", "filter by tag (repeatable)")
 	limit := fs.Int("limit", 0, "max full entries (server default 5, max 20)")
 	budget := fs.Int("budget", 0, "cap the response at ~this many bytes (0 = no cap); the rendered output stops printing entries, --json asks the server to cap and list what did not fit under \"outline\"")
-	minScore := fs.Float64("min-score", 0, "drop hits scoring below this; scores depend on the server's search mode (trigram vs hybrid), so calibrate before use (0 = off)")
+	minScore := fs.Float64("min-score", 0, "drop hits scoring below this; scores depend on the server's search mode (matched-fragment weight plus boosts vs RRF rank fusion), so calibrate before use (0 = off)")
 	asJSON := fs.Bool("json", false, "print the raw JSON response")
 	pos, err := parseArgs(fs, args)
 	if err != nil {

--- a/cmd/ochakai/main.go
+++ b/cmd/ochakai/main.go
@@ -140,7 +140,7 @@ func setup(ctx context.Context, log *slog.Logger) (*service.Service, *config.Con
 		embedder = v
 		log.Info("semantic search enabled", "model", cfg.Embedding.Model, "dim", cfg.Embedding.Dim)
 	} else {
-		log.Info("semantic search disabled; using trigram search only")
+		log.Info("semantic search disabled; using lexical search only")
 	}
 	// Attachment bytes live only on GCS (design doc 0013).
 	if cfg.GCSBucket != "" {

--- a/examples/claude-code/README.md
+++ b/examples/claude-code/README.md
@@ -42,8 +42,8 @@ never blocks a prompt or a stop.
 | `OCHAKAI_RECALL_MIN_SCORE` | Drop hits below this score before injecting (default 0 = inject whenever anything matches) |
 
 Search scores are **not calibrated**: they depend on the server's search
-mode (trigram vs hybrid embeddings) and on your corpus — English trigram
-matches score far higher than Japanese ones. Before setting a floor, run
+mode (matched-fragment weight plus boosts in lexical mode, RRF rank
+fusion in hybrid mode) and on your corpus. Before setting a floor, run
 `ochakai search "<typical prompt>" | cut -f1-2` for a few relevant and
 irrelevant prompts and pick a value that separates them; there is no
 universal default, which is why the hook ships with the floor off.

--- a/examples/claude-code/hooks/ochakai-recall.sh
+++ b/examples/claude-code/hooks/ochakai-recall.sh
@@ -10,8 +10,8 @@
 # (`ochakai use <url>`). Tune with:
 #   OCHAKAI_RECALL_BUDGET     max injected bytes (default 4000)
 #   OCHAKAI_RECALL_MIN_SCORE  drop hits below this score (default 0 = off).
-#     Scores depend on the server's search mode and your corpus — English
-#     trigram matches score far higher than CJK ones — so measure with
+#     Scores depend on the server's search mode and your corpus, and are
+#     not comparable between modes — so measure with
 #     `ochakai search ... | cut -f1` before picking a floor.
 #
 # Failures are silent by design: a knowledge base being down must never

--- a/internal/apiclient/apiclient.go
+++ b/internal/apiclient/apiclient.go
@@ -106,8 +106,10 @@ type SearchParams struct {
 	// Sort switches the endpoint from searching to listing:
 	// "verified_at" returns entries by verification age, oldest first
 	// (the golden-query canary feed); "usage" returns entries by demand,
-	// most-searched first (the draft review feed, hits carry usage). The
-	// server rejects a Query combined with Sort; listed hits carry score 0.
+	// most-searched first (the draft review feed, hits carry usage);
+	// "failed" returns entries callers reported wrong, worst first (the
+	// re-verification feed, design doc 0025 §6). The server rejects a
+	// Query combined with Sort; listed hits carry score 0.
 	Sort  string
 	Limit int
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -170,8 +170,8 @@ func (s *Service) Update(ctx context.Context, k *domain.Knowledge, actor domain.
 // that ochakai has no authorization and that verification is judged from
 // provenance, and this does not reopen it: an agent may still create, may
 // still edit drafts, may still promote a draft to verified. What it may
-// not do from a surface with no If-Match channel (MCP, design doc 0025
-// §11) is silently replace a state a human put there.
+// not do from a surface with no If-Match channel (MCP, design doc 0030
+// §3.4) is silently replace a state a human put there.
 //
 // Rejected matters at least as much as verified, and it is the one the
 // obvious rule would have missed. Create refuses a live entry, so an agent

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -749,9 +749,10 @@ function debounce(fn, ms) {
   debounce._t = setTimeout(fn, ms);
 }
 
-// Below this score a lexical hit is almost certainly noise: real matches
-// carry a 0.3 substring bonus, while trigram similarity of unrelated text
-// hovers near the server's 0.05 floor (plus a 0.05 verified boost). Only
+// Below this score a lexical hit is almost certainly noise: a real match
+// contains the query whole and carries the server's 0.3 bonus for it,
+// while an entry sharing one common fragment with a question scores a
+// small fraction of the query's fragments (plus 0.05 if verified). Only
 // meaningful in lexical mode — hybrid (RRF) scores live on a ~1/60 scale,
 // detected below by the top score, where no useful floor exists.
 const WEAK_SCORE = 0.15;
@@ -784,7 +785,7 @@ async function runSearch() {
       return;
     }
     // With a query, split off low-relevance hits so junk doesn't render as
-    // if it matched — semantic/trigram search always returns *something*.
+    // if it matched — semantic and lexical search always return *something*.
     let strong = hits, weak = [];
     if (explore.q && !isFeed && hits[0].score > 0.05) {
       strong = hits.filter(h => h.score >= WEAK_SCORE);


### PR DESCRIPTION
Six places still describe things as they were before #124/#133 renamed the lexical scoring and before #153 repointed the dangling design-doc citations. All doc/comment/help text; no behavior change.

- **`internal/service/service.go`** cited "design doc 0025 §11", which does not exist (0025 has §1–§6). #153 repointed 17 of these; this one survived because the citation wraps across two comment lines — and 0030's §1 names this exact dangling reference as the reason 0030 was written. Now 0030 §3.4.
- **`--min-score` help** and **`examples/claude-code/README.md`** still said scores depend on "trigram vs hybrid". openapi already says "matched-fragment weight plus boosts vs RRF rank fusion"; these now match. The examples README also claimed English trigram matches outscore Japanese ones, which was the old `similarity()` behavior — fragment matching is a substring test, so the asymmetry it warned about is not the one that exists.
- **The startup log** said "using trigram search only". The mode is lexical: fragments, IDF weighting, and substring tests, of which a trigram *index* serves the patterns long enough to index. Calling the mode "trigram" names the index instead of the ranking.
- **`internal/webui/index.html`** justified `WEAK_SCORE = 0.15` with "trigram similarity of unrelated text hovers near the server's 0.05 floor" — describing a scoring function that no longer exists. The constant is still right; its reason now matches how a score is actually built.
- **`apiclient.SearchParams.Sort`** documented `verified_at` and `usage` but not `failed`, which the server, CLI, completions, openapi and MCP schema all carry. This is the godoc an embedding host reads.

References to the pg_trgm *index* (README, `store.go`, migrations 0001/0016) are left alone: those are accurate.

`gofmt`, `go vet`, and `go test -race ./...` (against a fresh PostgreSQL) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)