### PR TITLE
Drop the browser's credential headers in serve-ui, always

### DIFF
--- a/cmd/ochakai/serveui.go
+++ b/cmd/ochakai/serveui.go
@@ -90,9 +90,15 @@ func serveUIHandler(proxy http.Handler) http.Handler {
 
 // newServiceProxy reverse-proxies to target as this service (not as the
 // browser user): every request carries the service's Google-signed ID
-// token in X-Serverless-Authorization, the header Cloud Run validates
-// in preference to Authorization — which therefore passes through
-// untouched for the backend's httpauth to ignore.
+// token in X-Serverless-Authorization, the header Cloud Run validates in
+// preference to Authorization.
+//
+// Both credential headers are dropped before that, whatever the browser
+// sent and whether or not a token is available, as `ochakai ui` drops
+// them. httpauth reads Authorization when X-Serverless-Authorization is
+// absent, so a token fetch that fails — the one moment the proxy has no
+// identity of its own — is exactly when a forwarded browser header would
+// get to name the actor instead.
 //
 // When iap is non-nil the request is additionally attributed to the
 // person driving the browser, taken from IAP's signed assertion (design
@@ -105,6 +111,9 @@ func newServiceProxy(target *url.URL, tokens serviceTokenSource, iap iapVerifier
 	proxy.Director = func(r *http.Request) {
 		director(r)
 		r.Host = target.Host
+		// Whatever the browser sent, this proxy speaks as the service.
+		r.Header.Del("Authorization")
+		r.Header.Del("X-Serverless-Authorization")
 		// Cloud Run service-to-service auth; harmless if unavailable
 		// (e.g. running locally against an unrestricted ochakai).
 		if tok, err := tokens.token(); err == nil {

--- a/cmd/ochakai/serveui_test.go
+++ b/cmd/ochakai/serveui_test.go
@@ -56,8 +56,9 @@ func TestServeUIRequiresOchakaiURL(t *testing.T) {
 
 // The proxy authenticates as the service: X-Serverless-Authorization
 // carries its ID token (the header Cloud Run validates in preference to
-// Authorization), the Host header is rewritten to the target, and any
-// browser-sent Authorization passes through untouched.
+// Authorization), the Host header is rewritten to the target, and the
+// browser's own credential headers are dropped -- this proxy speaks as
+// the service, never as whoever is holding the page.
 func TestServeUIProxySignsAsService(t *testing.T) {
 	var got http.Header
 	var gotHost string
@@ -86,8 +87,8 @@ func TestServeUIProxySignsAsService(t *testing.T) {
 	if auth := got.Get("X-Serverless-Authorization"); auth != "Bearer sa-id-token" {
 		t.Errorf("X-Serverless-Authorization = %q, want the service's token", auth)
 	}
-	if auth := got.Get("Authorization"); auth != "Bearer browser-supplied" {
-		t.Errorf("Authorization = %q, want pass-through", auth)
+	if auth := got.Get("Authorization"); auth != "" {
+		t.Errorf("Authorization = %q, want the browser's header dropped", auth)
 	}
 	if gotHost != u.Host {
 		t.Errorf("upstream Host = %q, want %q", gotHost, u.Host)
@@ -108,7 +109,14 @@ func TestServeUIProxyForwardsWithoutToken(t *testing.T) {
 	local := httptest.NewServer(h)
 	defer local.Close()
 
-	resp, err := http.Get(local.URL + "/mcp")
+	req, _ := http.NewRequest(http.MethodGet, local.URL+"/mcp", nil)
+	// A browser that sends credentials of its own, at the one moment the
+	// proxy has none: httpauth falls back to Authorization when
+	// X-Serverless-Authorization is absent, so a forwarded header here
+	// would name the actor the page chose.
+	req.Header.Set("Authorization", "Bearer browser-supplied")
+	req.Header.Set("X-Serverless-Authorization", "Bearer browser-forged")
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,8 +124,10 @@ func TestServeUIProxyForwardsWithoutToken(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("proxied GET = %d, want 200", resp.StatusCode)
 	}
-	if auth := got.Get("X-Serverless-Authorization"); auth != "" {
-		t.Errorf("X-Serverless-Authorization = %q, want none", auth)
+	for _, h := range []string{"X-Serverless-Authorization", "Authorization"} {
+		if auth := got.Get(h); auth != "" {
+			t.Errorf("%s = %q; with no service token the request must carry none", h, auth)
+		}
 	}
 }
 


### PR DESCRIPTION
`serve-ui`'s proxy set `X-Serverless-Authorization` only when the metadata token fetch succeeded, and deliberately passed a browser-sent `Authorization` through — the comment said the backend's `httpauth` would ignore it.

It ignores it only while `X-Serverless-Authorization` is present. `ActorFromHeader` falls back to `Authorization` when that header is absent, and it parses claims **without verifying the signature**, trusting Cloud Run to have done it. So the one moment the proxy has no identity of its own — a failed token fetch — is exactly the moment a header the browser chose gets to name the actor. A forged `X-Serverless-Authorization` from the browser was forwarded the same way.

In the intended deployment Cloud Run validates inbound `X-Serverless-Authorization` and this is unreachable. It is reachable in the posture the docs warn about (a backend reachable without Cloud Run IAM), and the sibling proxy already got this right: `ochakai ui` deletes `Authorization` and the delegation header before setting its own, for the same reason 0032 makes `stripDelegation` unconditional.

## Change

`newServiceProxy` deletes `Authorization` and `X-Serverless-Authorization` before it tries the token, so the request carries the service's credentials or none — never the page's. This matches `stripDelegation`, which already ran whether or not IAP was configured.

## Test

`TestServeUIProxySignsAsService` now asserts the browser's `Authorization` is dropped rather than forwarded, and `TestServeUIProxyForwardsWithoutToken` sends both credential headers at the moment no service token is available and asserts neither survives. Both fail without the change.

`gofmt`, `go vet`, and `go test -race ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)