### PR TITLE
Survive a source loaded without its optional keys, and stop the contract denying the stale feed

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1034,7 +1034,10 @@ components:
             stale — OKF's lifecycle date (SPEC §5.5, design doc 0036
             §3.9). A date rather than a TTL so staleness is a plain
             comparison against today. Advisory: nothing hides a stale
-            entry, and no feed sorts by it.
+            entry and search ranking never reads it — a passed date means
+            due for a re-check, not wrong. The one surface that reads it
+            is sort=stale_after, the feed of entries whose declared date
+            has passed (design doc 0037 §2.1).
         runtime:
           type: string
           description: >

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -1992,7 +1992,14 @@ async function viewEditor(id, prefix = '') {
   // replacing the container's HTML on a keystroke would drop focus and the
   // caret. Only add and remove re-render, and both mark the form dirty
   // themselves, since the form-level input listener above never sees them.
-  const sources = (entry.sources || []).map(s => ({ ...s, usage_window: { ...(s.usage_window || {}) } }));
+  // A stored source carries only the keys it has (omitempty), so a loaded
+  // row may lack id, title or author entirely; the save path trims every
+  // one of them. The defaults keep those reads on strings — usage_count
+  // stays absent, because absent and 0 are different claims.
+  const sources = (entry.sources || []).map(s => ({
+    resource: '', id: '', title: '', author: '', last_modified: '',
+    ...s, usage_window: { ...(s.usage_window || {}) },
+  }));
   const params = (entry.parameters || []).map(p => ({ ...p }));
 
   const srcRow = (s, i) => `
@@ -2202,9 +2209,13 @@ async function viewEditor(id, prefix = '') {
     }
     // A source with nothing in it is a row the user opened and left, not a
     // citation — dropping it here keeps an accidental ＋ from failing the
-    // save, while a half-filled one still gets the server's answer below.
+    // save, while a half-filled one still gets the resource check below.
+    // "Filled" means any field at all, the dates and the count included:
+    // a row somebody typed a value into is half-filled, not abandoned.
     const filledSources = sources.filter(s =>
-      s.resource.trim() || s.id.trim() || s.title.trim() || s.author.trim());
+      s.resource.trim() || s.id.trim() || s.title.trim() || s.author.trim() ||
+      s.last_modified || String(s.usage_count ?? '').trim() ||
+      s.usage_window.from || s.usage_window.to);
     const blank = filledSources.findIndex(s => !s.resource.trim());
     if (blank >= 0) {
       errBox.innerHTML = `<div class="error-banner">Source ${blank + 1} needs a resource — the artifact it cites. Fill it in or remove the row.</div>`;

--- a/internal/webui/webui_test.go
+++ b/internal/webui/webui_test.go
@@ -98,6 +98,38 @@ func TestEveryWritableFieldReachesBothSavePaths(t *testing.T) {
 	}
 }
 
+// A stored source carries only the keys it has (JSON omitempty), so a
+// loaded row can lack id, title and author entirely. The save path trims
+// every one of those to tell an abandoned blank row from a half-filled
+// one — and on a source stored with only a resource, clearing that
+// resource in the editor made the walk reach the missing keys: the click
+// handler threw, no banner appeared, and the save died silently instead
+// of saying "Source N needs a resource". The editor therefore fills in
+// string defaults when it copies entry.sources into the form's backing
+// array (usage_count stays absent — absent and 0 are different claims).
+func TestLoadedSourcesGetStringDefaults(t *testing.T) {
+	page := string(Index)
+	i := strings.Index(page, "const sources = (entry.sources || [])")
+	if i < 0 {
+		t.Fatal("the editor's sources initializer moved without updating this guard")
+	}
+	init := page[i:]
+	if end := strings.Index(init, "));"); end >= 0 {
+		init = init[:end]
+	}
+	for _, want := range []string{"resource: ''", "id: ''", "title: ''", "author: ''", "last_modified: ''"} {
+		if !strings.Contains(init, want) {
+			t.Errorf("loaded sources get no default for %s, so the save path can trim undefined:\n%s", want, init)
+		}
+	}
+	if !strings.Contains(init, "...s") {
+		t.Errorf("the defaults no longer merge under the stored source, so stored values would be lost:\n%s", init)
+	}
+	if strings.Contains(init, "usage_count: ") {
+		t.Errorf("usage_count has a default; absent and 0 are different claims (OKF SPEC §5.1):\n%s", init)
+	}
+}
+
 // Date inputs were left out of the input rule, so stale_after arrived with
 // the UA's own font, padding and intrinsic width — and, with no
 // color-scheme declared, a white calendar popup on a dark page. Both are


### PR DESCRIPTION
Two fixes from the 0.14.0 pre-release review.

## Web UI: clearing a source's resource killed the save silently

The editor copies `entry.sources` into its backing array as stored, and a stored source carries only the keys it has (JSON `omitempty`) — most carry just a `resource`. The save path trims `id`, `title` and `author` to tell an abandoned blank row from a half-filled one, so clearing that resource in the editor walked into the missing keys: the click handler threw a `TypeError`, no banner appeared, and Save did nothing — silently — instead of saying "Source N needs a resource."

- The initializer now fills in string defaults when loading (`usage_count` stays absent: absent and 0 are different claims, OKF SPEC §5.1).
- "Filled" now means any field at all: a row holding only a `last_modified`, a usage count, or a window override was typed into, so it gets the resource check rather than being silently dropped from the payload.
- A source-reading guard test (`TestLoadedSourcesGetStringDefaults`) pins the defaults, in the style of the existing webui tests.

## openapi.yaml: `stale_after` said "no feed sorts by it" beside the feed that does

The field description predated design doc 0037 and contradicted the `sort` enum in the same file. It now keeps what is still true (nothing hides or demotes a stale entry; a passed date means due for a re-check, not wrong) and points at `sort=stale_after` (0037 §2.1).

Checked: `gofmt -l`, `go vet`, `go test -race ./...`, `CGO_ENABLED=0 go build ./...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)