### PR TITLE
Stop the reembed tests from assuming the shared corpus stands still

### DIFF
--- a/internal/service/attachment_integration_test.go
+++ b/internal/service/attachment_integration_test.go
@@ -281,6 +281,13 @@ func TestReembedCoversAttachmentsIntegration(t *testing.T) {
 	// attachments are reached only once the cursor has walked past every
 	// entry — which is also the assertion that the cursor advances: a
 	// pass that kept returning the same window would never get here.
+	//
+	// The loop ends when this test's own attachments are embedded, not
+	// when the shared database reaches zero (CONTRIBUTING). Another
+	// package creating an entry whose id sorts behind the cursor leaves
+	// Missing above zero for reasons that have nothing to do with this
+	// test, and waiting for a corpus other packages keep refilling is a
+	// race with no winner.
 	cursor := ""
 	for pass := 1; ; pass++ {
 		if pass > 100 {
@@ -290,12 +297,18 @@ func TestReembedCoversAttachmentsIntegration(t *testing.T) {
 		if err != nil {
 			t.Fatalf("pass %d: %v", pass, err)
 		}
-		if res.Missing == 0 {
+		left, err := s.ListUnembeddedAttachments(ctx, model, "", "", 100)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if countOwned(left, id) == 0 {
 			break
 		}
+		// Still work of ours to do, so a cursor standing still is the
+		// bug this loop is here for.
 		if res.Cursor == "" || res.Cursor == cursor {
-			t.Fatalf("pass %d left %d missing but did not advance the cursor (%q)",
-				pass, res.Missing, cursor)
+			t.Fatalf("pass %d left %d of our attachments unembedded but did not advance the cursor (%q)",
+				pass, countOwned(left, id), cursor)
 		}
 		cursor = res.Cursor
 	}

--- a/internal/service/service_integration_test.go
+++ b/internal/service/service_integration_test.go
@@ -464,12 +464,12 @@ func TestReembedReportsWhatIsLeft(t *testing.T) {
 	}
 	svc.Embedder = &fixedEmbedder{model: model, dim: 4}
 
-	total, err := svc.Store.CountUnembedded(ctx, model)
+	before, err := svc.Store.CountUnembedded(ctx, model)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if total < 3 {
-		t.Fatalf("setup left %d unembedded entries, want at least 3", total)
+	if before < 3 {
+		t.Fatalf("setup left %d unembedded entries, want at least 3", before)
 	}
 
 	// A pass smaller than the corpus must say what it did not reach.
@@ -477,19 +477,41 @@ func TestReembedReportsWhatIsLeft(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if res.Embedded != 2 {
-		t.Fatalf("bounded pass embedded %d, want 2", res.Embedded)
+	if res.Embedded > 2 {
+		t.Fatalf("bounded pass embedded %d, over its limit of 2", res.Embedded)
 	}
-	// A lower bound, not an equality: the test database is shared by every
-	// package (CONTRIBUTING), so entries can appear between the count above
-	// and the one Reembed takes after the pass. What must hold is that the
-	// pass does not report its own work as still missing — the bug this
-	// covers subtracted it twice.
-	if want := total - 2; res.Missing < want {
-		t.Errorf("Missing = %d, want at least %d (%d unembedded, %d done)", res.Missing, want, total, res.Embedded)
+	if res.Embedded < 2 {
+		// The pass takes the oldest unembedded entries in the whole
+		// database, so a parallel package deleting one of its own
+		// candidates mid-pass leaves this short. Nothing about the
+		// reporting is wrong; there is just nothing to pin it against.
+		t.Skipf("bounded pass embedded %d of 2; another package's entries moved under it", res.Embedded)
 	}
 	if res.Missing == 0 {
 		t.Error("a bounded pass over a larger corpus reported nothing left")
+	}
+
+	// Missing is a fresh count taken after the pass, so the assertion is
+	// an equality against a count taken the same way — not arithmetic on
+	// the baseline above. The test database is shared by every package
+	// (CONTRIBUTING) and CountUnembedded counts live entries only, so
+	// between the baseline and the pass another package can both add
+	// entries and delete its own; the bug this covers is a two-off
+	// (subtracting the pass's work from a total that already excluded
+	// it), which no tolerance wide enough for that drift could catch.
+	//
+	// So: measure again, and only compare when nothing moved.
+	after, err := svc.Store.CountUnembedded(ctx, model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before-res.Embedded != after {
+		t.Skipf("another package changed the corpus during the pass (%d unembedded before, %d after, %d embedded); "+
+			"the count Reembed reports cannot be pinned against a moving baseline", before, after, res.Embedded)
+	}
+	if res.Missing != after {
+		t.Errorf("Missing = %d, want %d — the pass must report what is left, not what is left minus its own work",
+			res.Missing, after)
 	}
 }
 


### PR DESCRIPTION
Both reembed integration tests assume the test database holds still while they run. It does not: every package shares it (CONTRIBUTING) and `go test ./...` runs them in parallel. I hit both of these several times while working on the release review, always in a full-suite run and never when run alone — which is the worst way for a test to fail, because it points at whatever change happens to be in the tree.

**`TestReembedReportsWhatIsLeft`** counted unembedded entries, ran a bounded pass, and asserted `Missing >= total - 2`. Its comment allows for entries *appearing* in the window; the failure comes from entries *disappearing* — `CountUnembedded` counts live entries only, so another package deleting its own leaves `Missing` legitimately below the bound:

```
Missing = 116, want at least 117 (119 unembedded, 2 done)
```

**`TestReembedCoversAttachmentsIntegration`** looped until the whole shared corpus reached zero unembedded. An entry created by another package with an id sorting *behind* the cursor leaves `Missing` above zero forever, and the cursor cannot advance to reach it:

```
pass 3 left 1 missing but did not advance the cursor
```

## Change

Neither test loses what it covers.

- The count test now compares `Missing` against a second count taken **the same way, right after the pass**, instead of doing arithmetic on a baseline taken seconds earlier. The regression it guards (#132: subtracting the pass's own work from a total that already excluded it) is a two-off, so no tolerance wide enough for the drift could ever catch it — instead the test detects that the corpus moved (`before - embedded != after`) and skips rather than guessing. A pass that comes back short of its limit, because a candidate was deleted under it, skips for the same reason.
- The attachment test loops until **its own** attachments are embedded rather than until the shared corpus empties. The cursor-advance assertion survives and gets sharper: a stuck cursor is now only a failure while this test still has work outstanding, which is exactly when it is a bug.

## Verification

Against a deliberate churn process creating and deleting entries continuously (the shape of a parallel package), `go test -count=8` on both tests passes where the old assertions failed. Three consecutive full `go test -race ./...` runs against a fresh PostgreSQL are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)