### PR TITLE
Release review: close the gaps the surfaces left in each other

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -113,6 +113,8 @@ paths:
           content:
             application/json:
               schema: { $ref: "#/components/schemas/Knowledge" }
+          headers:
+            ETag: { $ref: "#/components/headers/ETag" }
         "400": { $ref: "#/components/responses/Error" }
         "409": { $ref: "#/components/responses/Error" }
   /api/v1/browse:
@@ -393,6 +395,8 @@ paths:
           content:
             application/json:
               schema: { $ref: "#/components/schemas/Knowledge" }
+          headers:
+            ETag: { $ref: "#/components/headers/ETag" }
         "400": { $ref: "#/components/responses/Error" }
         "404": { $ref: "#/components/responses/Error" }
         "409": { $ref: "#/components/responses/Error" }
@@ -779,8 +783,9 @@ components:
       description: >
         Optimistic-concurrency precondition (design doc 0030): the
         entry's version — its updated_at in RFC3339Nano, as a prior read
-        returned it in the ETag response header (quotes optional; the
-        JSON body's updated_at field is the same value). The write
+        or write returned it in the ETag response header (quotes
+        optional; the JSON body's updated_at field is the same value).
+        Every response carrying an entry carries the header. The write
         happens only if the entry still has this version; an entry
         changed since it was read is a 412 and nothing is written.
         Absent or "*" means no precondition — last write wins. A value

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -175,6 +175,12 @@ paths:
         golden query answering the question) arrives in the same response.
         Rejected entries never appear. limit caps the primary entries
         (default 5, max 20); linked companions share a 2×limit total cap.
+
+        Changed in 0.13.0 (design doc 0033): `hits` carries the ranking
+        only — id, type, title, status, score. It used to repeat every
+        top entry in full, so the knowledge arrived twice and the budget
+        bound one copy of it. A client that read bodies out of `hits`
+        reads them from `entries` instead, where they always were.
       parameters:
         - name: q
           in: query

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -750,7 +750,7 @@ func cmdUpdate(ctx context.Context, args []string) error {
 // an unchanged payload writes nothing and verified_at is carried over.
 func cmdVerify(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
-		"Usage: ochakai verify [flags] <id>\n\nRecord a verification against the entry as it stands: you become\nverified_by and verified_at is stamped now. Promotes a draft, and\nre-affirms an entry that is already verified — which is what takes it\nout of the verification-age and reported-wrong feeds. Verifying a\nrejected entry clears the rejection: the status becomes verified and\nrejected_by/rejected_at are dropped (the revision history keeps both).",
+		"Usage: ochakai verify [flags] <id>\n\nRecord a verification against the entry as it stands: you become\nverified_by and verified_at is stamped now. Promotes a draft, and\nre-affirms an entry that is already verified — which is what takes it\nout of both review feeds (--sort verified_at, --sort failed). Verifying\na rejected entry clears the rejection: the status becomes verified and\nrejected_by/rejected_at are dropped (the revision history keeps both).",
 		"  ochakai verify metrics/revenue\n  ochakai verify metrics/revenue --json | jq -r .verified_at\n")
 	asJSON := fs.Bool("json", false, "print the verified entry as JSON")
 	pos, err := parseArgs(fs, args)

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -750,8 +750,9 @@ func cmdUpdate(ctx context.Context, args []string) error {
 // an unchanged payload writes nothing and verified_at is carried over.
 func cmdVerify(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
-		"Usage: ochakai verify [flags] <id>\n\nRecord a verification against the entry as it stands: you become\nverified_by and verified_at is stamped now. Promotes a draft, and\nre-affirms an entry that is already verified — which is what takes it\nout of the verification-age and needs-review feeds.",
-		"  ochakai verify metrics/revenue\n")
+		"Usage: ochakai verify [flags] <id>\n\nRecord a verification against the entry as it stands: you become\nverified_by and verified_at is stamped now. Promotes a draft, and\nre-affirms an entry that is already verified — which is what takes it\nout of the verification-age and reported-wrong feeds. Verifying a\nrejected entry clears the rejection: the status becomes verified and\nrejected_by/rejected_at are dropped (the revision history keeps both).",
+		"  ochakai verify metrics/revenue\n  ochakai verify metrics/revenue --json | jq -r .verified_at\n")
+	asJSON := fs.Bool("json", false, "print the verified entry as JSON")
 	pos, err := parseArgs(fs, args)
 	if err != nil {
 		return err
@@ -771,6 +772,9 @@ func cmdVerify(ctx context.Context, args []string) error {
 	k, err := c.Verify(ctx, id)
 	if err != nil {
 		return err
+	}
+	if *asJSON {
+		return printJSON(k)
 	}
 	fmt.Printf("verified ochakai://%s by %s\n", k.ID, k.VerifiedBy)
 	return nil

--- a/cmd/ochakai/client_test.go
+++ b/cmd/ochakai/client_test.go
@@ -293,3 +293,46 @@ func TestUpdateIfMatchSendsHeaderAndExplainsConflict(t *testing.T) {
 		}
 	}
 }
+
+// A verification's whole product is a timestamp and a name, and the only
+// way to read them back was a second call: verify printed one line and
+// dropped the entry the server had already returned. --json hands the
+// same response every other write verb hands over, so a canary can stamp
+// and record verified_at in one round trip.
+func TestVerifyJSONPrintsTheEntry(t *testing.T) {
+	verified := time.Date(2026, 7, 26, 9, 0, 0, 0, time.UTC)
+	human := domain.Actor{Kind: domain.ActorHuman, Name: "na0"}
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v1/verify/{id...}", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(domain.Knowledge{
+			Type: domain.TypeQueries, ID: r.PathValue("id"), Status: domain.StatusVerified,
+			Title: "Monthly revenue", VerifiedBy: &human, VerifiedAt: &verified,
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	orig := os.Stdout
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = pw
+	verifyErr := cmdVerify(context.Background(), []string{"queries/monthly-revenue", "--json", "--url", srv.URL})
+	pw.Close()
+	os.Stdout = orig
+	out, err := io.ReadAll(pr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if verifyErr != nil {
+		t.Fatal(verifyErr)
+	}
+	var got domain.Knowledge
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("--json did not print JSON (%v): %s", err, out)
+	}
+	if got.ID != "queries/monthly-revenue" || got.VerifiedAt == nil || !got.VerifiedAt.Equal(verified) {
+		t.Errorf("verified entry = %+v, want the server's response with verified_at", got)
+	}
+}

--- a/cmd/ochakai/completion.go
+++ b/cmd/ochakai/completion.go
@@ -111,7 +111,10 @@ _ochakai() {
     update)
       _arguments '-f[input file]:file:_files' '--if-match[update only if the entry still has this version (updated_at)]:version:' '--json[print the entry as JSON]' '--url[server URL]:url:'
       ;;
-    verify|delete|purge|detach|move)
+    verify)
+      _arguments '--json[print the entry as JSON]' '--url[server URL]:url:'
+      ;;
+    delete|purge|detach|move)
       _arguments '--url[server URL]:url:'
       ;;
     attach)
