### PR TITLE
Stamp verified_at and rejected_at at stored precision

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -320,8 +320,13 @@ func (s *Service) Move(ctx context.Context, id, newID string, actor domain.Actor
 // no promotion restriction (design doc 0002): anyone who can reach ochakai
 // may verify or reject, and verified_by / rejected_by record who did —
 // trust is judged from provenance.
+//
+// The timestamp comes from store.NowStored, like every other entity
+// timestamp (design doc 0030 §3.2): time.Now()'s nanoseconds do not
+// survive timestamptz, so a write's response carried a verified_at that
+// no later read of the same entry would ever return.
 func (s *Service) applyVerification(k *domain.Knowledge, old *domain.Knowledge, actor domain.Actor) {
-	now := time.Now().UTC()
+	now := store.NowStored()
 	wasVerified := old != nil && old.Status == domain.StatusVerified
 	if k.Status == domain.StatusVerified && !wasVerified {
 		k.VerifiedBy, k.VerifiedAt = &actor, &now

--- a/internal/service/service_integration_test.go
+++ b/internal/service/service_integration_test.go
@@ -524,3 +524,54 @@ func (e *fixedEmbedder) Embed(_ context.Context, _ embed.Task, texts []string) (
 	}
 	return out, nil
 }
+
+// Every entity timestamp has to survive the round trip through
+// timestamptz, or a write's response describes an entry the database
+// never held (design doc 0030 §3.2). updated_at has been stored-precision
+// since #108; verified_at and rejected_at were still stamped from
+// time.Now(), so a client that read them back saw a different instant --
+// the same nanosecond mismatch that breaks conditional updates, on the
+// two fields the review feeds sort by.
+func TestVerificationTimestampsSurviveTheRoundTripIntegration(t *testing.T) {
+	ctx := context.Background()
+	svc := newIntegrationService(t, ctx)
+	actor := domain.Actor{Kind: "human", Name: "test"}
+
+	for _, tc := range []struct {
+		status domain.Status
+		field  string
+		at     func(*domain.Knowledge) *time.Time
+	}{
+		{domain.StatusVerified, "verified_at", func(k *domain.Knowledge) *time.Time { return k.VerifiedAt }},
+		{domain.StatusRejected, "rejected_at", func(k *domain.Knowledge) *time.Time { return k.RejectedAt }},
+	} {
+		t.Run(string(tc.status), func(t *testing.T) {
+			id := uid("stampit")
+			written, err := svc.Create(ctx, &domain.Knowledge{
+				Type: domain.TypeTerms, ID: id, Title: id, Status: tc.status,
+			}, actor)
+			if err != nil {
+				t.Fatal(err)
+			}
+			stamped := tc.at(written)
+			if stamped == nil {
+				t.Fatalf("create with status=%s stamped no %s", tc.status, tc.field)
+			}
+			// Asserted directly, because a clock without nanosecond
+			// resolution (macOS) would let the round-trip check below
+			// pass on a value that loses precision on Linux.
+			if truncated := stamped.Truncate(time.Microsecond); !truncated.Equal(*stamped) {
+				t.Errorf("%s carries sub-microsecond precision timestamptz cannot store: %s",
+					tc.field, stamped.Format(time.RFC3339Nano))
+			}
+			read, err := svc.Get(ctx, id)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got, want := *tc.at(read), *tc.at(written); !got.Equal(want) {
+				t.Errorf("%s: write returned %s, database holds %s", tc.field,
+					want.Format(time.RFC3339Nano), got.Format(time.RFC3339Nano))
+			}
+		})
+	}
+}

--- a/internal/store/attachment.go
+++ b/internal/store/attachment.go
@@ -280,7 +280,7 @@ func (s *Store) touchAndRevise(ctx context.Context, tx pgx.Tx, k *domain.Knowled
 	// not survive the round trip through timestamptz, so the revision
 	// snapshot would carry a version the stored row never had (design
 	// doc 0030).
-	k.UpdatedAt = nowStored()
+	k.UpdatedAt = NowStored()
 	if _, err := tx.Exec(ctx,
 		`UPDATE knowledge SET updated_at=$2 WHERE id=$1`, k.ID, k.UpdatedAt); err != nil {
 		return err

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -40,14 +40,17 @@ var ErrCuratedTombstone = errors.New("knowledge id holds a curated tombstone")
 // no single call can erase history that was in use a moment ago.
 var ErrNotDeleted = errors.New("knowledge is live; soft-delete it before purging")
 
-// nowStored is the current UTC time truncated to the microsecond precision
+// NowStored is the current UTC time truncated to the microsecond precision
 // PostgreSQL timestamptz stores. Setting entity timestamps from it means an
 // in-memory updated_at always equals the value that round-trips through the
 // database — the invariant the ETag/If-Match optimistic lock depends on
-// (design doc 0030): time.Now()'s nanoseconds would otherwise make the
+// (design doc 0030 §3.2): time.Now()'s nanoseconds would otherwise make the
 // value returned by a write differ from the stored one on nanosecond-
 // resolution clocks (Linux), breaking a client's next conditional update.
-func nowStored() time.Time { return time.Now().UTC().Truncate(time.Microsecond) }
+//
+// Exported because the service layer stamps timestamps of its own —
+// verified_at, rejected_at — and they answer to the same column.
+func NowStored() time.Time { return time.Now().UTC().Truncate(time.Microsecond) }
 
 type Store struct {
 	pool *pgxpool.Pool
@@ -245,7 +248,7 @@ func (s *Store) ListLinkingTo(ctx context.Context, id string, limit int) ([]doma
 // Update refuses deleted rows), and its history stays in the revisions
 // either way.
 func (s *Store) Create(ctx context.Context, k *domain.Knowledge, keepCuratedTombstones bool) error {
-	now := nowStored()
+	now := NowStored()
 	k.CreatedAt, k.UpdatedAt = now, now
 	// Reviving a tombstone overwrites its status in place. When the caller
 	// must not replace a human ruling (design doc 0015 §3.1), the revival
@@ -321,7 +324,7 @@ func (s *Store) Create(ctx context.Context, k *domain.Knowledge, keepCuratedTomb
 // read-modify-write race that silently lost updates. A nil ifMatch keeps
 // the prior last-write-wins behavior for callers that do not opt in.
 func (s *Store) Update(ctx context.Context, k *domain.Knowledge, actor domain.Actor, ifMatch *time.Time) error {
-	k.UpdatedAt = nowStored()
+	k.UpdatedAt = NowStored()
 	return s.withTx(ctx, func(tx pgx.Tx) error {
 		links, attrs, err := marshalJSONFields(k)
 		if err != nil {
@@ -533,7 +536,7 @@ func (s *Store) Move(ctx context.Context, oldID, newID string, actor domain.Acto
 	if err != nil {
 		return nil, err
 	}
-	k.UpdatedAt = nowStored()
+	k.UpdatedAt = NowStored()
 	err = s.withTx(ctx, func(tx pgx.Tx) error {
 		// A soft-deleted entry still owns the id — the row holds the primary
 		// key and its revisions hold (id, rev) — so the destination is taken
@@ -631,7 +634,7 @@ func (s *Store) rewriteReferences(ctx context.Context, tx pgx.Tx, oldID string, 
 	if err != nil {
 		return err
 	}
-	now := nowStored()
+	now := NowStored()
 	movedDirs := path.Dir(oldID) != path.Dir(newID)
 	for i := range referrers {
 		r := &referrers[i]


### PR DESCRIPTION
0030 §3.2 states the precision invariant: entity timestamps come from `nowStored`, because `time.Now()`'s nanoseconds do not survive `timestamptz` and a write that returns a value the database never held breaks the client's next conditional update. #108 applied it to `updated_at`, #155 to the attachment revision paths — `applyVerification` was still on `time.Now().UTC()`.

`verified_at` and `rejected_at` are not the ETag, so no lock breaks. What did happen: a create or update that promoted an entry answered with a `verified_at` that no later read of that entry would ever return — on the two fields the canary feed (`sort=verified_at`) and the re-verification feed sort by, and the ones a reviewer compares across an export/import round trip.

## Change

- `nowStored` becomes `store.NowStored`. The service stamps timestamps answering to the same column, so the rule gets one home instead of a second copy of the truncation.
- `applyVerification` uses it.

## Test

`TestVerificationTimestampsSurviveTheRoundTripIntegration` asserts both halves, because only one of them can fail on a given platform:

- the returned value carries no sub-microsecond component — deterministic anywhere, since a macOS clock has no nanoseconds to lose in the first place;
- a subsequent read returns the same instant.

With the old stamping restored, it fails:

```
rejected_at carries sub-microsecond precision timestamptz cannot store: 2026-07-26T04:32:26.8971805Z
rejected_at: write returned ...8971805Z, database holds ...89718+09:00
```

`gofmt`, `go vet`, and `go test -race ./...` (against a fresh PostgreSQL) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)