### PR TITLE
Cut 0.14.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Version
       description: Output of `ochakai version`, or the image tag you deployed.
-      placeholder: "0.13.0"
+      placeholder: "0.14.0"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,12 @@ last entry.
 
 ## [Unreleased]
 
-Targets 0.14.0. The baseline for everything below is **0.13.0**, not
-0.12.x: OKF v0.2 export itself shipped in 0.13.0.
+Nothing yet.
+
+## [0.14.0] - 2026-07-27
+
+The baseline for everything below is **0.13.0**, not 0.12.x: OKF v0.2
+export itself shipped in 0.13.0.
 
 ### Added
 
@@ -553,7 +557,8 @@ worth naming: SQL injection in `compile_sql` through undeclared field
 pass-through, fixed in 0.8.0 — v0.7.0 and earlier are affected. Details
 are in git history.
 
-[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/na0fu3y/ochakai/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/na0fu3y/ochakai/compare/v0.12.1...v0.13.0
 [0.12.1]: https://github.com/na0fu3y/ochakai/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/na0fu3y/ochakai/compare/v0.11.0...v0.12.0

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -10,7 +10,7 @@ info:
     human-facing browse/revisions/backlinks reads, and attachment writes —
     so users can build their own web UIs. ochakai executes no SQL and uses
     no LLM.
-  version: 0.13.0
+  version: 0.14.0
   license:
     name: MIT
 servers:


### PR DESCRIPTION
Release prep for 0.14.0. No behavior changes.

- `CHANGELOG.md` — `[Unreleased]` becomes `[0.14.0] - 2026-07-27`, with a
  fresh empty Unreleased and the compare links updated.
- `api/openapi.yaml` — `info.version` 0.13.0 → 0.14.0. It had drifted:
  main already carried the envelope fields and the `sort=stale_after` /
  `source=` arguments from designs 0036 and 0037.
- `.github/ISSUE_TEMPLATE/bug_report.yml` — version placeholder.

0.14.0 rather than 0.13.1: the changelog records five **BREAKING**
entries, led by `attrs` losing the keys that moved into the envelope.

After this merges, `v0.14.0` gets tagged, which is the first tag that will
carry binaries — `.goreleaser.yaml` landed in #190 but assets only start
from the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
