### PR TITLE
Close two windows left by reads outside the write transaction

### DIFF
--- a/internal/store/attachment.go
+++ b/internal/store/attachment.go
@@ -244,14 +244,22 @@ func (s *Store) AttachmentBytes(ctx context.Context, sha256 string) ([]byte, err
 // whose snapshot includes the attachment list after the change —
 // attach/detach are changes to the entry, and every change is kept.
 func (s *Store) touchAndRevise(ctx context.Context, tx pgx.Tx, k *domain.Knowledge, change string, actor domain.Actor) error {
-	// nowStored, like every other write path: time.Now()'s nanoseconds do
+	// NowStored, like every other write path: time.Now()'s nanoseconds do
 	// not survive the round trip through timestamptz, so the revision
 	// snapshot would carry a version the stored row never had (design
 	// doc 0030).
 	k.UpdatedAt = NowStored()
-	if _, err := tx.Exec(ctx,
-		`UPDATE knowledge SET updated_at=$2 WHERE id=$1`, k.ID, k.UpdatedAt); err != nil {
+	// deleted_at IS NULL, as on every other write: the entry was read
+	// outside this transaction, so a delete can land in the window, and
+	// an attachment plus its revision planted on a tombstone would
+	// resurface whenever someone revived the entry.
+	tag, err := tx.Exec(ctx,
+		`UPDATE knowledge SET updated_at=$2 WHERE id=$1 AND deleted_at IS NULL`, k.ID, k.UpdatedAt)
+	if err != nil {
 		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
 	}
 	atts, err := listAttachmentsTx(ctx, tx, k.ID)
 	if err != nil {

--- a/internal/store/blob_integration_test.go
+++ b/internal/store/blob_integration_test.go
@@ -2,9 +2,12 @@ package store
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/na0fu3y/ochakai/internal/domain"
 )
@@ -118,5 +121,107 @@ func TestIntegrationBlobStoreOnly(t *testing.T) {
 	if _, _, err := bare.GetAttachment(ctx, k.ID, "chart.png"); err == nil ||
 		!strings.Contains(err.Error(), "OCHAKAI_GCS_BUCKET") {
 		t.Errorf("read without a blob store = %v, want config hint", err)
+	}
+}
+
+// An attach and a delete can be in flight together: PutAttachment reads
+// the entry outside its transaction, so a delete can commit in the window
+// between that read and the write. The attach must lose. Before the guard
+// it wrote the attachment and an "attach" revision onto the tombstone,
+// where they sat invisible until someone revived the entry and got back a
+// file they never attached to the entry they were reviving.
+func TestIntegrationAttachRacingDeleteLoses(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	s.UseBlobStore(newFakeBlobStore())
+	actor := domain.Actor{Kind: "human", Name: "test"}
+
+	id := fmt.Sprintf("it-attach-race-%d", time.Now().UnixNano())
+	defer func() {
+		_, _ = s.pool.Exec(ctx, `DELETE FROM attachment WHERE knowledge_id = $1`, id)
+		for _, table := range []string{"knowledge_revision", "knowledge"} {
+			_, _ = s.pool.Exec(ctx, `DELETE FROM `+table+` WHERE id = $1`, id)
+		}
+	}()
+	if err := s.Create(ctx, &domain.Knowledge{
+		Type: domain.TypeTerms, ID: id, Title: id, Status: domain.StatusDraft, CreatedBy: actor,
+	}, false); err != nil {
+		t.Fatal(err)
+	}
+
+	// A delete that has not committed yet: PutAttachment's own read runs
+	// on another connection and still sees a live entry, which is the
+	// window the guard closes.
+	del, err := s.pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = del.Rollback(ctx) }()
+	if _, err := del.Exec(ctx,
+		`UPDATE knowledge SET deleted_at = now(), updated_at = now() WHERE id = $1`, id); err != nil {
+		t.Fatal(err)
+	}
+
+	attached := make(chan error, 1)
+	go func() {
+		png := append([]byte("\x89PNG\r\n\x1a\n"), []byte("racing bytes")...)
+		_, err := s.PutAttachment(ctx, id, "chart.png", "image/png", "", png, actor)
+		attached <- err
+	}()
+
+	// Wait for the attach to reach the entry row and block on the delete.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		var waiting int
+		if err := s.pool.QueryRow(ctx,
+			`SELECT count(*) FROM pg_stat_activity
+			  WHERE wait_event_type = 'Lock' AND query LIKE '%knowledge%'`).Scan(&waiting); err != nil {
+			t.Fatal(err)
+		}
+		if waiting > 0 {
+			break
+		}
+		select {
+		case err := <-attached:
+			t.Fatalf("attach finished without blocking: %v", err)
+		default:
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("attach never blocked on the delete")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if err := del.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := <-attached; !errors.Is(err, ErrNotFound) {
+		t.Fatalf("attach racing a delete: got %v, want ErrNotFound", err)
+	}
+	var atts, revs int
+	if err := s.pool.QueryRow(ctx,
+		`SELECT count(*) FROM attachment WHERE knowledge_id = $1`, id).Scan(&atts); err != nil {
+		t.Fatal(err)
+	}
+	if atts != 0 {
+		t.Errorf("refused attach left %d attachment rows on the tombstone", atts)
+	}
+	if err := s.pool.QueryRow(ctx,
+		`SELECT count(*) FROM knowledge_revision WHERE id = $1 AND change = 'attach'`, id).Scan(&revs); err != nil {
+		t.Fatal(err)
+	}
+	if revs != 0 {
+		t.Errorf("refused attach left %d attach revisions", revs)
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -16,11 +16,19 @@ import (
 	"unicode"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/na0fu3y/ochakai/internal/blob"
 	"github.com/na0fu3y/ochakai/internal/domain"
 )
+
+// isUniqueViolation reports whether err is PostgreSQL's unique_violation
+// (SQLSTATE 23505) — a race lost to another writer on the same key.
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505"
+}
 
 var ErrNotFound = errors.New("knowledge not found")
 var ErrAlreadyExists = errors.New("knowledge already exists")
@@ -399,12 +407,12 @@ func (s *Store) Update(ctx context.Context, k *domain.Knowledge, actor domain.Ac
 // A rejection is cleared, mirroring the status transitions Update makes:
 // an entry cannot be both vouched for and turned down.
 //
-// The timestamp comes from the database, not from nowStored: the feed
+// The timestamp comes from the database, not from NowStored: the feed
 // compares it against the last failure report, which RecordOutcome stamps
 // with the database's now(). Two clocks a millisecond apart are enough to
 // hide a report that arrived after the verification, or to keep one that
 // arrived before it — so both sides read the same clock, and RETURNING
-// hands back exactly what was stored (the ETag invariant nowStored exists
+// hands back exactly what was stored (the ETag invariant NowStored exists
 // for).
 func (s *Store) Verify(ctx context.Context, id string, actor domain.Actor) (*domain.Knowledge, error) {
 	var k *domain.Knowledge
@@ -593,6 +601,14 @@ func (s *Store) Move(ctx context.Context, oldID, newID string, actor domain.Acto
 		tag, err := tx.Exec(ctx,
 			`UPDATE knowledge SET id=$2, updated_at=$3 WHERE id=$1 AND deleted_at IS NULL`,
 			oldID, newID, k.UpdatedAt)
+		if isUniqueViolation(err) {
+			// The probe above found the destination free, but it took no
+			// lock — a create can land on newID in the window. The primary
+			// key stops it either way; this is so the caller reads the
+			// same answer as when the id was already taken, rather than a
+			// 500 with a constraint name in it.
+			return fmt.Errorf("%w: %s", ErrAlreadyExists, newID)
+		}
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Two small races of the same shape as the ones `SoftDelete` and `Move` already guard: the entry is read on the pool, the write happens in a transaction, and something can commit in between.

## `touchAndRevise` wrote onto tombstones

`UPDATE knowledge SET updated_at=$2 WHERE id=$1` carried no `deleted_at` condition, so an attach or detach racing a delete planted the attachment **and** an `"attach"` revision on the tombstone. Nothing surfaced at the time — the entry is invisible — until someone revived it with `create` and got back a file they never attached to the entry they were reviving.

Now the same `deleted_at IS NULL` every other write path carries, returning `ErrNotFound` when it does not match. That is exactly what the callers' own pre-read returns for a deleted entry, so nothing above changes.

## Move reported a duplicate key as a 500

The destination probe takes no lock (there is no row to lock yet), so a `create` landing on `newID` in the window turned the rename into a raw `duplicate key value violates unique constraint` — a 500 with a constraint name in it. The primary key stopped the corruption either way; this is about the caller reading the same `ErrAlreadyExists` it gets when the id was taken all along.

## Test

`TestIntegrationAttachRacingDeleteLoses` drives the interleaving deterministically: an uncommitted delete, the attach blocking on the entry row, then the commit. `PutAttachment`'s own read sees a live entry throughout, which is why the pre-check cannot close this — without the guard the attach reports success and leaves the rows behind:

```
attach racing a delete: got <nil>, want ErrNotFound
```

`gofmt`, `go vet`, and `go test -race ./...` (against a fresh PostgreSQL) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)