### PR TITLE
Save the build cache CI has been throwing away every run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,9 +26,28 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
+          # setup-go's built-in cache keys on go.sum alone and is shared
+          # by every job, so the first job to finish freezes it and this
+          # job's build cache (race-instrumented deps, vet facts) never
+          # gets saved. Cache explicitly instead, per job, saving on
+          # every run: the run_id suffix makes each key unique, and
+          # restore-keys start from the most recent previous run.
+          cache: false
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: test-go-${{ hashFiles('go.sum') }}-${{ github.run_id }}
+          restore-keys: |
+            test-go-${{ hashFiles('go.sum') }}-
+            test-go-
       - run: test -z "$(gofmt -l .)" || { gofmt -l .; exit 1; }
       - run: go vet ./...
-      - run: go test -race ./...
+      # -count=1: with a warm build cache go would reuse cached test
+      # results, but the store tests talk to Postgres, which the test
+      # cache cannot see — make them run every time.
+      - run: go test -race -count=1 ./...
         env:
           OCHAKAI_TEST_DATABASE_URL: postgres://t:t@localhost:55433/t?sslmode=disable
       - run: CGO_ENABLED=0 go build -trimpath ./...
@@ -39,6 +58,17 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
+          cache: false # same shared-key problem as in the test job
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+            ~/.cache/golangci-lint
+          key: lint-go-${{ hashFiles('go.sum') }}-${{ github.run_id }}
+          restore-keys: |
+            lint-go-${{ hashFiles('go.sum') }}-
+            lint-go-
       # Pinned, unlike govulncheck: a new govulncheck release failing CI
       # means a new vulnerability, but a new linter release failing CI
       # only means a new check.


### PR DESCRIPTION
## 何が起きていたか

直近の成功ランで test ジョブは 6.5 分かかっており、内訳は `go vet` 2m07s、`go test -race` 3m12s、build 42s。一方でテスト本体は全パッケージ合計で約 25 秒しかありません。時間のほぼ全部が依存関係の再コンパイルでした。

ログには 3 ジョブすべてで `Cache hit occurred on the primary key, not saving cache` が出ていました。setup-go の組み込みキャッシュは **go.sum のハッシュだけをキーにしていて 3 ジョブで共有**されるため、最初に保存を終えたジョブ — 実際には 15 秒で終わる govulncheck — の中身でキーが埋まり、test ジョブが作る race 計装ビルドや vet の解析結果は go.sum が変わるまで二度と保存されません。つまり毎回コールドビルドでした。

## 変更

- test / lint で `cache: false` にして `actions/cache` を明示。キーを**ジョブ別 + `github.run_id` 付き**にして毎ランで保存し、`restore-keys` で直前のランから復元する。
- lint は `~/.cache/golangci-lint`(golangci-lint 自身の解析キャッシュ)も対象に追加。lint ジョブは現在 2m55s。
- govulncheck は組み込みキャッシュのまま。合計 15 秒で取り分がない。
- `go test -race` に `-count=1`。キャッシュが温まると Go はテスト結果自体も再利用するが、store のテストは Postgres と通信し、その状態はテストキャッシュから見えないため、毎回実行させる(現行の挙動の維持)。

`actions/cache` は他のアクションと同じくコミット SHA でピン(v6.1.0)。

## 効果

このランはキャッシュを作る側なので今まで通りですが、2 回目以降は `go vet` が十数秒、`go test -race` が実テスト分の 40 秒前後、build が数秒になり、**test ジョブは 6.5 分 → 1.5 分程度**の見込みです。go.sum 変更時も `restore-keys` の前方一致で部分再利用できます。

検査の内容は変えていないため、設計文書の追加はありません(0035 が定めているのはどの検査をゲートにするかで、そこは不変)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)