### PR TITLE
End a bare ochakai:// URI where the sentence ends

### DIFF
--- a/internal/domain/links.go
+++ b/internal/domain/links.go
@@ -69,13 +69,48 @@ func LinksFromBody(id, body string) []Link {
 			add(m[3], m[2])
 		}
 		for _, m := range bareURIRe.FindAllStringSubmatch(line, -1) {
-			if consumed[m[1]] { // already taken as a markdown link target
+			uri := trimSentencePunctuation(m[1])
+			if consumed[uri] || consumed[m[1]] { // already taken as a markdown link target
 				continue
 			}
-			add(m[1], "")
+			add(uri, "")
 		}
 	}
 	return links
+}
+
+// asciiEnders end an English sentence; cjkEnders end a Japanese one.
+// They are treated differently because English prose puts a space after
+// the stop and Japanese does not, so only the trailing run can be trimmed
+// in one and the match has to be cut at the first occurrence in the
+// other. Both apply to bare URIs alone: a markdown link's target has
+// explicit delimiters, so whatever the parentheses hold is meant.
+const (
+	asciiEnders = ".,;:!?"
+	cjkEnders   = "。、，．！？"
+)
+
+// trimSentencePunctuation ends a bare URI where the sentence around it
+// ends. "See ochakai://metrics/revenue." names metrics/revenue, not
+// "metrics/revenue." — which resolves to no entry, so the target gains no
+// backlink, a context pack never expands through it, and a move never
+// repairs it. Nothing reports the miss: a link to an id nobody wrote
+// looks exactly like a link to an entry not written yet.
+//
+// The trailing trim cannot serve Japanese, where "ochakai://tables/orders
+// を参照" has no space to stop at — so the match is also cut at the first
+// full-width stop, which no id in practice contains. Latin ids that
+// contain a dot ("ga4/events/purchase.v2") keep it: only a trailing run
+// is trimmed.
+//
+// An id may technically end in "." (only a leading dot is refused) and is
+// unreachable this way. It stays addressable in the form that says where
+// it ends: a markdown link.
+func trimSentencePunctuation(uri string) string {
+	if i := strings.IndexAny(uri, cjkEnders); i >= 0 {
+		uri = uri[:i]
+	}
+	return strings.TrimRight(uri, asciiEnders)
 }
 
 // resolveTarget turns one link target into an entry id, or "" when the
