### PR TITLE
Give the search-or-list decision one home instead of two

### DIFF
--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -106,6 +106,35 @@ func parseArgs(fs *flag.FlagSet, args []string) ([]string, error) {
 	}
 }
 
+// exactArgs parses flags and requires exactly n positional arguments. A
+// wrong count prints the command's own usage and returns errReported: the
+// help text says what the command takes, so repeating it in an error
+// message would only be a second, shorter description to keep in sync.
+func exactArgs(fs *flag.FlagSet, args []string, n int) ([]string, error) {
+	pos, err := parseArgs(fs, args)
+	if err != nil {
+		return nil, err
+	}
+	if len(pos) != n {
+		fs.Usage()
+		return nil, errReported
+	}
+	return pos, nil
+}
+
+// idArgs is exactArgs for the commands whose first positional argument is
+// an entry id: it returns that id parsed, and the arguments after it.
+func idArgs(fs *flag.FlagSet, args []string, n int) (id string, rest []string, err error) {
+	pos, err := exactArgs(fs, args, n)
+	if err != nil {
+		return "", nil, err
+	}
+	if id, err = parseRef(pos[0]); err != nil {
+		return "", nil, err
+	}
+	return id, pos[1:], nil
+}
+
 func newClient(ctx context.Context, url string) (*apiclient.Client, error) {
 	if url == "" {
 		return nil, errors.New("server URL required: run `ochakai use <url>`, set OCHAKAI_URL, or pass --url")
@@ -398,15 +427,7 @@ func cmdUsage(ctx context.Context, args []string) error {
 		"Usage: ochakai usage [flags] <id>\n\nShow how often an entry was actually used: appeared in search results,\nfetched individually, reported worked or failed — and when it was last\nused. The measure of the write-back loop: evidence for promoting a\ndraft, and a staleness signal for verified entries nobody uses.",
 		"  ochakai usage queries/monthly-revenue\n  ochakai usage metrics/revenue --json\n")
 	asJSON := fs.Bool("json", false, "print JSON")
-	pos, err := parseArgs(fs, args)
-	if err != nil {
-		return err
-	}
-	if len(pos) != 1 {
-		fs.Usage()
-		return errReported
-	}
-	id, err := parseRef(pos[0])
+	id, _, err := idArgs(fs, args, 1)
 	if err != nil {
 		return err
 	}
@@ -436,15 +457,7 @@ func cmdReport(ctx context.Context, args []string) error {
 		"  ochakai report queries/monthly-revenue worked\n  ochakai report queries/monthly-revenue failed --note \"joins dropped 2024 rows after schema change\"\n")
 	note := fs.String("note", "", "context recorded with the report: what was run, what went wrong (max 2000 bytes)")
 	asJSON := fs.Bool("json", false, "print the updated usage totals as JSON")
-	pos, err := parseArgs(fs, args)
-	if err != nil {
-		return err
-	}
-	if len(pos) != 2 {
-		fs.Usage()
-		return errReported
-	}
-	id, err := parseRef(pos[0])
+	id, rest, err := idArgs(fs, args, 2)
 	if err != nil {
 		return err
 	}
@@ -452,14 +465,14 @@ func cmdReport(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	u, err := c.ReportOutcome(ctx, id, pos[1], *note)
+	u, err := c.ReportOutcome(ctx, id, rest[0], *note)
 	if err != nil {
 		return err
 	}
 	if *asJSON {
 		return printJSON(u)
 	}
-	fmt.Printf("reported %s ochakai://%s (worked %d, failed %d)\n", pos[1], id, u.Worked, u.Failed)
+	fmt.Printf("reported %s ochakai://%s (worked %d, failed %d)\n", rest[0], id, u.Worked, u.Failed)
 	return nil
 }
 
@@ -469,15 +482,7 @@ func cmdRevisions(ctx context.Context, args []string) error {
 		"  ochakai revisions metrics/revenue\n  ochakai revisions queries/monthly-revenue --json | jq '.revisions[0].snapshot'\n")
 	limit := fs.Int("limit", 0, "max revisions (server default 50, max 200)")
 	asJSON := fs.Bool("json", false, "print the raw JSON response (includes full snapshots)")
-	pos, err := parseArgs(fs, args)
-	if err != nil {
-		return err
-	}
-	if len(pos) != 1 {
-		fs.Usage()
-		return errReported
-	}
-	id, err := parseRef(pos[0])
+	id, _, err := idArgs(fs, args, 1)
 	if err != nil {
 		return err
 	}
@@ -505,15 +510,7 @@ func cmdBacklinks(ctx context.Context, args []string) error {
 		"  ochakai backlinks metrics/revenue\n  ochakai backlinks metrics/revenue --json | jq '.entries[].id'\n")
 	limit := fs.Int("limit", 0, "max entries (server default 20, max 100)")
 	asJSON := fs.Bool("json", false, "print the raw JSON response")
-	pos, err := parseArgs(fs, args)
-	if err != nil {
-		return err
-	}
-	if len(pos) != 1 {
-		fs.Usage()
-		return errReported
-	}
-	id, err := parseRef(pos[0])
+	id, _, err := idArgs(fs, args, 1)
 	if err != nil {
 		return err
 	}
@@ -545,15 +542,7 @@ func cmdGet(ctx context.Context, args []string) error {
 		"  ochakai get metrics/revenue\n  ochakai get queries/monthly-revenue --json | jq -r '.attrs.sql'\n  ochakai get insights/revenue-reading --download ./img\n")
 	asJSON := fs.Bool("json", false, "print JSON instead of the OKF document")
 	download := fs.String("download", "", "save the entry's attachments into this directory")
-	pos, err := parseArgs(fs, args)
-	if err != nil {
-		return err
-	}
-	if len(pos) != 1 {
-		fs.Usage()
-		return errReported
-	}
-	id, err := parseRef(pos[0])
+	id, _, err := idArgs(fs, args, 1)
 	if err != nil {
 		return err
 	}
@@ -658,15 +647,7 @@ func cmdDetach(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
 		"Usage: ochakai detach [flags] <id> <name>\n\nRemove an attachment from a knowledge entry (the change is kept as a\nrevision; content-addressed bytes stay referenced by history).",
 		"  ochakai detach insights/revenue-reading weekly.png\n")
-	pos, err := parseArgs(fs, args)
-	if err != nil {
-		return err
-	}
-	if len(pos) != 2 {
-		fs.Usage()
-		return errReported
-	}
-	id, err := parseRef(pos[0])
+	id, rest, err := idArgs(fs, args, 2)
 	if err != nil {
 		return err
 	}
@@ -674,10 +655,10 @@ func cmdDetach(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	if err := c.Detach(ctx, id, pos[1]); err != nil {
+	if err := c.Detach(ctx, id, rest[0]); err != nil {
 		return err
 	}
-	fmt.Printf("detached %s/%s\n", id, pos[1])
+	fmt.Printf("detached %s/%s\n", id, rest[0])
 	return nil
 }
 
@@ -732,15 +713,7 @@ func cmdUpdate(ctx context.Context, args []string) error {
 	file := fs.String("f", "", "input file (default: stdin)")
 	ifMatch := fs.String("if-match", "", "update only if the entry still has this `version` — its updated_at (`ochakai get <id> --json` prints it as .updated_at; a REST GET returns it as the ETag header); a stale version fails with a conflict instead of overwriting")
 	asJSON := fs.Bool("json", false, "print the updated entry as JSON")
-	pos, err := parseArgs(fs, args)
-	if err != nil {
-		return err
-	}
-	if len(pos) != 1 {
-		fs.Usage()
-		return errReported
-	}
-	id, err := parseRef(pos[0])
+	id, _, err := idArgs(fs, args, 1)
 	if err != nil {
 		return err
 	}
@@ -781,15 +754,7 @@ func cmdVerify(ctx context.Context, args []string) error {
 		"Usage: ochakai verify [flags] <id>\n\nRecord a verification against the entry as it stands: you become\nverified_by and verified_at is stamped now. Promotes a draft, and\nre-affirms an entry that is already verified — which is what takes it\nout of both review feeds (--sort verified_at, --sort failed). Verifying\na rejected entry clears the rejection: the status becomes verified and\nrejected_by/rejected_at are dropped (the revision history keeps both).",
 		"  ochakai verify metrics/revenue\n  ochakai verify metrics/revenue --json | jq -r .verified_at\n")
 	asJSON := fs.Bool("json", false, "print the verified entry as JSON")
-	pos, err := parseArgs(fs, args)
-	if err != nil {
-		return err
-	}
-	if len(pos) != 1 {
-		fs.Usage()
-		return errReported
-	}
-	id, err := parseRef(pos[0])
+	id, _, err := idArgs(fs, args, 1)
 	if err != nil {
 		return err
 	}
@@ -812,15 +777,7 @@ func cmdDelete(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
 		"Usage: ochakai delete [flags] <id>\n\nSoft-delete a knowledge entry (history is retained server-side).",
 		"  ochakai delete terms/obsolete-kpi\n")
-	pos, err := parseArgs(fs, args)
-	if err != nil {
-		return err
-	}
-	if len(pos) != 1 {
-		fs.Usage()
-		return errReported
-	}
-	id, err := parseRef(pos[0])
+	id, _, err := idArgs(fs, args, 1)
 	if err != nil {
 		return err
 	}
@@ -844,15 +801,7 @@ func cmdPurge(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
 		"Usage: ochakai purge [flags] <id>\n\nHard-delete an already soft-deleted entry: the entry, its revisions,\nusage, and attachment metadata are erased and the id is freed for a\nmove. History is gone — `ochakai delete` first, then purge. A live\nentry is refused.",
 		"  ochakai delete terms/obsolete-kpi\n  ochakai purge terms/obsolete-kpi\n")
-	pos, err := parseArgs(fs, args)
-	if err != nil {
-		return err
-	}
-	if len(pos) != 1 {
-		fs.Usage()
-		return errReported
-	}
-	id, err := parseRef(pos[0])
+	id, _, err := idArgs(fs, args, 1)
 	if err != nil {
 		return err
 	}
@@ -878,13 +827,8 @@ func cmdReembed(ctx context.Context, args []string) error {
 	limit := fs.Int("limit", 0, "max entries to embed per pass (server default 200)")
 	once := fs.Bool("once", false, "run a single pass instead of continuing until nothing is left")
 	asJSON := fs.Bool("json", false, "print the raw JSON response of each pass")
-	pos, err := parseArgs(fs, args)
-	if err != nil {
+	if _, err := exactArgs(fs, args, 0); err != nil {
 		return err
-	}
-	if len(pos) != 0 {
-		fs.Usage()
-		return errReported
 	}
 	c, err := newClient(ctx, *url)
 	if err != nil {
@@ -939,19 +883,11 @@ func cmdMove(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
 		"Usage: ochakai move [flags] <id> <new-id>\n\nMove (rename) a knowledge entry to a new id. Revisions, usage, and\nattachments follow, and inbound references (link targets, attrs.model)\nare rewritten so nothing breaks.",
 		"  ochakai move insights/revenue-seasonality insights/sales/revenue-seasonality\n")
-	pos, err := parseArgs(fs, args)
+	id, rest, err := idArgs(fs, args, 2)
 	if err != nil {
 		return err
 	}
-	if len(pos) != 2 {
-		fs.Usage()
-		return errReported
-	}
-	id, err := parseRef(pos[0])
-	if err != nil {
-		return err
-	}
-	newID, err := parseRef(pos[1])
+	newID, err := parseRef(rest[0])
 	if err != nil {
 		return err
 	}
@@ -972,13 +908,9 @@ func cmdExport(ctx context.Context, args []string) error {
 		"Usage: ochakai export [flags] <dir | ->\n\nDownload the whole knowledge base as an OKF bundle (markdown + YAML\nfrontmatter) into dir, or stream the tar.gz to stdout with \"-\".\nYour knowledge is yours.",
 		"  ochakai export ./knowledge\n  ochakai export - > ochakai-okf.tar.gz\n  ochakai export --no-attachments - > entries.tar.gz   # bytes are in GCS; copy them from there\n")
 	noAtt := fs.Bool("no-attachments", false, "export the markdown only, skipping attachment files")
-	pos, err := parseArgs(fs, args)
+	pos, err := exactArgs(fs, args, 1)
 	if err != nil {
 		return err
-	}
-	if len(pos) != 1 {
-		fs.Usage()
-		return errReported
 	}
 	c, err := newClient(ctx, *url)
 	if err != nil {
@@ -1006,13 +938,9 @@ func cmdImport(ctx context.Context, args []string) error {
 		"Usage: ochakai import [flags] <dir | file.tar.gz | ->\n\nImport an OKF bundle (a directory of markdown + YAML frontmatter, or\na tar.gz of one; \"-\" reads the tar.gz from stdin). The inverse of\n`ochakai export`: each path names its entry (the path minus .md is\nthe id), the frontmatter type key names the type (required — files\nwithout one are skipped and reported), reserved index.md / log.md\nfiles are skipped, unknown frontmatter keys are kept as attrs, and\nexisting entries are replaced (kept as revisions; entries identical\nto what is stored are left untouched and reported as unchanged;\nentries the server rejects as invalid — e.g. one whose type is not a\nsingle line — are skipped and reported).\nFiles referenced by an entry's body markdown links become its\nattachments, wherever they sit in the bundle (their location is\npreserved for re-export); unreferenced data files inside an entry's\ndirectory (<id>/<name>) attach to that entry. The packed shape is\nthe structure: an archive wrapped in a single directory imports\nunder that directory — the bundle keeps its own namespace. Works\nwith any OKF bundle, not just ochakai's own.",
 		"  ochakai import ./knowledge\n  ochakai import ga4-bundle.tar.gz --dry-run\n  ochakai export - | OCHAKAI_URL=https://other ochakai import -\n")
 	dryRun := fs.Bool("dry-run", false, "parse and list what would be written, write nothing")
-	pos, err := parseArgs(fs, args)
+	pos, err := exactArgs(fs, args, 1)
 	if err != nil {
 		return err
-	}
-	if len(pos) != 1 {
-		fs.Usage()
-		return errReported
 	}
 	files, err := readBundle(pos[0])
 	if err != nil {

--- a/cmd/ochakai/instances.go
+++ b/cmd/ochakai/instances.go
@@ -173,13 +173,8 @@ func cmdWhoami(ctx context.Context, args []string) error {
 		"Usage: ochakai whoami [flags]\n\nPrint which server client commands target and where that choice came\nfrom (--url / $OCHAKAI_URL / `ochakai use`), the identity your\ncredentials present (the server's actor resolution is authoritative),\nand whether the server is reachable.",
 		"  ochakai whoami\n  ochakai whoami --json\n")
 	asJSON := fs.Bool("json", false, "print JSON")
-	pos, err := parseArgs(fs, args)
-	if err != nil {
+	if _, err := exactArgs(fs, args, 0); err != nil {
 		return err
-	}
-	if len(pos) != 0 {
-		fs.Usage()
-		return errReported
 	}
 	if *target == "" {
 		return errors.New("no server selected: run `ochakai use <url>`, set OCHAKAI_URL, or pass --url")

--- a/cmd/ochakai/ui.go
+++ b/cmd/ochakai/ui.go
@@ -29,13 +29,8 @@ func cmdUI(ctx context.Context, args []string) error {
 		"Usage: ochakai ui [flags]\n\nServe the web UI at http://127.0.0.1:<port> against the selected\nserver. API calls are proxied with your own Google identity (resolved\nthe same way as every other client command), so no deployment is\nneeded and your edits are recorded as human:<you>. The proxy also\nexposes /mcp, so it doubles as an authenticated local MCP endpoint.\nFor a team-shared UI on Cloud Run, deploy `ochakai serve-ui`.",
 		"  ochakai ui\n  ochakai ui --port 9000\n  claude mcp add --transport http ochakai http://127.0.0.1:8098/mcp\n")
 	port := fs.Int("port", 8098, "port to listen on (always bound to 127.0.0.1: whoever reaches the proxy acts as you)")
-	pos, err := parseArgs(fs, args)
-	if err != nil {
+	if _, err := exactArgs(fs, args, 0); err != nil {
 		return err
-	}
-	if len(pos) != 0 {
-		fs.Usage()
-		return errReported
 	}
 
 	c, err := newClient(ctx, *target)

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -184,36 +184,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			Types: domain.ToTypes(in.Types), Statuses: domain.ToStatuses(in.Statuses),
 			Tags: in.Tags, Source: in.Source,
 		}
-		if in.Sort != "" {
-			if !domain.ValidListSort(in.Sort) {
-				return nil, searchOut{}, fmt.Errorf("invalid sort %q (valid: %s)", in.Sort, strings.Join(domain.ListSorts, ", "))
-			}
-			if in.Query != "" {
-				return nil, searchOut{}, fmt.Errorf("sort=%s lists entries; it cannot be combined with a search query", in.Sort)
-			}
-			list := svc.ListByVerifiedAt
-			switch in.Sort {
-			case "usage":
-				list = svc.ListByUsage
-			case "failed":
-				list = svc.ListByFailed
-			case "stale_after":
-				list = svc.ListByStaleAfter
-			}
-			hits, err := list(ctx, f, in.Limit)
-			if err != nil {
-				return nil, searchOut{}, err
-			}
-			return nil, searchOut{Hits: hits}, nil
-		}
-		if in.Query == "" && in.Source != "" {
-			hits, err := svc.ListBySource(ctx, f, in.Limit)
-			if err != nil {
-				return nil, searchOut{}, err
-			}
-			return nil, searchOut{Hits: hits}, nil
-		}
-		hits, err := svc.Search(ctx, in.Query, f, in.Limit)
+		hits, err := svc.SearchOrList(ctx, in.Query, in.Sort, f, in.Limit)
 		if err != nil {
 			return nil, searchOut{}, err
 		}

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -56,46 +56,7 @@ func Handler(svc *service.Service) http.Handler {
 			Tags:     q["tag"],
 			Source:   q.Get("source"),
 		}
-		if sort := q.Get("sort"); sort != "" {
-			if !domain.ValidListSort(sort) {
-				writeError(w, service.Invalidf("invalid sort (valid: %s)", strings.Join(domain.ListSorts, ", ")))
-				return
-			}
-			if q.Get("q") != "" {
-				writeError(w, service.Invalidf("sort=%s lists entries; it cannot be combined with a search query (q)", sort))
-				return
-			}
-			var hits []domain.SearchHit
-			switch sort {
-			case "usage":
-				hits, err = svc.ListByUsage(r.Context(), f, limit)
-			case "failed":
-				hits, err = svc.ListByFailed(r.Context(), f, limit)
-			case "stale_after":
-				hits, err = svc.ListByStaleAfter(r.Context(), f, limit)
-			default:
-				hits, err = svc.ListByVerifiedAt(r.Context(), f, limit)
-			}
-			if err != nil {
-				writeError(w, err)
-				return
-			}
-			writeHits(w, r, svc, hits)
-			return
-		}
-		// A source filter with nothing to search by is the reverse lookup:
-		// "what derives from this material" has no text to rank, so it
-		// lists (design doc 0037 §2.3).
-		if q.Get("q") == "" && f.Source != "" {
-			hits, err := svc.ListBySource(r.Context(), f, limit)
-			if err != nil {
-				writeError(w, err)
-				return
-			}
-			writeHits(w, r, svc, hits)
-			return
-		}
-		hits, err := svc.Search(r.Context(), q.Get("q"), f, limit)
+		hits, err := svc.SearchOrList(r.Context(), q.Get("q"), q.Get("sort"), f, limit)
 		if err != nil {
 			writeError(w, err)
 			return

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -790,61 +790,85 @@ func jsonSize(v any) int {
 	return len(b)
 }
 
-// ListByVerifiedAt lists entries by verification age, oldest first — the
-// feed for canary runs over verified golden queries (see
-// docs/guides/golden-query-canary.md). Not a search: no usage is recorded.
-// Results are SearchHits with score 0, so the REST and MCP responses keep
-// the exact wire shape of a search across both modes.
-func (s *Service) ListByVerifiedAt(ctx context.Context, f store.Filter, limit int) ([]domain.SearchHit, error) {
-	if limit <= 0 || limit > 1000 {
-		limit = 100
-	}
-	entries, err := s.Store.ListByVerifiedAt(ctx, f, limit)
-	if err != nil {
-		return nil, err
-	}
-	hits := make([]domain.SearchHit, len(entries))
-	for i, k := range entries {
-		hits[i] = domain.SearchHit{Knowledge: k}
-	}
-	return hits, nil
-}
-
-// ListBySource lists the entries citing one resource — the reverse of
-// sources[].resource (design doc 0037 §2.3). Reached when a caller gives
-// a source filter and nothing to search by: the question is "what derives
-// from this material", which has no text to rank. Not a search: no usage
-// is recorded, and hits carry score 0 like every other list mode.
-func (s *Service) ListBySource(ctx context.Context, f store.Filter, limit int) ([]domain.SearchHit, error) {
-	if limit <= 0 || limit > 1000 {
-		limit = 100
-	}
-	entries, err := s.Store.ListBySource(ctx, f, limit)
-	if err != nil {
-		return nil, err
-	}
-	hits := make([]domain.SearchHit, len(entries))
-	for i, k := range entries {
-		hits[i] = domain.SearchHit{Knowledge: k}
-	}
-	return hits, nil
-}
-
-// ListByStaleAfter lists the entries whose declared expiry has passed,
-// most overdue first — the feed for knowledge its own author dated
-// (design doc 0037 §2.1). Only entries stale today: a date that has not
-// come due is not work yet.
+// SearchOrList answers the query surface REST (GET /api/v1/knowledge) and
+// MCP (search_knowledge) both expose, so the two cannot drift: one place
+// decides whether a request searches or lists, validates the mode, and
+// runs it. A sort mode names one of the listing feeds (see list); with no
+// sort, a source filter and no query is the reverse lookup; otherwise it
+// is a search.
 //
-// The one feed verifying does not empty. verified_at and failed are
-// server observations, and re-checking updates them; stale_after is what
-// the writer declared, so clearing it means editing the entry to declare
-// a new expiry (design doc 0037 §2.2). Not a search: no usage recorded,
-// score 0, same wire shape as every other list mode.
-func (s *Service) ListByStaleAfter(ctx context.Context, f store.Filter, limit int) ([]domain.SearchHit, error) {
+// Sort and query are mutually exclusive rather than combined: a feed is a
+// queue a reviewer works through, and ranking it by relevance to a query
+// would leave the reviewer with neither the whole queue nor the best
+// matches. The CLI refuses the same pair before it ever gets here.
+func (s *Service) SearchOrList(ctx context.Context, query, sort string, f store.Filter, limit int) ([]domain.SearchHit, error) {
+	if sort != "" {
+		if !domain.ValidListSort(sort) {
+			return nil, Invalidf("invalid sort %q (valid: %s)", sort, strings.Join(domain.ListSorts, ", "))
+		}
+		if strings.TrimSpace(query) != "" {
+			return nil, Invalidf("sort=%s lists entries; it cannot be combined with a search query", sort)
+		}
+		return s.list(ctx, sort, f, limit)
+	}
+	// A source filter with nothing to search by is the reverse lookup:
+	// "what derives from this material" has no text to rank, so it lists
+	// (design doc 0037 §2.3).
+	if strings.TrimSpace(query) == "" && f.Source != "" {
+		return s.list(ctx, sortBySource, f, limit)
+	}
+	return s.Search(ctx, query, f, limit)
+}
+
+// sortBySource is the listing mode a source filter with no query selects.
+// Not one of domain.ListSorts: no caller can ask for it by name, because
+// the filter already says what is wanted.
+const sortBySource = "source"
+
+// list runs one of the listing feeds. None of them is a search: no usage
+// is recorded (reading a review queue must not inflate the very signal it
+// ranks by), and every hit carries score 0, so the REST and MCP responses
+// keep the exact wire shape of a search across all modes.
+//
+//   - verified_at — by verification age, oldest first (never-verified
+//     last): the feed for canary runs over verified golden queries (see
+//     docs/guides/golden-query-canary.md).
+//   - usage — by demand, most-searched first, never-used drafts
+//     oldest-first at the bottom: the web UI's draft review queue. Hits
+//     carry their usage totals so the reviewer sees the evidence inline.
+//   - failed — entries whose failure reports are still unanswered, worst
+//     first: the re-verification feed (design doc 0025), the
+//     evidence-based counterpart to verified_at. Verifying (or rejecting)
+//     takes an entry out of it, so a base that is kept up yields an empty
+//     one. Hits carry their usage totals.
+//   - stale_after — entries whose declared expiry has passed, most
+//     overdue first (design doc 0037 §2.1); only entries stale today, a
+//     date that has not come due is not work yet. The one feed verifying
+//     does not empty: verified_at and failed are server observations,
+//     while stale_after is what the writer declared, so clearing it means
+//     editing the entry to declare a new expiry (design doc 0037 §2.2).
+//   - source — the entries citing one resource, the reverse of
+//     sources[].resource (design doc 0037 §2.3).
+func (s *Service) list(ctx context.Context, sort string, f store.Filter, limit int) ([]domain.SearchHit, error) {
 	if limit <= 0 || limit > 1000 {
 		limit = 100
 	}
-	entries, err := s.Store.ListByStaleAfter(ctx, f, limit)
+	// The two usage feeds rank by the usage totals and hand them back with
+	// each hit, so they are hits already.
+	switch sort {
+	case "usage":
+		return s.Store.ListByUsage(ctx, f, limit)
+	case "failed":
+		return s.Store.ListByFailed(ctx, f, limit)
+	}
+	list := s.Store.ListByVerifiedAt
+	switch sort {
+	case "stale_after":
+		list = s.Store.ListByStaleAfter
+	case sortBySource:
+		list = s.Store.ListBySource
+	}
+	entries, err := list(ctx, f, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -853,34 +877,6 @@ func (s *Service) ListByStaleAfter(ctx context.Context, f store.Filter, limit in
 		hits[i] = domain.SearchHit{Knowledge: k}
 	}
 	return hits, nil
-}
-
-// ListByUsage lists entries by demand — most-searched first, never-used
-// drafts oldest-first at the bottom — for the web UI draft review queue.
-// Not a search: no usage is recorded (reading the queue must not inflate
-// the very signal it ranks by). Each hit carries its usage totals; score
-// is 0, keeping the wire shape of a search across all list modes.
-func (s *Service) ListByUsage(ctx context.Context, f store.Filter, limit int) ([]domain.SearchHit, error) {
-	if limit <= 0 || limit > 1000 {
-		limit = 100
-	}
-	return s.Store.ListByUsage(ctx, f, limit)
-}
-
-// ListByFailed lists entries whose failure reports are still unanswered,
-// worst first — the re-verification feed (design doc 0025): in-force
-// knowledge that callers report is producing wrong results, the
-// evidence-based counterpart to the verified_at feed. Verifying an entry
-// (or rejecting it) takes it out of the feed, so a base that is kept up
-// yields an empty one. Not a search: no usage is recorded (triaging the
-// queue must not inflate the signal it ranks by). Each hit carries its
-// usage totals; score is 0, keeping the wire shape of a search across all
-// list modes.
-func (s *Service) ListByFailed(ctx context.Context, f store.Filter, limit int) ([]domain.SearchHit, error) {
-	if limit <= 0 || limit > 1000 {
-		limit = 100
-	}
-	return s.Store.ListByFailed(ctx, f, limit)
 }
 
 // Revisions returns an entry's change history, newest first — the

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -112,6 +112,33 @@ func TestSearchRejectsEmptyQuery(t *testing.T) {
 	}
 }
 
+// TestSearchOrListValidation pins the mode rules REST and MCP both
+// delegate here, so the two surfaces cannot answer the same request
+// differently: an unknown sort is a client error, and a sort combined
+// with a query is one for every mode in domain.ListSorts (a feed is a
+// queue to work through, not something to rank by relevance). All of it
+// runs before any store access — the Service below has none.
+func TestSearchOrListValidation(t *testing.T) {
+	s := &Service{}
+	ctx := context.Background()
+	var inputErr *InvalidInputError
+
+	_, err := s.SearchOrList(ctx, "", "created_at", store.Filter{}, 0)
+	if !errors.As(err, &inputErr) || !strings.Contains(err.Error(), "invalid sort") {
+		t.Errorf("unknown sort: got %v, want an invalid-sort InvalidInputError", err)
+	}
+	for _, sort := range domain.ListSorts {
+		_, err := s.SearchOrList(ctx, "revenue", sort, store.Filter{}, 0)
+		if !errors.As(err, &inputErr) || !strings.Contains(err.Error(), "cannot be combined") {
+			t.Errorf("sort=%s with a query: got %v, want a cannot-be-combined InvalidInputError", sort, err)
+		}
+	}
+	if _, err := s.SearchOrList(ctx, "  ", "", store.Filter{}, 0); !errors.As(err, &inputErr) ||
+		!strings.Contains(err.Error(), "needs a query") {
+		t.Errorf("neither query nor sort: got %v, want a needs-a-query InvalidInputError", err)
+	}
+}
+
 // TestReportOutcomeValidation pins the input checks that run before any
 // store access: an unknown outcome and an oversized note are client
 // errors (InvalidInputError → 400), never a nil-store panic.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -253,9 +253,25 @@ func actorPtrs(a *domain.Actor) (kind, name *string, via string) {
 	return &a.Kind, &a.Name, a.Via
 }
 
-func (s *Store) Get(ctx context.Context, id string) (*domain.Knowledge, error) {
+// queryKnowledge runs a query selecting knowledgeCols and collects the
+// entries it returns.
+func (s *Store) queryKnowledge(ctx context.Context, sql string, args ...any) ([]domain.Knowledge, error) {
+	rows, err := s.pool.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, err
+	}
+	return pgx.CollectRows(rows, scanKnowledge)
+}
+
+// getOne returns the single entry holding id on the live or the deleted
+// side of the row's lifetime, or ErrNotFound when that side is empty.
+func (s *Store) getOne(ctx context.Context, id string, deleted bool) (*domain.Knowledge, error) {
+	cond := "deleted_at IS NULL"
+	if deleted {
+		cond = "deleted_at IS NOT NULL"
+	}
 	rows, err := s.pool.Query(ctx,
-		`SELECT `+knowledgeCols+` FROM knowledge WHERE id = $1 AND deleted_at IS NULL`, id)
+		`SELECT `+knowledgeCols+` FROM knowledge WHERE id = $1 AND `+cond, id)
 	if err != nil {
 		return nil, err
 	}
@@ -267,6 +283,10 @@ func (s *Store) Get(ctx context.Context, id string) (*domain.Knowledge, error) {
 		return nil, err
 	}
 	return &k, nil
+}
+
+func (s *Store) Get(ctx context.Context, id string) (*domain.Knowledge, error) {
+	return s.getOne(ctx, id, false)
 }
 
 // GetTombstone returns the soft-deleted entry holding id, or ErrNotFound
@@ -275,19 +295,7 @@ func (s *Store) Get(ctx context.Context, id string) (*domain.Knowledge, error) {
 // and status_note, so a surface that must not overwrite a ruling has to
 // be able to see the ruling a tombstone still carries.
 func (s *Store) GetTombstone(ctx context.Context, id string) (*domain.Knowledge, error) {
-	rows, err := s.pool.Query(ctx,
-		`SELECT `+knowledgeCols+` FROM knowledge WHERE id = $1 AND deleted_at IS NOT NULL`, id)
-	if err != nil {
-		return nil, err
-	}
-	k, err := pgx.CollectExactlyOneRow(rows, scanKnowledge)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, ErrNotFound
-	}
-	if err != nil {
-		return nil, err
-	}
-	return &k, nil
+	return s.getOne(ctx, id, true)
 }
 
 // ListLinkingTo returns live entries whose links point at id, most
@@ -295,17 +303,13 @@ func (s *Store) GetTombstone(ctx context.Context, id string) (*domain.Knowledge,
 // insight that explains a metric links to the metric, not the other way
 // round. Both bare and ochakai:// target forms match.
 func (s *Store) ListLinkingTo(ctx context.Context, id string, limit int) ([]domain.Knowledge, error) {
-	rows, err := s.pool.Query(ctx,
+	return s.queryKnowledge(ctx,
 		`SELECT `+knowledgeCols+` FROM knowledge
 		 WHERE deleted_at IS NULL AND (links @> $1 OR links @> $2)
 		 ORDER BY updated_at DESC LIMIT $3`,
 		fmt.Sprintf(`[{"target": %q}]`, id),
 		fmt.Sprintf(`[{"target": %q}]`, "ochakai://"+id),
 		limit)
-	if err != nil {
-		return nil, err
-	}
-	return pgx.CollectRows(rows, scanKnowledge)
 }
 
 // Create inserts a new entry. A live entry with the same id is
@@ -1103,9 +1107,7 @@ func (s *Store) SearchLexical(ctx context.Context, query string, f Filter, limit
 	if err != nil {
 		return nil, err
 	}
-	return pgx.CollectRows(rows, func(row pgx.CollectableRow) (domain.SearchHit, error) {
-		return scanHit(row)
-	})
+	return pgx.CollectRows(rows, scanHit)
 }
 
 // SearchVector ranks by cosine distance against stored embeddings.
@@ -1192,9 +1194,7 @@ func (s *Store) annSearch(ctx context.Context, limit int, q string, args []any) 
 	if err != nil {
 		return nil, err
 	}
-	return pgx.CollectRows(rows, func(row pgx.CollectableRow) (domain.SearchHit, error) {
-		return scanHit(row)
-	})
+	return pgx.CollectRows(rows, scanHit)
 }
 
 func scanHit(row pgx.CollectableRow) (domain.SearchHit, error) {
@@ -1264,13 +1264,8 @@ func sourceContainment(resource string) []byte {
 // order beats a relevance score nothing computed.
 func (s *Store) ListBySource(ctx context.Context, f Filter, limit int) ([]domain.Knowledge, error) {
 	where, args := f.buildWhere("")
-	q := fmt.Sprintf(`SELECT `+knowledgeCols+` FROM knowledge WHERE %s
-		ORDER BY id LIMIT %d`, where, limit)
-	rows, err := s.pool.Query(ctx, q, args...)
-	if err != nil {
-		return nil, err
-	}
-	return pgx.CollectRows(rows, scanKnowledge)
+	return s.queryKnowledge(ctx, fmt.Sprintf(`SELECT `+knowledgeCols+` FROM knowledge WHERE %s
+		ORDER BY id LIMIT %d`, where, limit), args...)
 }
 
 // ListByStaleAfter returns the entries whose declared expiry has passed,
@@ -1292,14 +1287,9 @@ func (s *Store) ListByStaleAfter(ctx context.Context, f Filter, limit int) ([]do
 	// doc 0036 §3.9), and current_date would hand that decision to
 	// whatever TimeZone the database session happens to carry — the same
 	// entry would be stale on one deployment and not on another.
-	q := fmt.Sprintf(`SELECT `+knowledgeCols+` FROM knowledge WHERE %s
+	return s.queryKnowledge(ctx, fmt.Sprintf(`SELECT `+knowledgeCols+` FROM knowledge WHERE %s
 		AND stale_after IS NOT NULL AND stale_after <= (now() AT TIME ZONE 'UTC')::date
-		ORDER BY stale_after ASC, id LIMIT %d`, where, limit)
-	rows, err := s.pool.Query(ctx, q, args...)
-	if err != nil {
-		return nil, err
-	}
-	return pgx.CollectRows(rows, scanKnowledge)
+		ORDER BY stale_after ASC, id LIMIT %d`, where, limit), args...)
 }
 
 // ListByVerifiedAt returns filtered entries ordered by verification age,
@@ -1307,13 +1297,8 @@ func (s *Store) ListByStaleAfter(ctx context.Context, f Filter, limit int) ([]do
 // query canary runs: "which verified queries have gone longest unchecked".
 func (s *Store) ListByVerifiedAt(ctx context.Context, f Filter, limit int) ([]domain.Knowledge, error) {
 	where, args := f.buildWhere("")
-	q := fmt.Sprintf(`SELECT `+knowledgeCols+` FROM knowledge WHERE %s
-		ORDER BY verified_at ASC NULLS LAST, id LIMIT %d`, where, limit)
-	rows, err := s.pool.Query(ctx, q, args...)
-	if err != nil {
-		return nil, err
-	}
-	return pgx.CollectRows(rows, scanKnowledge)
+	return s.queryKnowledge(ctx, fmt.Sprintf(`SELECT `+knowledgeCols+` FROM knowledge WHERE %s
+		ORDER BY verified_at ASC NULLS LAST, id LIMIT %d`, where, limit), args...)
 }
 
 // usageLateral aggregates a knowledge entry's per-event running totals


### PR DESCRIPTION
## What and why

Refactor only — no wire change, no new capability, no design decision touched.

**The one that matters: the search-or-list decision lived in two places.**
`GET /api/v1/knowledge` and the MCP `search_knowledge` tool each validated
the sort mode, refused the sort+query pair, dispatched to one of five
service methods, and handled the source-only reverse lookup — separately,
in wording that had already drifted. Adding a sixth sort mode meant
writing the same switch twice and hoping. Design doc 0015 exists because
that is how surfaces diverge.

It now lives in `service.SearchOrList`; both surfaces call it and render
the result. REST's handler goes 41 lines → 6, MCP's 31 → 5. The five
per-feed service methods were one function written five times (three
byte-identical below the doc comment), so they collapse into `list`, each
feed's rationale kept in the doc comment. Unchanged: the limit contract
(default 100, max 1000), "not a search, so no usage is recorded", score 0
in every list mode. The only visible difference is that the two surfaces
now return the same error text instead of nearly the same — REST's
`invalid sort` quotes the offending value, and the sort+query refusal drops
its `(q)` suffix.

Two more, mechanical:

- **CLI**: the twelve-line ritual (parse flags → count positionals → print
  usage → parse the id) was copied into thirteen commands. `exactArgs` and
  `idArgs` say it once. Behavior identical, including which mistakes print
  the usage.
- **store**: `Get` and `GetTombstone` differed only in a `deleted_at`
  condition; four list queries carried the same query-check-collect tail.
  The SQL is unchanged character for character — only the plumbing is
  shared. Also drops two closures that did nothing but call `scanHit`.

Net −142 lines.

## Checks

CI runs exactly this; make it pass locally first (CONTRIBUTING.md has the
context, including the store integration test and the fuzz targets).

- [x] `gofmt -l .` prints nothing; `go vet ./...`; `go test -race ./...`
- [x] `CGO_ENABLED=0 go build -trimpath ./...`
- [x] golangci-lint (0 issues) and govulncheck (0 affecting this code)
- [x] Behavior changes come with tests — `TestSearchOrListValidation` moves
      the mode rules' test to the layer that now owns them, and loops over
      `domain.ListSorts` so a new mode is covered the day it is added

The store integration test is included, which is what actually exercises
the extracted `getOne` / `queryKnowledge`: run locally against
`pgvector/pgvector:pg17` on 55433 with `OCHAKAI_TEST_DATABASE_URL` set
(`internal/store` 11.7s, plus the REST, MCP and service integration tests
in the same pass), and again on CI's own PostgreSQL service. Nothing is
skipped in either place.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — nothing on the wire moved;
      `apiclient` and the OpenAPI spec are untouched
- [x] The change lands on every surface it belongs on — REST and MCP now
      share one implementation of the rule they were each spelling out, and
      the CLI's own refusal (before the request) is unchanged

## Design docs

- [x] Not applicable: no accepted decision is altered. 0025 §implementation
      and 0037 §2.1/§2.3 describe contracts (limit bounds, no usage
      recording, list-not-search) that this preserves; only the Go method
      those notes name has moved.
- [x] Commit messages and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

