### PR TITLE
Fix the three places the surfaces tell users the wrong thing

### DIFF
--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -676,6 +676,12 @@ func cmdCreate(ctx context.Context, args []string) error {
 			return err
 		}
 	}
+	// An OKF document carries no id, so the argument is the only place most
+	// inputs can get one. Saying so here beats the server's `invalid id ""`,
+	// which describes the id format and not the missing argument.
+	if k.ID == "" {
+		return errors.New("no id: pass the entry's path as the argument (e.g. `ochakai create queries/monthly-revenue -f entry.md`)")
+	}
 	c, err := newClient(ctx, *url)
 	if err != nil {
 		return err

--- a/cmd/ochakai/main.go
+++ b/cmd/ochakai/main.go
@@ -88,7 +88,7 @@ Client commands (talk to a server; --url > $OCHAKAI_URL > "use" selection):
   use [name | url]        pick the server for later commands (saved locally)
   whoami                  print target server, identity, and reachability
   search [query]          search knowledge; verified entries rank higher
-  browse [type[/prefix]]  list one level of the ID hierarchy (folder view)
+  browse [prefix]         list one level of the ID hierarchy (folder view)
   context <question>      the one-call read before a data question (full entries)
   get <id>                print one entry as an OKF document
   create [id] [-f file]   create an entry from OKF markdown or JSON

--- a/cmd/ochakai/main_test.go
+++ b/cmd/ochakai/main_test.go
@@ -12,8 +12,47 @@ import (
 func TestUsageAddressesEntriesByPath(t *testing.T) {
 	var b strings.Builder
 	usage(&b)
-	if strings.Contains(b.String(), "<type>/<id>") {
-		t.Errorf("usage() still documents the pre-0017 <type>/<id> address:\n%s", b.String())
+	// "type[/prefix]" is the same claim in browse's clothing: a prefix is
+	// a path prefix, and its first segment is a directory, not a type.
+	for _, stale := range []string{"<type>/<id>", "type[/"} {
+		if strings.Contains(b.String(), stale) {
+			t.Errorf("usage() still documents the pre-0017 address form %q:\n%s", stale, b.String())
+		}
+	}
+}
+
+// Guard: every `ochakai create` we ship names the entry's id. The id is an
+// argument and an OKF document carries none (design doc 0017), so a
+// flags-only invocation is one an agent following our own instructions
+// cannot complete — it fails on the server with a format complaint about
+// an id it was never told to pass.
+func TestShippedCreateExamplesPassAnID(t *testing.T) {
+	for _, f := range []string{
+		"../../README.md",
+		"../../CONTRIBUTING.md",
+		"../../examples/claude-code/CLAUDE.md",
+		"../../examples/claude-code/hooks/ochakai-write-back.sh",
+		"../../docs/guides/golden-query-canary.md",
+	} {
+		content, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		for _, line := range strings.Split(string(content), "\n") {
+			_, rest, found := strings.Cut(line, "ochakai create")
+			if !found {
+				continue
+			}
+			rest = strings.TrimLeft(rest, " ")
+			// `ochakai create -h` prints the help that explains the id; it is
+			// the one invocation that needs none.
+			if strings.HasPrefix(rest, "-h") || strings.HasPrefix(rest, "--help") {
+				continue
+			}
+			if rest == "" || strings.HasPrefix(rest, "-") {
+				t.Errorf("%s documents `ochakai create` without an id: %s", f, strings.TrimSpace(line))
+			}
+		}
 	}
 }
 

--- a/examples/claude-code/CLAUDE.md
+++ b/examples/claude-code/CLAUDE.md
@@ -42,9 +42,11 @@ entries. Search it before writing analytics SQL; write learnings back.
   flag verified entries for re-verification, so the next agent doesn't
   trust a stale entry blind. Always report `failed` when a verified entry
   led you to a wrong number.
-- `ochakai create -f entry.md` — write a learning back (OKF markdown as
-  printed by `get`, or JSON; see `ochakai create -h`). Entries start as
-  `draft`; your identity is recorded as provenance automatically.
+- `ochakai create <id> -f entry.md` — write a learning back (OKF markdown
+  as printed by `get`, or JSON; see `ochakai create -h`). The id is the
+  entry's path (`queries/sales/monthly-revenue`) and it is an argument:
+  an OKF document does not carry one. Entries start as `draft`; your
+  identity is recorded as provenance automatically.
 - `ochakai export <dir>` — snapshot the whole knowledge base as markdown;
   `ochakai import <dir>` loads a bundle back (any OKF bundle works).
 Types beyond these are welcome (any slug works — e.g. `runbook/…`), and


### PR DESCRIPTION
Release review of the four surfaces (MCP / REST / CLI / Web UI) for
simplicity of use. Coverage and the per-surface omissions still line up
with [0015](docs/design/0015-surface-consistency.md) — the CLI covers
every REST operation, MCP stayed at 9 tools (10 before `compile_sql`
went), and the Web UI's absences are the ones 0015 §3.4 lists. What the
review turned up were three statements that no longer match the code.

## What changed

- **`ochakai --help` addressed browse as `type[/prefix]`.** A prefix is a
  path prefix; its first segment is a directory, not a type (design doc
  0017). The other commands lost the two-part form when the help was
  brought up to 0017 this cycle — browse was missed, and the existing
  guard only looked for the literal `<type>/<id>`.

- **`examples/claude-code/CLAUDE.md` documented `ochakai create -f entry.md`.**
  That is the file the README tells people to copy into their project,
  and the command cannot work: the id is an argument and an OKF document
  carries none, so an agent following our own instructions writes nothing
  back and gets a 400 about the id's *format*. The write-back hook next
  to it already says `ochakai create <path>`.

- **The CLI now refuses a missing id locally**, naming the argument
  instead of letting the server complain about a format the caller was
  never told to fill in.

Guards for the first two (`TestUsageAddressesEntriesByPath` extended,
`TestShippedCreateExamplesPassAnID` added) so neither drifts back.

## Not changed — reported for your call

Four judgment calls came out of the same review and are left alone here:
the MCP surface's static text has grown to roughly 9.8 KB across
instructions, tool descriptions and schemas (with the write-back habit
restated in five places plus a per-response `hint`); `search --sort`
changes the meaning of its own leading output column per mode; `context
--budget` caps client-side when rendering and server-side under `--json`;
and the CLI can `verify` in one command but needs a full
read-modify-write to reject, which is the sugar 0015 §4 left conditional.

## Checks

`gofmt -l .` clean, `go vet ./cmd/...`, `go test ./cmd/... ./internal/mcpserver/... ./internal/restapi/...` pass.
Store integration tests were not run (no database in this environment).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPFWgfvwLBooAMe7dAHa8h)_