### PR TITLE
docs: fix the two things §5b got wrong about IAP identity

### DIFF
--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -434,18 +434,31 @@ which is one author for the whole team. To record who actually made it,
 tell serve-ui which IAP audience to trust and let ochakai accept the
 webui as a delegator (design docs 0027, 0032):
 
-```sh
-# The JWT audience code for this IAP resource, from the IAP console
-# (⋮ next to the resource → "Get JWT audience code"). serve-ui refuses
-# to guess it: a wrong value would mean verifying nothing.
-gcloud run services update ochakai-webui --region=$REGION \
-  --update-env-vars="OCHAKAI_IAP_AUDIENCE=$IAP_AUDIENCE"
+**Set them in this order.** The moment serve-ui starts forwarding
+identities, ochakai answers 403 unless it already accepts this caller
+(it never downgrades silently) — so grant the delegation first, and the
+UI never sees the window in between.
 
-# ochakai must also accept this caller's forwarded identities, or it
-# answers 403 (it never downgrades silently).
+```sh
+# 1. ochakai must accept this caller's forwarded identities.
 gcloud run services update ochakai --region=$REGION \
   --update-env-vars="OCHAKAI_DELEGATING_CALLERS=ochakai-webui@$PROJECT_ID.iam.gserviceaccount.com"
+
+# 2. Tell serve-ui which IAP audience to trust. It refuses to guess:
+# a wrong value would mean verifying nothing. For IAP enabled directly
+# on Cloud Run — what §5b deploys — the audience is
+# /projects/PROJECT_NUMBER/locations/REGION/services/SERVICE_NAME.
+# (Behind a load balancer it is the backend service instead, and the
+# IAP console gives it: ⋮ next to the resource → "Get JWT audience code".)
+IAP_AUDIENCE="/projects/$(gcloud projects describe $PROJECT_ID --format='value(projectNumber)')/locations/$REGION/services/ochakai-webui"
+
+gcloud run services update ochakai-webui --region=$REGION \
+  --update-env-vars="OCHAKAI_IAP_AUDIENCE=$IAP_AUDIENCE"
 ```
+
+The startup log says which way it went: `recording browser users by
+their IAP identity` with the audience it will require, or `no
+OCHAKAI_IAP_AUDIENCE; writes are recorded as this service account`.
 
 Writes then read `human:tanaka@example.co.jp via agent:ochakai-webui@…`
 — both identities, never just one. serve-ui verifies IAP's signature,


### PR DESCRIPTION
Enabling design doc 0032 on `ochakai-example` (0.13.0) turned up two defects in the Cloud Run guide, both found by following it.

## The order was backwards

§5b set `OCHAKAI_IAP_AUDIENCE` first and `OCHAKAI_DELEGATING_CALLERS` second. The paragraph right below already says ochakai answers **403** rather than downgrading silently — so between the two commands, which are two separate Cloud Run rollouts, every write from the UI fails. Granting the delegation first closes that window.

## The audience was a dead end

The guide pointed at the IAP console's "Get JWT audience code". That describes a **load-balancer-fronted** resource; what §5b actually deploys is IAP enabled directly on Cloud Run (`gcloud beta run deploy --iap`), whose audience is fully determined:

```
/projects/PROJECT_NUMBER/locations/REGION/services/SERVICE_NAME
```

The guide now gives that format plus a one-liner that fills it in, and keeps the console detour documented for the load balancer case. `serve-ui` still refuses to guess — the operator supplies the value, they just no longer have to hunt for it.

## Also

Names the two startup log lines that say which way it went (`recording browser users by their IAP identity` / `no OCHAKAI_IAP_AUDIENCE; …`). Once IAP is in front of the service the operator cannot curl their way to an answer, so the log is the only confirmation available from outside.

## Verification

Deployed exactly this sequence against `ochakai-example`: the computed audience was accepted, and a Web UI write is now recorded as `human:na0@datanest.jp via agent:ochakai-webui@…` on both the API (`created_by`/`updated_by`) and the OKF export (`generated: {by, via, at}`, design doc 0034 §3.2).

Docs only — no code, no design decision changed (0027 and 0032 stand as written).

🤖 Generated with [Claude Code](https://claude.com/claude-code)