### PR TITLE
Follow OKF v0.2: trust and lifecycle in the spec's own keys (design 0034)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,10 +166,12 @@ for what they still don't do:
   client-agnostic by construction: the same verified knowledge serves
   Claude Code, hosted MCP agents, CI jobs, and whatever you build next.
 - **An exit, guaranteed.** The whole knowledge base round-trips through
-  [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf)
+  [OKF v0.2](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf)
   bundles (`ochakai export` / `ochakai import`) — plain markdown + YAML
-  frontmatter that lives happily in git. Import accepts any producer's
-  OKF bundle, not just ochakai's own. MIT-licensed
+  frontmatter that lives happily in git, with provenance and trust in the
+  spec's own keys (`generated`, `verified`, `status`, `stale_after`), so
+  any OKF consumer can read how much to trust an entry. Import accepts any
+  producer's OKF bundle, v0.1 or v0.2, not just ochakai's own. MIT-licensed
   and self-hostable per tenant: your knowledge is never a hostage.
 
 And it stays small by refusing things:
@@ -235,6 +237,7 @@ over time, run them as canaries from your CI:
 | `Semantic Model` | Apache Ossie semantic model, spec verbatim in `attrs.spec` |
 | `Metric` | Semantic metric definition (Apache Ossie), synonyms |
 | `Golden Query` | Golden query: natural-language question + verified SQL |
+| `Attested Computation` | A sanctioned computation and the means to check a run of it: the computation in a `# Computation` body fence, the contract (`runtime`, `parameters`, `executor`, `attester`) in `attrs` |
 | `Insight` | How to read a metric: baselines, seasonality, caveats, thresholds |
 | `Glossary Term` | Glossary term |
 | `BigQuery Dataset` | BigQuery dataset catalog entry: a container grouping tables |
@@ -277,6 +280,31 @@ enabled — text with any embedding model, images and PDFs with
 doc 0020).
 Attachment bytes live in GCS and are fetched on demand, and attachments
 round-trip through OKF bundles as plain files next to their entry.
+
+**Trust travels with the knowledge.** An exported entry carries the OKF
+v0.2 trust and lifecycle families (SPEC §5), so a consumer that has never
+heard of ochakai can still tell how much to trust it:
+
+```yaml
+type: Golden Query
+title: Monthly revenue by channel
+status: stable                 # draft | stable | deprecated
+stale_after: 2026-12-31        # advisory: re-check on and after this day
+generated: { by: agent:analyst@example.iam.gserviceaccount.com, at: 2026-07-26T04:12:00Z }
+verified:
+  - { by: human:tanaka@example.co.jp, at: 2026-07-26T09:30:00Z }
+```
+
+`generated` is who the content stands by and when it last changed;
+`verified` is who confirmed it — absent means unverified, and a `human:`
+entry is what makes it human-reviewed (SPEC §5.3). ochakai's `verified`
+status is exactly that: `stable` plus a verification, which is where a
+v0.2 consumer looks. The reverse mapping keeps the round-trip exact
+without treating a foreign bundle's `stable` as reviewed. What you write
+in `attrs` — including OKF's `sources` and the Attested Computation
+contract — passes through untouched, in place. Provenance itself is never
+read back from a bundle: it is what this instance observed, not what a
+document claims (design docs 0009, 0034).
 
 **Japanese knowledge bases should turn embeddings on.** PostgreSQL's
 full-text search does not tokenize Japanese, so the lexical half of search

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -673,11 +673,14 @@ paths:
         file to /api/v1/attachments/{id}/{name}, attributing it to the
         entry whose directory it sits in or whose body links to it.
         `index.md` files are generated on export and are not entries.
-        Frontmatter keys the server owns — `created_by`, `verified_by`,
-        `verified_at`, `rejected_by`, `rejected_at`, `timestamp` — are
+        Frontmatter keys the server owns — `generated`, `verified`,
+        `created_by`, `rejected_by`, `rejected_at`, and the pre-v0.2
+        spellings `timestamp` / `verified_by` / `verified_at` — are
         ignored on write; provenance comes from the caller's identity
-        (design docs 0005 §3.3, 0009). `ochakai import` is exactly this
-        loop.
+        (design docs 0009, 0034 §3.2). The one exception is that the
+        presence of a `verified` key decides how OKF's `stable` status
+        maps onto ochakai's (design doc 0034 §3.4). `ochakai import` is
+        exactly this loop.
       parameters:
         - name: attachments
           in: query
@@ -817,13 +820,14 @@ components:
       type: string
       description: >
         The OKF type vocabulary, verbatim — the built-ins (Semantic Model,
-        Metric, Golden Query, Insight, Glossary Term, BigQuery Dataset,
-        BigQuery Table, Reference) are recommendations with server behavior
-        attached, not a closed set (design docs 0005, 0018, 0023). Any
+        Metric, Golden Query, Attested Computation, Insight, Glossary Term,
+        BigQuery Dataset, BigQuery Table, Reference) are recommendations,
+        not a closed set, and no server behavior hangs off any of them
+        (design docs 0023, 0028 §3, 0034 §3.6). Any
         single-line value works as a type; OKF registers no taxonomy, so
         the spelling is the meaning and it round-trips unchanged. Matching
         is case-insensitive; the spelling you write is the one stored.
-      examples: [Semantic Model, Metric, Golden Query, Insight, Glossary Term, BigQuery Dataset, BigQuery Table, Reference, Data Contract]
+      examples: [Semantic Model, Metric, Golden Query, Attested Computation, Insight, Glossary Term, BigQuery Dataset, BigQuery Table, Reference, Data Contract]
       pattern: "^[^/\\r\\n]{1,128}$"
     Status:
       type: string
@@ -898,7 +902,24 @@ components:
         status_note:
           type: string
           description: Free-form reason for the current status (why rejected/deprecated).
+        stale_after:
+          type: string
+          format: date
+          description: >
+            Absolute date (YYYY-MM-DD) on and after which the entry is
+            stale — OKF's lifecycle date (SPEC §5.5, design doc 0034
+            §3.5). A date rather than a TTL so staleness is a plain
+            comparison against today. Advisory: nothing hides a stale
+            entry, and no feed sorts by it.
         created_by: { $ref: "#/components/schemas/Actor", readOnly: true }
