### PR TITLE
Make the documented deployment something you can review as a diff

### DIFF
--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -18,6 +18,14 @@ Cloud SQL dominates the bill. Regions in Asia (e.g. `asia-northeast1`) cost
 slightly more; pick what matches your latency needs. Teardown commands are
 at the bottom.
 
+**Prefer infrastructure as code?**
+[deploy/terraform](../terraform) stands up §1–§4b (and §5b's web UI) as a
+Terraform module, so a deployment can be reviewed as a diff, reproduced per
+environment, and destroyed cleanly. This guide stays the reference: it
+explains why each piece is shaped the way it is, and covers the parts the
+module deliberately leaves out — §5c, §6's org-policy guardrails, and §8's
+upgrade notes.
+
 ## 1. Prerequisites
 
 ```sh

--- a/deploy/terraform/.gitignore
+++ b/deploy/terraform/.gitignore
@@ -1,0 +1,9 @@
+# Local working state. terraform.tfvars names your project and who may reach
+# it; the state file describes your deployment. Neither belongs in this
+# repository — this is a module to copy and adapt, not a deployment.
+.terraform/
+.terraform.lock.hcl
+terraform.tfvars
+*.tfstate
+*.tfstate.*
+crash.log

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -1,0 +1,162 @@
+# Terraform module for the Cloud Run + Cloud SQL deployment
+
+The baseline of [deploy/cloudrun/README.md](../cloudrun/README.md) as code,
+so that a deployment can be reviewed as a diff, reproduced per environment,
+and torn down cleanly.
+
+**The gcloud guide remains the reference and the source of truth.** It
+explains why each piece is shaped the way it is, covers everything this
+module leaves out, and is the thing to read first. This module is a
+convenience for standing up what it describes — where the two disagree, the
+guide is right and this module has a bug.
+
+## What it creates
+
+The defaults reproduce the guide's cost-minimized example (~$10/month, almost
+entirely the Cloud SQL instance):
+
+| | |
+|---|---|
+| Artifact Registry | a **remote repository** proxying `ghcr.io` (§1) — Cloud Run cannot pull from GHCR directly |
+| Cloud SQL | `db-f1-micro`, Postgres 17, 10 GB SSD, single zone, no backups, `cloudsql.iam_authentication=on` (§2) |
+| Service account | `ochakai-run`, with `roles/cloudsql.client` + `roles/cloudsql.instanceUser`, and an IAM database login (§3) |
+| Cloud Run | the ochakai service, scaled to zero, **not publicly invokable**, `OCHAKAI_DB_IAM_AUTH=true` (§3) |
+| IAM | `roles/run.invoker` for the members you name — the entire access-control surface |
+
+Optional, all off by default: private IP (§2b), Vertex AI embeddings (§4),
+GCS attachments (§4b), the IAP-fronted web UI (§5b).
+
+### No password, anywhere
+
+There is no `random_password` in this module, no Secret Manager entry, no
+service-account key, and no `password` argument on any resource. The runtime
+authenticates to Postgres with Cloud SQL IAM database authentication, where
+the connection password is a short-lived IAM token fetched at connect time.
+That is why `OCHAKAI_DATABASE_URL` can sit in a plain environment variable,
+and it is the project's central design decision, not a detail (design docs
+0002, 0003).
+
+Two consequences worth knowing before you read further:
+
+- The module does **not** create the guide's password-holding admin user.
+  Direct database access for people is an IAM login instead
+  (`maintenance_users`), which is where guide §6 ends up anyway.
+- Terraform therefore cannot run the one-time schema bootstrap SQL — doing so
+  would mean holding a password. That step stays manual; see below.
+
+### Never publicly invokable
+
+`invoker_members` refuses `allUsers` and `allAuthenticatedUsers`, and no
+resource here grants them. This is not just about access: ochakai does no
+authorization of its own and reads the caller identity Cloud Run has already
+verified in order to record provenance. Without the IAM check in front, those
+headers would be forgeable, and every recorded author would be a guess. The
+same rule keeps the deployment compatible with the Domain Restricted Sharing
+org policy.
+
+## Usage
+
+```sh
+cd deploy/terraform
+cp terraform.tfvars.example terraform.tfvars   # edit: project, region, image tag, invokers
+terraform init
+terraform plan
+terraform apply    # Cloud SQL instance creation takes 10-15 minutes
+```
+
+Then the one manual step, and the service is ready:
+
+```sh
+terraform output -raw database_bootstrap_sql
+terraform output -raw use_command
+```
+
+### The one manual step: schema bootstrap
+
+Extensions have to be created by a `cloudsqlsuperuser` member — Cloud SQL's
+pgvector is not a trusted extension — and the runtime's object grants have to
+be issued by someone. Pre-creating the extensions is what lets the runtime
+identity hold nothing but explicit object grants: its startup migration then
+only ever hits the privilege-free `CREATE EXTENSION IF NOT EXISTS` skip path.
+
+An IAM login never qualifies as `cloudsqlsuperuser`, so use the built-in
+`postgres` user with a break-glass password you mint and discard rather than
+store (guide §6):
+
+```sh
+gcloud sql users set-password postgres --instance=ochakai --prompt-for-password
+cloud-sql-proxy "$(terraform output -raw sql_connection_name)" --port 55432 &
+psql "host=localhost port=55432 dbname=ochakai user=postgres"
+# paste: terraform output -raw database_bootstrap_sql
+```
+
+Afterwards set the password to another value you throw away. Nothing is
+stored, and admin access stays IAM-gated.
+
+If you named `maintenance_users`, let them see the tables the runtime will
+own (startup migrations create them as the service account, so ownership
+follows the writer, not the deployer), in the same session:
+
+```sql
+GRANT "<database_user output>" TO "you@your-org.example";
+```
+
+They connect with `cloud-sql-proxy --auto-iam-authn` and their own identity
+from then on — no password on that path either.
+
+## Options
+
+| Variable | Guide | Effect |
+|---|---|---|
+| `enable_private_ip` | §2b | Drops the Cloud SQL public endpoint; peering range + Direct VPC egress on Cloud Run. Free. Local `cloud-sql-proxy` access then needs a VPC-attached workstation or a temporary public IP. |
+| `enable_vertex_embeddings` | §4 | `roles/aiplatform.user` + `OCHAKAI_VERTEX_PROJECT`. Search becomes hybrid. Entries written before this was on stay unembedded until `ochakai reembed`. |
+| `enable_gcs_attachments` | §4b | Bucket + `roles/storage.objectUser` + `OCHAKAI_GCS_BUCKET`. Without it, attach operations return 501. |
+| `enable_webui` | §5b | `serve-ui` as a second Cloud Run service behind IAP, same image, dedicated identity. `webui_records_browser_user` (default on) records the person in the browser rather than the UI's service account. |
+| `maintenance_users` | §6 | Cloud SQL IAM logins for people, no passwords. |
+| `database_backups` | §6 | Daily backups. Off by default for cost; turn it on for anything you care about. |
+
+Enabling the web UI pulls in the `google-beta` provider: IAP on Cloud Run
+(`iap_enabled`) is still a beta surface. The provider is declared either way,
+so it is downloaded even when the UI is off, where it does nothing.
+
+## What this module does not cover
+
+Deliberately. Each is in the guide; reach for it there.
+
+- **The schema bootstrap SQL** (§3) — needs a database password, see above.
+- **Loading knowledge and connecting Claude Code** (§5) — client-side, and
+  the CLI needs no configuration beyond `ochakai use`.
+- **Delegated provenance for your own application** (§5c) — the variable is
+  here (`delegating_callers`), but the application and its service account
+  are yours to deploy.
+- **Org-policy guardrails** (§6: `sql.restrictAuthorizedNetworks`,
+  `sql.restrictPublicIp`, `iam.allowedPolicyMemberDomains`) — they belong at
+  the organization level, above any one deployment, and need the Org Policy
+  Administrator role.
+- **Retiring the password admin user** (§6) — nothing to retire: this module
+  never creates one.
+- **`--ssl-mode=ENCRYPTED_ONLY`, point-in-time recovery, Binary
+  Authorization, Cloud SQL data-access audit logs** (§6) — hardening beyond
+  the baseline, one `gcloud` command or console setting each.
+- **Upgrading an existing deployment** (§8) — change `image_tag` and apply;
+  migrations run at startup. The version notes in §8 still apply, and
+  importing an existing gcloud-built deployment into this module's state is
+  not something this module tries to make easy.
+
+## Teardown
+
+`deletion_protection` defaults to true and guards both the Cloud SQL instance
+and the Cloud Run services at the Terraform and the API level, so it has to
+come off first:
+
+```sh
+terraform apply -var deletion_protection=false
+terraform destroy
+```
+
+If attachments are enabled, the bucket refuses to be destroyed while it holds
+objects — those are the only copy of every file anyone attached. Add
+`-var gcs_force_destroy=true` to the same `apply` when you mean it.
+
+Enabled APIs are left enabled: turning one off is a project-wide act and
+other things may depend on it.

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -1,0 +1,529 @@
+# The baseline deployment of deploy/cloudrun/README.md, expressed as
+# infrastructure as code. Sections below follow that guide's numbering, and
+# every resource here traces to a command there.
+#
+# Two properties are load-bearing and are the reason several obvious-looking
+# things are missing:
+#
+#   * Secret-zero. There is no password in this module, no random_password,
+#     no Secret Manager entry, no service-account key. The runtime logs in to
+#     Postgres with Cloud SQL IAM database authentication, where the
+#     "password" is a short-lived IAM token fetched at connect time. If a
+#     change to this module ever needs a generated credential, the change is
+#     wrong for this project (design docs 0002, 0003).
+#
+#   * The service is never publicly invokable. ochakai performs no
+#     authorization of its own: it reads the caller identity Cloud Run has
+#     already verified and records it as provenance. Those headers only mean
+#     something behind Cloud Run's IAM check, so allUsers would not merely
+#     widen access, it would make provenance forgeable.
+
+data "google_project" "this" {
+  project_id = var.project_id
+}
+
+locals {
+  webui_name = "${var.name}-webui"
+
+  # Pulled through the Artifact Registry remote repository below, not from
+  # ghcr.io directly.
+  image = "${var.region}-docker.pkg.dev/${var.project_id}/${var.artifact_registry_repository_id}/${var.image_repository}:${var.image_tag}"
+
+  connection_name = google_sql_database_instance.ochakai.connection_name
+
+  # The database principal for a service account is its email with the
+  # .gserviceaccount.com suffix removed — that is the name Postgres knows it
+  # by, and it must match the "user=" in the connection string exactly.
+  db_service_account_user = trimsuffix(google_service_account.ochakai.email, ".gserviceaccount.com")
+
+  gcs_bucket_name = coalesce(var.gcs_bucket_name, "${var.project_id}-ochakai-blobs")
+
+  # The webui forwards the identity of the person signed in through IAP, so
+  # the server has to accept it as a delegator. Granting this before the
+  # webui exists is deliberate: ochakai answers 403 rather than silently
+  # downgrading to the service account, so the grant must never lag behind.
+  delegating_callers = distinct(concat(
+    var.delegating_callers,
+    var.enable_webui && var.webui_records_browser_user ? [google_service_account.webui[0].email] : [],
+  ))
+
+  iap_audience = "/projects/${data.google_project.this.number}/locations/${var.region}/services/${local.webui_name}"
+
+  server_env = merge(
+    {
+      # No password appears here, and none exists to appear. This is what
+      # makes plain environment variables the right place for the connection
+      # string; with password auth it would have to be a Secret Manager
+      # reference instead.
+      OCHAKAI_DB_IAM_AUTH = "true"
+      OCHAKAI_DATABASE_URL = join("", [
+        "postgres:///${google_sql_database.ochakai.name}",
+        "?host=/cloudsql/${local.connection_name}",
+        "&user=${local.db_service_account_user}",
+      ])
+    },
+    var.enable_gcs_attachments ? { OCHAKAI_GCS_BUCKET = local.gcs_bucket_name } : {},
+    var.enable_vertex_embeddings ? { OCHAKAI_VERTEX_PROJECT = var.project_id } : {},
+    var.enable_vertex_embeddings && var.vertex_model != null ? { OCHAKAI_VERTEX_MODEL = var.vertex_model } : {},
+    var.enable_vertex_embeddings && var.vertex_location != null ? { OCHAKAI_VERTEX_LOCATION = var.vertex_location } : {},
+    var.enable_vertex_embeddings && var.embedding_dim != null ? { OCHAKAI_EMBEDDING_DIM = tostring(var.embedding_dim) } : {},
+    length(local.delegating_callers) > 0 ? { OCHAKAI_DELEGATING_CALLERS = join(",", local.delegating_callers) } : {},
+  )
+
+  webui_env = merge(
+    { OCHAKAI_URL = google_cloud_run_v2_service.ochakai.uri },
+    var.webui_records_browser_user ? { OCHAKAI_IAP_AUDIENCE = local.iap_audience } : {},
+  )
+
+  services = var.manage_project_services ? toset(concat(
+    [
+      "run.googleapis.com",
+      "sqladmin.googleapis.com",
+      "sql-component.googleapis.com",
+      "artifactregistry.googleapis.com",
+    ],
+    var.enable_private_ip ? ["compute.googleapis.com", "servicenetworking.googleapis.com"] : [],
+    var.enable_vertex_embeddings ? ["aiplatform.googleapis.com"] : [],
+    var.enable_webui ? ["iap.googleapis.com", "cloudresourcemanager.googleapis.com"] : [],
+  )) : toset([])
+}
+
+# --- 1. Prerequisites -----------------------------------------------------
+
+resource "google_project_service" "this" {
+  for_each = local.services
+
+  project = var.project_id
+  service = each.value
+
+  # Turning an API off again is a project-wide act, and other things in the
+  # project may depend on it. Teardown removes this deployment's resources,
+  # not the project's capabilities.
+  disable_on_destroy = false
+}
+
+# Cloud Run cannot pull from ghcr.io, so pull through Artifact Registry
+# instead. A remote repository is a caching proxy, not a copy: the digest
+# stays identical to the GHCR one, so the GHCR build attestations still
+# describe exactly what runs here (`gh attestation verify
+# oci://ghcr.io/na0fu3y/ochakai:<tag> -R na0fu3y/ochakai`). Nothing needs to
+# be pushed, and new tags are fetched on demand at deploy time.
+resource "google_artifact_registry_repository" "ghcr" {
+  project       = var.project_id
+  location      = var.region
+  repository_id = var.artifact_registry_repository_id
+  description   = "Remote repository proxying ghcr.io, so Cloud Run can pull the ochakai image"
+  format        = "DOCKER"
+  mode          = "REMOTE_REPOSITORY"
+
+  remote_repository_config {
+    description = "ghcr.io"
+
+    docker_repository {
+      custom_repository {
+        uri = "https://ghcr.io"
+      }
+    }
+  }
+
+  depends_on = [google_project_service.this]
+}
+
+# --- 2. The database ------------------------------------------------------
+
+resource "google_sql_database_instance" "ochakai" {
+  project          = var.project_id
+  name             = var.name
+  region           = var.region
+  database_version = var.database_version
+
+  # Terraform-level and API-level guards. Both have to come off (apply, then
+  # destroy) before this instance can be deleted — see the module README.
+  deletion_protection = var.deletion_protection
+
+  settings {
+    edition                     = "ENTERPRISE"
+    tier                        = var.database_tier
+    availability_type           = "ZONAL"
+    disk_size                   = var.database_disk_size_gb
+    disk_type                   = "PD_SSD"
+    disk_autoresize             = false
+    deletion_protection_enabled = var.deletion_protection
+
+    # The setting that makes the whole deployment passwordless: it lets a
+    # Google identity authenticate to Postgres with a short-lived IAM token.
+    database_flags {
+      name  = "cloudsql.iam_authentication"
+      value = "on"
+    }
+
+    backup_configuration {
+      enabled    = var.database_backups
+      start_time = var.database_backups ? var.database_backup_start_time : null
+    }
+
+    ip_configuration {
+      # With private IP there is no reachable endpoint at all. Without it the
+      # public IP is still not open to the internet: the authorized_networks
+      # list below is deliberately empty, which drops direct connections. The
+      # only way in is the Cloud SQL connector — IAM-checked and mTLS'd —
+      # which is what both Cloud Run and cloud-sql-proxy use. Adding an entry
+      # here is what would open the database; do not.
+      ipv4_enabled    = !var.enable_private_ip
+      private_network = var.enable_private_ip ? data.google_compute_network.this[0].id : null
+    }
+  }
+
+  depends_on = [
+    google_project_service.this,
+    google_service_networking_connection.this,
+  ]
+}
+
+resource "google_sql_database" "ochakai" {
+  project  = var.project_id
+  name     = var.name
+  instance = google_sql_database_instance.ochakai.name
+}
+
+# Note what is absent: the guide's password-holding admin user. This module
+# does not create it, because a generated password would be the only stored
+# secret in an otherwise secret-zero system (guide §6 exists to retire it).
+# Direct database access for people goes through IAM logins instead, and the
+# one-time schema bootstrap uses a break-glass password minted by hand and
+# discarded — see the module README.
+
+resource "google_sql_user" "maintenance" {
+  for_each = toset(var.maintenance_users)
+
+  project  = var.project_id
+  instance = google_sql_database_instance.ochakai.name
+  name     = each.value
+  type     = "CLOUD_IAM_USER"
+}
+
+resource "google_project_iam_member" "maintenance_instance_user" {
+  for_each = toset(var.maintenance_users)
+
+  project = var.project_id
+  role    = "roles/cloudsql.instanceUser"
+  member  = "user:${each.value}"
+}
+
+# --- 2b. Optional hardening: private IP only ------------------------------
+
+data "google_compute_network" "this" {
+  count = var.enable_private_ip ? 1 : 0
+
+  project = var.project_id
+  name    = var.network
+}
+
+data "google_compute_subnetwork" "this" {
+  count = var.enable_private_ip ? 1 : 0
+
+  project = var.project_id
+  region  = var.region
+  name    = var.subnetwork
+}
+
+# One-time per VPC: a range Google's managed services get peered into. Free.
+resource "google_compute_global_address" "private_services" {
+  count = var.enable_private_ip ? 1 : 0
+
+  project       = var.project_id
+  name          = "google-managed-services-${var.network}"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = data.google_compute_network.this[0].id
+
+  depends_on = [google_project_service.this]
+}
+
+resource "google_service_networking_connection" "this" {
+  count = var.enable_private_ip ? 1 : 0
+
+  network                 = data.google_compute_network.this[0].id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.private_services[0].name]
+
+  depends_on = [google_project_service.this]
+}
+
+# --- 3. The runtime identity ----------------------------------------------
+
+resource "google_service_account" "ochakai" {
+  project      = var.project_id
+  account_id   = "${var.name}-run"
+  display_name = "ochakai service"
+}
+
+resource "google_project_iam_member" "ochakai_cloudsql_client" {
+  project = var.project_id
+  role    = "roles/cloudsql.client"
+  member  = "serviceAccount:${google_service_account.ochakai.email}"
+}
+
+# Distinct from cloudsql.client: client permits opening the connector,
+# instanceUser permits logging in as an IAM principal once through it.
+resource "google_project_iam_member" "ochakai_cloudsql_instance_user" {
+  project = var.project_id
+  role    = "roles/cloudsql.instanceUser"
+  member  = "serviceAccount:${google_service_account.ochakai.email}"
+}
+
+resource "google_sql_user" "ochakai_run" {
+  project  = var.project_id
+  instance = google_sql_database_instance.ochakai.name
+  name     = local.db_service_account_user
+  type     = "CLOUD_IAM_SERVICE_ACCOUNT"
+}
+
+# The Postgres-side setup for this principal — the extensions and the object
+# grants — is not expressible here without a database password, so it stays a
+# documented one-time manual step. `terraform output database_bootstrap_sql`
+# prints the statements with the right principal already filled in. The
+# runtime deliberately gets neither cloudsqlsuperuser nor any role
+# membership: only explicit object grants.
+
+# --- 4. Optional: Vertex AI embeddings ------------------------------------
+
+resource "google_project_iam_member" "ochakai_vertex" {
+  count = var.enable_vertex_embeddings ? 1 : 0
+
+  project = var.project_id
+  role    = "roles/aiplatform.user"
+  member  = "serviceAccount:${google_service_account.ochakai.email}"
+}
+
+# --- 4b. Optional: attachments in GCS -------------------------------------
+
+resource "google_storage_bucket" "attachments" {
+  count = var.enable_gcs_attachments ? 1 : 0
+
+  project                     = var.project_id
+  name                        = local.gcs_bucket_name
+  location                    = var.region
+  uniform_bucket_level_access = true
+  public_access_prevention    = "enforced"
+
+  # Attachment objects are content-addressed (blob/<sha256>), create-only and
+  # never deleted by ochakai, so the bucket holds the only copy of every file
+  # anyone attached.
+  force_destroy = var.gcs_force_destroy
+}
+
+resource "google_storage_bucket_iam_member" "ochakai" {
+  count = var.enable_gcs_attachments ? 1 : 0
+
+  bucket = google_storage_bucket.attachments[0].name
+  role   = "roles/storage.objectUser"
+  member = "serviceAccount:${google_service_account.ochakai.email}"
+}
+
+# --- 3. The service -------------------------------------------------------
+
+resource "google_cloud_run_v2_service" "ochakai" {
+  project  = var.project_id
+  name     = var.name
+  location = var.region
+
+  deletion_protection = var.deletion_protection
+
+  template {
+    service_account = google_service_account.ochakai.email
+
+    # Scale to zero when idle, and never more than one instance: the cost
+    # table's "~$0 when idle" depends on the first, and a single small
+    # Postgres instance is sized for the second.
+    scaling {
+      min_instance_count = 0
+      max_instance_count = 1
+    }
+
+    containers {
+      image = local.image
+
+      resources {
+        limits = {
+          cpu    = "1"
+          memory = "512Mi"
+        }
+        # Request-based billing: CPU is only charged while a request is in
+        # flight, which is the other half of "~$0 when idle".
+        cpu_idle = true
+      }
+
+      dynamic "env" {
+        for_each = local.server_env
+        content {
+          name  = env.key
+          value = env.value
+        }
+      }
+
+      volume_mounts {
+        name       = "cloudsql"
+        mount_path = "/cloudsql"
+      }
+    }
+
+    # The Cloud SQL connector socket, the /cloudsql/<connection-name> path the
+    # OCHAKAI_DATABASE_URL points at. This works unchanged whether the
+    # instance has a public or a private IP.
+    volumes {
+      name = "cloudsql"
+      cloud_sql_instance {
+        instances = [local.connection_name]
+      }
+    }
+
+    # Direct VPC egress, so the container can route to the instance's private
+    # address when there is no public one.
+    dynamic "vpc_access" {
+      for_each = var.enable_private_ip ? [1] : []
+      content {
+        egress = "PRIVATE_RANGES_ONLY"
+        network_interfaces {
+          network    = data.google_compute_network.this[0].id
+          subnetwork = data.google_compute_subnetwork.this[0].id
+        }
+      }
+    }
+  }
+
+  depends_on = [
+    google_project_service.this,
+    google_artifact_registry_repository.ghcr,
+    google_sql_user.ochakai_run,
+    google_project_iam_member.ochakai_cloudsql_client,
+    google_project_iam_member.ochakai_cloudsql_instance_user,
+  ]
+}
+
+# The only thing that decides who can reach ochakai. There is no allUsers
+# binding anywhere in this module, which is also what keeps the deployment
+# compatible with the Domain Restricted Sharing org policy.
+resource "google_cloud_run_v2_service_iam_member" "invokers" {
+  for_each = toset(var.invoker_members)
+
+  project  = var.project_id
+  location = var.region
+  name     = google_cloud_run_v2_service.ochakai.name
+  role     = "roles/run.invoker"
+  member   = each.value
+}
+
+# --- 5b. Optional: the team web UI behind IAP -----------------------------
+
+resource "google_service_account" "webui" {
+  count = var.enable_webui ? 1 : 0
+
+  project      = var.project_id
+  account_id   = "${var.name}-webui"
+  display_name = "ochakai web UI"
+}
+
+# The webui reaches ochakai as itself, attaching this identity to every API
+# call, which is how the server stays organization-restricted behind a
+# browser-facing page.
+resource "google_cloud_run_v2_service_iam_member" "webui_invokes_ochakai" {
+  count = var.enable_webui ? 1 : 0
+
+  project  = var.project_id
+  location = var.region
+  name     = google_cloud_run_v2_service.ochakai.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.webui[0].email}"
+}
+
+# The same image as the server, started with serve-ui instead of the default
+# serve. There is no second image to build, and the UI is always the exact
+# version of the server it fronts.
+resource "google_cloud_run_v2_service" "webui" {
+  count    = var.enable_webui ? 1 : 0
+  provider = google-beta
+
+  project  = var.project_id
+  name     = local.webui_name
+  location = var.region
+
+  deletion_protection = var.deletion_protection
+
+  # Browsers sign in with their Google account and only the members granted
+  # below get through. Note that this is IAP, not an allUsers grant: the
+  # service itself stays non-public.
+  iap_enabled = true
+
+  template {
+    service_account = google_service_account.webui[0].email
+
+    scaling {
+      min_instance_count = 0
+      max_instance_count = 1
+    }
+
+    containers {
+      image = local.image
+      args  = ["serve-ui"]
+
+      resources {
+        limits = {
+          cpu    = "1"
+          memory = "256Mi"
+        }
+        cpu_idle = true
+      }
+
+      dynamic "env" {
+        for_each = local.webui_env
+        content {
+          name  = env.key
+          value = env.value
+        }
+      }
+    }
+  }
+
+  # Ordering matters and Terraform gets it right for free here: the webui's
+  # OCHAKAI_URL reads the server's uri, so the server — carrying the
+  # delegation grant this UI depends on — is always settled first. The server
+  # answers 403 rather than downgrading silently, so the reverse order would
+  # leave a window where browser edits fail.
+  depends_on = [google_project_service.this]
+}
+
+# IAP fronts the service by invoking it as its own service agent, so that
+# agent needs run.invoker. gcloud's `--iap` does this as a side effect of
+# deploying; here it is explicit.
+resource "google_project_service_identity" "iap" {
+  count    = var.enable_webui ? 1 : 0
+  provider = google-beta
+
+  project = var.project_id
+  service = "iap.googleapis.com"
+
+  depends_on = [google_project_service.this]
+}
+
+resource "google_cloud_run_v2_service_iam_member" "iap_agent" {
+  count = var.enable_webui ? 1 : 0
+
+  project  = var.project_id
+  location = var.region
+  name     = google_cloud_run_v2_service.webui[0].name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_project_service_identity.iap[0].email}"
+}
+
+# Who may sign in through IAP.
+resource "google_iap_web_cloud_run_service_iam_member" "members" {
+  for_each = var.enable_webui ? toset(var.webui_iap_members) : toset([])
+
+  project                = var.project_id
+  location               = var.region
+  cloud_run_service_name = google_cloud_run_v2_service.webui[0].name
+  role                   = "roles/iap.httpsResourceAccessor"
+  member                 = each.value
+}