@@ -185,9 +188,10 @@ _ochakai() {
       opts="--note --json --url" ;;
     create)        opts="-f --json --url" ;;
     update)        opts="-f --if-match --json --url" ;;
-    verify|delete|purge|detach|move) opts="--url" ;;
+    verify)        opts="--json --url" ;;
+    delete|purge|detach|move) opts="--url" ;;
     attach)        opts="--name --json --url" ;;
-    reembed)       opts="--url --limit --once --json" ;;
+    reembed)       opts="--limit --once --json --url" ;;
     export)        opts="--url --no-attachments" ;;
     import)        opts="--dry-run --url" ;;
     whoami)        opts="--json --url" ;;
@@ -246,7 +250,7 @@ complete -c ochakai -n '__fish_seen_subcommand_from search browse context get cr
 complete -c ochakai -n '__fish_seen_subcommand_from ui' -l port -x -d 'port on 127.0.0.1'
 complete -c ochakai -n '__fish_seen_subcommand_from import' -l dry-run -d 'parse and list, write nothing'
 complete -c ochakai -n '__fish_seen_subcommand_from import' -F
-complete -c ochakai -n '__fish_seen_subcommand_from search browse context get create update reembed attach usage report revisions backlinks whoami' -l json -d 'print raw JSON'
+complete -c ochakai -n '__fish_seen_subcommand_from search browse context get create update verify reembed attach usage report revisions backlinks whoami' -l json -d 'print raw JSON'
 complete -c ochakai -n '__fish_seen_subcommand_from report' -l note -x -d 'context recorded with the report'
 complete -c ochakai -n '__fish_seen_subcommand_from report' -a 'worked failed'
 complete -c ochakai -n '__fish_seen_subcommand_from get' -l download -r -a '(__fish_complete_directories)' -d 'save attachments into this directory'