+        updated_by:
+          allOf: [{ $ref: "#/components/schemas/Actor" }]
+          readOnly: true
+          description: >
+            Who last changed the content — exported as OKF's
+            generated.by (design doc 0034 §3.3). Not created_by: after
+            somebody else edits an entry, the creator is no longer who
+            the content stands by. Verifying does not change it.
         verified_by: { $ref: "#/components/schemas/Actor", readOnly: true }
         verified_at: { type: string, format: date-time, readOnly: true }
         rejected_by: { $ref: "#/components/schemas/Actor", readOnly: true }

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -986,9 +986,16 @@ func cmdImport(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	entries, atts, skipped := okf.FromBundle(files)
+	entries, atts, skipped, notes := okf.FromBundle(files)
 	for _, s := range skipped {
 		fmt.Fprintln(os.Stderr, "skip:", s)
+	}
+	// Notes are not skips: the entry is imported, with one field read
+	// differently than it was written. Reporting them keeps a foreign
+	// bundle's reinterpreted status or dropped stale_after visible without
+	// pretending the document was rejected (OKF SPEC §11).
+	for _, n := range notes {
+		fmt.Fprintln(os.Stderr, "note:", n)
 	}
 	if *dryRun {
 		for i := range entries {
@@ -1185,7 +1192,11 @@ func readEntry(path string) (*domain.Knowledge, error) {
 func decodeEntry(data []byte) (*domain.Knowledge, error) {
 	trimmed := bytes.TrimLeft(data, " \t\r\n")
 	if bytes.HasPrefix(trimmed, []byte("---")) {
-		return okf.Parse(trimmed)
+		k, notes, err := okf.Parse(trimmed)
+		for _, n := range notes {
+			fmt.Fprintln(os.Stderr, "note:", n)
+		}
+		return k, err
 	}
 	var k domain.Knowledge
 	if err := json.Unmarshal(data, &k); err != nil {

--- a/cmd/ochakai/completion.go
+++ b/cmd/ochakai/completion.go
@@ -71,7 +71,7 @@ _ochakai() {
   case $words[2] in
     search)
       _arguments \
-        '*--type[filter by type]:type:("Semantic Model" Metric "Golden Query" Insight "Glossary Term" "BigQuery Dataset" "BigQuery Table" Reference)' \
+        '*--type[filter by type]:type:("Semantic Model" Metric "Golden Query" "Attested Computation" Insight "Glossary Term" "BigQuery Dataset" "BigQuery Table" Reference)' \
         '*--status[filter by status]:status:(draft verified deprecated rejected)' \
         '*--tag[filter by tag]:tag:' \
         '--sort[list instead of searching: by verification age, demand, or failed reports]:sort:(verified_at usage failed)' \
@@ -81,7 +81,7 @@ _ochakai() {
       ;;
     context)
       _arguments \
-        '*--type[filter by type]:type:("Semantic Model" Metric "Golden Query" Insight "Glossary Term" "BigQuery Dataset" "BigQuery Table" Reference)' \
+        '*--type[filter by type]:type:("Semantic Model" Metric "Golden Query" "Attested Computation" Insight "Glossary Term" "BigQuery Dataset" "BigQuery Table" Reference)' \
         '*--status[filter by status]:status:(draft verified deprecated rejected)' \
         '*--tag[filter by tag]:tag:' \
         '--limit[max full entries]:limit:' \
@@ -164,7 +164,7 @@ _ochakai() {
   fi
 
   case $prev in
-    --type|-type) COMPREPLY=($(compgen -W "'Semantic Model' Metric 'Golden Query' Insight 'Glossary Term' 'BigQuery Dataset' 'BigQuery Table' Reference" -- "$cur")); return ;;
+    --type|-type) COMPREPLY=($(compgen -W "'Semantic Model' Metric 'Golden Query' 'Attested Computation' Insight 'Glossary Term' 'BigQuery Dataset' 'BigQuery Table' Reference" -- "$cur")); return ;;
     --status|-status) COMPREPLY=($(compgen -W "draft verified deprecated rejected" -- "$cur")); return ;;
     --sort|-sort) COMPREPLY=($(compgen -W "verified_at usage failed" -- "$cur")); return ;;
     -f) compopt -o default 2>/dev/null; COMPREPLY=(); return ;;
@@ -252,7 +252,7 @@ complete -c ochakai -n '__fish_seen_subcommand_from report' -a 'worked failed'
 complete -c ochakai -n '__fish_seen_subcommand_from get' -l download -r -a '(__fish_complete_directories)' -d 'save attachments into this directory'
 complete -c ochakai -n '__fish_seen_subcommand_from attach' -l name -x -d 'attachment name'
 complete -c ochakai -n '__fish_seen_subcommand_from attach' -F
-complete -c ochakai -n '__fish_seen_subcommand_from search context' -l type -x -a '"Semantic Model" Metric "Golden Query" Insight "Glossary Term" "BigQuery Dataset" "BigQuery Table" Reference' -d 'filter by type'
+complete -c ochakai -n '__fish_seen_subcommand_from search context' -l type -x -a '"Semantic Model" Metric "Golden Query" "Attested Computation" Insight "Glossary Term" "BigQuery Dataset" "BigQuery Table" Reference' -d 'filter by type'
 complete -c ochakai -n '__fish_seen_subcommand_from search context' -l status -x -a 'draft verified deprecated rejected' -d 'filter by status'
 complete -c ochakai -n '__fish_seen_subcommand_from search' -l sort -x -a 'verified_at usage failed' -d 'list instead of searching: by verification age, demand, or failed reports'
 complete -c ochakai -n '__fish_seen_subcommand_from search context' -l tag -x -d 'filter by tag'

--- a/docs/design/0005-okf-compatibility.md
+++ b/docs/design/0005-okf-compatibility.md
@@ -1,6 +1,8 @@
 # ochakai 設計ドキュメント 0005: OKF 互換とナレッジの構造
 
-Status: Accepted(2026-07-17 の議論で決定)。[0016](0016-knowledge-catalog-alignment.md) が一部を改訂
+Status: **Superseded by [0034](0034-okf-v0-2.md)**(OKF v0.2 対応にあたり、
+OKF 互換領域の現在の姿を 0034 が全面的に置き換えた)。改訂の履歴:
+[0016](0016-knowledge-catalog-alignment.md) が一部を改訂
 (推奨タイプは複数形スラグに、`resource` は封筒フィールドに)。§3.1 のパス規則
 (第 1 セグメント = タイプ)と §3.3 の一部・§3.5 のレガシーエイリアスは
 [0017](0017-path-addressing.md) が改訂

--- a/docs/design/0009-provenance-portability.md
+++ b/docs/design/0009-provenance-portability.md
@@ -1,6 +1,9 @@
 # ochakai 設計ドキュメント 0009: OKF/Git 往復と provenance の所有権
 
-Status: Proposed
+Status: Proposed。§4 の「OKF SPEC への先回りをしない(標準キーが定義されたら
+写像を再検討する)」は条件が満たされ、[0034](0034-okf-v0-2.md) §3.2 が
+OKF v0.2 の `generated` / `verified` への写像を決めた(§3 の世界観 —
+バンドルは知識を運び、provenance は読み戻さない — は 0034 §2.2 でそのまま維持)
 Date: 2026-07-18
 
 ## 1. 目的

--- a/docs/design/0016-knowledge-catalog-alignment.md
+++ b/docs/design/0016-knowledge-catalog-alignment.md
@@ -1,6 +1,6 @@
 # ochakai 設計ドキュメント 0016: knowledge-catalog リファレンスバンドルへの準拠
 
-Status: Accepted(2026-07-19 の議論で決定)。推奨タイプの複数形スラグは [0023](0023-okf-type-vocabulary.md) が OKF 表示名そのものに置き換え(カタログ準拠の残り — `resource` の封筒フィールド化など — は有効)。§2.5 のうち compile の `dialect` に関する部分は [0028](0028-retire-compile-sql.md) の compile 撤去により対象が消滅(BigQuery 修飾の表示名は有効)
+Status: **Superseded by [0034](0034-okf-v0-2.md)**(カタログ準拠の残り — `resource` の封筒フィールド化、本文セクションの規約 — は 0034 が引き継いだ)。改訂の履歴: 推奨タイプの複数形スラグは [0023](0023-okf-type-vocabulary.md) が OKF 表示名そのものに置き換え。§2.5 のうち compile の `dialect` に関する部分は [0028](0028-retire-compile-sql.md) の compile 撤去により対象が消滅(BigQuery 修飾の表示名は有効)
 Date: 2026-07-19
 
 ## 1. 目的

--- a/docs/design/0023-okf-type-vocabulary.md
+++ b/docs/design/0023-okf-type-vocabulary.md
@@ -1,6 +1,8 @@
 # ochakai 設計ドキュメント 0023: 型の語彙を OKF に一本化する
 
-Status: Accepted(2026-07-20)
+Status: Accepted(2026-07-20)。§3.1 の型の一覧に
+[0034](0034-okf-v0-2.md) §3.6 が `Attested Computation`(OKF v0.2 §10)を
+足して 9 型にした
 Date: 2026-07-20
 
 ## 1. 目的

--- a/docs/design/0034-okf-v0-2.md
+++ b/docs/design/0034-okf-v0-2.md
@@ -1,0 +1,393 @@
+# ochakai 設計ドキュメント 0034: OKF v0.2 準拠 — 互換規則の全面置き換え
+
+Status: Accepted(2026-07-26)。[0005](0005-okf-compatibility.md) と
+[0016](0016-knowledge-catalog-alignment.md) を Superseded にし、
+[0009](0009-provenance-portability.md) §4 と [0023](0023-okf-type-vocabulary.md) §3.1 を改訂する。
+実装は同 PR、0.13.0 で出る
+Date: 2026-07-26
+
+## 1. 目的
+
+[OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf)
+が **v0.2** に更新され、これまで各プロデューサが拡張キーで自作していた
+provenance・trust・lifecycle に標準の綴りができた(SPEC §5、§7、§10)。
+v0.2 は additive な minor バンプだが、**2 つだけ破壊的なリネーム**を持つ
+(§13.1): `timestamp` は `generated.at` に、本文の `# Citations` は
+`sources` に置き換わる。
+
+ochakai の OKF 互換は 0005 で決めたあと、0016(カタログ準拠)・0017
+(パスが住所)・0019(ID 文字種)・0022(ファイル名が名前)・0023(型の
+語彙)・0024(リンクは本文から)で 5 回改訂され、さらに 0028 で compile 面が
+消えた。**現在の姿を読むのに 7 本を Status ヘッダ順にたどる必要がある**。
+v0.2 対応は frontmatter の中核に触るので、部分改訂を 6 枚目として積まず
+(CONTRIBUTING「amendment chains を避ける」)、本ドキュメントを
+**OKF 互換領域の全面置き換え**として書く。0017 / 0019 / 0022 / 0023 /
+0024 / 0013(添付)はそれぞれ単一主題の現行ドキュメントとして有効であり、
+本ドキュメントはそれらを前提として参照する。
+
+0009 §4 は「SPEC 側に provenance の標準キーが定義される動きをウォッチし、
+標準化されたら写像を再検討する」と明記していた。その条件が満たされた。
+
+## 2. 世界観
+
+### 2.1 推奨はするが、強制しない(0005 §2 を継承)
+
+推奨タイプは**推奨**であって閉集合ではない。利用者が自分のドキュメント
+種別(runbook、data-contract、ADR……)を持ち込むことを妨げず、自由な
+タイプは一級市民である — 検索・CRUD・検証ステータス・provenance・
+リビジョンはすべて同じように機能し、振る舞いが付かないだけである。
+SPEC §4.1 も「型は中央登録されない」と定めており、語彙は**振る舞いの
+レジストリではない**(0028 §3)。
+
+### 2.2 バンドルは知識を運び、provenance はインスタンス固有(0009 §3.1 を継承)
+
+v0.2 で「誰が生成し、誰が検証したか」に標準の書き方ができたが、
+**インポートでそれを読み戻さない方針は変えない**。`generated` /
+`verified` は「このインスタンスでサーバーが観測した事実」であって、
+ドキュメントの自己申告ではない。ochakai には認可機構がない(0002)以上、
+ペイロードから provenance を受けた瞬間に、誰でも任意の provenance を
+名乗れることになる。
+
+エクスポートされた `generated` / `verified` は**参考情報(歴史的記録)**
+である。標準化されたことで**外部の consumer が読める**ようになったのが
+v0.2 の利得であり、ochakai 自身が読み戻す理由にはならない。
+
+ただし v0.2 は 1 か所だけ、読み**取る**価値のある情報を足した:
+`verified` キーの**存在**である。これは trust tier(§5.3)の唯一の根拠で
+あり、`status` の写像に使う(§3.4)。存在は読むが、`by` / `at` の値は
+採らない。
+
+### 2.3 封筒フィールドと拡張キーの線引き
+
+v0.2 は optional なキーの族を 4 つ足した。どれを `domain.Knowledge` の
+封筒フィールドに上げ、どれを `attrs` 素通しにするかの基準を明文化する。
+
+**封筒に上げるのは、ochakai 自身が観測・照合・表示するものだけ。**
+
+- サーバーが観測する事実(provenance・検証・更新時刻)。
+- サーバーが照合する鍵(型・ID・タグ・ステータス)。
+- 全サーフェスが一様に表示する必要があるもの。
+
+**それ以外は拡張キーとして `attrs` を素通しする。** SPEC §4.1 の
+プロデューサ拡張キーの規則(未知のキーは保存し、往復させ、拒否しない)は
+すでに実装されており、値は元の位置・元の綴りで往復する。サーバーが
+読まないものを封筒に上げると、検証面・OpenAPI・MCP スキーマ・Web UI が
+増えるのに、増えた分を誰も使わない。
+
+## 3. 決定
+
+### 3.1 宣言バージョンを 0.2 にする
+
+バンドルルートの `index.md` は `okf_version: "0.2"` を宣言する
+(SPEC §12。frontmatter が許される唯一の index)。`internal/okf.Version`
+を `"0.2"` にする。
+
+### 3.2 trust: `timestamp` / `verified_*` を `generated` / `verified` に完全移行する
+
+SPEC §13.1 の破壊的リネームに正面から従い、v0.1 の綴りは**出さない**。
+
+```yaml
+generated: { by: agent:analyst@example.iam.gserviceaccount.com, at: 2026-07-26T04:12:00Z }
+verified:
+  - { by: human:tanaka@example.co.jp, at: 2026-07-26T09:30:00Z }
+```
+
+| v0.2 キー | ochakai の出所 |
+|---|---|
+| `generated.by` | **最後に内容を変えた actor**(§3.3 で足す `updated_by`) |
+| `generated.at` | `updated_at` |
+| `verified[].by` / `verified[].at` | `verified_by` / `verified_at` |
+
+- `generated.at` は厳密には「サーバーが最後にこの行を書いた時刻」である。
+  `SameContent` が無変更の書き込みを弾くので通常は SPEC §5.2 の "last
+  meaningful change" と一致するが、**verify(0025 §6.2)と添付の
+  attach/detach も `updated_at` を進める** — `updated_at` は ETag の版
+  でもあるため、進めないと楽観ロックが壊れる。どちらも concept
+  ドキュメント自体を書き換えてはいないので `generated.by` は動かさない
+  (検証は内容の生成ではなく、添付はドキュメントの外のファイルである)。
+  専用の列を足してまで `at` を分ける価値はないと判断した。
+- `verified` は **1 要素のリスト形式**で出す。SPEC §5.2 は bare mapping も
+  許すが、ochakai が将来複数の検証を保つようになってもワイヤ形が変わらない
+  リスト形を選ぶ。インポート側は SPEC §11 の要求どおり bare mapping を
+  1 要素リストとして扱う。
+- **status が verified なら `verified` キーを必ず出す**(actor を持たない
+  エントリでも)。キーの不在が unverified を意味する(§5.3)以上、これは
+  §3.4 の写像が往復するための不変条件でもある — `stable` だけを書いて
+  戻すと draft に落ちる。逆に、verified でないエントリは `verified` キーごと
+  出さない。
+- **`timestamp` / `verified_by` / `verified_at` は出力から消える。**
+  インポートは v0.1 の綴りも読める(SPEC §13.1 のフォールバック)が、
+  どちらも 0009 のとおり値は採らない。
+
+**委譲(0027)は mapping 内の拡張キー `via` で表す。**
+
+```yaml
+generated: { by: human:tanaka@example.co.jp, via: agent:insightflow@example.iam.gserviceaccount.com, at: ... }
+```
+
+`Actor.String()` の `"A via B"` 文字列を `by` に押し込むと §7 の actor 形式
+から外れる。`by` は actor 単体に保ち、委譲は兄弟キーにする — SPEC §4.1 の
+「未知のキーは保存し、拒否しない」に収まり、`human:` 前置が保たれるので
+trust tier(§5.3)も正しく出る。REST / MCP のワイヤ形式(`Actor` の JSON)は
+変えない。
+
+**ochakai 固有の provenance は拡張キーとして残す。** `created_by`
+(作成者。OKF は「最後に変えた人」しか持たない)、`rejected_by` /
+`rejected_at`(§3.4)。いずれも歴史的記録であり、インポートは従来どおり
+値を採らない。
+
+### 3.3 `updated_by` を封筒に足す(マイグレーション 0019)
+
+`generated.by` は「現在の内容を生成したのは誰か」であり、ochakai は今
+これを列に持たない — 持っているのは `created_by` と、リビジョンの
+`changed_by` だけである。`created_by` で代用すると、他人が更新した後に
+「生成者」が嘘になる。
+
+- `domain.Knowledge` に `UpdatedBy Actor` を足し、`knowledge` に列を足す
+  (`updated_by_kind` / `updated_by_name` / `updated_by_via` — 既存の
+  `created_by_*`(0001)と `*_by_via`(0017)と同じ形)。
+- create / update / move が内容を書いたときに呼び出し元でスタンプする。
+  move では、動いたエントリ自身と、本文を書き換えられた参照元の両方に
+  付く(どちらも `update` / `move` リビジョンとして記録される変更である)。
+  **verify(0025 §6.2)と attach/detach ではスタンプしない** — 検証は
+  内容の変更ではなく `verified` に積む行為であり、添付は concept
+  ドキュメントの外のファイルである。
+- 内容が変わらない update(`SameContent`)もスタンプしない。何も書かない
+  書き込みが生成者を付け替えては意味が反転する。
+- バックフィル: 最新の create / update / move リビジョンの `changed_by`、
+  無ければ `created_by`。
+- REST / MCP のワイヤ形式に `updated_by` が載る(0015: 4 サーフェスに
+  一様に出す)。
+
+### 3.4 `status` は OKF 語彙で出し、`verified` の有無で読み戻す
+
+SPEC §5.4 の語彙は `draft | stable | deprecated` の 3 値で、ochakai の 4 値
+(draft / verified / deprecated / rejected)とは重ならない。v0.2 では
+**「検証済み」は status ではなく `verified` の有無**で表す(§5.3)。
+
+**エクスポート:**
+
+| ochakai | `status` | 併記 |
+|---|---|---|
+| `draft` | `draft` | — |
+| `verified` | `stable` | `verified: [{by, at}]` |
+| `deprecated` | `deprecated` | `status_note` |
+| `rejected` | `deprecated` | `status_note`、拡張キー `rejected_by` / `rejected_at` |
+
+**インポート:**
+
+| frontmatter | `verified` キー | ochakai |
+|---|---|---|
+| `draft` | 有無を問わず | `draft` |
+| `stable` | あり | `verified` |
+| `stable` | なし | `draft` |
+| `deprecated` | 有無を問わず | `deprecated` |
+| `status` 省略 | あり | `verified` |
+| `status` 省略 | なし | **未設定のまま**(書き込み経路の既定に委ねる) |
+| `verified` / `rejected`(ochakai ≤0.12 が書いたレガシー値) | — | そのまま |
+| 上記以外 | — | `draft`。エントリは落とさず、レポートに 1 行残す |
+
+`verified` キーは**存在だけ**を読む。v0.1 文書では `verified_at` の存在が
+同じことを言うので、そちらも見る。`by` / `at` の値は採らない(§2.2)。
+
+- **ochakai → ochakai の往復は保たれる**(verified → `stable` +
+  `verified:` → verified)。ochakai は status=verified のとき必ず
+  `verified` を出す(§3.2)ので、この判定は曖昧にならない。
+- **外来バンドルの `stable` は verified にしない。** OKF の `stable` は
+  「消費してよい」であって「人が確認した」ではなく、trust tier は
+  `verified` からしか読めない(§5.3)。
+- **`status` 省略は「未設定」として通す。** SPEC §5.4 の既定は `stable`
+  だが、ochakai には既に「status を名乗らない書き込み」の規則がある —
+  create なら draft、update なら現状維持。ここで値を作ると、status を
+  持たない文書を再インポートするたびに**既存エントリを黙って draft に
+  降格させる**。既定は書き込み経路に委ねるのが正しく、結果として新規は
+  draft に着地するので §5.4 との実質的な差もない。
+- **未知の status でドキュメントを落とさない**(SPEC §11)。改訂前は
+  `ValidStatus` の閉集合検査により、外来 v0.2 バンドルの `status: stable`
+  が 400 で落ちていた。これは v0.2 に対する明確な非準拠であり、本改訂で直る。
+- `status: stable` は明示的に出す(省略しない)。往復の判定が
+  「キーがある/ない」に依存しなくなる。
+- **再解釈は黙って行わない。** 未知の status、日付でない `stale_after` の
+  ようにドキュメントを受けつつ値を読み替えた場合、パーサは note を返し、
+  `ochakai import` が `note:` 行として出す。**skip とは別勘定**である —
+  エントリは取り込まれているのだから、スキップ件数に混ぜてはいけない。
+
+### 3.5 `stale_after` を封筒に足す
+
+```yaml
+stale_after: 2026-12-31
+```
+
+lifecycle の宣言(SPEC §5.5)。`status` と同じく**書き手が主張する**
+lifecycle であり、`domain.Knowledge` の封筒フィールドとして受ける
+(§2.3 の基準: 全サーフェスが一様に表示し、照合の対象になりうる)。
+
+- 形は `YYYY-MM-DD` の絶対日付。タイムゾーン意味論を持ち込まないため
+  `date` 列とし、比較は素の日付比較(`today >= stale_after`)。日付として
+  成立しない値は書き込み時に 400、インポートでは note を残して落とす
+  (§3.4 の最後)。
+- ペイロードから受ける(`status_note` と同じく書き手のもの)。
+  `SameContent` の比較対象に含める。省略は「クリア」を意味する — PUT は
+  全置換であり、他の内容フィールドと同じ扱いである。
+- **フィードは足さない。** 0025 の 2 フィード(`sort=verified_at` /
+  `sort=failed`)は*サーバーが観測した*証拠で並ぶ。`stale_after` は
+  書き手の宣言であり別軸である。実際に使われ始めてから 0025 の改訂として
+  検討する。当面は各サーフェスで読み書き・表示できれば足りる。
+
+### 3.6 型の語彙に `Attested Computation` を足す(0023 §3.1 の改訂)
+
+SPEC §10 の新しい concept 型を推奨語彙に加え、9 型にする。表示順は
+`Semantic Model` / `Metric` / `Golden Query` / **`Attested Computation`** /
+`Insight` / `Glossary Term` / `BigQuery Dataset` / `BigQuery Table` /
+`Reference`。
+
+- **サーバーの振る舞いは付かない。** `runtime` / `parameters` /
+  `computation` / `executor` / `attester` は拡張キーとして `attrs` を
+  素通しし、サーバーは読まない・検証しない・実行しない。0001 の中核制約
+  (LLM ゼロ・SQL 非実行)にも、0028 が「決定的な生成もクライアント側」と
+  引き直した線にも触れない。ochakai が引き受けるのは**記録**である —
+  記録された契約を実行し attest するのは consumer(§10.5 も consumer 側の
+  手順として書かれている)。
+- 語彙に足す意味は 0023 §3.1 と同じ: 型の綴りがそのまま意味であり、
+  推奨語彙に載っていれば `get_context` や検索フィルタで「実行してよい
+  計算の定義」を一語で指せる。振る舞いの無い型はすでに複数ある。
+- 0028 §4 の「compile 再実装の条件」との関係: OKF が sanctioned
+  computation の記録形式を定めたことで、**ochakai がコンパイラを持たない
+  まま、同じ需要をバンドルの語彙で満たせる**ようになった。0028 の判断は
+  補強されており、覆らない。
+
+### 3.7 `sources` は拡張キーのまま(素通し)
+
+SPEC §5.1 の `sources`(と `usage_window`、per-source の `author` /
+`usage_count` / `last_modified`)は封筒に上げず、`attrs` の拡張キーとして
+往復させる。
+
+- §2.3 の基準に照らすと、`sources` は**書き手が主張する外部素材の記録**で
+  あり、サーバーは観測も照合も表示もしない。構造化しても検証面と
+  スキーマが増えるだけで、増えた分を誰も読まない。
+- 素通しの往復はすでに成立している(0005 以来のプロデューサ拡張キーの
+  規則)。ネストしたリストも値ごとそのまま保存され、元の位置に戻る。
+  ただし v0.2 で**日付を値に持つ拡張キーが普通になった**
+  (`sources[].last_modified`、`usage_window`)。YAML は引用符の無い日付を
+  型付きの時刻として読むため、そのまま JSON に落とすと `2026-06-01` が
+  `2026-06-01T00:00:00Z` になって戻ってくる。時刻成分を持たない値は日付
+  として書き戻し、書き手が書いていないものを書かないようにする。
+- 本文の footnote による per-claim 帰属(§5.1)と `# Computation` 見出し
+  (§4.2)も同じ扱い — 本文の慣習であり、コード変更を要さない。
+- **再検討の条件**: 検索・フィルタ・UI のいずれかが `sources` の中身を
+  読む必要が実際に出たとき(例: 「この外部資料に由来するエントリ」の
+  逆引き)。そのとき封筒に上げる。
+
+なお ochakai 自身の利用集計(`search_hits` / `fetches` / `worked` /
+`failed`、0001 §9)は §5.1 の `usage_count` と発想が同じだが、
+**別物として扱う**。`usage_count` は*引用する側*が*引用される素材*に付ける
+信号であり、ochakai の集計は*このインスタンスでの*観測である。エクスポート
+時に相互変換はしない。
+
+### 3.8 actor 規約(SPEC §7)との関係
+
+ochakai は `human:<id>` / `agent:<id>` を出す。§7 は `human:<id>` /
+`process:<id>` / `<producer>/<version>` を挙げる。
+
+- **`human:` はそのまま一致する。** trust tier(§5.3)は `human:` 前置
+  だけを見るので、tier の判定は正しく出る。§7 が「人手・人による確認には
+  MUST で `human:` を使え」と定める要求も満たしている。
+- **`agent:` は維持する。** ochakai の agent はほとんどが IAM
+  サービスアカウント名でバージョンを持たない。`<producer>/<version>` に
+  合わせるために偽のバージョンを足したり、意味の違う `process:` に
+  読み替えたりはしない。§5.3 が human 以外を一括で machine-confirmed と
+  するので、区別の必要も無い。
+
+### 3.9 往復(round-trip)の規則 — 現在の全体像
+
+0005 §3.3 の表を、その後の改訂(0017 / 0019 / 0022 / 0023 / 0024 / 0013)と
+本改訂を織り込んだ現在の形で置く。
+
+| 事象 | 規則 |
+|---|---|
+| パスと ID | バンドルパスは `<id>.md`。ID がアドレスであり、パスは型を主張しない(0017)。セグメントは非空・128 バイト以内・制御文字なし・`.` 始まりでない(0019 §2)。NFC 正規化して照合する(0022) |
+| タイプ | frontmatter の `type` が唯一の出所で、値は OKF の綴りそのもの(0023)。照合は大小文字非依存、保存は原表記。`type` を持たない .md は concept ではないのでスキップしてレポート |
+| `title` | 任意。空なら ID の最終セグメントが名前(0022)。空の title は出力しない |
+| `resource` | 封筒キー。`type` の直後に出す(カタログのリファレンスバンドルのキー順) |
+| trust / lifecycle | `generated` / `verified` / `status` / `stale_after`(§3.2、§3.4、§3.5) |
+| 未知の frontmatter キー | プロデューサ拡張キー(SPEC §4.1)として値ごと `attrs` に保存し、エクスポートでトップレベルに書き戻す。封筒キーと同名の attr はエクスポートせず封筒が勝つ。YAML が型付けした日付は、時刻成分が無ければ日付として書き戻す(§3.7) |
+| サーバー所有キー | `generated` / `verified` / `created_by` / `rejected_*`、および v0.1 の `timestamp` / `verified_by` / `verified_at` は**値を採らない**(0009)。`attrs` にも入れない。例外は `verified` の**存在**で、§3.4 の status 写像にだけ使う |
+| リンク | 構造化フィールドを持たず、本文の markdown リンクから導出する(0024)。`# Links` セクションは出力しない |
+| 添付 | 参照駆動で帰属し、正準レイアウトは `<id>/<name>`。外来の位置は `okf_path` で保存する(0008 / 0013) |
+| `index.md` / `log.md` | OKF の予約ファイル。インポートは黙ってスキップ。`index.md` はエクスポートで全階層に再生成する(frontmatter なし、ルートのみ `okf_version`) |
+| 隠しファイル | セグメントが `.` で始まるパスは黙ってスキップ |
+| 非 Markdown ファイル | 添付にならないものはスキップしてレポート |
+| アーカイブの包み | アンラップしない。包みディレクトリは名前空間である(0017 §4.3) |
+| 改行コード | CRLF は LF に正規化して受ける |
+| 拒否の粒度 | ドキュメント単位でスキップし、バンドル全体は失敗させない(0019、SPEC §11) |
+| 再解釈の報告 | 取り込んだうえで値を読み替えたものは note として返し、skip とは別に報告する(§3.4) |
+
+### 3.10 インポートの入口
+
+`ochakai import <dir | file.tar.gz | ->`(REST 経由)のみ。DB 直結の
+`import-okf` は 0007 で廃止済みで、復活させない。新しい API 面は作らず、
+既存の POST / PUT の繰り返しとしてクライアント側で実装する(0004)。
+
+### 3.11 各サーフェスの更新(0015)
+
+- **domain**: `UpdatedBy`、`StaleAfter`、`Attested Computation`、
+  `Status` の写像ヘルパ(OKF 語彙 ⇄ ochakai 4 値)、推奨語彙の
+  1 箇所化(`TypesHint`)。
+- **store**: マイグレーション 0019(`updated_by_*`、`stale_after`)、
+  書き込み時のスタンプ、リビジョンスナップショット。
+- **service**: create / update(内容が変わったときだけ)で `UpdatedBy` を
+  スタンプし、`stale_after` を検証する。verify では触らない。
+- **internal/okf**: `Version`、`frontmatter` 構造体、`reservedKeys` に
+  `generated` / `verified` / `stale_after` を追加、`parseDoc` の
+  サーバー所有キー一覧と status 写像、note の返却。
+- **restapi / mcpserver / apiclient / CLI / Web UI / openapi.yaml**:
+  `updated_by` と `stale_after` の読み書き、型の補完・enum への
+  `Attested Computation` 追加、ツール説明とヘルプの文言、
+  `import` の `note:` 出力。
+- **README / docs**: frontmatter の例を v0.2 に、`sources` と
+  Attested Computation を「拡張キーで書ける」慣習として案内。
+
+REST は `domain.Knowledge` を直接デコードするため、`stale_after` は
+ハンドラの変更なしに受かる。`updated_by` は書き込み経路がサーバー側で
+上書きするので、ペイロードから名乗ることはできない。
+
+## 4. 壊れるもの(0.13.0)
+
+- **エクスポートの frontmatter 形状が変わる。** `timestamp` /
+  `verified_by` / `verified_at` が消え、`generated` / `verified` になる。
+  `status: verified` は `stable` + `verified` になる。旧形式を読む外部
+  ツールがあれば追従が要る(インポート側は旧形式も読める)。
+- **`rejected` の往復が非可逆になる。** エクスポートで `deprecated` に
+  なるため、export → import で `rejected` は `deprecated` になる。却下は
+  ochakai ローカルのキュレーション状態であり、バンドルはインスタンス固有の
+  判断を運ばない(0009)という整理の帰結である。理由は `status_note` に
+  残り、`rejected_by` / `rejected_at` は拡張キーとして歴史的記録に残る。
+- **`status: stable` を受け付けるようになる**(現状は 400)。未知の status
+  値も draft として受け、落とさなくなる。これは非準拠の修正である。
+- ワイヤ形式に `updated_by` と `stale_after` が増える(追加のみ)。
+- `okf_version` が `"0.2"` になる。
+- 日付を値に持つ拡張キーの往復が変わる(§3.7)。これまで
+  `2026-06-01T00:00:00Z` として書き戻されていた日付が `2026-06-01` に
+  戻る。書き手が書いたものに近づく方向の変更である。
+
+実装中に見つけた既存のバグも 1 つ直した(本改訂の帰結ではない):
+Web UI の詳細画面から status を変えると、全置換 PUT のペイロードに
+`resource` が含まれておらず**消えていた**。封筒の書き込み可能フィールドを
+1 箇所に集め、`stale_after` と併せて載せた。
+
+## 5. やらないこと
+
+- **`sources` の封筒化**(§3.7 の再検討条件まで)。
+- **`stale_after` のフィード**(§3.5)。0025 の証拠ベースのフィードと
+  混ぜない。
+- **attester / executor の実行**。§10 は consumer 側の手順であり、
+  ochakai は記録しかしない(0001)。0028 の再実装条件も変えない。
+- **バンドルからの provenance の読み戻し**(0009 §3.3 のまま)。
+  `verified` の存在だけを status 写像に使う(§2.2)。
+- **`agent:` の `process:` への読み替え**(§3.8)。
+- **`# Citations` 本文リストのパース**。SPEC §13.1 は v0.1 文書について
+  MAY と定めるが、ochakai は本文を解釈しない(リンク導出を除く、0024)。
+  `# Citations` はこれまでどおり本文として往復する。
+- **型ごとのスキーマ強制**。`Attested Computation` の `runtime` は SPEC で
+  REQUIRED だが、ochakai は attrs を検証しない(0005 §4 以来の方針、
+  0028 で `Semantic Model` の書き込み時検証も撤去済み)。

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -33,18 +33,24 @@ PR の中に残る。
   エンドユーザーを名乗り、provenance がサービスアカウント 1 つに
   潰れる問題を解く。
 - [0009 OKF/Git 往復と provenance の所有権](0009-provenance-portability.md)
-  — **Proposed**。export → Git → import の往復で provenance が誰のものに
+  — **Proposed**(§4 の「SPEC への先回りをしない」は 0034 が写像を決定)。
+  export → Git → import の往復で provenance が誰のものに
   なるかの整理(バンドルは知識のみを運び、provenance はインスタンス固有)。
 
 ## ナレッジモデル(構造・ID・型・名前・リンク)
 
+- [0034 OKF v0.2 準拠](0034-okf-v0-2.md) — **Accepted**(実装済み、0.13.0 で出る)。
+  **OKF 互換領域の現行ドキュメント**。trust/lifecycle を v0.2 のキー
+  (`generated` / `verified` / `status` / `stale_after`)へ完全移行し、
+  `Attested Computation` を語彙に足し、往復規則の全体像を 1 本にまとめる。
 - [0005 OKF 互換とナレッジの構造](0005-okf-compatibility.md) —
-  **Accepted**(一部を 0016 / 0017 が改訂)。OKF バンドルとの双方向互換 —
-  任意ネストのパス、自由文字列タイプ、バンドルインポート、サーバー所有キー。
+  **Superseded by 0034**(改訂の履歴として 0016 / 0017 も参照)。
+  OKF バンドルとの双方向互換の出発点 — 任意ネストのパス、自由文字列タイプ、
+  バンドルインポート、サーバー所有キー。
 - [0016 knowledge-catalog リファレンスバンドルへの準拠](0016-knowledge-catalog-alignment.md)
-  — **Accepted**(型の語彙は 0023 が置き換え、§2.5 の compile `dialect`
-  は 0028 で対象消滅)。リファレンスバンドルへの
-  準拠(`resource` の封筒フィールド化ほか)。
+  — **Superseded by 0034**(型の語彙は 0023 が先に置き換え、§2.5 の
+  compile `dialect` は 0028 で対象消滅)。
+  リファレンスバンドルへの準拠(`resource` の封筒フィールド化ほか)。
 - [0017 パスが住所、タイプは属性](0017-path-addressing.md) —
   **Accepted**(ID 文字種は 0019 §2、型の語彙は 0023 が改訂)。
   ID がアドレスであり、パスはもはや型を主張しない。
@@ -54,8 +60,8 @@ PR の中に残る。
 - [0022 ファイル名が名前](0022-filename-as-name.md) — **Accepted**。
   title の任意化、ID の検索対象化、NFC 正規化。
 - [0023 型の語彙を OKF に一本化する](0023-okf-type-vocabulary.md) —
-  **Accepted**。内部スラグと OKF 表示名の二重語彙を廃止し、型の値は
-  OKF の綴りそのものに。
+  **Accepted**(§3.1 の一覧に 0034 が `Attested Computation` を追加)。
+  内部スラグと OKF 表示名の二重語彙を廃止し、型の値は OKF の綴りそのものに。
 - [0024 リンクは本文から導出する](0024-links-from-body.md) —
   **Accepted**。構造化 `links` フィールドを廃止し、リンクは本文
   markdown から導出する。

--- a/internal/domain/knowledge.go
+++ b/internal/domain/knowledge.go
@@ -23,20 +23,38 @@ import (
 type Type string
 
 const (
-	TypeModels     Type = "Semantic Model"   // Apache Ossie semantic model, spec verbatim in attrs.spec (design doc 0018; unvalidated since 0028)
-	TypeMetrics    Type = "Metric"           // semantic metric definition (Apache Ossie)
-	TypeQueries    Type = "Golden Query"     // golden query: question + verified SQL
-	TypeInsights   Type = "Insight"          // how to read a metric: baselines, caveats
-	TypeTerms      Type = "Glossary Term"    // glossary term
-	TypeDatasets   Type = "BigQuery Dataset" // dataset: a container grouping tables
-	TypeTables     Type = "BigQuery Table"   // table catalog entry
-	TypeReferences Type = "Reference"        // mirror of external material (enums, licenses, schema docs)
+	TypeModels       Type = "Semantic Model"       // Apache Ossie semantic model, spec verbatim in attrs.spec (design doc 0018; unvalidated since 0028)
+	TypeMetrics      Type = "Metric"               // semantic metric definition (Apache Ossie)
+	TypeQueries      Type = "Golden Query"         // golden query: question + verified SQL
+	TypeComputations Type = "Attested Computation" // sanctioned computation and the means to check a run of it (OKF SPEC §10, design doc 0034 §3.6)
+	TypeInsights     Type = "Insight"              // how to read a metric: baselines, caveats
+	TypeTerms        Type = "Glossary Term"        // glossary term
+	TypeDatasets     Type = "BigQuery Dataset"     // dataset: a container grouping tables
+	TypeTables       Type = "BigQuery Table"       // table catalog entry
+	TypeReferences   Type = "Reference"            // mirror of external material (enums, licenses, schema docs)
 )
 
 // Types lists the recommended (built-in) knowledge types, in display order
 // (containers before their contents: models define metrics, datasets
 // group tables).
-var Types = []Type{TypeModels, TypeMetrics, TypeQueries, TypeInsights, TypeTerms, TypeDatasets, TypeTables, TypeReferences}
+//
+// No server behavior hangs off any of them — the list is a vocabulary, not
+// a registry (design doc 0028 §3). Attested Computation is the clearest
+// case: ochakai records the contract (runtime, parameters, executor,
+// attester) as ordinary attrs and never runs it. Executing the computation
+// and checking the receipt belong to the consumer (OKF SPEC §10.5), which
+// is the same line design doc 0028 drew when compile_sql went away.
+var Types = []Type{TypeModels, TypeMetrics, TypeQueries, TypeComputations, TypeInsights, TypeTerms, TypeDatasets, TypeTables, TypeReferences}
+
+// TypesHint renders the recommended vocabulary for help and error text,
+// so no surface keeps its own copy of the list to fall behind.
+func TypesHint() string {
+	names := make([]string, len(Types))
+	for i, t := range Types {
+		names[i] = string(t)
+	}
+	return strings.Join(names, ", ")
+}
 
 // BuiltinType reports whether t is one of the recommended types, matched
 // case-insensitively (EqualType), the same way search filters match
@@ -144,6 +162,97 @@ func ValidStatus(s Status) bool {
 	return false
 }
 
+// OKF lifecycle values (SPEC §5.4). Three where ochakai has four: OKF
+// spells "a human confirmed this" with the verified key, not with a
+// status, so verified maps onto stable plus a verified entry.
+const (
+	OKFStatusDraft      = "draft"
+	OKFStatusStable     = "stable"
+	OKFStatusDeprecated = "deprecated"
+)
+
+// OKFStatus returns the OKF v0.2 lifecycle value for s (design doc 0034
+// §3.4). Rejected exports as deprecated: OKF has no state for "was never
+// accepted", and the reason survives in status_note while rejected_by /
+// rejected_at stay as ochakai extension keys. The mapping is deliberately
+// lossy in that one direction — a rejection is this instance's curation
+// record, and a bundle carries knowledge, not instance-local rulings
+// (design doc 0009).
+func OKFStatus(s Status) string {
+	switch s {
+	case StatusDraft:
+		return OKFStatusDraft
+	case StatusVerified:
+		return OKFStatusStable
+	case StatusDeprecated, StatusRejected:
+		return OKFStatusDeprecated
+	}
+	// A status ochakai does not know cannot have landed in the store, but
+	// export must still write something OKF-shaped.
+	return OKFStatusDraft
+}
+
+// StatusFromOKF maps a frontmatter status onto ochakai's vocabulary.
+// hasVerified reports whether the document carried a verified key at all
+// — under SPEC §5.3 that key, not the status, is what says a concept was
+// confirmed, so a foreign bundle's stable entries land as drafts unless
+// they carry one. ochakai's own exports always write verified alongside
+// stable, so an ochakai → ochakai round-trip is exact.
+//
+// The values ochakai wrote before v0.2 (verified, rejected) are still
+// accepted verbatim: bundles exported by 0.12 and earlier must keep
+// importing as what they say.
+//
+// An unrecognized value is a draft, never a rejection of the document
+// (SPEC §11 forbids rejecting a concept over an unknown field value). ok
+// reports whether the value was recognized, so an importer can mention
+// what it did rather than silently reinterpreting.
+//
+// An absent status stays unset ("") rather than becoming a value: OKF
+// reads absence as stable (§5.4), but ochakai already has a rule for a
+// write that names no status — draft on create, unchanged on update — and
+// that rule is what keeps a re-imported document from silently demoting
+// the entry it lands on. The one exception is a document that carries a
+// verified key with no status: that is a confirmation, and saying so is
+// the whole point of §5.3.
+func StatusFromOKF(raw string, hasVerified bool) (s Status, ok bool) {
+	switch raw {
+	case "":
+		if hasVerified {
+			return StatusVerified, true
+		}
+		return "", true
+	case OKFStatusDraft:
+		return StatusDraft, true
+	case OKFStatusStable:
+		if hasVerified {
+			return StatusVerified, true
+		}
+		return StatusDraft, true
+	case OKFStatusDeprecated:
+		return StatusDeprecated, true
+	case string(StatusVerified), string(StatusRejected):
+		return Status(raw), true // written by ochakai 0.12 and earlier
+	}
+	return StatusDraft, false
+}
+
+// StaleAfterLayout is the date form OKF fixes for stale_after (SPEC §5.5):
+// an absolute day, not a relative TTL, so staleness stays a plain date
+// comparison with no reference to when the entry was read — and with no
+// timezone to argue about.
+const StaleAfterLayout = "2006-01-02"
+
+// ValidStaleAfter reports whether s can be a stale_after: unset, or a
+// YYYY-MM-DD date that exists.
+func ValidStaleAfter(s string) bool {
+	if s == "" {
+		return true
+	}
+	_, err := time.Parse(StaleAfterLayout, s)
+	return err == nil
+}
+
 // Usage event kinds recorded per knowledge entry (design doc 0001 §9).
 // The first two are recorded passively by reads; worked/failed are
 // deliberate outcome reports (report_outcome) closing the write-back loop.
@@ -245,7 +354,9 @@ type Knowledge struct {
 	Tags        []string       `json:"tags,omitempty"`
 	Status      Status         `json:"status"`
 	StatusNote  string         `json:"status_note,omitempty"` // free-form reason for the current status (why rejected/deprecated)
+	StaleAfter  string         `json:"stale_after,omitempty"` // YYYY-MM-DD; the entry is stale on and after this day (OKF SPEC §5.5, design doc 0034 §3.5)
 	CreatedBy   Actor          `json:"created_by"`
+	UpdatedBy   Actor          `json:"updated_by"` // who last changed the content — OKF's generated.by (design doc 0034 §3.3)
 	VerifiedBy  *Actor         `json:"verified_by,omitempty"`
 	VerifiedAt  *time.Time     `json:"verified_at,omitempty"`
 	RejectedBy  *Actor         `json:"rejected_by,omitempty"`
@@ -292,16 +403,18 @@ func Normalize(s string) string { return norm.NFC.String(s) }
 
 // SameContent reports whether o carries the same authored content as k:
 // the fields a writer controls (title, description, resource, tags, status,
-// status_note, links, attrs, body). Server-managed provenance and
-// timestamps (created_*, verified_*, rejected_*, updated_at) and the
-// attachment list are not content. Attrs are compared as canonical JSON,
-// so the same value decoded from YAML (int) and from JSONB (float64)
-// compares equal; values JSON cannot encode compare as different.
+// status_note, stale_after, links, attrs, body). Server-managed provenance
+// and timestamps (created_*, updated_by, verified_*, rejected_*,
+// updated_at) and the attachment list are not content. Attrs are compared
+// as canonical JSON, so the same value decoded from YAML (int) and from
+// JSONB (float64) compares equal; values JSON cannot encode compare as
+// different.
 func (k *Knowledge) SameContent(o *Knowledge) bool {
 	return k.Type == o.Type && k.ID == o.ID &&
 		k.Title == o.Title && k.Description == o.Description &&
 		k.Resource == o.Resource &&
 		k.Status == o.Status && k.StatusNote == o.StatusNote &&
+		k.StaleAfter == o.StaleAfter &&
 		k.Body == o.Body &&
 		slices.Equal(k.Tags, o.Tags) &&
 		slices.Equal(k.Links, o.Links) &&

--- a/internal/domain/knowledge_test.go
+++ b/internal/domain/knowledge_test.go
@@ -223,3 +223,92 @@ func TestToTypesAndToStatuses(t *testing.T) {
 		t.Errorf("ToTypes(nil) = %v, want empty", got)
 	}
 }
+
+// The OKF lifecycle vocabulary is three values to ochakai's four, and the
+// verified key — not the status — is what says a concept was confirmed
+// (SPEC §5.3-5.4, design doc 0034 §3.4).
+func TestOKFStatusMapping(t *testing.T) {
+	for _, tc := range []struct {
+		in   Status
+		want string
+	}{
+		{StatusDraft, "draft"},
+		{StatusVerified, "stable"},
+		{StatusDeprecated, "deprecated"},
+		{StatusRejected, "deprecated"}, // OKF has no "never accepted"
+	} {
+		if got := OKFStatus(tc.in); got != tc.want {
+			t.Errorf("OKFStatus(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+
+	for _, tc := range []struct {
+		raw         string
+		hasVerified bool
+		want        Status
+		wantKnown   bool
+	}{
+		{"stable", true, StatusVerified, true},
+		{"stable", false, StatusDraft, true},
+		{"draft", false, StatusDraft, true},
+		{"draft", true, StatusDraft, true}, // an explicit draft stays one
+		{"deprecated", false, StatusDeprecated, true},
+		{"", false, "", true}, // unset: the write path applies its own default
+		{"", true, StatusVerified, true},
+		{"verified", false, StatusVerified, true}, // written by 0.12 and earlier
+		{"rejected", false, StatusRejected, true},
+		{"retired", false, StatusDraft, false},
+	} {
+		got, known := StatusFromOKF(tc.raw, tc.hasVerified)
+		if got != tc.want || known != tc.wantKnown {
+			t.Errorf("StatusFromOKF(%q, %v) = (%q, %v), want (%q, %v)",
+				tc.raw, tc.hasVerified, got, known, tc.want, tc.wantKnown)
+		}
+	}
+
+	// Every status ochakai can store survives a round-trip through the OKF
+	// vocabulary, except the one the mapping folds on purpose.
+	for _, s := range Statuses {
+		got, known := StatusFromOKF(OKFStatus(s), s == StatusVerified)
+		if !known {
+			t.Errorf("OKFStatus(%q) produced a value StatusFromOKF does not know", s)
+		}
+		if s == StatusRejected {
+			if got != StatusDeprecated {
+				t.Errorf("rejected should land as deprecated, got %q", got)
+			}
+			continue
+		}
+		if got != s {
+			t.Errorf("round-trip of %q gave %q", s, got)
+		}
+	}
+}
+
+func TestValidStaleAfter(t *testing.T) {
+	for _, ok := range []string{"", "2026-12-31", "2026-01-01"} {
+		if !ValidStaleAfter(ok) {
+			t.Errorf("ValidStaleAfter(%q) = false", ok)
+		}
+	}
+	for _, bad := range []string{"soon", "2026-13-01", "2026-02-30", "2026-1-2",
+		"2026-12-31T00:00:00Z", "30 days"} {
+		if ValidStaleAfter(bad) {
+			t.Errorf("ValidStaleAfter(%q) = true", bad)
+		}
+	}
+}
+
+// The recommended vocabulary is one list; every surface that names it
+// reads from there, so adding a type cannot leave a stale copy behind.
+func TestTypesHintCoversEveryBuiltin(t *testing.T) {
+	hint := TypesHint()
+	for _, ty := range Types {
+		if !strings.Contains(hint, string(ty)) {
+			t.Errorf("TypesHint() omits %q: %s", ty, hint)
+		}
+	}
+	if !BuiltinType(TypeComputations) {
+		t.Error("Attested Computation should be a recommended type (design doc 0034 §3.6)")
+	}
+}

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -96,7 +96,8 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"It executes no SQL and uses no LLM. " +
 			"Before answering a data question, call get_context once — it returns the relevant " +
 			"entries in full, links expanded. " +
-			"Prefer verified knowledge and judge trust from provenance (created_by / verified_by). " +
+			"Prefer verified knowledge and judge trust from provenance (created_by / updated_by / verified_by), " +
+			"and treat an entry whose stale_after has passed as due for re-checking, not as wrong. " +
 			"After acting on knowledge (running a golden query, writing SQL from a metric definition), report " +
 			"whether it actually worked with report_outcome — failed reports are how stale " +
 			"verified knowledge gets caught. " +
@@ -262,7 +263,13 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"Before creating, search existing entries including statuses=[\"rejected\"] to avoid " +
 			"re-proposing knowledge that was already rejected (status_note records why). " +
 			"For BigQuery Table/BigQuery Dataset/Reference entries, set resource to the asset's canonical URI and favor " +
-			"the conventional body sections: # Schema, # Common query patterns, # Citations. " +
+			"the conventional body sections: # Schema, # Common query patterns. " +
+			"An \"Attested Computation\" entry records a sanctioned computation others must run instead of " +
+			"improvising: put the computation in a # Computation fence in body and the contract in attrs " +
+			"(runtime, parameters, executor, attester). ochakai stores it and never runs it. " +
+			"Cite the material an entry derives from in attrs.sources — a list of {id, resource, title} — " +
+			"and attribute single claims with markdown footnotes keyed to those ids. " +
+			"Set stale_after when the knowledge has a known expiry date. " +
 			"A semantic model is a \"Semantic Model\" entry with the Apache Ossie model object in attrs.spec " +
 			"(one entry per model). Give each metric its own entry too (last id segment = the metric " +
 			"name, e.g. metrics/<name>) with attrs.expression holding the expression, so the " +
@@ -287,7 +294,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "update_knowledge",
 		Annotations: nonDestructive,
-		Description: "Update a knowledge entry (full replacement of title/description/resource/tags/status/attrs/body — " +
+		Description: "Update a knowledge entry (full replacement of title/description/resource/tags/status/stale_after/attrs/body — " +
 			"an omitted title clears it, making the filename the name). " +
 			"Links are not a field: they come from the markdown links in body, so keep the ones you want to keep. " +
 			"Every change is kept as a revision; an update identical to the stored content writes nothing. " +
@@ -555,7 +562,7 @@ type deleteOut struct {
 }
 
 type writeIn struct {
-	Type        string         `json:"type" jsonschema:"what the entry is: the OKF type, one line; recommended: Metric, Golden Query, Insight, Glossary Term, BigQuery Dataset, BigQuery Table, Reference — any custom type works"`
+	Type        string         `json:"type" jsonschema:"what the entry is: the OKF type, one line; recommended: Metric, Golden Query, Attested Computation, Insight, Glossary Term, BigQuery Dataset, BigQuery Table, Reference — any custom type works"`
 	ID          string         `json:"id" jsonschema:"where the entry lives: its full path, segments separated by / (e.g. metrics/revenue, 用語/売上); place together what should be read together; the last segment must not be \"index\" or \"log\""`
 	Title       string         `json:"title,omitempty" jsonschema:"display name; optional — when omitted, the id's last segment (the filename) is the name; set one only when the filename isn't enough"`
 	Description string         `json:"description,omitempty"`
@@ -563,6 +570,7 @@ type writeIn struct {
 	Tags        []string       `json:"tags,omitempty"`
 	Status      string         `json:"status,omitempty" jsonschema:"draft, verified, deprecated, or rejected; defaults to draft"`
 	StatusNote  string         `json:"status_note,omitempty" jsonschema:"free-form reason for the current status (why rejected/deprecated)"`
+	StaleAfter  string         `json:"stale_after,omitempty" jsonschema:"absolute date (YYYY-MM-DD) after which this entry should be re-checked, e.g. when the quarter it describes closes; omit when nothing dates it"`
 	Attrs       map[string]any `json:"attrs,omitempty" jsonschema:"type-specific structured attributes, e.g. question/sql for a query"`
 	Body        string         `json:"body,omitempty" jsonschema:"markdown body; link to other entries by writing a markdown link to their path — [revenue](/metrics/revenue.md) — and those links become the entry's links"`
 }
@@ -577,6 +585,7 @@ func (in writeIn) toKnowledge() *domain.Knowledge {
 		Tags:        in.Tags,
 		Status:      domain.Status(in.Status),
 		StatusNote:  in.StatusNote,
+		StaleAfter:  in.StaleAfter,
 		Attrs:       in.Attrs,
 		Body:        in.Body,
 	}

--- a/internal/okf/attachment_test.go
+++ b/internal/okf/attachment_test.go
@@ -28,7 +28,7 @@ func TestFromBundleAttachments(t *testing.T) {
 		"terms/broken.md": []byte("---\ntype: Glossary Term\ntitle: x\n---\n\n" +
 			"![missing](nowhere/gone.png)\n"), // broken links are tolerated, never an error
 	}
-	entries, atts, skipped := FromBundle(files)
+	entries, atts, skipped, _ := FromBundle(files)
 	if len(entries) != 3 {
 		t.Fatalf("entries = %d, want 3", len(entries))
 	}
@@ -57,7 +57,7 @@ func TestFromBundleRootConceptAttachment(t *testing.T) {
 		"overview.md":   []byte("---\ntype: Insight\ntitle: overview\n---\n\n![chart](img/chart.png)\n"),
 		"img/chart.png": pngBytes(),
 	}
-	_, atts, _ := FromBundle(files)
+	_, atts, _, _ := FromBundle(files)
 	if len(atts) != 1 || atts[0].Path != "img/chart.png" || atts[0].ID != "overview" {
 		t.Fatalf("atts = %+v", atts)
 	}
@@ -74,7 +74,7 @@ func TestFromBundleAttachmentAllowlist(t *testing.T) {
 		"data.csv":   []byte("a,b,c"),
 		"big.png":    append(pngBytes(), make([]byte, domain.MaxAttachmentSize)...),
 	}
-	_, atts, skipped := FromBundle(files)
+	_, atts, skipped, _ := FromBundle(files)
 	if len(atts) != 0 {
 		t.Errorf("nothing should attach, got %+v", atts)
 	}
@@ -94,7 +94,7 @@ func TestFromBundleFileAttachments(t *testing.T) {
 		"data/seeds.txt":         []byte("https://example.com/schema\nhttps://example.com/docs\n"),
 		"tables/orders/spec.pdf": []byte("%PDF-1.7 fake pdf body"),
 	}
-	_, atts, skipped := FromBundle(files)
+	_, atts, skipped, _ := FromBundle(files)
 	got := map[string]string{}
 	for _, a := range atts {
 		got[a.ID+"/"+a.Name] = a.Path
@@ -123,7 +123,7 @@ func TestFromBundleNamespaceAttribution(t *testing.T) {
 		"tables/orders/seeds.txt": []byte("seed data, referenced by no body\n"),
 		"orphan/seeds.txt":        []byte("no entry named orphan\n"),
 	}
-	entries, atts, skipped := FromBundle(files)
+	entries, atts, skipped, _ := FromBundle(files)
 	if len(entries) != 1 {
 		t.Fatalf("entries = %d, want 1", len(entries))
 	}
@@ -150,7 +150,7 @@ func TestFromBundleNamespaceHierarchicalID(t *testing.T) {
 		"queries/sales/monthly.md":           []byte("---\ntype: Golden Query\ntitle: monthly\n---\n"),
 		"queries/sales/monthly/expected.txt": []byte("month,revenue\n2026-01,100\n"),
 	}
-	_, atts, skipped := FromBundle(files)
+	_, atts, skipped, _ := FromBundle(files)
 	if len(atts) != 1 || atts[0].ID != "queries/sales/monthly" || atts[0].Name != "expected.txt" {
 		t.Fatalf("atts = %+v", atts)
 	}

--- a/internal/okf/bundle.go
+++ b/internal/okf/bundle.go
@@ -34,7 +34,7 @@ import (
 // There is no archive unwrapping: `tar czf ga4.tgz ga4/` imports under
 // "ga4/" — the packed shape is the structure, and a wrapper directory is
 // how a bundle keeps its own namespace (design doc 0017 §4.3).
-func FromBundle(files map[string][]byte) (entries []domain.Knowledge, atts []BundleAttachment, skipped []string) {
+func FromBundle(files map[string][]byte) (entries []domain.Knowledge, atts []BundleAttachment, skipped, notes []string) {
 	paths := make([]string, 0, len(files))
 	for p := range files {
 		paths = append(paths, p)
@@ -54,10 +54,13 @@ func FromBundle(files map[string][]byte) (entries []domain.Knowledge, atts []Bun
 			nonMarkdown = append(nonMarkdown, p)
 			continue
 		}
-		k, err := fromBundleFile(clean, files[p])
+		k, docNotes, err := fromBundleFile(clean, files[p])
 		if err != nil {
 			skipped = append(skipped, p+": "+err.Error())
 			continue
+		}
+		for _, n := range docNotes {
+			notes = append(notes, p+": "+n)
 		}
 		entries = append(entries, *k)
 	}
@@ -74,7 +77,7 @@ func FromBundle(files map[string][]byte) (entries []domain.Knowledge, atts []Bun
 	}
 
 	sort.Slice(entries, func(i, j int) bool { return entries[i].ID < entries[j].ID })
-	return entries, atts, skipped
+	return entries, atts, skipped, notes
 }
 
 // cleanPath canonicalizes one bundle path: relative prefix stripped,
@@ -98,20 +101,20 @@ func hiddenPath(clean string) bool {
 	return false
 }
 
-func fromBundleFile(clean string, content []byte) (*domain.Knowledge, error) {
-	k, rawType, err := parseDoc(content)
+func fromBundleFile(clean string, content []byte) (*domain.Knowledge, []string, error) {
+	k, rawType, notes, err := parseDoc(content)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	// Frontmatter is the type's only source: the path no longer claims
 	// one, and OKF requires the key — a file without it is not a concept
 	// (design doc 0017, no guessing).
 	if k.Type == "" {
-		return nil, fmt.Errorf("no type: frontmatter type %q is unusable (the type key is required; any single-line value works)", rawType)
+		return nil, nil, fmt.Errorf("no type: frontmatter type %q is unusable (the type key is required; any single-line value works)", rawType)
 	}
 	k.ID = strings.TrimSuffix(clean, ".md")
 	if !domain.ValidID(k.ID) {
-		return nil, fmt.Errorf("path yields invalid id %q", k.ID)
+		return nil, nil, fmt.Errorf("path yields invalid id %q", k.ID)
 	}
-	return k, nil
+	return k, notes, nil
 }

--- a/internal/okf/bundle_test.go
+++ b/internal/okf/bundle_test.go
@@ -103,7 +103,7 @@ func TestBundleRoundTrip(t *testing.T) {
 			Body:        "本文。", UpdatedAt: now},
 	}
 	files := bundle(t, want)
-	got, _, skipped := FromBundle(files)
+	got, _, skipped, _ := FromBundle(files)
 	if len(skipped) != 0 {
 		t.Fatalf("skipped %v", skipped)
 	}
@@ -135,7 +135,7 @@ func TestBundleTitleOptional(t *testing.T) {
 	files := map[string][]byte{
 		"insights/サンプル.md": []byte("---\ntype: Insight\n---\n\n本文。\n"),
 	}
-	entries, _, skipped := FromBundle(files)
+	entries, _, skipped, _ := FromBundle(files)
 	if len(skipped) != 0 {
 		t.Fatalf("skipped %v", skipped)
 	}
@@ -162,7 +162,7 @@ func TestFromBundleNFCPaths(t *testing.T) {
 			"![chart](" + nfd + "/chart.png)\n"),
 		"insights/" + nfd + "/chart.png": pngBytes(),
 	}
-	entries, atts, skipped := FromBundle(files)
+	entries, atts, skipped, _ := FromBundle(files)
 	if len(skipped) != 0 {
 		t.Fatalf("skipped %v", skipped)
 	}
@@ -190,7 +190,7 @@ func TestFromBundleForeign(t *testing.T) {
 		"notes/2026/q3.md": []byte("---\ntitle: Q3 notes\n---\n"), // no frontmatter type at all
 		"viz.html":         []byte("<html></html>"),
 	}
-	entries, _, skipped := FromBundle(files)
+	entries, _, skipped, _ := FromBundle(files)
 	if len(skipped) != 2 || !strings.Contains(skipped[0], "notes/2026/q3.md") || !strings.Contains(skipped[1], "viz.html") {
 		t.Errorf("skipped = %v, want the typeless document and viz.html", skipped)
 	}
@@ -246,7 +246,7 @@ func TestFromBundleFixture(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	entries, _, skipped := FromBundle(files)
+	entries, _, skipped, _ := FromBundle(files)
 	if len(skipped) != 1 || !strings.Contains(skipped[0], "viz.html") {
 		t.Errorf("skipped = %v, want only viz.html", skipped)
 	}
@@ -299,7 +299,7 @@ func TestFromBundleWrappedArchive(t *testing.T) {
 		"._ga4":                []byte("apple double"),
 		"ga4/.DS_Store":        []byte("finder noise"),
 	}
-	entries, _, skipped := FromBundle(wrapped)
+	entries, _, skipped, _ := FromBundle(wrapped)
 	if len(skipped) != 0 {
 		t.Errorf("skipped = %v, want none (hidden files skip silently)", skipped)
 	}

--- a/internal/okf/okf.go
+++ b/internal/okf/okf.go
@@ -28,37 +28,58 @@ import (
 // nothing is lost on the way out, so nothing has to be restored.
 
 // Version is the OKF spec version ochakai produces, declared in the
-// bundle-root index.md (SPEC §11).
-const Version = "0.1"
+// bundle-root index.md (SPEC §12).
+const Version = "0.2"
 
 // frontmatter is the OKF frontmatter for one concept: the required "type",
-// the recommended keys, and ochakai extension keys. Entry attrs are not
-// nested here — Document emits them as producer-defined top-level keys
-// (SPEC §4.1), so foreign extension keys round-trip in place.
+// the recommended keys, the v0.2 trust and lifecycle families (SPEC §5),
+// and ochakai extension keys. Entry attrs are not nested here — Document
+// emits them as producer-defined top-level keys (SPEC §4.1), so foreign
+// extension keys round-trip in place.
+//
+// The v0.1 spellings are gone, following SPEC §13.1: timestamp is now
+// generated.at, and verified_by/verified_at are now a verified list. Parse
+// still reads the old keys so bundles written by ochakai 0.12 and earlier
+// import unchanged — but nothing writes them again.
 type frontmatter struct {
 	Type        string   `yaml:"type"`
 	Resource    string   `yaml:"resource,omitempty"` // right after type, matching the knowledge-catalog reference bundles
 	Title       string   `yaml:"title,omitempty"`    // empty means the filename is the name (design doc 0022) — omitted, so titleless documents round-trip unchanged
 	Description string   `yaml:"description,omitempty"`
 	Tags        []string `yaml:"tags,omitempty"`
-	Timestamp   string   `yaml:"timestamp"`
-	Status      string   `yaml:"status"`
+	Status      string   `yaml:"status"` // OKF vocabulary: draft | stable | deprecated (design doc 0034 §3.4)
 	StatusNote  string   `yaml:"status_note,omitempty"`
-	CreatedBy   string   `yaml:"created_by"`
-	VerifiedBy  string   `yaml:"verified_by,omitempty"`
-	VerifiedAt  string   `yaml:"verified_at,omitempty"`
+	StaleAfter  string   `yaml:"stale_after,omitempty"`
+	Generated   event    `yaml:"generated"`
+	Verified    []event  `yaml:"verified,omitempty"` // absent means unverified — the trust tier is read from this key's presence (SPEC §5.3)
+	CreatedBy   string   `yaml:"created_by"`         // ochakai extension: OKF records only who produced the current content
 	RejectedBy  string   `yaml:"rejected_by,omitempty"`
 	RejectedAt  string   `yaml:"rejected_at,omitempty"`
 }
 
+// event is one entry of the trust family: who, when, and — as a producer
+// extension — on whose behalf. OKF's actor convention (SPEC §7) has no
+// room for delegation, and folding "A via B" into by would leave a string
+// that is not an actor; a sibling key keeps by parseable and the human:
+// prefix intact, so trust tiers still read correctly (design docs 0027,
+// 0034 §3.2).
+type event struct {
+	By  string `yaml:"by,omitempty"` // required by SPEC §5.2; omitted only for an entry that carries no actor at all
+	Via string `yaml:"via,omitempty"`
+	At  string `yaml:"at,omitempty"`
+}
+
 // reservedKeys are the frontmatter keys the envelope owns. An attr with a
 // reserved name is not exported as an extension key: the envelope value
-// wins.
+// wins. The v0.1 trust keys stay listed: an entry that imported one into
+// attrs before this release must not re-emit it beside the v0.2 key that
+// replaced it.
 var reservedKeys = map[string]bool{
 	"type": true, "id": true, "title": true, "description": true,
-	"resource": true, "tags": true, "timestamp": true, "status": true,
-	"status_note": true, "created_by": true, "verified_by": true,
-	"verified_at": true, "rejected_by": true, "rejected_at": true,
+	"resource": true, "tags": true, "status": true, "status_note": true,
+	"stale_after": true, "generated": true, "verified": true,
+	"created_by": true, "rejected_by": true, "rejected_at": true,
+	"timestamp": true, "verified_by": true, "verified_at": true,
 }
 
 // Indexes renders a bundle's directory index.md files and nothing else,
@@ -153,7 +174,31 @@ func (d *dir) writeIndexes(files map[string][]byte, prefix string) {
 	}
 }
 
+// actorEvent renders one trust event. The actor's kind:name form already
+// matches SPEC §7 for people ("human:tanaka@example.co.jp"); agents keep
+// ochakai's "agent:" prefix rather than being dressed up as a versioned
+// producer or relabelled process, because §5.3 keys trust tiers off the
+// human: prefix alone and nothing else in the convention is load-bearing
+// (design doc 0034 §3.8).
+func actorEvent(a *domain.Actor, at *time.Time) event {
+	var e event
+	if a != nil && (a.Kind != "" || a.Name != "") {
+		e.By, e.Via = a.Kind+":"+a.Name, a.Via
+	}
+	if at != nil {
+		e.At = at.UTC().Format(time.RFC3339)
+	}
+	return e
+}
+
 // Document renders one knowledge entry as an OKF concept document.
+//
+// The trust family follows SPEC §5.2: generated is who the content stands
+// by and when it last changed, verified is the list of confirmations (one,
+// for now — ochakai keeps the latest). status carries OKF's three-value
+// lifecycle, so "verified" leaves the status key entirely and becomes
+// stable plus a verified entry, which is where a v0.2 consumer looks for
+// it (design doc 0034 §3.4).
 func Document(k *domain.Knowledge) ([]byte, error) {
 	fm := frontmatter{
 		Type:        string(k.Type),
@@ -161,16 +206,20 @@ func Document(k *domain.Knowledge) ([]byte, error) {
 		Title:       k.Title,
 		Description: k.Description,
 		Tags:        k.Tags,
-		Timestamp:   k.UpdatedAt.UTC().Format(time.RFC3339),
-		Status:      string(k.Status),
+		Status:      domain.OKFStatus(k.Status),
 		StatusNote:  k.StatusNote,
+		StaleAfter:  k.StaleAfter,
+		Generated:   actorEvent(&k.UpdatedBy, &k.UpdatedAt),
 		CreatedBy:   k.CreatedBy.String(),
 	}
-	if k.VerifiedBy != nil {
-		fm.VerifiedBy = k.VerifiedBy.String()
-	}
-	if k.VerifiedAt != nil {
-		fm.VerifiedAt = k.VerifiedAt.UTC().Format(time.RFC3339)
+	// Status verified always writes a verified entry, even for an entry
+	// carrying no verification actor. The key's presence is what a v0.2
+	// consumer reads the trust tier from (SPEC §5.3), and what carries
+	// "verified" back through an import (design doc 0034 §3.4) — an
+	// exported status of stable with no verified key means unverified, and
+	// would come back as a draft.
+	if k.Status == domain.StatusVerified || k.VerifiedAt != nil || k.VerifiedBy != nil {
+		fm.Verified = []event{actorEvent(k.VerifiedBy, k.VerifiedAt)}
 	}
 	if k.RejectedBy != nil {
 		fm.RejectedBy = k.RejectedBy.String()

--- a/internal/okf/okf_test.go
+++ b/internal/okf/okf_test.go
@@ -21,7 +21,9 @@ func sample() []domain.Knowledge {
 			Type: domain.TypeInsights, ID: "insights/revenue-seasonality",
 			Title: "売上の季節性", Description: "12月は繁忙期",
 			Tags: []string{"sales"}, Status: domain.StatusVerified,
+			StaleAfter: "2026-12-31",
 			CreatedBy:  domain.Actor{Kind: "agent", Name: "claude-code"},
+			UpdatedBy:  domain.Actor{Kind: "agent", Name: "claude-code"},
 			VerifiedBy: &domain.Actor{Kind: "human", Name: "na0"}, VerifiedAt: &verifiedAt,
 			Attrs:     map[string]any{"kind": "seasonality"},
 			Body:      "12月は+40%が通常。[売上](/metrics/revenue.md) の話である。",
@@ -31,6 +33,7 @@ func sample() []domain.Knowledge {
 			Type: domain.TypeTables, ID: "tables/orders",
 			Title: "orders", Status: domain.StatusDraft,
 			CreatedBy: domain.Actor{Kind: "human", Name: "na0"},
+			UpdatedBy: domain.Actor{Kind: "human", Name: "na0", Via: "agent:insightflow"},
 			Resource:  "myproject.shop.orders",
 			Attrs:     map[string]any{"model": "sales_analytics"},
 			UpdatedAt: verifiedAt,
@@ -56,17 +59,36 @@ func TestDocumentFrontmatterAndBody(t *testing.T) {
 	if err := yaml.Unmarshal([]byte(parts[1]), &fm); err != nil {
 		t.Fatalf("frontmatter is not valid YAML: %v", err)
 	}
+	// v0.2 spellings only: timestamp became generated.at, and the flat
+	// verified_by/verified_at became the verified list (SPEC §13.1). A
+	// verified entry is stable plus a verification, not status: verified
+	// (design doc 0034 §3.4).
 	for key, want := range map[string]any{
 		"type":        "Insight",
 		"title":       "売上の季節性",
-		"status":      "verified",
+		"status":      "stable",
+		"stale_after": "2026-12-31",
 		"created_by":  "agent:claude-code",
-		"verified_by": "human:na0",
-		"timestamp":   "2026-07-01T00:00:00Z",
 	} {
 		if fm[key] != want {
 			t.Errorf("frontmatter %s = %v, want %v", key, fm[key], want)
 		}
+	}
+	for _, gone := range []string{"timestamp", "verified_by", "verified_at"} {
+		if _, ok := fm[gone]; ok {
+			t.Errorf("v0.1 key %s must not be written any more:\n%s", gone, parts[1])
+		}
+	}
+	generated, _ := fm["generated"].(map[string]any)
+	if generated["by"] != "agent:claude-code" || generated["at"] != "2026-07-01T00:00:00Z" {
+		t.Errorf("generated = %v, want the last content author and change time", fm["generated"])
+	}
+	verified, _ := fm["verified"].([]any)
+	if len(verified) != 1 {
+		t.Fatalf("verified = %v, want a one-element list", fm["verified"])
+	}
+	if v, _ := verified[0].(map[string]any); v["by"] != "human:na0" || v["at"] != "2026-07-01T00:00:00Z" {
+		t.Errorf("verified[0] = %v, want the human reviewer and time", verified[0])
 	}
 	if _, ok := fm["id"]; ok {
 		t.Errorf("id must not export — the path is the id (design doc 0016):\n%s", parts[1])
@@ -100,8 +122,11 @@ func TestDocumentRejectedProvenance(t *testing.T) {
 		t.Fatal(err)
 	}
 	s := string(doc)
+	// OKF has no state for "was never accepted", so a rejection exports as
+	// deprecated; the reason and the actor survive as status_note and the
+	// ochakai extension keys (design doc 0034 §3.4).
 	for _, want := range []string{
-		"status: rejected",
+		"status: deprecated",
 		"status_note: revenue-seasonality と重複",
 		"rejected_by: human:na0",
 		`rejected_at: "2026-07-16T00:00:00Z"`,
@@ -109,6 +134,28 @@ func TestDocumentRejectedProvenance(t *testing.T) {
 		if !strings.Contains(s, want) {
 			t.Errorf("document missing %q:\n%s", want, s)
 		}
+	}
+	if strings.Contains(s, "verified:") {
+		t.Errorf("an unverified entry must carry no verified key — its absence is the trust tier (SPEC §5.3):\n%s", s)
+	}
+}
+
+// The delegating caller travels as a sibling of by, so by stays a bare
+// actor and the human: prefix a consumer keys trust off stays readable
+// (design docs 0027, 0034 §3.2).
+func TestDocumentDelegatedActor(t *testing.T) {
+	entries := sample()
+	doc, err := Document(&entries[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fm map[string]any
+	if err := yaml.Unmarshal([]byte(strings.SplitN(string(doc), "---\n", 3)[1]), &fm); err != nil {
+		t.Fatal(err)
+	}
+	generated, _ := fm["generated"].(map[string]any)
+	if generated["by"] != "human:na0" || generated["via"] != "agent:insightflow" {
+		t.Errorf("generated = %v, want by and via kept apart", fm["generated"])
 	}
 }
 
@@ -144,7 +191,7 @@ func TestBundleLayoutAndIndexes(t *testing.T) {
 	if !strings.Contains(root, "[insights/](insights/index.md)") {
 		t.Errorf("root index missing type link:\n%s", root)
 	}
-	if !strings.HasPrefix(root, "---\nokf_version: \"0.1\"\n---\n") {
+	if !strings.HasPrefix(root, "---\nokf_version: \"0.2\"\n---\n") {
 		t.Errorf("root index must declare okf_version:\n%s", root)
 	}
 }

--- a/internal/okf/parse.go
+++ b/internal/okf/parse.go
@@ -3,6 +3,7 @@ package okf
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 
@@ -12,20 +13,55 @@ import (
 // Parse is the inverse of Document: it reads an OKF concept document
 // (YAML frontmatter + markdown body) into a knowledge entry, so
 // `ochakai get` output round-trips through `ochakai update`. Server-owned
-// keys (timestamp, created_by, verified_*) are ignored — provenance comes
-// from authentication, never from the payload. Links are not read here
-// either: they are derived from the body's markdown links when the entry
-// is written (design doc 0024), so a "# Links" section is just prose that
+// keys (generated, verified, created_by, rejected_*, and their v0.1
+// spellings) are ignored — provenance comes from authentication, never
+// from the payload (design doc 0009). Links are not read here either:
+// they are derived from the body's markdown links when the entry is
+// written (design doc 0024), so a "# Links" section is just prose that
 // happens to contain links, and is picked up as such.
-func Parse(doc []byte) (*domain.Knowledge, error) {
-	k, rawType, err := parseDoc(doc)
+//
+// notes carries what the parse decided, for the caller to report: nothing
+// here rejects a document over a field value, per SPEC §11, but a
+// reinterpreted field should not be silent either.
+func Parse(doc []byte) (k *domain.Knowledge, notes []string, err error) {
+	k, rawType, notes, err := parseDoc(doc)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if k.Type == "" {
-		return nil, fmt.Errorf(`unusable type %q (one line, no "/", up to 128 bytes; recommended: Metric, Golden Query, Insight, Glossary Term, BigQuery Dataset, BigQuery Table, Reference)`, rawType)
+		return nil, nil, fmt.Errorf(`unusable type %q (one line, no "/", up to 128 bytes; recommended: %s)`, rawType, domain.TypesHint())
 	}
-	return k, nil
+	return k, notes, nil
+}
+
+// yamlScalar renders decoded YAML timestamps back as text, recursing into
+// lists and mappings. YAML types an unquoted date, so `stale_after:
+// 2026-12-31` arrives as a time.Time — and an extension key holding one
+// (OKF's sources[].last_modified, usage_window) would be stored as JSON
+// and come back out as a full RFC 3339 timestamp, quietly turning the
+// producer's date into something it did not write. A value with no clock
+// component is a date; anything else keeps its instant.
+func yamlScalar(v any) any {
+	switch v := v.(type) {
+	case time.Time:
+		if v.Hour() == 0 && v.Minute() == 0 && v.Second() == 0 && v.Nanosecond() == 0 {
+			return v.Format(domain.StaleAfterLayout)
+		}
+		return v.Format(time.RFC3339)
+	case []any:
+		out := make([]any, len(v))
+		for i := range v {
+			out[i] = yamlScalar(v[i])
+		}
+		return out
+	case map[string]any:
+		out := make(map[string]any, len(v))
+		for k, e := range v {
+			out[k] = yamlScalar(e)
+		}
+		return out
+	}
+	return v
 }
 
 // parseDoc parses one OKF document, also returning the frontmatter type
@@ -33,20 +69,27 @@ func Parse(doc []byte) (*domain.Knowledge, error) {
 // frontmatter carries no type a knowledge entry can hold.
 //
 // Frontmatter keys fall into three groups. Envelope keys (type, id, title,
-// description, tags, status, status_note) map to Knowledge fields.
-// Server-owned keys (timestamp, created_by, verified_*, rejected_*) are
-// ignored \u2014 provenance comes from authentication. Everything else is a
-// producer-defined extension key (OKF SPEC \u00a74.1) and is kept as-is in
-// attrs, so foreign keys like "resource" or "owner" survive a round-trip
-// at their original top-level position. A nested "attrs" map (the shape
-// older ochakai exports wrote) is folded in for backward compatibility.
-func parseDoc(doc []byte) (*domain.Knowledge, string, error) {
+// description, tags, status, status_note, stale_after) map to Knowledge
+// fields. Server-owned keys (generated, verified, created_by, rejected_*,
+// and the v0.1 spellings timestamp / verified_by / verified_at) are
+// ignored \u2014 provenance comes from authentication (design doc 0009).
+// Everything else is a producer-defined extension key (OKF SPEC \u00a74.1) and
+// is kept as-is in attrs, so foreign keys like "sources" or "runtime"
+// survive a round-trip at their original top-level position. A nested
+// "attrs" map (the shape older ochakai exports wrote) is folded in for
+// backward compatibility.
+//
+// The one thing read out of the trust family is whether a verified key is
+// present at all: under SPEC \u00a75.3 that, not the status, is what says a
+// concept was confirmed, so it decides how "stable" lands here (design doc
+// 0034 \u00a73.4). Its actors and timestamps are still not read.
+func parseDoc(doc []byte) (*domain.Knowledge, string, []string, error) {
 	s := strings.TrimPrefix(string(doc), "\ufeff")
 	// OKF specifies UTF-8 markdown but not line endings; normalize CRLF so
 	// the delimiter scan below works on bundles authored on Windows.
 	s = strings.ReplaceAll(s, "\r\n", "\n")
 	if !strings.HasPrefix(s, "---\n") {
-		return nil, "", fmt.Errorf("not an OKF document: missing --- frontmatter")
+		return nil, "", nil, fmt.Errorf("not an OKF document: missing --- frontmatter")
 	}
 	rest := strings.TrimPrefix(s, "---\n")
 	end := strings.Index(rest, "\n---\n")
@@ -59,25 +102,25 @@ func parseDoc(doc []byte) (*domain.Knowledge, string, error) {
 	case strings.HasSuffix(rest, "\n---"): // document ends at the delimiter
 		fmPart = rest[:len(rest)-len("---")]
 	default:
-		return nil, "", fmt.Errorf("not an OKF document: unterminated frontmatter")
+		return nil, "", nil, fmt.Errorf("not an OKF document: unterminated frontmatter")
 	}
 
 	var raw map[string]any
 	if err := yaml.Unmarshal([]byte(fmPart), &raw); err != nil {
-		return nil, "", fmt.Errorf("invalid frontmatter: %w", err)
+		return nil, "", nil, fmt.Errorf("invalid frontmatter: %w", err)
 	}
 	var str = func(key string) (string, error) {
 		v, ok := raw[key]
 		if !ok || v == nil {
 			return "", nil
 		}
-		s, ok := v.(string)
+		s, ok := yamlScalar(v).(string)
 		if !ok {
 			return "", fmt.Errorf("invalid frontmatter: %s is not a string", key)
 		}
 		return s, nil
 	}
-	var fm struct{ typ, resource, id, title, description, status, statusNote string }
+	var fm struct{ typ, resource, id, title, description, status, statusNote, staleAfter string }
 	for _, f := range []struct {
 		key string
 		dst *string
@@ -85,10 +128,11 @@ func parseDoc(doc []byte) (*domain.Knowledge, string, error) {
 		{"type", &fm.typ}, {"resource", &fm.resource}, {"id", &fm.id},
 		{"title", &fm.title}, {"description", &fm.description},
 		{"status", &fm.status}, {"status_note", &fm.statusNote},
+		{"stale_after", &fm.staleAfter},
 	} {
 		var err error
 		if *f.dst, err = str(f.key); err != nil {
-			return nil, "", err
+			return nil, "", nil, err
 		}
 	}
 	var tags []string
@@ -98,14 +142,14 @@ func parseDoc(doc []byte) (*domain.Knowledge, string, error) {
 			for _, t := range v {
 				s, ok := t.(string)
 				if !ok {
-					return nil, "", fmt.Errorf("invalid frontmatter: tags is not a list of strings")
+					return nil, "", nil, fmt.Errorf("invalid frontmatter: tags is not a list of strings")
 				}
 				tags = append(tags, s)
 			}
 		case string:
 			// The knowledge-catalog reference bundles sometimes write tags as
 			// one comma-separated string ("tags: sales, orders"); OKF's
-			// permissive consumption model (SPEC §9) says take it, not
+			// permissive consumption model (SPEC §11) says take it, not
 			// reject the document.
 			for _, s := range strings.Split(v, ",") {
 				if s = strings.TrimSpace(s); s != "" {
@@ -113,7 +157,7 @@ func parseDoc(doc []byte) (*domain.Knowledge, string, error) {
 				}
 			}
 		default:
-			return nil, "", fmt.Errorf("invalid frontmatter: tags is not a list")
+			return nil, "", nil, fmt.Errorf("invalid frontmatter: tags is not a list")
 		}
 	}
 
@@ -122,14 +166,17 @@ func parseDoc(doc []byte) (*domain.Knowledge, string, error) {
 		if attrs == nil {
 			attrs = map[string]any{}
 		}
-		attrs[key] = v
+		attrs[key] = yamlScalar(v)
 	}
 	for key, v := range raw {
 		switch key {
-		case "type", "resource", "id", "title", "description", "tags", "status", "status_note":
+		case "type", "resource", "id", "title", "description", "tags", "status", "status_note", "stale_after":
 			// envelope, extracted above
-		case "timestamp", "created_by", "verified_by", "verified_at", "rejected_by", "rejected_at":
-			// server-owned, never from the payload
+		case "generated", "verified", "created_by", "rejected_by", "rejected_at",
+			"timestamp", "verified_by", "verified_at":
+			// server-owned, never from the payload — the last three are the
+			// v0.1 spellings, still read (and still ignored) so bundles
+			// written before v0.2 import unchanged (SPEC §13.1)
 		default:
 			setAttr(key, v)
 		}
@@ -140,6 +187,21 @@ func parseDoc(doc []byte) (*domain.Knowledge, string, error) {
 		typ = ""
 	}
 
+	var notes []string
+	_, hasVerified := raw["verified"]
+	if !hasVerified {
+		// A v0.1 document says the same thing with the flat keys.
+		_, hasVerified = raw["verified_at"]
+	}
+	status, known := domain.StatusFromOKF(strings.TrimSpace(fm.status), hasVerified)
+	if !known {
+		notes = append(notes, fmt.Sprintf("status %q is not an OKF lifecycle value (draft, stable, deprecated); read as %s", fm.status, status))
+	}
+	if !domain.ValidStaleAfter(fm.staleAfter) {
+		notes = append(notes, fmt.Sprintf("stale_after %q is not a YYYY-MM-DD date; dropped", fm.staleAfter))
+		fm.staleAfter = ""
+	}
+
 	return &domain.Knowledge{
 		Type:        typ,
 		ID:          fm.id,
@@ -147,9 +209,10 @@ func parseDoc(doc []byte) (*domain.Knowledge, string, error) {
 		Description: fm.description,
 		Resource:    fm.resource,
 		Tags:        tags,
-		Status:      domain.Status(fm.status),
+		Status:      status,
 		StatusNote:  fm.statusNote,
+		StaleAfter:  fm.staleAfter,
 		Attrs:       attrs,
 		Body:        strings.TrimSpace(body),
-	}, fm.typ, nil
+	}, fm.typ, notes, nil
 }

--- a/internal/okf/parse_test.go
+++ b/internal/okf/parse_test.go
@@ -16,7 +16,7 @@ func TestParseRoundTrip(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		got, err := Parse(doc)
+		got, _, err := Parse(doc)
 		if err != nil {
 			t.Fatalf("Parse(%s): %v", want.URI(), err)
 		}
@@ -51,7 +51,7 @@ func TestParseRoundTrip(t *testing.T) {
 }
 
 func TestParseAcceptsRawTypeAndHandWrittenDoc(t *testing.T) {
-	k, err := Parse([]byte(`---
+	k, _, err := Parse([]byte(`---
 type: Golden Query
 id: monthly-revenue
 title: 月次売上
@@ -85,7 +85,7 @@ func TestParseRejectsGarbage(t *testing.T) {
 		"---\ntype: \ntitle: x\n---\n",    // empty
 		"---\ntype: [a]\ntitle: x\n---\n", // type is not a string
 	} {
-		if _, err := Parse([]byte(doc)); err == nil {
+		if _, _, err := Parse([]byte(doc)); err == nil {
 			t.Errorf("Parse(%q) succeeded, want error", doc)
 		}
 	}
@@ -96,7 +96,7 @@ func TestParseRejectsGarbage(t *testing.T) {
 // stashed in a preservation attr, so the document round-trips because
 // nothing was changed in the first place.
 func TestParseFreeTypes(t *testing.T) {
-	k, err := Parse([]byte("---\ntype: runbook\nid: restore-backup\ntitle: リストア手順\n---\n"))
+	k, _, err := Parse([]byte("---\ntype: runbook\nid: restore-backup\ntitle: リストア手順\n---\n"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,7 +104,7 @@ func TestParseFreeTypes(t *testing.T) {
 		t.Errorf("one-word type: got type=%q attrs=%v", k.Type, k.Attrs)
 	}
 
-	k, err = Parse([]byte("---\ntype: Data Contract\nid: orders-contract\ntitle: 注文契約\n---\n"))
+	k, _, err = Parse([]byte("---\ntype: Data Contract\nid: orders-contract\ntitle: 注文契約\n---\n"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -128,7 +128,7 @@ func TestParseFreeTypes(t *testing.T) {
 // (SPEC §4.1): they land in attrs as-is and export back to the top level,
 // so a foreign bundle's resource/owner keys survive a round-trip in place.
 func TestParseKeepsUnknownKeys(t *testing.T) {
-	k, err := Parse([]byte(`---
+	k, _, err := Parse([]byte(`---
 type: Reference
 title: Average Pageviews
 resource: https://developers.google.com/analytics/bigquery/basic-queries
@@ -175,7 +175,7 @@ Body.
 }
 
 func TestParseStatusNoteRoundTrip(t *testing.T) {
-	k, err := Parse([]byte("---\ntype: insight\nid: dup\ntitle: 重複\nstatus: rejected\nstatus_note: 既存と重複\n---\n"))
+	k, _, err := Parse([]byte("---\ntype: insight\nid: dup\ntitle: 重複\nstatus: rejected\nstatus_note: 既存と重複\n---\n"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -188,7 +188,7 @@ func TestParseStatusNoteRoundTrip(t *testing.T) {
 }
 
 func TestParseNormalizesCRLF(t *testing.T) {
-	k, err := Parse([]byte("---\r\ntype: Glossary Term\r\nid: churn\r\ntitle: 解約\r\n---\r\n\r\n本文。\r\n"))
+	k, _, err := Parse([]byte("---\r\ntype: Glossary Term\r\nid: churn\r\ntitle: 解約\r\n---\r\n\r\n本文。\r\n"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -202,7 +202,7 @@ func TestParseKeepsLinksSectionAsBody(t *testing.T) {
 	// structured links. It is ordinary prose now (design doc 0024) — the
 	// links inside it are found by the same extraction as any other.
 	body := "Intro.\n\n# Links\n\nSee [the dashboard](https://example.com) for details."
-	got, err := Parse([]byte("---\ntype: Insight\n---\n\n" + body + "\n"))
+	got, _, err := Parse([]byte("---\ntype: Insight\n---\n\n" + body + "\n"))
 	if err != nil {
 		t.Fatalf("Parse: %v", err)
 	}
@@ -217,12 +217,176 @@ func TestParseKeepsLinksSectionAsBody(t *testing.T) {
 // The knowledge-catalog reference bundles sometimes write tags as one
 // comma-separated string; permissive consumption (SPEC §9) accepts it.
 func TestParseScalarTags(t *testing.T) {
-	k, err := Parse([]byte("---\ntype: Dataset\ntitle: SO\ntags: Stack Overflow, public data, community, Q&A\n---\n"))
+	k, _, err := Parse([]byte("---\ntype: Dataset\ntitle: SO\ntags: Stack Overflow, public data, community, Q&A\n---\n"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	want := []string{"Stack Overflow", "public data", "community", "Q&A"}
 	if !reflect.DeepEqual(k.Tags, want) {
 		t.Errorf("tags = %v, want %v", k.Tags, want)
+	}
+}
+
+// The v0.2 lifecycle vocabulary is three values where ochakai has four,
+// and "a human confirmed this" is the verified key, not a status
+// (SPEC §5.3-5.4, design doc 0034 §3.4).
+func TestParseStatusMapping(t *testing.T) {
+	const verified = "verified:\n  - { by: human:na0, at: 2026-07-01T00:00:00Z }\n"
+	for _, tc := range []struct {
+		name, frontmatter string
+		want              domain.Status
+		wantNote          bool
+	}{
+		{"stable with a verification is verified", "status: stable\n" + verified, domain.StatusVerified, false},
+		{"stable alone is not a review", "status: stable\n", domain.StatusDraft, false},
+		{"a bare verified mapping counts too (SPEC §5.2)", "status: stable\nverified: { by: human:na0, at: 2026-07-01T00:00:00Z }\n", domain.StatusVerified, false},
+		{"draft stays draft", "status: draft\n", domain.StatusDraft, false},
+		{"deprecated stays deprecated", "status: deprecated\n", domain.StatusDeprecated, false},
+		{"an absent status stays unset for the write path to default", "", "", false},
+		{"an absent status with a verification is a confirmation", verified, domain.StatusVerified, false},
+		{"ochakai 0.12 wrote status: verified", "status: verified\n", domain.StatusVerified, false},
+		{"ochakai 0.12 wrote status: rejected", "status: rejected\n", domain.StatusRejected, false},
+		{"an unknown value is a draft, not a rejected document", "status: retired\n", domain.StatusDraft, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			k, notes, err := Parse([]byte("---\ntype: Insight\n" + tc.frontmatter + "---\n"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if k.Status != tc.want {
+				t.Errorf("status = %q, want %q", k.Status, tc.want)
+			}
+			if got := len(notes) > 0; got != tc.wantNote {
+				t.Errorf("notes = %v, want a note: %v", notes, tc.wantNote)
+			}
+			// The trust family is read for its presence only; the actors
+			// and times stay outside the payload (design doc 0009).
+			if k.VerifiedBy != nil || k.VerifiedAt != nil {
+				t.Errorf("a bundle must not set verification provenance: %v %v", k.VerifiedBy, k.VerifiedAt)
+			}
+			for _, key := range []string{"verified", "generated", "status"} {
+				if _, ok := k.Attrs[key]; ok {
+					t.Errorf("%s leaked into attrs: %v", key, k.Attrs)
+				}
+			}
+		})
+	}
+}
+
+// A v0.1 document keeps importing: the renamed keys are read (and, being
+// server-owned, ignored) rather than landing in attrs where a re-export
+// would write them beside their v0.2 replacements (SPEC §13.1).
+func TestParseV01Document(t *testing.T) {
+	k, _, err := Parse([]byte(`---
+type: Insight
+title: 売上の季節性
+status: verified
+timestamp: '2026-05-28T22:51:43+00:00'
+created_by: 'agent:claude-code'
+verified_by: 'human:na0'
+verified_at: '2026-06-01T00:00:00Z'
+---
+
+Body.
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if k.Status != domain.StatusVerified {
+		t.Errorf("status = %q, want verified", k.Status)
+	}
+	if len(k.Attrs) != 0 {
+		t.Errorf("v0.1 trust keys must not become attrs: %v", k.Attrs)
+	}
+	doc, err := Document(k)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, gone := range []string{"timestamp:", "verified_by:", "verified_at:"} {
+		if strings.Contains(string(doc), gone) {
+			t.Errorf("re-export wrote the v0.1 key %q:\n%s", gone, doc)
+		}
+	}
+}
+
+func TestParseStaleAfter(t *testing.T) {
+	k, notes, err := Parse([]byte("---\ntype: Insight\nstale_after: 2026-12-31\n---\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if k.StaleAfter != "2026-12-31" || len(notes) != 0 {
+		t.Errorf("stale_after = %q, notes = %v", k.StaleAfter, notes)
+	}
+	if _, ok := k.Attrs["stale_after"]; ok {
+		t.Errorf("stale_after is an envelope key, not an attr: %v", k.Attrs)
+	}
+	doc, err := Document(k)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(doc), "stale_after: \"2026-12-31\"") {
+		t.Errorf("stale_after lost on export:\n%s", doc)
+	}
+
+	// A malformed date is dropped with a note — the document still imports
+	// (SPEC §11).
+	k, notes, err = Parse([]byte("---\ntype: Insight\nstale_after: soon\n---\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if k.StaleAfter != "" || len(notes) != 1 {
+		t.Errorf("stale_after = %q, notes = %v", k.StaleAfter, notes)
+	}
+}
+
+// OKF's own families are producer data ochakai does not interpret: sources
+// and the Attested Computation contract ride through attrs, in place
+// (design doc 0034 §§3.6-3.7).
+func TestParseKeepsOKFFamiliesAsAttrs(t *testing.T) {
+	doc := []byte(`---
+type: Attested Computation
+title: Revenue for fiscal year
+runtime: bigquery
+parameters:
+  - { name: year, type: integer, required: true }
+executor:
+  resource: references/skills/run-on-bq.md
+  receipt: [job_id, executed_sql, result]
+attester:
+  resource: references/attesters/revenue.py
+sources:
+  - id: rev-policy
+    resource: https://wiki.example/finance/revenue-recognition
+    title: Revenue recognition policy
+usage_window: { from: 2026-06-01, to: 2026-06-30 }
+---
+
+# Computation
+
+    SELECT SUM(amount) FROM finance.recognized_revenue WHERE fiscal_year = @year
+`)
+	k, notes, err := Parse(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(notes) != 0 {
+		t.Errorf("nothing here needs reinterpreting: %v", notes)
+	}
+	if k.Type != domain.TypeComputations {
+		t.Errorf("type = %q, want %q", k.Type, domain.TypeComputations)
+	}
+	for _, key := range []string{"runtime", "parameters", "executor", "attester", "sources", "usage_window"} {
+		if _, ok := k.Attrs[key]; !ok {
+			t.Errorf("%s did not survive as an attr: %v", key, k.Attrs)
+		}
+	}
+	out, err := Document(k)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"runtime: bigquery", "attester:", "sources:", "usage_window:", "# Computation"} {
+		if !strings.Contains(string(out), want) {
+			t.Errorf("re-export missing %q:\n%s", want, out)
+		}
 	}
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -105,7 +105,7 @@ func (s *Service) create(ctx context.Context, k *domain.Knowledge, actor domain.
 		k.Status = domain.StatusDraft
 	}
 	s.applyVerification(k, nil, actor)
-	k.CreatedBy = actor
+	k.CreatedBy, k.UpdatedBy = actor, actor
 	if err := s.Store.Create(ctx, k, keepCuratedTombstones); err != nil {
 		return nil, err
 	}
@@ -150,6 +150,10 @@ func (s *Service) Update(ctx context.Context, k *domain.Knowledge, actor domain.
 	if k.SameContent(old) {
 		return old, false, nil
 	}
+	// Past this point the content really changes, so the caller is who the
+	// entry now stands by — OKF's generated.by (design doc 0034 §3.3).
+	// Unchanged writes return above and leave the old one in place.
+	k.UpdatedBy = actor
 	s.applyVerification(k, old, actor)
 	// Pass the precondition through so the write is also guarded against a
 	// concurrent update landing between the Get above and the write.
@@ -372,13 +376,16 @@ func deriveLinks(k *domain.Knowledge) {
 
 func validate(k *domain.Knowledge) error {
 	if !domain.ValidType(k.Type) {
-		return Invalidf(`invalid type %q (one line, no "/", up to 128 bytes; recommended: Metric, Golden Query, Insight, Glossary Term, BigQuery Dataset, BigQuery Table, Reference)`, k.Type)
+		return Invalidf(`invalid type %q (one line, no "/", up to 128 bytes; recommended: %s)`, k.Type, domain.TypesHint())
 	}
 	if !domain.ValidID(k.ID) {
 		return Invalidf(`invalid id %q (path segments separated by "/", e.g. sales/orders; segments must not start with "." and the last must not be "index" or "log")`, k.ID)
 	}
 	if k.Status != "" && !domain.ValidStatus(k.Status) {
 		return Invalidf("invalid status %q (valid: draft, verified, deprecated, rejected)", k.Status)
+	}
+	if !domain.ValidStaleAfter(k.StaleAfter) {
+		return Invalidf("invalid stale_after %q (an absolute date, YYYY-MM-DD, e.g. 2026-12-31)", k.StaleAfter)
 	}
 	return nil
 }

--- a/internal/service/service_integration_test.go
+++ b/internal/service/service_integration_test.go
@@ -597,3 +597,94 @@ func TestVerificationTimestampsSurviveTheRoundTripIntegration(t *testing.T) {
 		})
 	}
 }
+
+// updated_by is OKF's generated.by: who the content stands by now. It
+// follows content changes and nothing else — a verification confirms the
+// content, it does not produce it, which is the distinction v0.2 draws
+// between verified and generated (design doc 0034 §3.3).
+func TestUpdatedByFollowsContentIntegration(t *testing.T) {
+	ctx := context.Background()
+	svc := newIntegrationService(t, ctx)
+	author := domain.Actor{Kind: "agent", Name: "claude-code"}
+	editor := domain.Actor{Kind: "human", Name: "tanaka"}
+	reviewer := domain.Actor{Kind: "human", Name: "na0"}
+
+	id := uid("generated-by")
+	k, err := svc.Create(ctx, &domain.Knowledge{
+		Type: domain.TypeTerms, ID: id, Title: id, Body: "First.",
+		StaleAfter: "2026-12-31",
+	}, author)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if k.UpdatedBy != author || k.CreatedBy != author {
+		t.Fatalf("create: created_by=%v updated_by=%v, want both %v", k.CreatedBy, k.UpdatedBy, author)
+	}
+	if k.StaleAfter != "2026-12-31" {
+		t.Errorf("stale_after = %q on the create response", k.StaleAfter)
+	}
+
+	// An update that changes nothing writes nothing, so it must not
+	// re-attribute the content either.
+	if _, changed, err := svc.Update(ctx, &domain.Knowledge{
+		Type: domain.TypeTerms, ID: id, Title: id, Body: "First.", StaleAfter: "2026-12-31",
+	}, editor, nil); err != nil || changed {
+		t.Fatalf("no-op update: changed=%v err=%v", changed, err)
+	}
+	read, err := svc.Get(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if read.UpdatedBy != author {
+		t.Errorf("a no-op update re-attributed the content to %v", read.UpdatedBy)
+	}
+	if read.StaleAfter != "2026-12-31" {
+		t.Errorf("stale_after = %q after a round-trip through the database", read.StaleAfter)
+	}
+
+	if _, changed, err := svc.Update(ctx, &domain.Knowledge{
+		Type: domain.TypeTerms, ID: id, Title: id, Body: "Second.",
+	}, editor, nil); err != nil || !changed {
+		t.Fatalf("real update: changed=%v err=%v", changed, err)
+	}
+	if read, err = svc.Get(ctx, id); err != nil {
+		t.Fatal(err)
+	}
+	if read.UpdatedBy != editor {
+		t.Errorf("updated_by = %v after an edit by %v", read.UpdatedBy, editor)
+	}
+	if read.CreatedBy != author {
+		t.Errorf("created_by moved to %v; it belongs to whoever created the entry", read.CreatedBy)
+	}
+	if read.StaleAfter != "" {
+		t.Errorf("stale_after = %q; an update that omits it clears it, like every other content field", read.StaleAfter)
+	}
+
+	if _, err := svc.Verify(ctx, id, reviewer); err != nil {
+		t.Fatal(err)
+	}
+	if read, err = svc.Get(ctx, id); err != nil {
+		t.Fatal(err)
+	}
+	if read.UpdatedBy != editor {
+		t.Errorf("a verification changed updated_by to %v; confirming is not producing", read.UpdatedBy)
+	}
+	if read.VerifiedBy == nil || *read.VerifiedBy != reviewer {
+		t.Errorf("verified_by = %v, want %v", read.VerifiedBy, reviewer)
+	}
+}
+
+// A stale_after that is not an absolute date is refused at the boundary
+// rather than reaching the date column (OKF SPEC §5.5).
+func TestStaleAfterValidationIntegration(t *testing.T) {
+	ctx := context.Background()
+	svc := newIntegrationService(t, ctx)
+	actor := domain.Actor{Kind: "human", Name: "test"}
+	_, err := svc.Create(ctx, &domain.Knowledge{
+		Type: domain.TypeTerms, ID: uid("bad-stale"), Title: "x", StaleAfter: "30 days",
+	}, actor)
+	var invalid *InvalidInputError
+	if !errors.As(err, &invalid) {
+		t.Fatalf("create with a relative stale_after: %v, want an invalid-input error", err)
+	}
+}

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -324,9 +324,12 @@ func TestExampleGoldenQueryRegisters(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	k, err := okf.Parse(doc)
+	k, notes, err := okf.Parse(doc)
 	if err != nil {
 		t.Fatalf("okf.Parse: %v", err)
+	}
+	if len(notes) > 0 {
+		t.Errorf("the shipped example should parse without reinterpretation: %v", notes)
 	}
 	k.ID = "queries/monthly-revenue"
 	if k.Type != domain.TypeQueries {

--- a/internal/store/migrate_integration_test.go
+++ b/internal/store/migrate_integration_test.go
@@ -675,3 +675,92 @@ func TestIntegrationEmbeddingDimChangeIsRefused(t *testing.T) {
 		t.Errorf("re-running with the stored dimension: %v", err)
 	}
 }
+
+// TestMigrationUpdatedByBackfill checks 0019's backfill: updated_by is the
+// actor of the newest revision that changed content, and created_by only
+// for entries whose revisions cannot answer. A verify revision must not
+// win — confirming an entry is not producing its content, which is the
+// whole distinction v0.2 draws between verified and generated (design doc
+// 0034 §3.3).
+func TestMigrationUpdatedByBackfill(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(s.Close)
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck // rollback is the cleanup
+
+	for _, q := range []string{
+		`CREATE SCHEMA okf2_scratch`,
+		`SET LOCAL search_path TO okf2_scratch`,
+		`CREATE TABLE knowledge (
+			id text PRIMARY KEY,
+			created_by_kind text NOT NULL, created_by_name text NOT NULL,
+			created_by_via text NOT NULL DEFAULT '')`,
+		`CREATE TABLE knowledge_revision (
+			id text NOT NULL, rev int NOT NULL, change text NOT NULL,
+			changed_by_kind text NOT NULL, changed_by_name text NOT NULL,
+			changed_by_via text NOT NULL DEFAULT '')`,
+		`INSERT INTO knowledge (id, created_by_kind, created_by_name) VALUES
+			('insights/edited', 'agent', 'claude-code'),
+			('insights/verified-later', 'agent', 'claude-code'),
+			('insights/delegated', 'agent', 'claude-code'),
+			('insights/no-revisions', 'human', 'na0')`,
+		`INSERT INTO knowledge_revision (id, rev, change, changed_by_kind, changed_by_name, changed_by_via) VALUES
+			('insights/edited', 1, 'create', 'agent', 'claude-code', ''),
+			('insights/edited', 2, 'update', 'human', 'tanaka', ''),
+			('insights/verified-later', 1, 'create', 'agent', 'claude-code', ''),
+			('insights/verified-later', 2, 'verify', 'human', 'na0', ''),
+			('insights/delegated', 1, 'create', 'agent', 'claude-code', ''),
+			('insights/delegated', 2, 'move', 'human', 'tanaka', 'agent:insightflow')`,
+	} {
+		if _, err := tx.Exec(ctx, q); err != nil {
+			t.Fatalf("scratch setup: %v\n%s", err, q)
+		}
+	}
+
+	sql, err := migrationFS.ReadFile("migrations/0019_okf_v0_2.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec(ctx, string(sql)); err != nil {
+		t.Fatalf("apply 0019: %v", err)
+	}
+
+	for _, tc := range []struct{ id, want string }{
+		{"insights/edited", "human:tanaka"},                          // the last content change
+		{"insights/verified-later", "agent:claude-code"},             // a verify is not a content change
+		{"insights/delegated", "human:tanaka via agent:insightflow"}, // delegation carries too
+		{"insights/no-revisions", "human:na0"},                       // falls back to created_by
+	} {
+		var a domain.Actor
+		if err := tx.QueryRow(ctx,
+			`SELECT updated_by_kind, updated_by_name, updated_by_via FROM knowledge WHERE id = $1`,
+			tc.id).Scan(&a.Kind, &a.Name, &a.Via); err != nil {
+			t.Fatalf("%s: %v", tc.id, err)
+		}
+		if a.String() != tc.want {
+			t.Errorf("%s updated_by = %q, want %q", tc.id, a.String(), tc.want)
+		}
+	}
+
+	// The column exists and takes a date; NULL means "nothing dates this".
+	var staleAfter *time.Time
+	if err := tx.QueryRow(ctx,
+		`SELECT stale_after FROM knowledge WHERE id = 'insights/edited'`).Scan(&staleAfter); err != nil {
+		t.Fatalf("stale_after: %v", err)
+	}
+	if staleAfter != nil {
+		t.Errorf("stale_after = %v, want NULL for an entry that never set one", staleAfter)
+	}
+}

--- a/internal/store/migrations/0019_okf_v0_2.sql
+++ b/internal/store/migrations/0019_okf_v0_2.sql
@@ -1,0 +1,42 @@
+-- OKF v0.2 (design doc 0034) needs two things the envelope did not have.
+--
+-- updated_by: OKF's generated.by is "who produced the content as it now
+-- stands" (SPEC §5.2). ochakai only knew created_by — accurate until
+-- somebody else edits the entry, after which exporting created_by as the
+-- generator is a lie. The revision table always held the answer; this
+-- lifts it onto the entry so a read (and an export) does not have to walk
+-- history.
+--
+-- stale_after: the lifecycle date from SPEC §5.5. A date, not a
+-- timestamp: staleness is `today >= stale_after`, and neither side of
+-- that comparison should depend on a timezone.
+--
+-- The backfill takes the actor of the newest revision that changed
+-- content (create, update, move), falling back to created_by for rows
+-- whose revisions predate the change kinds or were purged. Verify
+-- revisions are deliberately excluded: confirming an entry is not
+-- producing its content, which is exactly the distinction v0.2 draws
+-- between verified and generated.
+
+ALTER TABLE knowledge ADD COLUMN IF NOT EXISTS updated_by_kind text NOT NULL DEFAULT '';
+ALTER TABLE knowledge ADD COLUMN IF NOT EXISTS updated_by_name text NOT NULL DEFAULT '';
+ALTER TABLE knowledge ADD COLUMN IF NOT EXISTS updated_by_via  text NOT NULL DEFAULT '';
+ALTER TABLE knowledge ADD COLUMN IF NOT EXISTS stale_after     date;
+
+UPDATE knowledge k SET
+    updated_by_kind = COALESCE(r.changed_by_kind, k.created_by_kind),
+    updated_by_name = COALESCE(r.changed_by_name, k.created_by_name),
+    updated_by_via  = COALESCE(r.changed_by_via, k.created_by_via)
+FROM (
+    SELECT DISTINCT ON (id) id, changed_by_kind, changed_by_name, changed_by_via
+    FROM knowledge_revision
+    WHERE change IN ('create', 'update', 'move')
+    ORDER BY id, rev DESC
+) r
+WHERE r.id = k.id AND k.updated_by_kind = '';
+
+UPDATE knowledge SET
+    updated_by_kind = created_by_kind,
+    updated_by_name = created_by_name,
+    updated_by_via  = created_by_via
+WHERE updated_by_kind = '';

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -152,8 +152,9 @@ type Filter struct {
 	Tags     []string
 }
 
-const knowledgeCols = `type, id, title, description, resource, tags, status, status_note,
+const knowledgeCols = `type, id, title, description, resource, tags, status, status_note, stale_after,
 	created_by_kind, created_by_name, created_by_via,
+	updated_by_kind, updated_by_name, updated_by_via,
 	verified_by_kind, verified_by_name, verified_by_via, verified_at,
 	rejected_by_kind, rejected_by_name, rejected_by_via, rejected_at,
 	links, attrs, body, created_at, updated_at`
@@ -165,21 +166,41 @@ const knowledgeCols = `type, id, title, description, resource, tags, status, sta
 func knowledgeDest(k *domain.Knowledge) (dests []any, finish func() error) {
 	var verifiedKind, verifiedName, rejectedKind, rejectedName *string
 	var verifiedVia, rejectedVia string
+	var staleAfter *time.Time
 	var links, attrs []byte
-	dests = []any{&k.Type, &k.ID, &k.Title, &k.Description, &k.Resource, &k.Tags, &k.Status, &k.StatusNote,
+	dests = []any{&k.Type, &k.ID, &k.Title, &k.Description, &k.Resource, &k.Tags, &k.Status, &k.StatusNote, &staleAfter,
 		&k.CreatedBy.Kind, &k.CreatedBy.Name, &k.CreatedBy.Via,
+		&k.UpdatedBy.Kind, &k.UpdatedBy.Name, &k.UpdatedBy.Via,
 		&verifiedKind, &verifiedName, &verifiedVia, &k.VerifiedAt,
 		&rejectedKind, &rejectedName, &rejectedVia, &k.RejectedAt,
 		&links, &attrs, &k.Body, &k.CreatedAt, &k.UpdatedAt}
 	finish = func() error {
 		k.VerifiedBy = actorFrom(verifiedKind, verifiedName, verifiedVia)
 		k.RejectedBy = actorFrom(rejectedKind, rejectedName, rejectedVia)
+		if staleAfter != nil {
+			k.StaleAfter = staleAfter.UTC().Format(domain.StaleAfterLayout)
+		}
 		if err := json.Unmarshal(links, &k.Links); err != nil {
 			return err
 		}
 		return json.Unmarshal(attrs, &k.Attrs)
 	}
 	return dests, finish
+}
+
+// staleAfterArg turns the entry's stale_after into a date argument: NULL
+// when unset. The value is validated at the service boundary, so a
+// malformed one here is a bug, not user input — it fails the write rather
+// than being silently dropped.
+func staleAfterArg(s string) (*time.Time, error) {
+	if s == "" {
+		return nil, nil
+	}
+	d, err := time.Parse(domain.StaleAfterLayout, s)
+	if err != nil {
+		return nil, fmt.Errorf("stale_after %q: %w", s, err)
+	}
+	return &d, nil
 }
 
 func scanKnowledge(row pgx.CollectableRow) (domain.Knowledge, error) {
@@ -279,18 +300,23 @@ func (s *Store) Create(ctx context.Context, k *domain.Knowledge, keepCuratedTomb
 	// instead of being erased by it.
 	revive := ""
 	if keepCuratedTombstones {
-		revive = ` AND knowledge.status <> ALL($25::text[])`
+		revive = ` AND knowledge.status <> ALL($29::text[])`
 	}
 	return s.withTx(ctx, func(tx pgx.Tx) error {
 		links, attrs, err := marshalJSONFields(k)
 		if err != nil {
 			return err
 		}
+		staleAfter, err := staleAfterArg(k.StaleAfter)
+		if err != nil {
+			return err
+		}
 		verifiedKind, verifiedName, verifiedVia := actorPtrs(k.VerifiedBy)
 		rejectedKind, rejectedName, rejectedVia := actorPtrs(k.RejectedBy)
 		args := []any{
-			k.Type, k.ID, k.Title, k.Description, k.Resource, k.Tags, k.Status, k.StatusNote,
+			k.Type, k.ID, k.Title, k.Description, k.Resource, k.Tags, k.Status, k.StatusNote, staleAfter,
 			k.CreatedBy.Kind, k.CreatedBy.Name, k.CreatedBy.Via,
+			k.UpdatedBy.Kind, k.UpdatedBy.Name, k.UpdatedBy.Via,
 			verifiedKind, verifiedName, verifiedVia, k.VerifiedAt,
 			rejectedKind, rejectedName, rejectedVia, k.RejectedAt,
 			links, attrs, k.Body, k.CreatedAt, k.UpdatedAt,
@@ -303,13 +329,15 @@ func (s *Store) Create(ctx context.Context, k *domain.Knowledge, keepCuratedTomb
 			args = append(args, curated)
 		}
 		tag, err := tx.Exec(ctx, `INSERT INTO knowledge (`+knowledgeCols+`)
-			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28)
 			ON CONFLICT (id) DO UPDATE SET
 				type=EXCLUDED.type,
 				title=EXCLUDED.title, description=EXCLUDED.description, resource=EXCLUDED.resource, tags=EXCLUDED.tags,
-				status=EXCLUDED.status, status_note=EXCLUDED.status_note,
+				status=EXCLUDED.status, status_note=EXCLUDED.status_note, stale_after=EXCLUDED.stale_after,
 				created_by_kind=EXCLUDED.created_by_kind, created_by_name=EXCLUDED.created_by_name,
 				created_by_via=EXCLUDED.created_by_via,
+				updated_by_kind=EXCLUDED.updated_by_kind, updated_by_name=EXCLUDED.updated_by_name,
+				updated_by_via=EXCLUDED.updated_by_via,
 				verified_by_kind=EXCLUDED.verified_by_kind, verified_by_name=EXCLUDED.verified_by_name,
 				verified_by_via=EXCLUDED.verified_by_via, verified_at=EXCLUDED.verified_at,
 				rejected_by_kind=EXCLUDED.rejected_by_kind, rejected_by_name=EXCLUDED.rejected_by_name,
@@ -352,10 +380,15 @@ func (s *Store) Update(ctx context.Context, k *domain.Knowledge, actor domain.Ac
 		if err != nil {
 			return err
 		}
+		staleAfter, err := staleAfterArg(k.StaleAfter)
+		if err != nil {
+			return err
+		}
 		verifiedKind, verifiedName, verifiedVia := actorPtrs(k.VerifiedBy)
 		rejectedKind, rejectedName, rejectedVia := actorPtrs(k.RejectedBy)
 		cond := ""
-		args := []any{k.ID, k.Type, k.Title, k.Description, k.Resource, k.Tags, k.Status, k.StatusNote,
+		args := []any{k.ID, k.Type, k.Title, k.Description, k.Resource, k.Tags, k.Status, k.StatusNote, staleAfter,
+			k.UpdatedBy.Kind, k.UpdatedBy.Name, k.UpdatedBy.Via,
 			verifiedKind, verifiedName, verifiedVia, k.VerifiedAt,
 			rejectedKind, rejectedName, rejectedVia, k.RejectedAt,
 			links, attrs, k.Body, k.UpdatedAt}
@@ -364,10 +397,11 @@ func (s *Store) Update(ctx context.Context, k *domain.Knowledge, actor domain.Ac
 			cond = fmt.Sprintf(" AND updated_at=$%d", len(args))
 		}
 		tag, err := tx.Exec(ctx, `UPDATE knowledge SET
-			type=$2, title=$3, description=$4, resource=$5, tags=$6, status=$7, status_note=$8,
-			verified_by_kind=$9, verified_by_name=$10, verified_by_via=$11, verified_at=$12,
-			rejected_by_kind=$13, rejected_by_name=$14, rejected_by_via=$15, rejected_at=$16,
-			links=$17, attrs=$18, body=$19, updated_at=$20
+			type=$2, title=$3, description=$4, resource=$5, tags=$6, status=$7, status_note=$8, stale_after=$9,
+			updated_by_kind=$10, updated_by_name=$11, updated_by_via=$12,
+			verified_by_kind=$13, verified_by_name=$14, verified_by_via=$15, verified_at=$16,
+			rejected_by_kind=$17, rejected_by_name=$18, rejected_by_via=$19, rejected_at=$20,
+			links=$21, attrs=$22, body=$23, updated_at=$24
 			WHERE id=$1 AND deleted_at IS NULL`+cond, args...)
 		if err != nil {
 			return err
@@ -575,6 +609,10 @@ func (s *Store) Move(ctx context.Context, oldID, newID string, actor domain.Acto
 		return nil, err
 	}
 	k.UpdatedAt = NowStored()
+	// A move rewrites the entry's own relative links and every referrer's
+	// body, so the mover is who the content now stands by: generated.by
+	// in an export (design doc 0034 §3.3).
+	k.UpdatedBy = actor
 	err = s.withTx(ctx, func(tx pgx.Tx) error {
 		// A soft-deleted entry still owns the id — the row holds the primary
 		// key and its revisions hold (id, rev) — so the destination is taken
@@ -599,8 +637,10 @@ func (s *Store) Move(ctx context.Context, oldID, newID string, actor domain.Acto
 		// exactly as in SoftDelete: the Get above ran outside this
 		// transaction.
 		tag, err := tx.Exec(ctx,
-			`UPDATE knowledge SET id=$2, updated_at=$3 WHERE id=$1 AND deleted_at IS NULL`,
-			oldID, newID, k.UpdatedAt)
+			`UPDATE knowledge SET id=$2, updated_at=$3,
+			 updated_by_kind=$4, updated_by_name=$5, updated_by_via=$6
+			 WHERE id=$1 AND deleted_at IS NULL`,
+			oldID, newID, k.UpdatedAt, actor.Kind, actor.Name, actor.Via)
 		if isUniqueViolation(err) {
 			// The probe above found the destination free, but it took no
 			// lock — a create can land on newID in the window. The primary
@@ -718,6 +758,10 @@ func (s *Store) rewriteReferences(ctx context.Context, tx pgx.Tx, oldID string, 
 		}
 		r.Body = body
 		r.Links = domain.LinksFromBody(r.ID, r.Body)
+		// The rewrite is a content change by the mover, and it is recorded
+		// as one ("update" revision below), so the entry's generated.by
+		// follows it (design doc 0034 §3.3).
+		r.UpdatedBy = actor
 		links, attrs, err := marshalJSONFields(r)
 		if err != nil {
 			return err
@@ -736,9 +780,10 @@ func (s *Store) rewriteReferences(ctx context.Context, tx pgx.Tx, oldID string, 
 		// body and a revision on an entry nobody can see, to resurface
 		// whenever someone revives it.
 		tag, err := tx.Exec(ctx,
-			`UPDATE knowledge SET links=$2, attrs=$3, body=$4, updated_at=$5
+			`UPDATE knowledge SET links=$2, attrs=$3, body=$4, updated_at=$5,
+			 updated_by_kind=$6, updated_by_name=$7, updated_by_via=$8
 			 WHERE id=$1 AND deleted_at IS NULL`,
-			r.ID, links, attrs, r.Body, r.UpdatedAt)
+			r.ID, links, attrs, r.Body, r.UpdatedAt, actor.Kind, actor.Name, actor.Via)
 		if err != nil {
 			return err
 		}

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -665,12 +665,28 @@ func TestIntegrationMove(t *testing.T) {
 		t.Fatalf("move onto a soft-deleted entry: got %v, want ErrAlreadyExists", err)
 	}
 
-	moved, err := s.Move(ctx, "it-move-src/metric", "it-move-dst/metric", actor)
+	mover := domain.Actor{Kind: "human", Name: "mover"}
+	moved, err := s.Move(ctx, "it-move-src/metric", "it-move-dst/metric", mover)
 	if err != nil {
 		t.Fatalf("Move: %v", err)
 	}
 	if moved.ID != "it-move-dst/metric" {
 		t.Errorf("moved.ID = %q", moved.ID)
+	}
+	// A move rewrites the moved entry's links and every referrer's body,
+	// so the mover is who those contents stand by — generated.by in an
+	// export (design doc 0034 §3.3).
+	if moved.UpdatedBy != mover {
+		t.Errorf("moved.UpdatedBy = %v, want %v", moved.UpdatedBy, mover)
+	}
+	for _, id := range []string{"it-move-dst/metric", "it-move-bare", "it-move-attrs"} {
+		k, err := s.Get(ctx, id)
+		if err != nil {
+			t.Fatalf("%s: %v", id, err)
+		}
+		if k.UpdatedBy != mover {
+			t.Errorf("%s updated_by = %v after the move, want %v", id, k.UpdatedBy, mover)
+		}
 	}
 	if _, err := s.Get(ctx, "it-move-src/metric"); !errors.Is(err, ErrNotFound) {
 		t.Errorf("old id still resolves: %v", err)

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -435,7 +435,7 @@ function esc(s) {
 // Keys are the OKF type vocabulary, which is what the server stores
 // (design doc 0023). Lookup is case-insensitive to match the server's
 // filter matching — the stored spelling is whatever the writer used.
-const TYPE_ICONS = { 'Semantic Model': '🧩', 'Metric': '📊', 'Golden Query': '🧾', 'Insight': '💡', 'Glossary Term': '📖', 'BigQuery Dataset': '🗂️', 'BigQuery Table': '🗃️', 'Reference': '🔖' };
+const TYPE_ICONS = { 'Semantic Model': '🧩', 'Metric': '📊', 'Golden Query': '🧾', 'Attested Computation': '🧮', 'Insight': '💡', 'Glossary Term': '📖', 'BigQuery Dataset': '🗂️', 'BigQuery Table': '🗃️', 'Reference': '🔖' };
 const ICON_BY_LOWER = new Map(Object.entries(TYPE_ICONS).map(([k, v]) => [k.toLowerCase(), v]));
 const icon = t => ICON_BY_LOWER.get(String(t ?? '').trim().toLowerCase()) || '📄';
 const KNOWN_TYPES = Object.keys(TYPE_ICONS);
@@ -1182,8 +1182,22 @@ async function viewDetail(id) {
     entry.created_by && entry.created_by.name ? `created by ${actorStr(entry.created_by)} ${fmtDate(entry.created_at)}` : `created ${fmtDate(entry.created_at)}`,
     entry.verified_by && entry.verified_by.name ? `verified by ${actorStr(entry.verified_by)} ${fmtDate(entry.verified_at)}` : '',
     entry.rejected_by && entry.rejected_by.name ? `rejected by ${actorStr(entry.rejected_by)} ${fmtDate(entry.rejected_at)}` : '',
-    entry.updated_at && entry.updated_at !== entry.created_at ? `updated ${fmtDate(entry.updated_at)}` : '',
+    // updated_by is OKF's generated.by: who the content stands by now,
+    // which is not always who created it (design doc 0034 §3.3).
+    entry.updated_at && entry.updated_at !== entry.created_at
+      ? (entry.updated_by && entry.updated_by.name
+          ? `updated by ${actorStr(entry.updated_by)} ${fmtDate(entry.updated_at)}`
+          : `updated ${fmtDate(entry.updated_at)}`)
+      : '',
   ].filter(Boolean).join(' · ');
+
+  // A passed stale_after is a prompt to re-check, never a claim the entry
+  // is wrong (OKF SPEC §5.5) — the comparison is a plain date one.
+  const staleNote = entry.stale_after
+    ? (entry.stale_after <= new Date().toISOString().slice(0, 10)
+        ? `<div class="status-note">Stale since ${esc(entry.stale_after)} — due for a re-check.</div>`
+        : `<div class="provenance">stale after ${esc(entry.stale_after)}</div>`)
+    : '';
 
   const tags = (entry.tags || []).map(t => `<span class="tag">${esc(t)}</span>`).join(' ');
   const atts = entry.attachments || [];
@@ -1227,6 +1241,7 @@ async function viewDetail(id) {
       revisions, usage, and attachments follow the entry.</p>
     </div>
     ${entry.status_note ? `<div class="status-note">${esc(entry.status_note)}</div>` : ''}
+    ${staleNote}
     <div class="tabs" id="tabs">
       <button data-tab="overview" class="active">Overview</button>
       <button data-tab="attrs">Attributes</button>
@@ -1489,7 +1504,9 @@ async function viewDetail(id) {
 // 0024) and ignores whatever a payload carries.
 function editablePayload(e) {
   const p = { type: e.type, id: e.id, title: e.title };
-  for (const k of ['description', 'tags', 'status', 'status_note', 'attrs', 'body']) {
+  // Every writable envelope field belongs here: a PUT is a full
+  // replacement, so one left out is one erased by a status change.
+  for (const k of ['description', 'resource', 'tags', 'status', 'status_note', 'stale_after', 'attrs', 'body']) {
     if (e[k] !== undefined && e[k] !== null) p[k] = e[k];
   }
   return p;
@@ -1646,7 +1663,7 @@ function wireReviewActions(container) {
 // in the tree routes here as #/new/<prefix>/.
 async function viewEditor(id, prefix = '') {
   const editing = id !== null;
-  let entry = { type: 'Insight', id: prefix, title: '', description: '', tags: [], status: 'draft', status_note: '', attrs: {}, body: '' };
+  let entry = { type: 'Insight', id: prefix, title: '', description: '', tags: [], status: 'draft', status_note: '', stale_after: '', attrs: {}, body: '' };
   if (editing) {
     try {
       entry = await api('/api/v1/knowledge/' + idPath(id));
@@ -1681,7 +1698,7 @@ async function viewEditor(id, prefix = '') {
           <label class="top" for="e-type">Type</label>
           <input type="text" id="e-type" list="type-list" value="${esc(entry.type)}" required>
           <datalist id="type-list">${KNOWN_TYPES.map(t => `<option value="${t}">`).join('')}</datalist>
-          <div class="hint">What the entry is: Metric, Golden Query, Insight, Glossary Term, BigQuery Dataset, BigQuery Table, Reference — or any type of your own.</div>
+          <div class="hint">What the entry is: Metric, Golden Query, Attested Computation, Insight, Glossary Term, BigQuery Dataset, BigQuery Table, Reference — or any type of your own.</div>
         </div>
         ${idField}
       </div>
@@ -1705,9 +1722,16 @@ async function viewEditor(id, prefix = '') {
           <select id="e-status">${STATUSES.map(s => `<option ${s === entry.status ? 'selected' : ''}>${s}</option>`).join('')}</select>
         </div>
       </div>
-      <div class="field">
-        <label class="top" for="e-note">Status note</label>
-        <input type="text" id="e-note" value="${esc(entry.status_note || '')}" placeholder="why deprecated / rejected">
+      <div class="row">
+        <div class="field">
+          <label class="top" for="e-note">Status note</label>
+          <input type="text" id="e-note" value="${esc(entry.status_note || '')}" placeholder="why deprecated / rejected">
+        </div>
+        <div class="field">
+          <label class="top" for="e-stale">Stale after</label>
+          <input type="date" id="e-stale" value="${esc(entry.stale_after || '')}">
+          <div class="hint">Optional — the day this stops being current.</div>
+        </div>
       </div>
       <div class="field">
         <label class="top" for="e-body">Body (markdown)</label>
@@ -1765,6 +1789,7 @@ async function viewEditor(id, prefix = '') {
       tags: $('#e-tags').value.split(',').map(s => s.trim()).filter(Boolean),
       status: $('#e-status').value,
       status_note: $('#e-note').value.trim(),
+      stale_after: $('#e-stale').value,
       body: $('#e-body').value,
     };
     const attrsRaw = $('#e-attrs').value.trim();


### PR DESCRIPTION
[OKF v0.2](https://cloud.google.com/blog/products/data-analytics/okf-v0-2-adds-trust-signals) standardized what every producer had been inventing extension keys for: where a concept came from, how much to trust it, whether it is still current. Design doc [0034](docs/design/0034-okf-v0-2.md) records the decisions; this PR implements them.

Two of v0.2's changes are breaking renames (SPEC §13.1), so this follows them rather than writing both spellings. Design doc 0009 §4 said to revisit the mapping once the spec standardized these keys — that condition is what triggered this.

## What an exported entry looks like now

```yaml
type: Golden Query
title: Monthly revenue by channel
status: stable                 # draft | stable | deprecated
stale_after: "2026-12-31"
generated:
    by: human:tanaka@example.co.jp
    via: agent:insightflow@example.iam.gserviceaccount.com
    at: "2026-07-26T04:12:00Z"
verified:
    - by: human:na0@example.co.jp
      at: "2026-07-26T09:30:00Z"
created_by: agent:analyst@example.iam.gserviceaccount.com
```

`verified` is no longer a status: it is `stable` plus a verification, which is where a v0.2 consumer reads the trust tier from (SPEC §5.3). Delegation (design doc 0027) rides as a `via` sibling of `by`, so `by` stays a bare actor and the `human:` prefix a consumer keys off stays readable.

## updated_by (migration 0019)

`generated.by` is "who the content stands by now", and the envelope had no such field. `created_by` is accurate right up until somebody else edits the entry. Migration 0019 adds `updated_by`, backfilled from the newest revision that changed content (create/update/move) — **verify revisions excluded**, because confirming an entry is not producing it, which is exactly the distinction v0.2 draws.

## Import

- A foreign bundle's `stable` lands as a **draft** unless it carries a `verified` key. Trust is never invented from a status; ochakai's own exports always write both, so the round-trip stays exact.
- Provenance is still never read back (design doc 0009) — only *whether* the `verified` key is present.
- **`status: stable` used to be a 400.** That was plain non-conformance with SPEC §11, so a v0.2 bundle from anyone else could not be imported at all. An unknown value is now a draft with a reported `note:` line, and the document is kept. Notes are counted separately from skips: the entry *was* imported.
- `status` omitted stays *unset* rather than becoming a value. Materializing OKF's `stable` default here would silently demote existing entries every time a status-less document is re-imported; ochakai already has a rule for a write that names no status (draft on create, unchanged on update).

## Also in scope

- **`stale_after`** as an envelope field, written and shown on all four surfaces. Advisory: nothing hides a stale entry and no feed sorts by it — 0025's feeds rank on observed evidence, and this is a writer's declaration.
- **`Attested Computation`** in the recommended vocabulary (9 types now). Recorded, never run: `runtime`/`parameters`/`executor`/`attester` pass through as attrs. Same line design doc 0028 drew when compile_sql went away, and SPEC §10.5 puts execution on the consumer too.
- **YAML-typed dates in extension keys are written back as dates.** v0.2 made date-valued extension keys ordinary (`sources[].last_modified`, `usage_window`); left alone, `2026-06-01` round-trips as `2026-06-01T00:00:00Z`, which the producer never wrote.
- `okf_version: "0.2"`.

## Unrelated bug found on the way

A status change from the web UI detail view dropped `resource`: the full-replacement PUT payload left it out. Every writable envelope field is now built from one list.

## Design docs

0034 replaces **0005 and 0016** as the OKF-compatibility record rather than stacking a sixth partial amendment on 0005 (CONTRIBUTING: avoid amendment chains), and amends **0009 §4** and **0023 §3.1**. The index is updated to match.

## Breaking (0.13.0)

- Export frontmatter shape: `timestamp` / `verified_by` / `verified_at` are gone; `status: verified` becomes `stable` + `verified`. Import still reads the v0.1 spellings.
- `rejected` round-trips as `deprecated` — OKF has no "never accepted" state. The reason stays in `status_note`, and `rejected_by` / `rejected_at` remain as extension keys.
- Wire format gains `updated_by` and `stale_after` (additive).

## Test plan

- `gofmt -l` / `go vet` / `go test -race ./...` / `CGO_ENABLED=0 go build -trimpath` — all clean.
- Integration tests run against a real pgvector container, including new coverage for: the 0019 backfill (edited / verified-later / delegated / no-revisions), `updated_by` following content through create → no-op update → update → verify, `stale_after` persistence and validation, and move re-attributing the moved entry and its referrers.
- New unit coverage for the status mapping in both directions, v0.1 document import, `stale_after` parsing, and the Attested Computation / `sources` families surviving a round-trip in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)