--- a/deploy/terraform/outputs.tf
+++ b/deploy/terraform/outputs.tf
@@ -1,0 +1,65 @@
+output "service_url" {
+  description = "URL of the ochakai service. Not reachable without an identity: a plain curl gets Google's 401, which is the point."
+  value       = google_cloud_run_v2_service.ochakai.uri
+}
+
+output "use_command" {
+  description = "The next thing to run. The CLI resolves Google ID tokens from your gcloud login, so there is nothing else to configure."
+  value       = "ochakai use ${google_cloud_run_v2_service.ochakai.uri}"
+}
+
+output "service_account_email" {
+  description = "The runtime identity. It authenticates to Postgres as itself and holds only explicit grants."
+  value       = google_service_account.ochakai.email
+}
+
+output "database_user" {
+  description = "The Postgres principal for the runtime identity — the service account email without the .gserviceaccount.com suffix."
+  value       = local.db_service_account_user
+}
+
+output "sql_connection_name" {
+  description = "Cloud SQL connection name, as used by cloud-sql-proxy and by the /cloudsql socket path."
+  value       = google_sql_database_instance.ochakai.connection_name
+}
+
+output "image" {
+  description = "The image the service runs, pulled through the Artifact Registry remote repository. Its digest matches the GHCR one, so `gh attestation verify oci://ghcr.io/na0fu3y/ochakai:<tag> -R na0fu3y/ochakai` still describes what is running."
+  value       = local.image
+}
+
+output "webui_url" {
+  description = "URL of the IAP-fronted web UI, or null when var.enable_webui is false."
+  value       = var.enable_webui ? google_cloud_run_v2_service.webui[0].uri : null
+}
+
+output "webui_service_account_email" {
+  description = "The web UI's identity, or null when var.enable_webui is false. Edits made through the UI are recorded as this account unless var.webui_records_browser_user is on."
+  value       = var.enable_webui ? google_service_account.webui[0].email : null
+}
+
+output "attachments_bucket" {
+  description = "Bucket holding attachment bytes, or null when var.enable_gcs_attachments is false."
+  value       = var.enable_gcs_attachments ? google_storage_bucket.attachments[0].name : null
+}
+
+output "database_bootstrap_sql" {
+  description = <<-EOT
+    The one step this module cannot take: Terraform would need a database
+    password to run SQL, and there is none. Run these once, as a
+    cloudsqlsuperuser member, before the first request. Extensions are
+    pre-created here so the runtime never needs elevated rights — its startup
+    migration only ever hits the privilege-free CREATE EXTENSION IF NOT
+    EXISTS skip path. See the module README for how to connect without
+    storing a password.
+  EOT
+  value       = <<-EOT
+    CREATE EXTENSION IF NOT EXISTS pg_trgm;
+    CREATE EXTENSION IF NOT EXISTS vector;
+    GRANT USAGE, CREATE ON SCHEMA public TO "${local.db_service_account_user}";
+    GRANT ALL ON ALL TABLES IN SCHEMA public TO "${local.db_service_account_user}";
+    GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO "${local.db_service_account_user}";
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO "${local.db_service_account_user}";
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO "${local.db_service_account_user}";
+  EOT
+}

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -1,0 +1,43 @@
+# Copy to terraform.tfvars and edit. The three required values first.
+
+project_id = "your-project"
+region     = "us-central1"
+
+# Pin a released version, not "latest", so a redeploy is a decision:
+# https://github.com/na0fu3y/ochakai/releases
+image_tag = "0.13.0"
+
+# Who can reach ochakai. This is the whole access-control surface — whoever
+# reaches it can read and write everything. Never allUsers.
+invoker_members = [
+  "domain:your-org.example",
+]
+
+# Everything below is optional and off by default. Uncommenting nothing gives
+# the ~$10/month baseline: Cloud Run scaled to zero and one db-f1-micro.
+
+# Hybrid search (trigram + Vertex AI embeddings). Recommended for Japanese
+# knowledge bases. Existing entries stay unembedded until `ochakai reembed`.
+# enable_vertex_embeddings = true
+
+# Attachments. Without a bucket the service is markdown-only and attach
+# operations return 501.
+# enable_gcs_attachments = true
+
+# Drop the Cloud SQL public endpoint. Free, but local admin access then needs
+# a VPC-attached workstation or a temporary public IP.
+# enable_private_ip = true
+
+# The browser UI for people who cannot run the CLI, behind IAP.
+# enable_webui      = true
+# webui_iap_members = ["domain:your-org.example"]
+
+# People who need to connect to the database directly for maintenance. They
+# get an IAM login (cloud-sql-proxy --auto-iam-authn), never a password.
+# maintenance_users = ["you@your-org.example"]
+
+# Real knowledge deserves backups; the cost example skips them.
+# database_backups = true
+
+# Set to false and apply once before `terraform destroy`.
+# deletion_protection = true

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -1,0 +1,270 @@
+# Required. Everything else has a default that reproduces the ~$10/month
+# baseline of deploy/cloudrun/README.md.
+
+variable "project_id" {
+  description = "Google Cloud project that will hold every resource in this module."
+  type        = string
+}
+
+variable "region" {
+  description = <<-EOT
+    Region for Cloud Run, Cloud SQL, Artifact Registry and (if enabled) the
+    attachment bucket. Deliberately has no default: the choice is a latency
+    and cost decision. The guide's cost table is quoted for us-central1;
+    Asian regions such as asia-northeast1 cost slightly more.
+  EOT
+  type        = string
+}
+
+variable "image_tag" {
+  description = <<-EOT
+    Release tag of ghcr.io/na0fu3y/ochakai to run, without the leading "v"
+    (for example "0.13.0"). Pinned rather than "latest" so that a redeploy is
+    a decision and shows up as a diff. See the releases page:
+    https://github.com/na0fu3y/ochakai/releases
+  EOT
+  type        = string
+
+  validation {
+    condition     = var.image_tag != "latest"
+    error_message = "Pin a released version instead of \"latest\", so that a redeploy is a decision (deploy/cloudrun/README.md §1)."
+  }
+}
+
+# --- Naming ---------------------------------------------------------------
+
+variable "name" {
+  description = "Base name for the Cloud Run service, the Cloud SQL instance, the database and the runtime service account. The webui service is named \"<name>-webui\"."
+  type        = string
+  default     = "ochakai"
+}
+
+variable "image_repository" {
+  description = "Path of the image inside ghcr.io. Change only when running a fork."
+  type        = string
+  default     = "na0fu3y/ochakai"
+}
+
+variable "artifact_registry_repository_id" {
+  description = "ID of the Artifact Registry remote repository that proxies ghcr.io."
+  type        = string
+  default     = "ghcr"
+}
+
+# --- Access ---------------------------------------------------------------
+
+variable "invoker_members" {
+  description = <<-EOT
+    IAM members granted roles/run.invoker on the ochakai service, in the
+    "domain:your-org.example" / "user:..." / "serviceAccount:..." form. This
+    is the entire access-control surface: whoever can reach ochakai can read
+    and write everything, and ochakai itself authorizes nothing (design doc
+    0002). Empty by default, so a fresh apply reaches nobody but the deployer.
+  EOT
+  type        = list(string)
+  default     = []
+
+  validation {
+    # The identity headers ochakai trusts for provenance are only meaningful
+    # behind Cloud Run's IAM check. A public service would let any caller
+    # claim to be anyone, so this state is made unrepresentable rather than
+    # merely discouraged (deploy/cloudrun/README.md §3).
+    condition     = !contains(var.invoker_members, "allUsers") && !contains(var.invoker_members, "allAuthenticatedUsers")
+    error_message = "ochakai must never be publicly invokable: its provenance headers are only trustworthy behind Cloud Run IAM. Grant a domain, group, user or service account instead."
+  }
+}
+
+variable "delegating_callers" {
+  description = <<-EOT
+    Callers allowed to forward an end user's identity with the
+    X-Ochakai-On-Behalf-Of header (OCHAKAI_DELEGATING_CALLERS, design doc
+    0027). For applications that embed ochakai and serve many people;
+    without it every one of their users collapses into the application's one
+    service account. Both identities are always recorded. The webui's own
+    service account is added automatically when var.enable_webui and
+    var.webui_records_browser_user are both true.
+  EOT
+  type        = list(string)
+  default     = []
+}
+
+variable "maintenance_users" {
+  description = <<-EOT
+    Email addresses of people who need to connect to the database directly
+    (cloud-sql-proxy --auto-iam-authn) for maintenance. Each gets a Cloud SQL
+    IAM login and roles/cloudsql.instanceUser — no password, which is the
+    whole point (deploy/cloudrun/README.md §6, "Retire the last password").
+    This module never creates the guide's password-holding admin user.
+  EOT
+  type        = list(string)
+  default     = []
+}
+
+# --- Database shape -------------------------------------------------------
+
+variable "database_version" {
+  description = "Cloud SQL Postgres version."
+  type        = string
+  default     = "POSTGRES_17"
+}
+
+variable "database_tier" {
+  description = "Cloud SQL machine type. db-f1-micro is the cheapest viable instance and carries the whole knowledge base at the scale a curated base reaches."
+  type        = string
+  default     = "db-f1-micro"
+}
+
+variable "database_disk_size_gb" {
+  description = "Cloud SQL disk size in GB. Auto-growth is off, so this is a hard ceiling and a hard cost ceiling."
+  type        = number
+  default     = 10
+}
+
+variable "database_backups" {
+  description = "Enable daily backups. Off by default to match the guide's cost-minimized example; turn it on for anything you care about (deploy/cloudrun/README.md §6)."
+  type        = bool
+  default     = false
+}
+
+variable "database_backup_start_time" {
+  description = "HH:MM UTC start time for backups. Only used when var.database_backups is true — enabling backups means picking a time."
+  type        = string
+  default     = "03:00"
+}
+
+variable "deletion_protection" {
+  description = <<-EOT
+    Guard the Cloud SQL instance and the Cloud Run service against
+    `terraform destroy`. True by default: the database is the knowledge base.
+    Set to false and apply once before tearing the deployment down.
+  EOT
+  type        = bool
+  default     = true
+}
+
+# --- Optional: private IP (guide §2b) -------------------------------------
+
+variable "enable_private_ip" {
+  description = <<-EOT
+    Remove the Cloud SQL public endpoint entirely and reach the instance over
+    private services access, with Direct VPC egress on Cloud Run. Costs
+    nothing extra. The trade-off is that local admin access (cloud-sql-proxy)
+    then needs a VPC-attached workstation or a temporary public IP.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "network" {
+  description = "VPC network used when var.enable_private_ip is true."
+  type        = string
+  default     = "default"
+}
+
+variable "subnetwork" {
+  description = "Subnetwork in var.region used for Cloud Run's Direct VPC egress when var.enable_private_ip is true."
+  type        = string
+  default     = "default"
+}
+
+# --- Optional: Vertex AI embeddings (guide §4) ----------------------------
+
+variable "enable_vertex_embeddings" {
+  description = <<-EOT
+    Turn search hybrid (trigram + vector, reciprocal rank fusion) using Vertex
+    AI embeddings through the service identity — no API keys. Off by default:
+    with it off ochakai calls no external API at all. Recommended for Japanese
+    knowledge bases, where trigram search degrades to a table scan.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "vertex_model" {
+  description = "OCHAKAI_VERTEX_MODEL. Leave null for the default (gemini-embedding-001). Use \"gemini-embedding-2\" to also search image and PDF attachments by content — it requires var.vertex_location of global, us or eu."
+  type        = string
+  default     = null
+}
+
+variable "vertex_location" {
+  description = "OCHAKAI_VERTEX_LOCATION. Leave null for the default (us-central1)."
+  type        = string
+  default     = null
+}
+
+variable "embedding_dim" {
+  description = "OCHAKAI_EMBEDDING_DIM. Leave null for the default (768). Changing this on a base that already holds vectors is refused at startup — the vector columns were created at the old width."
+  type        = number
+  default     = null
+}
+
+# --- Optional: attachments in GCS (guide §4b) -----------------------------
+
+variable "enable_gcs_attachments" {
+  description = <<-EOT
+    Create a bucket for attachment bytes and point ochakai at it. Without it
+    the service runs markdown-only: attach operations return 501 and imports
+    report attachments as failed. Auth is ADC via the service identity.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "gcs_bucket_name" {
+  description = "Name of the attachment bucket. Null means \"<project_id>-ochakai-blobs\"."
+  type        = string
+  default     = null
+}
+
+variable "gcs_force_destroy" {
+  description = "Allow `terraform destroy` to delete a bucket that still holds attachment bytes. False by default — those objects are the only copy."
+  type        = bool
+  default     = false
+}
+
+# --- Optional: the team web UI behind IAP (guide §5b) ---------------------
+
+variable "enable_webui" {
+  description = <<-EOT
+    Deploy `serve-ui` as a second Cloud Run service behind Identity-Aware
+    Proxy, for people who need browser access and cannot run the Go CLI. It
+    is the same image as the server, so there is no second thing to build and
+    the UI is always the exact version of the server it fronts. Personal use
+    needs none of this: `ochakai ui` serves the same page on loopback.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "webui_iap_members" {
+  description = "IAM members granted roles/iap.httpsResourceAccessor on the webui, i.e. who may sign in through IAP. Same \"domain:...\" / \"user:...\" form as var.invoker_members."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition     = !contains(var.webui_iap_members, "allUsers") && !contains(var.webui_iap_members, "allAuthenticatedUsers")
+    error_message = "The webui stays organization-restricted; nothing in this deployment needs an allUsers grant."
+  }
+}
+
+variable "webui_records_browser_user" {
+  description = <<-EOT
+    Record the person signed in to the browser as the author of their edits
+    (`human:tanaka@… via agent:<webui-sa>`) instead of the webui's own service
+    account. Sets OCHAKAI_IAP_AUDIENCE on the webui and adds the webui's
+    service account to the server's delegating callers (design docs 0027,
+    0032). Once set, serve-ui refuses any request IAP did not sign, so a
+    misconfiguration surfaces immediately rather than as months of writes
+    attributed to the wrong author.
+  EOT
+  type        = bool
+  default     = true
+}
+
+# --- Project services -----------------------------------------------------
+
+variable "manage_project_services" {
+  description = "Let this module enable the Google Cloud APIs it needs. Set to false if API enablement is handled elsewhere (an org-level module, or a project factory)."
+  type        = bool
+  default     = true
+}

--- a/deploy/terraform/versions.tf
+++ b/deploy/terraform/versions.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+    # Only the webui (var.enable_webui) needs this one: enabling IAP directly
+    # on a Cloud Run service is still a beta surface, so `iap_enabled` and the
+    # IAP service-agent resource exist in google-beta and not in google.
+    # Terraform requires the declaration whether or not the webui is enabled;
+    # with it disabled the provider is downloaded and then does nothing.
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+}


### PR DESCRIPTION
`deploy/cloudrun/README.md` is a genuinely complete walkthrough and stays the reference — but it is entirely copy-paste `gcloud`. A team adopting ochakai cannot review the deployment as a diff, reproduce it per environment, or tear it down cleanly. This adds a Terraform root module under `deploy/terraform/` for the baseline that guide describes, plus a short pointer to it near the top of the guide.

## What the module creates

Defaults reproduce the guide's ~$10/month example:

- Artifact Registry **remote repository** proxying `ghcr.io` (§1) — Cloud Run cannot pull from GHCR directly, and the proxy keeps the digest identical so GHCR attestations still describe what runs
- Cloud SQL `db-f1-micro`, Postgres 17, 10 GB SSD, single zone, no backups, `cloudsql.iam_authentication=on`, empty authorized-networks (§2)
- `ochakai-run` service account with `roles/cloudsql.client` + `roles/cloudsql.instanceUser` and a `CLOUD_IAM_SERVICE_ACCOUNT` database login (§3)
- the Cloud Run service, scaled to zero, `cpu_idle`, `OCHAKAI_DB_IAM_AUTH=true`, Cloud SQL volume, and **no `allUsers` binding anywhere** (§3)

Off by default, behind flags: private IP (§2b), Vertex embeddings (§4), GCS attachments (§4b), the IAP-fronted `serve-ui` (§5b).

## Two deliberate omissions

**No password admin user.** The guide's §2 admin user holds a generated password, and §6 is largely about retiring it. Generating one in Terraform would put the project's only stored secret back — so the module does not create it. Direct database access for people is `maintenance_users`: Cloud SQL IAM logins, no passwords.

**No schema bootstrap.** Running the §3 SQL from Terraform would mean holding a password to reach Postgres. It stays manual, documented in the module README with the guide's break-glass `postgres` password path, and `terraform output -raw database_bootstrap_sql` prints the statements with the right principal already filled in.

`invoker_members` and `webui_iap_members` **reject `allUsers`/`allAuthenticatedUsers` at the variable**, rather than merely documenting the rule — ochakai reads the Cloud-Run-verified caller identity for provenance, so a public service would make every recorded author forgeable.

## Verification — what actually ran

**Nothing was applied.** No `terraform apply`, no `terraform import`, no mutating `gcloud`. No infrastructure exists as a result of this PR.

Ran, with Terraform v1.5.6 and `hashicorp/google` v6.50.0:

- `terraform fmt -check -recursive deploy/terraform` — clean
- `terraform init -backend=false` + `terraform validate` — **Success**, on the default baseline
- the same on a scratch copy with **every option enabled** (private IP + Vertex + GCS + webui + maintenance users + backups) — **Success**
- the three variable validations exercised against a `terraform plan` in an isolated variables-only directory (no providers, no resources, no API calls): `allUsers`, `allAuthenticatedUsers` and `image_tag = "latest"` are all rejected, valid values pass
- every resource argument checked against the provider's own JSON schema before writing (`terraform providers schema -json`)

**Reviewed by eye only** — these could not be verified without applying:

- that the resources converge on a *working* deployment (ordering, IAM propagation, the guide's §7 notes about grants on fresh service accounts)
- IAP on Cloud Run. `iap_enabled` is not in the GA provider, so the webui service and the IAP service agent use `google-beta`. This is the least-exercised part of the module.
- private-IP peering against a pre-existing `default` network, which the module reads with data sources rather than creating

## Judgement calls the guide does not settle

1. **`deletion_protection` defaults to true** (Terraform- and API-level, on both the instance and the services). The guide's §9 teardown is a plain delete; Terraform convention and the fact that the database *is* the knowledge base argue the other way. Teardown therefore needs `terraform apply -var deletion_protection=false` first, which the module README states.
2. **APIs are managed by the module** (`manage_project_services`, default on) with `disable_on_destroy = false` — turning an API off is project-wide and other things may depend on it.
3. **`cpu_idle = true` is explicit.** The guide does not pass a CPU allocation flag, but its cost table says "request-based billing", so the intent is stated rather than left to a provider default.
4. **`ingress` is left at the provider default.** The guide's privacy comes from IAM, not from ingress restriction, and adding one would be a posture the guide does not describe.
5. **`--ssl-mode=ENCRYPTED_ONLY`, PITR, Binary Authorization, org-policy guardrails (§6) are not modelled** — org policy belongs above any one deployment, and the rest are one command each. Listed in the module README's "what this module does not cover".
6. **`.terraform.lock.hcl` is gitignored.** A lock generated here would carry darwin_arm64 hashes only; this is a module to copy and adapt, not a deployment.
7. **`maintenance_users` takes bare emails** and creates both the IAM login and the project role binding, since only users (not groups) can be Postgres logins.

## Files

Owns `deploy/terraform/**` only, plus a nine-line pointer near the top of `deploy/cloudrun/README.md`. Nothing else touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)