--- a/cmd/ochakai/completion_test.go
+++ b/cmd/ochakai/completion_test.go
@@ -71,7 +71,7 @@ var completionLongFlags = map[string][]string{
 	"get":       {"json", "download", "url"},
 	"create":    {"json", "url"},
 	"update":    {"if-match", "json", "url"},
-	"verify":    {"url"},
+	"verify":    {"json", "url"},
 	"delete":    {"url"},
 	"purge":     {"url"},
 	"reembed":   {"limit", "once", "json", "url"},

--- a/docs/design/0004-cli.md
+++ b/docs/design/0004-cli.md
@@ -1,6 +1,6 @@
 # ochakai 設計ドキュメント 0004: リモート CLI
 
-Status: Accepted(2026-07-16、#21 で実装)
+Status: Accepted(2026-07-16、#21 で実装)。§3 のコマンド表の `compile` 行・§4 の使用例・§6 の終了コード 2(compile の 422)は [0028](0028-retire-compile-sql.md) の compile 撤去により対象が消滅(終了コードは 0=成功 / 1=エラーの 2 値)。以降に足したコマンド(`verify` は [0025](0025-closing-the-loop.md) §6、`purge` は [0031](0031-purge.md)、`reembed`)は表に載っていない — CLI が REST の全操作を持つ原則(§2)は変わらない
 Date: 2026-07-16
 
 ## 1. 目的と位置づけ

--- a/docs/design/0015-surface-consistency.md
+++ b/docs/design/0015-surface-consistency.md
@@ -1,6 +1,6 @@
 # ochakai 設計ドキュメント 0015: サーフェス一貫性の方針
 
-Status: Accepted(2026-07-18 の議論で決定)
+Status: Accepted(2026-07-18 の議論で決定)。§4 の「verify は新 API を作らず PUT の糖衣として」は [0025](0025-closing-the-loop.md) §6 が覆した — 内容の変わらない PUT は何も書かないので糖衣では再検証を表現できず、`POST /api/v1/verify/{id}` を新設した(REST / CLI / Web UI に載り、MCP には載らない)
 Date: 2026-07-18
 
 ## 1. 目的

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -91,12 +91,14 @@ PR の中に残る。
 
 ## サーフェス(REST / MCP / CLI / Web UI)
 
-- [0004 リモート CLI](0004-cli.md) — **Accepted**。REST API の
+- [0004 リモート CLI](0004-cli.md) — **Accepted**(コマンド表の
+  `compile` 行と終了コード 2 は 0028 で対象消滅)。REST API の
   薄いクライアントとしての CLI。
 - [0007 DB 直結コマンドの廃止](0007-api-only-cli.md) — **Accepted**。
   データの出し入れを API 経由に一本化。DB 直結で残るのは `serve` のみ。
 - [0015 サーフェス一貫性の方針](0015-surface-consistency.md) —
-  **Accepted**。4 サーフェスの役割分担と、意図して実装しないもの。
+  **Accepted**(§4 の verify 糖衣の判断は 0025 §6 が覆した)。
+  4 サーフェスの役割分担と、意図して実装しないもの。
 - [0033 context の hits は順位に徹する](0033-context-hits-are-a-ranking.md)
   — **Accepted**。バイト予算の決定を記録し、`hits` から知識の複製を外す
   (全サーフェスで `id`/`type`/`title`/`status`/`score` のみ)。REST の
@@ -105,8 +107,9 @@ PR の中に残る。
 ## 検証ループと利用測定
 
 - [0025 書き戻しループを締める](0025-closing-the-loop.md) —
-  **Accepted**。検証の時効と、failed 報告・利用実績による再検証の
-  優先順位づけ。
+  **Accepted**(§6 は 0015 §4 の verify 糖衣の判断を覆した)。
+  検証の時効と、failed 報告・利用実績による再検証の優先順位づけ。
+  再検証を記録する `POST /api/v1/verify/{id}` はここが出所。
 - [0029 利用測定を読み取りパスから外す](0029-usage-recording-off-the-read-path.md)
   — **Accepted**。利用イベントをメモリにバッファして定期フラッシュし、
   利用統計は best-effort と明示する(上限超過は破棄、シャットダウンは

--- a/docs/guides/golden-query-canary.md
+++ b/docs/guides/golden-query-canary.md
@@ -40,12 +40,21 @@ ochakai はこの工程に関与しない。
 
 ### 4. 書き戻し — 認可ではなく記録で
 
-- **正常だった**: `update_knowledge` で `status: verified` のまま更新すると、
-  実行者が `verified_by`・現在時刻が `verified_at` に再スタンプされ、
-  次回の `sort=verified_at` で後ろに回る。
+- **正常だった**: 再検証として記録する — `ochakai verify queries/<id>`
+  (REST: `POST /api/v1/verify/queries/<id>`)。実行者が `verified_by`・
+  現在時刻が `verified_at` になり、次回の `sort=verified_at` で後ろに回る。
+  `update` ではこれを表現できない: 内容の変わらない更新は何も書かず、
+  `verified_at` は保存済みの値が持ち越されるので、「もう一度確かめた、
+  やはり正しい」がどこにも残らない。この出口のために verify がある
+  (設計ドキュメント 0025 §6)。MCP にはこのツールがない — 検証は人間の
+  判断であり、CI が回すカナリアは CI 自身の identity で記録される。
 - **失敗・警告**: 対象ナレッジへ `Insight`(`kind: caveat`)を draft で作成するか、
   `status: deprecated` + `status_note`(理由)への変更を提案する。判断は人間が
   provenance を見て行う。誤りと確定した場合は `status: rejected` + `status_note`。
+  status の変更は人間の面(Web UI / CLI)から行う: エージェントがカナリアを
+  回している場合、verified エントリの上書きと status 変更は MCP から拒否される
+  (設計ドキュメント 0015 §3.1)ので、エージェント側の出口は次項の
+  `report_outcome failed` と、別 id の draft 作成である。
 - **どちらの場合も成果を記録する**: `ochakai report queries/<id> worked` /
   `ochakai report queries/<id> failed --note "何が起きたか"`(REST:
   `POST /api/v1/usage/queries/<id>`、MCP: `report_outcome`)。worked / failed の
@@ -84,9 +93,22 @@ jobs:
               sql=$(jq -r .attrs.sql <<<"$hit")
               if ! bq query --nouse_legacy_sql --dry_run "$sql" >/dev/null 2>&1; then
                 echo "::error::golden query $id no longer compiles against the warehouse"
+                curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+                  -H 'Content-Type: application/json' \
+                  -d '{"outcome":"failed","note":"canary: dry-run failed"}' \
+                  "$OCHAKAI_URL/api/v1/usage/$id" >/dev/null
+              else
+                # 再検証として記録し、verified_at を今にする(→ 両フィードから外れる)
+                curl -s -X POST -H "Authorization: Bearer $TOKEN" \
+                  "$OCHAKAI_URL/api/v1/verify/$id" >/dev/null
               fi
             done
 ```
+
+正常時に `verify` を打つかは、そのカナリアが何を確かめたかによる。上のように
+`--dry_run` だけなら分かるのは「まだコンパイルできる」ことまでで、`verified_at`
+を今に進めるのは実実行して結果まで比較したときが素直である(前者だけを回すなら
+verify は落として、失敗報告だけを書き戻す)。
 
 `--dry_run` はスキーマ変更による破損(工程 3 の「失敗」)をコストゼロで検知する。
 結果変動まで見る場合は実実行して前回結果と比較する(行数と主要集計値を

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -488,7 +488,7 @@ type contextIn struct {
 	Statuses []string `json:"statuses,omitempty" jsonschema:"filter by status: draft, verified, deprecated, rejected"`
 	Tags     []string `json:"tags,omitempty" jsonschema:"filter by tag"`
 	Limit    int      `json:"limit,omitempty" jsonschema:"max primary entries: default 5, max 20 (out-of-range falls back to the default); linked companions share a 2x limit total cap"`
-	Budget   int      `json:"budget,omitempty" jsonschema:"max bytes of the response body (default 12000); entries past it are listed under \"outline\" with their size, fetchable by id with get_knowledge, and those rows are counted against the same budget. Raise it when you need whole entries, lower it when context is tight"`
+	Budget   int      `json:"budget,omitempty" jsonschema:"max bytes of the knowledge in the response — the entries plus the outline rows naming the rest (default 12000); nothing else carries a body, since \"hits\" is the ranking only. Entries past it are listed under \"outline\" with their size, fetchable by id with get_knowledge, and those rows count against the same budget. Raise it when you need whole entries, lower it when context is tight"`
 }
 
 type contextOut struct {

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -348,7 +348,10 @@ func TestContextSchemaBoundsResponse(t *testing.T) {
 		if !ok {
 			t.Fatal("get_context must expose budget")
 		}
-		for _, want := range []string{"12000", "outline"} {
+		// "the entries plus the outline rows" is what the cap actually
+		// binds (design doc 0033 §3.2); it is not the response body, and
+		// an agent that reads it as one will size it wrong.
+		for _, want := range []string{"12000", "outline", "the entries plus the outline rows"} {
 			if !strings.Contains(budget.Description, want) {
 				t.Errorf("budget description %q does not mention %q", budget.Description, want)
 			}

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -149,6 +149,10 @@ func Handler(svc *service.Service) http.Handler {
 			writeError(w, err)
 			return
 		}
+		// The version of what was just written, like every other response
+		// that carries an entry: a client that creates and then updates
+		// conditionally should not need a GET in between.
+		w.Header().Set("ETag", etagOf(created))
 		writeJSON(w, http.StatusCreated, created)
 	})
 
@@ -438,6 +442,7 @@ func Handler(svc *service.Service) http.Handler {
 			writeError(w, err)
 			return
 		}
+		w.Header().Set("ETag", etagOf(moved))
 		writeJSON(w, http.StatusOK, moved)
 	})
 

--- a/internal/restapi/restapi_integration_test.go
+++ b/internal/restapi/restapi_integration_test.go
@@ -437,9 +437,20 @@ func TestRESTIntegrationVerify(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp.Body.Close()
 	if resp.StatusCode != http.StatusCreated {
+		resp.Body.Close()
 		t.Fatalf("create status = %d", resp.StatusCode)
+	}
+	var created domain.Knowledge
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	// A create returns the entry, so it returns the version with it: a
+	// client that creates and then updates conditionally should not have
+	// to GET the entry it just wrote to learn what to put in If-Match.
+	if got, want := resp.Header.Get("ETag"), `"`+created.UpdatedAt.Format(time.RFC3339Nano)+`"`; got != want {
+		t.Errorf("create ETag = %q, want %q", got, want)
 	}
 
 	verify := func() domain.Knowledge {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -92,7 +92,47 @@ func (s *Service) CreateKeepingCurated(ctx context.Context, k *domain.Knowledge,
 			return nil, err
 		}
 	}
+	if errors.Is(err, store.ErrAlreadyExists) {
+		return nil, s.explainOccupiedID(ctx, k.ID, err)
+	}
 	return created, err
+}
+
+// explainOccupiedID says what holds an id and what to do instead. Every
+// other refusal this surface can meet names the next move — the update,
+// delete and revival guards all end in report_outcome failed or a draft
+// at another id — and this one did not: creating over a live entry
+// returned the store's bare "knowledge already exists", the one wall on
+// the surface with no door drawn on it.
+//
+// A live rejection is the case that matters. Design doc 0015 §3.1 turns
+// on agents reading a rejection before re-proposing what it turned down,
+// and the caller that lands here is precisely the one that skipped that
+// read: it needs to be told the id holds a ruling, not that something
+// unnamed is in the way. The error stays wrapped, so a caller matching
+// on ErrAlreadyExists still matches.
+func (s *Service) explainOccupiedID(ctx context.Context, id string, err error) error {
+	k, getErr := s.Store.Get(ctx, domain.Normalize(id))
+	if getErr != nil {
+		return err
+	}
+	var instead string
+	switch k.Status {
+	case domain.StatusRejected:
+		instead = "The rejection is the record of a decision and status_note says why; read it " +
+			"(get_knowledge) before proposing this again. If you disagree, create_knowledge a new " +
+			"entry at a different id and let a human judge it."
+	case domain.StatusVerified:
+		instead = "If it is wrong, say so with report_outcome failed — that puts it in the " +
+			"re-verification feed. If you have something better, create_knowledge it at a " +
+			"different id and let a human judge it."
+	case domain.StatusDeprecated:
+		instead = "Deprecated means it was correct and is no longer recommended. If it is worth " +
+			"reviving, create_knowledge a draft at a different id that says why."
+	default:
+		instead = "Nobody has ruled on it: update_knowledge replaces it in place."
+	}
+	return fmt.Errorf("%w: %s is a live %s entry. %s", err, id, k.Status, instead)
 }
 
 func (s *Service) create(ctx context.Context, k *domain.Knowledge, actor domain.Actor, keepCuratedTombstones bool) (*domain.Knowledge, error) {

--- a/internal/service/service_integration_test.go
+++ b/internal/service/service_integration_test.go
@@ -354,6 +354,41 @@ func TestRefuseIfCuratedIntegration(t *testing.T) {
 			t.Errorf("live entry: %v", err)
 		}
 	})
+
+	// Creating over a live entry is still ErrAlreadyExists, but it has to
+	// say what holds the id: the caller that lands here is the agent that
+	// skipped the "search rejected first" step, and a bare "already
+	// exists" leaves it guessing while every neighbouring refusal names
+	// the next move.
+	t.Run("a live entry says what holds the id", func(t *testing.T) {
+		for status, wantAdvice := range map[domain.Status]string{
+			domain.StatusRejected:   "status_note",
+			domain.StatusVerified:   "report_outcome failed",
+			domain.StatusDeprecated: "no longer recommended",
+			domain.StatusDraft:      "update_knowledge",
+		} {
+			id := "queries/" + uid("guard-live-"+string(status))
+			k, err := svc.Create(ctx, &domain.Knowledge{
+				Type: domain.TypeQueries, ID: id, Title: "ruled on",
+				StatusNote: "duplicate of an existing golden query"}, actor)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = svc.Delete(ctx, id, human) })
+			if status != domain.StatusDraft {
+				setStatus(t, k, status, human)
+			}
+
+			_, err = svc.CreateKeepingCurated(ctx, &domain.Knowledge{
+				Type: domain.TypeQueries, ID: id, Title: "re-proposal"}, actor)
+			if !errors.Is(err, store.ErrAlreadyExists) {
+				t.Fatalf("create over a live %s entry: got %v, want ErrAlreadyExists", status, err)
+			}
+			if !strings.Contains(err.Error(), string(status)) || !strings.Contains(err.Error(), wantAdvice) {
+				t.Errorf("create over a live %s entry names neither the status nor a way forward: %v", status, err)
+			}
+		}
+	})
 }
 
 // Reembed closes the gap between "semantic search is configured" and

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -11,7 +11,9 @@
      usage, revision history, backlinks, attachments, create/edit with
      the draft → verified workflow, move with reference rewriting (a Move
      action and tree drag & drop), the draft review queue (sort=usage),
-     and OKF export.
+     the two feeds that empty by verifying — reported wrong (sort=failed)
+     and verification age (sort=verified_at), reachable from the review
+     queue and #/search/reported-wrong — and OKF export.
      (/api/v1/context is an agent surface — see api/openapi.yaml.)
      A starting point for building your own UI. -->
 <html lang="en">
@@ -647,6 +649,15 @@ function route() {
     viewReview();
   } else if (head === 'search') {
     mark('search');
+    // #/search/reported-wrong and #/search/verification-age open a feed
+    // directly. Both are entrances to the review loop, and the filter bar
+    // was the only way in — a queue nobody can find stops being read as
+    // surely as one nobody can empty (design doc 0025 §6).
+    if (rest[0] === 'reported-wrong' || rest[0] === 'verification-age') {
+      explore.failedFeed = rest[0] === 'reported-wrong';
+      explore.staleFeed = rest[0] === 'verification-age';
+      explore.feedAll = false;
+    }
     viewExplore();
   } else {
     viewHome();
@@ -700,8 +711,8 @@ function viewExplore() {
            the canary list for re-checking golden queries. Uncheck <strong>verification age</strong> to search.</div>`
         : explore.failedFeed
         ? `<div class="feed-banner" style="flex:1;margin-bottom:0">Re-verification feed — entries whose failure reports
-           (report_outcome failed) are still unanswered, worst first. Verifying one takes it out of the feed.
-           Uncheck <strong>needs review</strong> to search.</div>`
+           (report_outcome failed) are still unanswered, worst first. Open one, re-read it, and verify it to take it
+           out of the feed. Uncheck <strong>reported wrong</strong> to search.</div>`
         : `<input type="text" id="q" placeholder="Search metrics, golden queries, insights, terms, tables…"
                   value="${esc(explore.q)}" autocomplete="off">`}
       <a class="btn" href="#/new" title="Create a knowledge entry">＋ New entry</a>
@@ -719,7 +730,7 @@ function viewExplore() {
         <label class="chip" title="Oldest-verified first — the canary feed for re-checking golden queries"><input
           type="checkbox" id="f-stale" aria-label="verification age feed" ${explore.staleFeed ? 'checked' : ''}>verification age</label>
         <label class="chip" title="Entries reported wrong (report_outcome failed) and not verified since — the re-verification feed"><input
-          type="checkbox" id="f-failed" aria-label="re-verification feed" ${explore.failedFeed ? 'checked' : ''}>needs review</label>
+          type="checkbox" id="f-failed" aria-label="re-verification feed" ${explore.failedFeed ? 'checked' : ''}>reported wrong</label>
       </div>
     </details>
     <div id="results"><div class="empty">…</div></div>
@@ -762,9 +773,13 @@ async function runSearch() {
   if (!out) return;
   const p = new URLSearchParams();
   const isFeed = explore.staleFeed || explore.failedFeed;
+  // The query as the server and the messages below see it: a box holding
+  // only spaces is no query, and saying `No knowledge found for “  ”`
+  // describes something the user did not ask.
+  const q = explore.q.trim();
   if (explore.staleFeed) p.set('sort', 'verified_at');
   else if (explore.failedFeed) p.set('sort', 'failed');
-  else if (explore.q.trim()) p.set('q', explore.q);
+  else if (q) p.set('q', explore.q);
   // No query typed yet (or only whitespace): the landing view lists by
   // demand instead of searching — an empty q is a 400 (searching needs
   // a query to rank by).
@@ -781,19 +796,24 @@ async function runSearch() {
     const { hits } = await api('/api/v1/knowledge?' + p);
     if (my !== runSearch._seq || out !== $('#results')) return; // stale response
     if (!hits || !hits.length) {
-      out.innerHTML = `<div class="empty">No knowledge found${explore.q ? ' for “' + esc(explore.q) + '”' : ''}.</div>`;
+      out.innerHTML = `<div class="empty">No knowledge found${q ? ' for “' + esc(q) + '”' : ''}.</div>`;
       return;
     }
     // With a query, split off low-relevance hits so junk doesn't render as
     // if it matched — semantic and lexical search always return *something*.
     let strong = hits, weak = [];
-    if (explore.q && !isFeed && hits[0].score > 0.05) {
+    if (q && !isFeed && hits[0].score > 0.05) {
       strong = hits.filter(h => h.score >= WEAK_SCORE);
       weak = hits.filter(h => h.score < WEAK_SCORE);
     }
     let html = strong.map(hitCard).join('');
     if (!strong.length) {
-      html = `<div class="empty">No strong matches for “${esc(explore.q)}”.</div>`;
+      html = `<div class="empty">No strong matches for “${esc(q)}”.</div>`;
+    }
+    // Nothing typed: this is the most-searched listing, not everything
+    // there is. The feeds say what they are; this one said nothing.
+    if (!isFeed && !q) {
+      html = `<div class="truncation-note">Nothing searched yet — the most-searched entries first.</div>` + html;
     }
     if (weak.length) {
       html += `<details class="weak-matches"><summary>${weak.length} weak match${weak.length > 1 ? 'es' : ''} —
@@ -803,7 +823,7 @@ async function runSearch() {
       html += isFeed && !explore.feedAll
         ? `<div class="truncation-note">Showing the first ${limit} entries ·
              <a href="#" id="feed-more">load up to 1000</a></div>`
-        : `<div class="truncation-note">Showing the first ${limit} ${explore.q ? 'matches' : 'entries'}
+        : `<div class="truncation-note">Showing the first ${limit} ${q ? 'matches' : 'entries'}
              (server cap) — narrow with filters or a more specific query.</div>`;
     }
     out.innerHTML = html;
@@ -1153,6 +1173,7 @@ function viewHome() {
     </div>
     <p style="color:var(--muted);font-size:.9rem">
       <a href="#/review">Review queue</a> — verify or reject what agents drafted ·
+      <a href="#/search/reported-wrong">Reported wrong</a> — verified knowledge that came back wrong ·
       <a href="#/new">＋ New entry</a> ·
       <a href="${BASE}/api/v1/export" title="Download the knowledge base as an OKF bundle (tar.gz)">Export OKF</a>
     </p>
@@ -1541,6 +1562,9 @@ function viewReview() {
     <p style="color:var(--muted);max-width:48rem">Drafts agents wrote back, most-demanded first — ranked by search hits, how
     often the draft already surfaces when people search. Verify what's true, reject what isn't (the reason is recorded as
     status_note so agents stop re-proposing it). Never-used drafts sink to the bottom; toggle <em>stale</em> to triage them.</p>
+    <p style="color:var(--muted);font-size:.9rem;max-width:48rem">Verified knowledge has two queues of its own:
+    <a href="#/search/reported-wrong">reported wrong</a> — entries whose failure reports are unanswered — and
+    <a href="#/search/verification-age">verification age</a>, oldest-verified first. Verifying an entry empties it from both.</p>
     <div class="toolbar">
       <label class="check"><input type="checkbox" id="r-stale" ${review.staleOnly ? 'checked' : ''}>
         stale only (0 hits, ≥ ${STALE_DAYS} days old)</label>

--- a/internal/webui/webui_test.go
+++ b/internal/webui/webui_test.go
@@ -27,3 +27,26 @@ func TestActorRenderingKeepsDelegation(t *testing.T) {
 		t.Errorf("actorStr drops the delegating caller:\n%s", body)
 	}
 }
+
+// The re-verification feed is the exit design doc 0025 §6 built for the
+// review loop, and it was reachable only by opening the search filter
+// bar and knowing which chip meant it. Both feeds have their own routes
+// now, and the review queue links them; a rename that drops the routes
+// would quietly hide the queues again.
+func TestFeedsAreLinkableFromTheReviewLoop(t *testing.T) {
+	page := string(Index)
+	for _, want := range []string{
+		"'reported-wrong'",               // the route the links point at
+		"'verification-age'",             // its verification-age sibling
+		`href="#/search/reported-wrong"`, // linked, not only routable
+	} {
+		if !strings.Contains(page, want) {
+			t.Errorf("page does not contain %s", want)
+		}
+	}
+	// "Review" is the draft queue in the top nav; a chip labelled with the
+	// same word for a different queue is the one naming collision here.
+	if strings.Contains(page, ">needs review<") {
+		t.Error("the failed-report chip is labelled \"needs review\" again, colliding with the Review tab")
+	}
+}


### PR DESCRIPTION
A pre-release review of the four surfaces (MCP / REST / CLI / Web UI) against design doc [0015](docs/design/0015-surface-consistency.md), asking whether the changes since v0.12.1 cost anything in simplicity of use.

**They did not.** The release is a net reduction: MCP went from 10 tools to 9 and its total description text grew by ~240 characters while absorbing three new guards, because retiring `compile_sql` paid for all of it; REST lost one endpoint and two schemas and gained purge as a parameter on an existing verb rather than a new path; the CLI lost its heaviest command (7 flags and a filter grammar) and gained three that take zero to three; the Web UI lost its largest form with no residue. Every addition is opt-in, so the simple path of every operation is byte-for-byte what it was — the one deliberate exception being the `hits` shape (design doc 0033).

What the review did find were places where the surfaces had drifted apart from each other or from the docs. This PR fixes them.

## The one that would have shipped broken

**The golden-query canary guide taught a write-back that records nothing.** It told operators to re-stamp a verification by updating the entry with `status: verified`. `Update` carries the stored `verified_at` over, and a content-identical update writes nothing at all, so a canary following the guide never left the `sort=verified_at` feed. It also named `update_knowledge`, which now refuses verified entries outright (0015 §3.1) — an agent-driven canary got an error. `POST /api/v1/verify/{id}` exists for exactly this case (0025 §6) and the guide never mentioned it. The guide now points at it, says why `update` cannot express it, and the CI snippet writes back on both branches.

## Design-doc index truthfulness

Two amendment notes were missing, both required by the rule in CONTRIBUTING that an area's docs plus their `Status:` notes describe the current state:

- **0004** still presents a `compile` command, its example, and exit code 2, all retired with `compile_sql` (0028). The CLI's exit codes are 0 and 1 now.
- **0015 §4** rules that a CLI verify may exist only as PUT sugar, never as a new API. 0025 §6 then added `POST /api/v1/verify/{id}`, for a good reason. Only the pointer between the two was missing.

Headers and index entries only — the decision records themselves are unchanged.

## Per-surface fixes

**MCP.** Creating over a live entry returned the store's bare `knowledge already exists` — the one refusal on the surface that named neither what was in the way nor what to do about it, while its neighbours all point at `report_outcome failed` or a draft at another id. The live *rejection* is the case that matters, since 0015 §3.1 turns on an agent reading a rejection before re-proposing what it turned down, and the caller landing here is exactly the one that skipped that read. It now says what holds the id, per status. The error stays wrapped in `store.ErrAlreadyExists`, so the REST 409 mapping and any `errors.Is` matching are unchanged, and the plain `Create` path is untouched. Separately, `budget` claimed to cap "the response body"; 0033 §3.2 settled that it caps the knowledge, and the openapi wording was already corrected — the tool schema, which is all an agent sees, was not.

**REST.** `GET`, `PUT` and `/verify` answer with an ETag; create and move answered with the same entry and no version, so a client wanting a conditional update after either had to GET what it had just written. Both set it now, and the `If-Match` parameter states the rule once instead of listing exceptions. The `/context` operation also now marks the 0033 `hits` change as a 0.13.0 break, with its migration, where a client actually reads it.

**CLI.** `verify` was the only write verb that printed a line and discarded the response — `create`, `update`, `report` and `attach` all take `--json`, and a canary that verifies then needs `verified_at` had to make a second GET. Its help also omitted a transition a curator wants before running it: verifying a rejected entry clears the rejection. Completions for all three shells follow.

**Web UI.** Three things were called some form of "review": the Review tab (drafts), the verification-age chip, and the failed-report chip labelled "needs review" — the last colliding with the tab while being a different queue on different entries emptied by a different action. It is "reported wrong" now. The re-verification feed also had no way in but the filter bar, so both feeds get routes (`#/search/reported-wrong`, `#/search/verification-age`), linked from the home page and from the draft review queue where a reviewer already is. Plus two small ones: a search box holding only spaces reported `No knowledge found for "  "` while actually listing by demand, and that landing listing never said what it was ordered by.

## Deliberately not changed

- **The re-verification feed still takes three interactions per entry** (open → ⋯ → Re-verify) against one click in the draft queue. The click-through forces a re-read; an inline verify button on a feed of entries that were reported wrong is a rubber stamp.
- **`truncated` is always `len(outline)`.** Redundant, documented, and on the wire — not worth a breaking change.
- **`get_context`'s `hint` repeats ~340 characters every call.** Deliberate: hosts drop MCP instructions, and the comment in the code says so.
- **No CLI verb was added or removed.** Coverage of `api/openapi.yaml` is already 1:1, with `import` the sanctioned exception (0015 §3.2).

## Checks

`gofmt -l .`, `go vet ./...`, `go test -race ./...`, and the `CGO_ENABLED=0` build all pass. The store and service integration tests need PostgreSQL, which this environment has no Docker for — CI covers them, and the new coverage lands there: the per-status advice on a live entry (`internal/service/service_integration_test.go`) and the create ETag (`internal/restapi/restapi_integration_test.go`). `govulncheck@latest` could not run here either; it builds itself with a Go older than the one go.mod pins.

New unit coverage that does run: `TestVerifyJSONPrintsTheEntry`, `TestFeedsAreLinkableFromTheReviewLoop`, and the budget wording is pinned in `TestContextSchemaBoundsResponse`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CqLERf1RjJaRXovFPW2Upi)_