### PR TITLE
Stop the cache from evicting itself, and stop building the linter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,17 +28,17 @@ jobs:
           go-version-file: go.mod
           # setup-go's built-in cache keys on go.sum alone and is shared
           # by every job, so the first job to finish freezes it and this
-          # job's build cache (race-instrumented deps, vet facts) never
-          # gets saved. Cache explicitly instead, per job, saving on
-          # every run: the run_id suffix makes each key unique, and
-          # restore-keys start from the most recent previous run.
+          # job's build cache — race-instrumented dependencies, vet facts
+          # — never gets saved. Cache explicitly instead, per job.
           cache: false
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
           key: test-go-${{ hashFiles('go.sum') }}-${{ github.run_id }}
+          # The run_id makes the key unique per run, so a restore is
+          # always a restore-keys prefix hit on the newest entry below it.
           restore-keys: |
             test-go-${{ hashFiles('go.sum') }}-
             test-go-
@@ -51,6 +51,20 @@ jobs:
         env:
           OCHAKAI_TEST_DATABASE_URL: postgres://t:t@localhost:55433/t?sslmode=disable
       - run: CGO_ENABLED=0 go build -trimpath ./...
+      # Save only from main. A cache saved by a pull request run is
+      # scoped to that pull request's merge ref and can only be restored
+      # by re-runs of the same pull request, while every branch can
+      # restore main's — so saving here too would spend ~700 MB of the
+      # repository's 10 GB on an entry almost nobody reads, and eviction
+      # is by least recent access, which would start dropping the main
+      # entries these jobs actually depend on.
+      - uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        if: success() && github.ref == 'refs/heads/main'
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: test-go-${{ hashFiles('go.sum') }}-${{ github.run_id }}
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -59,12 +73,14 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false # same shared-key problem as in the test job
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # golangci-lint keeps its own analysis cache, which the action
+      # below handles; this is the Go module and build cache it type
+      # checks us against.
+      - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-            ~/.cache/golangci-lint
           key: lint-go-${{ hashFiles('go.sum') }}-${{ github.run_id }}
           restore-keys: |
             lint-go-${{ hashFiles('go.sum') }}-
@@ -72,7 +88,24 @@ jobs:
       # Pinned, unlike govulncheck: a new govulncheck release failing CI
       # means a new vulnerability, but a new linter release failing CI
       # only means a new check.
-      - run: go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...
+      #
+      # Via the action rather than `go run`, which built the linter and
+      # every analyzer it bundles from source on each cold cache — about
+      # three minutes, and the reason this job's cache was 586 MB. The
+      # action installs a released binary instead. `args` is explicit
+      # because the default set of packages is not documented.
+      - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        with:
+          version: v2.12.2
+          args: ./...
+          skip-save-cache: ${{ github.ref != 'refs/heads/main' }}
+      - uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        if: success() && github.ref == 'refs/heads/main'
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: lint-go-${{ hashFiles('go.sum') }}-${{ github.run_id }}
   govulncheck:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
#185 を実測どおりの効果で残したまま、その実装を GitHub と golangci-lint の推奨と突き合わせて出てきた 2 点を直します。

## 1. 毎ラン保存をやめ、main からのみ保存する

#185 が間違えたのはここでした。PR ランが保存したキャッシュは `refs/pull/N/merge` にスコープされ、**同じ PR の再実行からしか復元できません**。一方どのブランチも main のキャッシュは復元できます。つまり PR 側の保存はほぼ捨て金で、しかも 1 ラン約 1.3 GB です。

リポジトリ上限は 10 GB、退避は**最終アクセスが古い順**。マージ直後の時点で既に 5.1 GiB / 17 エントリまで来ており、数ランで上限に達したあと、速度向上が依存している main のエントリから削られ始めるところでした。

GitHub 側もこの挙動を名指しで警告・抑制しています。

- [dependency caching リファレンス](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching) が **cache thrashing** として警告し、上限・LRU 退避・7 日無アクセス削除を規定
- [2026-01-16](https://github.blog/changelog/2026-01-16-rate-limiting-for-actions-cache-entries/) に 200 uploads/分 のレート制限が追加(理由が明示的に cache thrash 対策)
- [2026-06-26](https://github.blog/changelog/2026-06-26-read-only-actions-cache-for-untrusted-triggers/) に低信頼トリガーでキャッシュが read-only 化

`actions/cache/restore` を全ジョブに置き、`actions/cache/save` を `success() && github.ref == 'refs/heads/main'` に限定しました。tailscale が同じ形で、キーに `run_id` を残しつつ save を main に絞っています。PR は main の最新エントリから復元するため、マージ頻度の高いこの repo では実効速度はほぼ落ちません。

## 2. `go run` でリンタをビルドするのをやめる

コールドランのログでは、モジュール取得完了(17:14:55)から `0 issues.`(17:18:08)まで **約 190 秒**。golangci-lint 本体と同梱アナライザ全部をソースからビルドしていた時間で、lint キャッシュが 586 MB だったのも中身の大半がその成果物だからでした。

[golangci-lint の公式ドキュメント](https://golangci-lint.run/docs/welcome/install/ci/)は CI では action の利用を推奨し、[ソースからのインストール](https://golangci-lint.run/docs/welcome/install/local/#install-from-sources)は「ローカルの Go バージョンに依存する」「動作保証がない」「バイナリインストールより遅い」として非推奨としています。action は既定の `install-mode: binary` でリリース済みバイナリを取得するのでコンパイルが消えます。

- ピン留め方針は `version: v2.12.2` として維持(コメントの理由もそのまま)
- `args: ./...` を明示。引数省略時の対象パッケージが文書化されていないため、現行と同一の面であることを保証する
- action 自身が `~/.cache/golangci-lint` をキャッシュするので、手動キャッシュからは外して二重化を避けた。手動側に残したのは GOMODCACHE と GOCACHE(自コードの型検査に効く分)
- action の保存も `skip-save-cache` で main に揃えた

## 確認方法

このランは main ではないので **save は走らず、restore のみ**が正しい挙動です(ログに `Cache saved` が出ないことが確認点)。マージ後の main ラン初回でキャッシュが作られ、以降の PR がそれを引きます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)