@@ -271,6 +306,11 @@ func rewriteLine(line string, rewriteTarget func(string) string) string {
 		if inCode(m[0], m[1]) || overlapsLink(line, lo) {
 			continue
 		}
+		// The URI ends where the sentence around it does, as it does when
+		// the same line is read for links: rewriting the punctuation along
+		// with it would compare "metrics/revenue." against the moved id
+		// and leave the reference pointing at an entry that is gone.
+		hi = lo + len(trimSentencePunctuation(line[lo:hi]))
 		if t := rewriteTarget(line[lo:hi]); t != line[lo:hi] {
 			edits = append(edits, edit{lo, hi, t})
 		}

--- a/internal/domain/links_test.go
+++ b/internal/domain/links_test.go
@@ -33,6 +33,21 @@ func TestLinksFromBody(t *testing.T) {
 			body: "Autolink <ochakai://metrics/revenue> and bare ochakai://tables/orders here.",
 			want: []Link{{Target: "metrics/revenue"}, {Target: "tables/orders"}},
 		}, {
+			// A bare URI ends where the sentence does. Left in, the
+			// trailing stop became part of the id: no backlink, no
+			// expansion through the link, and a move that never repairs
+			// it — all silent, because a link to an id nobody wrote looks
+			// the same as one to an entry not written yet.
+			name: "a bare URI ends before the sentence's punctuation",
+			id:   "insights/a",
+			body: "See ochakai://metrics/revenue. Also ochakai://tables/orders、and ochakai://terms/arr?",
+			want: []Link{{Target: "metrics/revenue"}, {Target: "tables/orders"}, {Target: "terms/arr"}},
+		}, {
+			name: "a markdown link's target keeps what the parentheses hold",
+			id:   "insights/a",
+			body: "See [revenue](ochakai://metrics/revenue.) for the definition.",
+			want: []Link{{Target: "metrics/revenue.", Text: "revenue"}},
+		}, {
 			name: "external URLs are not entry links",
 			id:   "insights/a",
 			body: "See [the dashboard](https://example.com/metrics/revenue) and https://example.com/x.",
@@ -225,5 +240,36 @@ func TestLinkDisplayText(t *testing.T) {
 	// No anchor text: the target's last segment is the name (design doc 0022).
 	if got := (Link{Target: "metrics/revenue"}).DisplayText(); got != "revenue" {
 		t.Errorf("DisplayText = %q, want the target's last segment", got)
+	}
+}
+
+// Rewriting a body on move goes through the same reading of where a bare
+// URI ends, so a sentence-final URI has to be rewritten without eating
+// the stop -- and an id that legitimately carries a dot has to keep it.
+func TestBareURIPunctuationRoundTrip(t *testing.T) {
+	for _, tc := range []struct{ name, id, body, want string }{
+		{
+			name: "sentence-final URI keeps its full stop",
+			id:   "insights/a",
+			body: "See ochakai://metrics/revenue. Nothing else.",
+			want: "See ochakai://metrics/gross. Nothing else.",
+		}, {
+			name: "Japanese prose keeps the particle that follows",
+			id:   "insights/a",
+			body: "ochakai://metrics/revenue、を参照。",
+			want: "ochakai://metrics/gross、を参照。",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := RewriteBodyLinks(tc.id, tc.body, "metrics/revenue", "metrics/gross"); got != tc.want {
+				t.Errorf("RewriteBodyLinks(%q) = %q, want %q", tc.body, got, tc.want)
+			}
+		})
+	}
+
+	// A dot inside a latin id is part of the id: only a trailing run goes.
+	dotted := LinksFromBody("insights/a", "See ochakai://ga4/events/purchase.v2 for the shape.")
+	if len(dotted) != 1 || dotted[0].Target != "ga4/events/purchase.v2" {
+		t.Errorf("links = %+v, want ga4/events/purchase.v2 intact", dotted)
 	}
 }


### PR DESCRIPTION
Found while writing a fixture for another test, which is roughly how a user would find it: never.

`bareURIRe` matches everything up to whitespace or a bracket, so a URI written in prose swallowed the punctuation after it. `See ochakai://metrics/revenue.` produced a link to `metrics/revenue.` — an id nobody has. In Japanese it is worse: there is no space to stop at, so `ochakai://metrics/revenue、を参照` took the comma and the words after it.

Every consequence is silent:

- the target gains no backlink, so `get_context` never expands through the link;
- `RewriteBodyLinks` compares `metrics/revenue.` against the moved id, does not match, and **leaves the reference pointing at an entry that no longer exists** after a move;
- nothing reports it, because a link to an id nobody wrote is indistinguishable from a link to an entry not written yet.

This is the form the MCP tool descriptions and the instructions shipped to agents encourage (`ochakai://metrics/revenue`), written into sentences, which end in stops.

## Change

`trimSentencePunctuation` ends a bare URI where the sentence does, applied both when links are read and when a move rewrites them, so the two agree on where the id stops:

- a **trailing** run of `.,;:!?` is trimmed — so a latin id containing a dot (`ga4/events/purchase.v2`) keeps it, since only the tail goes;
- the match is **cut** at the first full-width stop (`。、，．！？`), because Japanese prose has no space to stop at and no id in practice contains one.

Markdown links are untouched: the parentheses say where the target ends, so `[revenue](ochakai://metrics/revenue.)` still names `metrics/revenue.` — which is how an id ending in a dot stays addressable.

## Tests

Three cases in `TestLinksFromBody` (English stop, Japanese comma, markdown link keeping its dot) and `TestBareURIPunctuationRoundTrip` for the move path, which fails before the rewrite half of the fix:

```
RewriteBodyLinks("See ochakai://metrics/revenue. Nothing else.") = "...revenue. Nothing else.", want "...gross. Nothing else."
```

`gofmt`, `go vet`, and `go test -race ./...` (against a fresh PostgreSQL) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)