### PR TITLE
Realign the recommended type vocabulary to what OKF spells out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,50 @@ last entry.
 
 ## [Unreleased]
 
-Nothing yet.
+### Changed
+
+- **BREAKING** — the recommended type vocabulary is realigned to what OKF
+  itself spells out, going from nine types to eleven (design doc 0038).
+  The test is SPEC §4.1's one demand of a producer — that a spelling be
+  descriptive and self-explanatory — applied in both directions.
+  - **Retired: `Semantic Model` and `Golden Query`.** `Semantic Model`
+    failed the test: since 0.13.0 removed compile and its write-time
+    validation, all that remained was a convention to put an Apache Ossie
+    object in `attrs.spec`, which nothing on the server reads and no
+    spelling explains. `Golden Query` is what an `Attested Computation`
+    with a `runtime` already is — SPEC §10.2 requires only `runtime` and
+    leaves `parameters`/`executor`/`attester` optional — so store a
+    golden query as one: the SQL in a `# Computation` body fence, the
+    question in `attrs.question`.
+  - **Added: `Skill`, `Playbook`, `Policy`, `API Endpoint`.** `Playbook`
+    and `API Endpoint` are SPEC §4.1 examples, and §4.4 writes a Playbook
+    out in full as its example of a concept bound to no resource.
+    `Policy` and `Skill` come from the reference bundles, and they close
+    a real gap: an entry's `sources[].resource` cites a Policy and its
+    `executor.resource` points at a Skill, so ochakai was storing both
+    ends of an edge while naming only one.
+  - **No migration runs and no stored entry changes.** The retired
+    spellings stay valid to write and are matched, searched, exported and
+    updated exactly as before — they are now free types (design doc
+    0005). The type is not renamed for you, because `runtime` is required
+    on an Attested Computation and only the author knows it.
+  - `domain.TypeModels` and `domain.TypeQueries` are gone from the Go
+    API. `--type 'Golden Query'` still returns those entries.
+  - No server behavior attaches to any of the four new types. The one
+    type-specific rule stays the `runtime` requirement on an Attested
+    Computation (design doc 0036 §3.10).
+  - The vocabulary was previously written out in eleven places at three
+    different lengths, with `Semantic Model` already missing from four of
+    them. Every list that Go emits — the MCP tool descriptions and all
+    three shell completions — now comes from `domain.TypesHint()`, and
+    the static ones (OpenAPI, the Web UI, the MCP jsonschema tags) are
+    pinned by tests that fail when a type is missing or a retired
+    spelling is still recommended (design doc 0038 §4.4).
+- The shipped example `examples/golden-query.md` and the canary guide are
+  rewritten onto `Attested Computation`. The example's SQL moves out of
+  `attrs.sql` into its `# Computation` fence: SPEC §10.2 makes the fence
+  the computation, and keeping a second copy left a consumer no way to
+  tell which was authoritative.
 
 ## [0.14.0] - 2026-07-27
 

--- a/README.md
+++ b/README.md
@@ -299,14 +299,16 @@ over time, run them as canaries from your CI:
 
 | Type | What it holds |
 |---|---|
-| `Semantic Model` | Apache Ossie semantic model, spec verbatim in `attrs.spec` |
-| `Metric` | Semantic metric definition (Apache Ossie), synonyms |
-| `Golden Query` | Golden query: natural-language question + verified SQL |
-| `Attested Computation` | A sanctioned computation and the means to check a run of it: the computation in a `# Computation` body fence, the contract in the `runtime` / `parameters` / `executor` / `attester` fields. ochakai records it and never runs it |
+| `Metric` | Semantic metric definition, synonyms |
+| `Attested Computation` | A sanctioned computation and the means to check a run of it: the computation in a `# Computation` body fence, the contract in the `runtime` / `parameters` / `executor` / `attester` fields. ochakai records it and never runs it. A golden query is one of these: `runtime` says where the SQL runs, `attrs.question` carries the question it answers |
+| `Skill` | A procedure an entry's `executor.resource` points at — how to actually run a computation on a given runtime |
+| `Playbook` | An operational procedure people and agents follow, bound to no resource: incident triage, an on-call runbook |
 | `Insight` | How to read a metric: baselines, seasonality, caveats, thresholds |
+| `Policy` | The rule that decides a number — revenue recognition, cost allocation. What an entry's `sources[].resource` cites |
 | `Glossary Term` | Glossary term |
 | `BigQuery Dataset` | BigQuery dataset catalog entry: a container grouping tables |
 | `BigQuery Table` | BigQuery table catalog entry: source, column notes, known issues |
+| `API Endpoint` | Catalog entry for an asset that is not a BigQuery one |
 | `Reference` | Mirror of external material: enum definitions, licenses, schema docs |
 
 These are recommendations, not a closed set — any single-line value works as a type for your
@@ -315,7 +317,7 @@ own document kinds, and IDs may be hierarchical
 The type values are the [OKF knowledge-catalog](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf/bundles)
 vocabulary verbatim: OKF registers no taxonomy, so the spelling is the
 meaning, and a bundle's types survive an import/export round-trip unchanged
-with no translation layer (design doc 0023). Matching is case-insensitive;
+with no translation layer (design docs 0023, 0038). Matching is case-insensitive;
 the spelling you write is the one stored. A type is not an address — the
 directory layout of an exported bundle comes from entry IDs alone (design
 doc 0017), so you are free to organize files however you like.
@@ -352,7 +354,8 @@ entry carries its provenance, trust and lifecycle (SPEC §5) where a
 consumer that has never heard of ochakai will look for them.
 
 ```yaml
-type: Golden Query
+type: Attested Computation
+runtime: bigquery
 title: Monthly revenue by channel
 sources:
   - id: rev-policy

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -849,15 +849,16 @@ components:
     Type:
       type: string
       description: >
-        The OKF type vocabulary, verbatim — the built-ins (Semantic Model,
-        Metric, Golden Query, Attested Computation, Insight, Glossary Term,
-        BigQuery Dataset, BigQuery Table, Reference) are recommendations,
+        The OKF type vocabulary, verbatim — the built-ins (Metric,
+        Attested Computation, Skill, Playbook, Insight, Policy,
+        Glossary Term, BigQuery Dataset, BigQuery Table, API Endpoint,
+        Reference) are recommendations,
         not a closed set, and no server behavior hangs off any of them
-        (design docs 0023, 0028 §3, 0036 §3.6). Any
+        (design doc 0038). Any
         single-line value works as a type; OKF registers no taxonomy, so
         the spelling is the meaning and it round-trips unchanged. Matching
         is case-insensitive; the spelling you write is the one stored.
-      examples: [Semantic Model, Metric, Golden Query, Attested Computation, Insight, Glossary Term, BigQuery Dataset, BigQuery Table, Reference, Data Contract]
+      examples: [Metric, Attested Computation, Skill, Playbook, Insight, Policy, Glossary Term, BigQuery Dataset, BigQuery Table, API Endpoint, Reference, Data Contract]
       pattern: "^[^/\\r\\n]{1,128}$"
     Status:
       type: string
@@ -1085,7 +1086,8 @@ components:
           type: object
           description: >
             Producer-defined extension keys (OKF SPEC §4.1) — e.g.
-            question/sql for a Golden Query, spec for a Semantic Model.
+            question/sql for an Attested Computation holding a verified
+            query, spec for a semantic model.
             Kept verbatim and written back at the top level of the exported
             frontmatter. Every key OKF v0.2 itself defines is a field of
             its own above; naming one here is rejected rather than stored

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -154,8 +154,8 @@ func parseRef(s string) (string, error) {
 
 func cmdSearch(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
-		"Usage: ochakai search [flags] [query]\n\nSearch the knowledge base; verified entries rank higher.\nOutput: score, uri, status, title — description (one hit per line).\nWith --sort verified_at the command lists by verification age instead\nof searching (oldest first, never-verified last — the golden-query\ncanary feed); output leads with verified_at. With --sort usage it lists\nby demand (most search_hits first, never-used oldest-first at the bottom\n— the draft review feed); output leads with the search_hits count.\nWith --sort failed it lists entries whose failure reports (report_outcome\nfailed) are still unanswered, worst first — the re-verification feed;\noutput leads with the failed count. `ochakai verify` takes an entry out\nof it, so a base that is kept up shows an empty feed.\nWith --sort stale_after it lists entries whose declared stale_after has\npassed, most overdue first; output leads with that date. Verifying does\nnot empty this one — the date is the writer's declaration, so clearing it\nmeans editing the entry to re-declare an expiry.\n--source is a filter, not a mode: it narrows to the entries citing one\nresource (the reverse of sources[].resource) and combines with a query\nor with any --sort.",
-		"  ochakai search \"gross margin\" --type Metric --type 'Glossary Term' --status verified\n  ochakai search churn --json | jq '.hits[0].attrs'\n  ochakai search --sort verified_at --type 'Golden Query' --status verified --limit 100\n  ochakai search --sort usage --status draft --limit 50   # review queue\n  ochakai search --sort failed --status verified            # re-verification queue\n  ochakai search --sort stale_after                         # past their declared expiry\n  ochakai search --source https://wiki.example/finance/revenue-recognition  # what cites this\n")
+		"Usage: ochakai search [flags] [query]\n\nSearch the knowledge base; verified entries rank higher.\nOutput: score, uri, status, title — description (one hit per line).\nWith --sort verified_at the command lists by verification age instead\nof searching (oldest first, never-verified last — the\ncanary feed); output leads with verified_at. With --sort usage it lists\nby demand (most search_hits first, never-used oldest-first at the bottom\n— the draft review feed); output leads with the search_hits count.\nWith --sort failed it lists entries whose failure reports (report_outcome\nfailed) are still unanswered, worst first — the re-verification feed;\noutput leads with the failed count. `ochakai verify` takes an entry out\nof it, so a base that is kept up shows an empty feed.\nWith --sort stale_after it lists entries whose declared stale_after has\npassed, most overdue first; output leads with that date. Verifying does\nnot empty this one — the date is the writer's declaration, so clearing it\nmeans editing the entry to re-declare an expiry.\n--source is a filter, not a mode: it narrows to the entries citing one\nresource (the reverse of sources[].resource) and combines with a query\nor with any --sort.",
+		"  ochakai search \"gross margin\" --type Metric --type 'Glossary Term' --status verified\n  ochakai search churn --json | jq '.hits[0].attrs'\n  ochakai search --sort verified_at --type 'Attested Computation' --status verified --limit 100\n  ochakai search --sort usage --status draft --limit 50   # review queue\n  ochakai search --sort failed --status verified            # re-verification queue\n  ochakai search --sort stale_after                         # past their declared expiry\n  ochakai search --source https://wiki.example/finance/revenue-recognition  # what cites this\n")
 	var types, statuses, tags repeated
 	fs.Var(&types, "type", "filter by type: "+typeList()+", or any custom type (repeatable)")
 	fs.Var(&statuses, "status", "filter by status: "+statusList()+" (repeatable)")
@@ -266,7 +266,7 @@ func cmdBrowse(ctx context.Context, args []string) error {
 func cmdContext(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
 		"Usage: ochakai context [flags] <question>\n\nGather what to read before answering a data question, in one call:\nthe full entries behind the top search hits (verified entries rank\nhigher), expanded one hop through links so the insight explaining a\nmetric travels with it. Markdown on stdout, ready for an agent's\ncontext window. No hits print nothing (exit 0).",
-		"  ochakai context \"why did revenue drop in March?\"\n  ochakai context \"monthly revenue\" --type 'Golden Query' --status verified --json\n  ochakai context \"$PROMPT\" --budget 4000   # hooks: cap the injected bytes\n")
+		"  ochakai context \"why did revenue drop in March?\"\n  ochakai context \"monthly revenue\" --type 'Attested Computation' --status verified --json\n  ochakai context \"$PROMPT\" --budget 4000   # hooks: cap the injected bytes\n")
 	var types, statuses, tags repeated
 	fs.Var(&types, "type", "filter by type: "+typeList()+", or any custom type (repeatable)")
 	fs.Var(&statuses, "status", "filter by status: "+statusList()+" (repeatable)")
@@ -307,7 +307,7 @@ func cmdContext(ctx context.Context, args []string) error {
 }
 
 // renderContext prints the pack as compact markdown: per entry a heading
-// with URI, status, and title, a provenance line, the golden-query
+// with URI, status, and title, a provenance line, the entry's
 // question and SQL when present, then the body. Once the byte budget is
 // spent the remaining entries are dropped with a note (the first entry
 // always renders); hits without a rendered entry become one-line pointers.
@@ -432,7 +432,7 @@ func cmdUsage(ctx context.Context, args []string) error {
 
 func cmdReport(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
-		"Usage: ochakai report [flags] <id> <worked|failed>\n\nReport whether acting on an entry gave a correct result — the last\nedge of the write-back loop. After running a golden query or SQL you\nwrote from an entry, report worked or failed (say what went wrong with\n--note); failed counts against verified entries flag them for\nre-verification. Prints the entry's updated usage totals.",
+		"Usage: ochakai report [flags] <id> <worked|failed>\n\nReport whether acting on an entry gave a correct result — the last\nedge of the write-back loop. After running an attested computation or SQL you\nwrote from an entry, report worked or failed (say what went wrong with\n--note); failed counts against verified entries flag them for\nre-verification. Prints the entry's updated usage totals.",
 		"  ochakai report queries/monthly-revenue worked\n  ochakai report queries/monthly-revenue failed --note \"joins dropped 2024 rows after schema change\"\n")
 	note := fs.String("note", "", "context recorded with the report: what was run, what went wrong (max 2000 bytes)")
 	asJSON := fs.Bool("json", false, "print the updated usage totals as JSON")

--- a/cmd/ochakai/client_test.go
+++ b/cmd/ochakai/client_test.go
@@ -142,12 +142,12 @@ func TestRenderContext(t *testing.T) {
 	human := domain.Actor{Kind: domain.ActorHuman, Name: "na0"}
 	res := &apiclient.ContextResult{
 		Hits: []domain.ContextRank{
-			{Type: domain.TypeQueries, ID: "queries/monthly-revenue", Status: domain.StatusVerified, Title: "Monthly revenue", Score: 0.9},
+			{Type: domain.TypeComputations, ID: "queries/monthly-revenue", Status: domain.StatusVerified, Title: "Monthly revenue", Score: 0.9},
 			{Type: domain.TypeTerms, ID: "terms/arr", Status: domain.StatusDraft, Title: "ARR", Score: 0.1},
 		},
 		Entries: []domain.Knowledge{
 			{
-				Type: domain.TypeQueries, ID: "queries/monthly-revenue", Status: domain.StatusVerified,
+				Type: domain.TypeComputations, ID: "queries/monthly-revenue", Status: domain.StatusVerified,
 				Title:      "Monthly revenue",
 				CreatedBy:  domain.Actor{Kind: domain.ActorAgent, Name: "claude"},
 				VerifiedBy: &human, VerifiedAt: &now,
@@ -305,7 +305,7 @@ func TestVerifyJSONPrintsTheEntry(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/v1/verify/{id...}", func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(domain.Knowledge{
-			Type: domain.TypeQueries, ID: r.PathValue("id"), Status: domain.StatusVerified,
+			Type: domain.TypeComputations, ID: r.PathValue("id"), Status: domain.StatusVerified,
 			Title: "Monthly revenue", VerifiedBy: &human, VerifiedAt: &verified,
 		})
 	})

--- a/cmd/ochakai/completion.go
+++ b/cmd/ochakai/completion.go
@@ -7,6 +7,23 @@ package main
 import (
 	"context"
 	"fmt"
+	"strings"
+
+	"github.com/na0fu3y/ochakai/internal/domain"
+)
+
+// typesMark stands in for the recommended vocabulary inside the three
+// scripts below. Interpolating it beats writing the list out three more
+// times: the vocabulary has one home, and narrowing it cannot leave a
+// retired spelling behind in a shell (design doc 0038 §4.4). Each shell
+// already wraps the whole list in one quote style, so the types that
+// contain a space take the other one.
+const typesMark = "@TYPES@"
+
+var (
+	zshCompletion  = strings.ReplaceAll(zshCompletionTmpl, typesMark, domain.TypesQuoted(`"`))
+	bashCompletion = strings.ReplaceAll(bashCompletionTmpl, typesMark, domain.TypesQuoted(`'`))
+	fishCompletion = strings.ReplaceAll(fishCompletionTmpl, typesMark, domain.TypesQuoted(`"`))
 )
 
 func cmdCompletion(_ context.Context, args []string) error {
@@ -29,7 +46,7 @@ func cmdCompletion(_ context.Context, args []string) error {
 // Server names for `ochakai use <Tab>` come from the bare list output
 // (name\turl per line, current marked in column 1-2): cut -c3- | cut -f1.
 
-const zshCompletion = `#compdef ochakai
+const zshCompletionTmpl = `#compdef ochakai
 # zsh completion for ochakai. Either source <(ochakai completion zsh)
 # in ~/.zshrc, or install it as an fpath file (no sourcing needed):
 #   ochakai completion zsh > "${fpath[1]}/_ochakai"
@@ -71,7 +88,7 @@ _ochakai() {
   case $words[2] in
     search)
       _arguments \
-        '*--type[filter by type]:type:("Semantic Model" Metric "Golden Query" "Attested Computation" Insight "Glossary Term" "BigQuery Dataset" "BigQuery Table" Reference)' \
+        '*--type[filter by type]:type:(@TYPES@)' \
         '*--status[filter by status]:status:(draft verified deprecated rejected)' \
         '*--tag[filter by tag]:tag:' \
         '--sort[list instead of searching: by verification age, demand, or failed reports]:sort:(verified_at usage failed)' \
@@ -81,7 +98,7 @@ _ochakai() {
       ;;
     context)
       _arguments \
-        '*--type[filter by type]:type:("Semantic Model" Metric "Golden Query" "Attested Computation" Insight "Glossary Term" "BigQuery Dataset" "BigQuery Table" Reference)' \
+        '*--type[filter by type]:type:(@TYPES@)' \
         '*--status[filter by status]:status:(draft verified deprecated rejected)' \
         '*--tag[filter by tag]:tag:' \
         '--limit[max full entries]:limit:' \
@@ -154,7 +171,7 @@ else
 fi
 `
 
-const bashCompletion = `# bash completion for ochakai — source <(ochakai completion bash)
+const bashCompletionTmpl = `# bash completion for ochakai — source <(ochakai completion bash)
 _ochakai() {
   local cur prev cmd opts
   cur=${COMP_WORDS[COMP_CWORD]}
@@ -167,7 +184,7 @@ _ochakai() {
   fi
 
   case $prev in
-    --type|-type) COMPREPLY=($(compgen -W "'Semantic Model' Metric 'Golden Query' 'Attested Computation' Insight 'Glossary Term' 'BigQuery Dataset' 'BigQuery Table' Reference" -- "$cur")); return ;;
+    --type|-type) COMPREPLY=($(compgen -W "@TYPES@" -- "$cur")); return ;;
     --status|-status) COMPREPLY=($(compgen -W "draft verified deprecated rejected" -- "$cur")); return ;;
     --sort|-sort) COMPREPLY=($(compgen -W "verified_at usage failed" -- "$cur")); return ;;
     -f) compopt -o default 2>/dev/null; COMPREPLY=(); return ;;
@@ -216,7 +233,7 @@ _ochakai() {
 complete -F _ochakai ochakai
 `
 
-const fishCompletion = `# fish completion for ochakai — ochakai completion fish | source
+const fishCompletionTmpl = `# fish completion for ochakai — ochakai completion fish | source
 complete -c ochakai -f
 
 complete -c ochakai -n __fish_use_subcommand -a search -d 'search knowledge; verified entries rank higher'
@@ -256,7 +273,7 @@ complete -c ochakai -n '__fish_seen_subcommand_from report' -a 'worked failed'
 complete -c ochakai -n '__fish_seen_subcommand_from get' -l download -r -a '(__fish_complete_directories)' -d 'save attachments into this directory'
 complete -c ochakai -n '__fish_seen_subcommand_from attach' -l name -x -d 'attachment name'
 complete -c ochakai -n '__fish_seen_subcommand_from attach' -F
-complete -c ochakai -n '__fish_seen_subcommand_from search context' -l type -x -a '"Semantic Model" Metric "Golden Query" "Attested Computation" Insight "Glossary Term" "BigQuery Dataset" "BigQuery Table" Reference' -d 'filter by type'
+complete -c ochakai -n '__fish_seen_subcommand_from search context' -l type -x -a '@TYPES@' -d 'filter by type'
 complete -c ochakai -n '__fish_seen_subcommand_from search context' -l status -x -a 'draft verified deprecated rejected' -d 'filter by status'
 complete -c ochakai -n '__fish_seen_subcommand_from search' -l sort -x -a 'verified_at usage failed' -d 'list instead of searching: by verification age, demand, or failed reports'
 complete -c ochakai -n '__fish_seen_subcommand_from search context' -l tag -x -d 'filter by tag'

--- a/cmd/ochakai/main.go
+++ b/cmd/ochakai/main.go
@@ -1,5 +1,5 @@
 // ochakai is a context provider for data agents: one knowledge base for
-// metric definitions, verified golden queries, interpretation knowledge,
+// metric definitions, attested computations, interpretation knowledge,
 // glossary terms, and table catalogs, served over MCP and REST.
 package main
 

--- a/cmd/ochakai/main_test.go
+++ b/cmd/ochakai/main_test.go
@@ -76,8 +76,18 @@ func TestShippedInstructionsUseCurrentTypeVocabulary(t *testing.T) {
 				t.Errorf("%s uses the pre-0023 type name %q", f, stale)
 			}
 		}
-		if !strings.Contains(s, "Golden Query") {
-			t.Errorf("%s never names the Golden Query type", f)
+		// Design doc 0038 retired two spellings. They stay valid to write,
+		// which is exactly why a doc can keep recommending one for years
+		// without anything failing — so the retired spellings are pinned
+		// here in the forms that tell a reader to use the type.
+		for _, retired := range []string{"type: Golden Query", "type=Golden%20Query",
+			"--type 'Golden Query'", "type: Semantic Model", "--type 'Semantic Model'"} {
+			if strings.Contains(s, retired) {
+				t.Errorf("%s still instructs the reader to use the retired type: %q", f, retired)
+			}
+		}
+		if !strings.Contains(s, "Attested Computation") {
+			t.Errorf("%s never names the Attested Computation type", f)
 		}
 	}
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -157,9 +157,15 @@ its filename — and ids are NFC-normalized and searchable in their own
 right (design doc [0022](design/0022-filename-as-name.md)).
 
 **Types are an open set with a recommended vocabulary.** The spellings
-are the OKF knowledge-catalog vocabulary verbatim — `Golden Query`, not a
-slug — so a bundle's types survive a round-trip with no translation layer
-in between (design doc [0023](design/0023-okf-type-vocabulary.md)). Any
+are the OKF knowledge-catalog vocabulary verbatim — `Attested
+Computation`, not a slug — so a bundle's types survive a round-trip with
+no translation layer in between (design doc
+[0023](design/0023-okf-type-vocabulary.md)). What earns a place in the
+recommended eleven is SPEC §4.1's one demand of a producer — that the
+spelling be descriptive and self-explanatory — read against the spellings
+OKF itself supplies, in the spec's own examples and in its reference
+bundles (design doc
+[0038](design/0038-type-vocabulary-realignment.md)). Any
 single-line string works as a type. `status`, by contrast, is a closed
 set: `draft`, `verified`, `deprecated`, `rejected`. `rejected` is the
 one that most stores lack — it records that a proposal was considered and

--- a/docs/design/0018-semantic-model-as-knowledge.md
+++ b/docs/design/0018-semantic-model-as-knowledge.md
@@ -1,8 +1,11 @@
 # ochakai 設計ドキュメント 0018: import-ossie の廃止 — セマンティックモデルを通常ナレッジにする
 
 Status: Accepted(2026-07-19)。[0028](0028-retire-compile-sql.md) が
-compile_sql と書き込み時検証(§4.2・§4.3)を撤去 — import-ossie 廃止と
-「モデルは通常のナレッジエントリ」の決定は有効
+compile_sql と書き込み時検証(§4.2・§4.3)を撤去し、
+[0038](0038-type-vocabulary-realignment.md) §3.1 が §4.1 の推奨タイプ
+`Semantic Model` を語彙から外した(モデルは自由型として引き続き
+第一級)— import-ossie 廃止と「モデルは通常のナレッジエントリ」の
+決定は有効
 Date: 2026-07-19
 
 ## 1. 目的

--- a/docs/design/0023-okf-type-vocabulary.md
+++ b/docs/design/0023-okf-type-vocabulary.md
@@ -1,8 +1,10 @@
 # ochakai 設計ドキュメント 0023: 型の語彙を OKF に一本化する
 
-Status: Accepted(2026-07-20)。§3.1 の型の一覧に
-[0035](0036-okf-schema-first.md) §3.6 が `Attested Computation`(OKF v0.2 §10)を
-足して 9 型にした
+Status: **Superseded by [0038](0038-type-vocabulary-realignment.md)**
+(型が OKF の綴りそのものであるという決定と §3.2-3.5 の規則は 0038 が
+引き継いだ)。改訂の履歴: §3.1 の一覧に
+[0036](0036-okf-schema-first.md) §3.6 が `Attested Computation`(OKF v0.2 §10)を
+足して 9 型にし、0038 が 2 型を外し 4 型を足して 11 型にした
 Date: 2026-07-20
 
 ## 1. 目的

--- a/docs/design/0028-retire-compile-sql.md
+++ b/docs/design/0028-retire-compile-sql.md
@@ -1,6 +1,9 @@
 # ochakai 設計ドキュメント 0028: compile_sql とセマンティックモデル面の撤去
 
-Status: Accepted(2026-07-25)
+Status: Accepted(2026-07-25)。§3 の「型 `Semantic Model` は推奨語彙に
+残す」は [0038](0038-type-vocabulary-realignment.md) §3.1 が覆した
+(語彙からは外れるが、エントリは自由型として無傷 — §5「既存エントリを
+削除・移行しない」は有効)
 Date: 2026-07-25
 
 ## 1. 決定

--- a/docs/design/0036-okf-schema-first.md
+++ b/docs/design/0036-okf-schema-first.md
@@ -4,7 +4,9 @@ Status: Accepted(2026-07-27)。[0005](0005-okf-compatibility.md) と
 [0016](0016-knowledge-catalog-alignment.md) を Superseded にし、
 [0009](0009-provenance-portability.md) §4 と
 [0023](0023-okf-type-vocabulary.md) §3.1 を改訂する。
-**OKF 互換領域の現行ドキュメント**。実装は同 PR、次のリリース(0.14.0)で出る
+**OKF 互換領域の現行ドキュメント**。実装は同 PR、次のリリース(0.14.0)で出る。
+§3.6 の 9 型は [0038](0038-type-vocabulary-realignment.md) が 11 型に組み替えた
+(`Attested Computation` を語彙に足した決定そのものは有効)
 Date: 2026-07-27
 
 ## 1. 目的

--- a/docs/design/0038-type-vocabulary-realignment.md
+++ b/docs/design/0038-type-vocabulary-realignment.md
@@ -1,0 +1,236 @@
+# ochakai 設計ドキュメント 0038: 推奨型の語彙を OKF の証拠に合わせ直す
+
+Status: Accepted(2026-07-27)。[0023](0023-okf-type-vocabulary.md) を
+Superseded にし、[0028](0028-retire-compile-sql.md) §3 の
+「`Semantic Model` は推奨語彙に残す」と
+[0036](0036-okf-schema-first.md) §3.6 の 9 型を改訂する。
+**型の語彙領域の現行ドキュメント**。実装は同 PR
+Date: 2026-07-27
+
+## 1. 目的
+
+推奨型の語彙を、ochakai が独自に育てた 9 型から、**OKF が実際に示している
+語彙**に合わせ直す。`Semantic Model` と `Golden Query` を外し、
+`Skill` / `Playbook` / `Policy` / `API Endpoint` を足して 11 型にする。
+
+これは 0023 の続きである。0023 は「型の綴りがそのまま意味である」
+(SPEC §4.1 の "the spelling is the meaning")を確立し、内部スラグとの
+二重語彙を消した。本ドキュメントは同じ規準を**語彙の中身**に適用する —
+綴りがそのまま意味になっていない型が 2 つ残っており、逆に **OKF の側が
+綴りを与えている概念を 4 つ取りこぼしていた**。
+
+本ドキュメントは 0023 の部分改訂ではなく置き換えである。0023 §3.1 の
+一覧はすでに 0036 §3.6 が 1 度改訂しており、ここに 2 つ目の部分改訂を
+重ねると「現在の語彙は何か」が 3 つのドキュメントの差分を合成しないと
+分からなくなる(CONTRIBUTING.md の改訂チェーン回避)。§4 が語彙の
+現在の姿を単独で述べる。
+
+## 2. 前提の確認: SPEC は語彙を推奨していない
+
+先に誤解を一つ潰しておく。SPEC §4.1 の
+`BigQuery Table` / `BigQuery Dataset` / `API Endpoint` / `Metric` /
+`Playbook` / `Reference` / `Attested Computation` という並びは
+**"Example values" であって推奨語彙ではない**。同じ節がこう続く:
+
+> Type values are **not** registered centrally. Producers SHOULD pick
+> values that are descriptive and self-explanatory; consumers MUST
+> tolerate unknown types gracefully, typically by treating them as
+> generic concepts.
+
+したがって「SPEC の例示に無いから外す」も「例示にあるから足す」も、
+それ単独では論法にならない。判断の材料は 2 つある:
+
+1. SPEC が producer に課している唯一の要請 —
+   **"descriptive and self-explanatory"**。
+2. **OKF が実際に綴りを与えた証拠**。SPEC の例示、SPEC 本文が worked
+   example として書き下した型、そして SPEC と同じリポジトリの
+   [リファレンスバンドル](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf/bundles)
+   が実際に使っている型である。
+
+この 2 つで測ると、現在の語彙は**両方向にずれている**。
+
+## 3. 現状のずれ
+
+### 3.1 綴りが意味になっていない 2 つ
+
+**`Semantic Model`。** 0028 が compile_sql と書き込み時検証を撤去した
+時点で、この型に残ったのは「`attrs.spec` に Apache Ossie のモデル
+オブジェクトを入れる」という**サーバーが誰も読まない規約**だけになった。
+0028 §3 は「振る舞いの無い型はすでに 3 つある — 語彙は振る舞いの
+レジストリではない」として残す判断をしたが、その理由づけは**振る舞いの
+有無しか見ていなかった**。
+
+見るべきは self-explanatory かどうかである。`Insight` や `Reference` は
+振る舞いが無くても綴りだけで意味が立つ。`Semantic Model` は立たない —
+Apache Ossie という外部仕様を知って初めて `attrs.spec` に何を入れるかが
+決まる。**綴りの外に意味がある型**であり、0023 が消したのはまさにこの構造
+である。0028 の判断は 0023 の規準に照らすと一貫していなかった。
+
+セマンティックモデルを ochakai に置くこと自体は 0018 のまま有効である。
+外すのは推奨語彙からだけで、モデルは自由型として引き続き第一級に扱われる。
+
+### 3.2 SPEC が綴りを与えたのに ochakai が持っていない 4 つ
+
+| 型 | OKF 側の根拠 |
+|---|---|
+| `API Endpoint` | SPEC §4.1 の例示 |
+| `Playbook` | SPEC §4.1 の例示、**§4.4 が worked example として全文を書いている**(「resource に紐づかない concept」の代表例、インシデント対応手順)、§9 のログ例にも登場 |
+| `Policy` | リファレンスバンドル `acme_retail/policies/`(2 件) |
+| `Skill` | リファレンスバンドル `acme_retail/skills/`、**SPEC §10.2 が `resource` の背後にあるものとして名指ししている**(「What sits behind a `resource` (a Skill, a script, a container) は packaging の選択」) |
+
+`Policy` と `Skill` は例示に無いが、**ochakai がすでに封筒フィールドとして
+持っている構造の行き先**である点が重い(§3.3)。
+
+### 3.3 `Golden Query` — 概念は残り、綴りだけが余分になった
+
+「質問 + 検証済み SQL」という概念は消えない。**それを表す型が SPEC に
+できた**ので、ochakai 独自の綴りを持ち続ける理由が無くなった。
+
+SPEC §10.2 で REQUIRED なのは `runtime` だけで、`parameters` /
+`executor` / `attester` は OPTIONAL である。つまりゴールデンクエリは
+
+```yaml
+type: Attested Computation
+runtime: bigquery
+question: 今年の月次売上は?      # プロデューサ拡張キー
+```
+
+に本文の `# Computation` フェンスを添えれば、**過不足なく Attested
+Computation として表現できる**。しかも得るものがある — `runtime` が
+明示され、必要なら `attester` を足して「この SQL が書き換えられていない
+こと」を下流に検証させられる。0036 §3.6 が「コンパイラを持たないまま
+同じ需要をバンドルの語彙で満たせる」と書いた線の先である。
+
+**`attrs.question` は型から独立している。** 埋め込みテキスト
+(`embeddingText`、`internal/service/service.go`)と CLI の `context`
+レンダリング(`cmd/ochakai/client.go`)はどちらも**属性**を読んでおり
+型では分岐しない。したがって型を外しても、質問文が検索に効くことも
+`question` が整形表示されることも変わらない。
+
+### 3.4 封筒フィールドの行き先に名前が無かった
+
+0036 が `sources` と Attested Computation の契約を封筒に載せたことで、
+ochakai は**他のエントリを指すフィールドを 3 本**持っている。その指し先に
+推奨語彙の名前が無かった:
+
+- `sources[].resource` → 典拠。リファレンスバンドルでは
+  `policies/revenue-recognition.md`(type `Policy`)を指している。
+- `executor.resource` → 実行手順。バンドルでは
+  `skills/run-on-bq.md`(type `Skill`)を指している。SPEC §10.2 も
+  `resource` の背後を「a Skill, a script, a container」と説明する。
+- `attester.resource` → 検証コード。バンドルでは `.py` ファイルであり、
+  concept ではなく添付である。**ここに型は要らない。**
+
+`Policy` と `Skill` を語彙に入れることは、**ochakai がすでに持っている
+グラフの辺に、両端の名前を与える**ことに等しい。0038 で足す 4 つのうち、
+この 2 つがもっとも実効的である。
+
+## 4. 決定: 推奨語彙は 11 型
+
+| 型 | 何を持つか |
+|---|---|
+| `Metric` | メトリクス定義、同義語 |
+| `Attested Computation` | 認可された計算と、その実行を検証する手段(ゴールデンクエリはこれ) |
+| `Skill` | 手順そのもの — `executor.resource` が指す実行手順 |
+| `Playbook` | 人・エージェントが従う運用手順(インシデント対応など) |
+| `Insight` | メトリクスの読み方: ベースライン、季節性、注意点、閾値 |
+| `Policy` | 数字の決め方を定める規範。`sources[].resource` の典拠になる |
+| `Glossary Term` | 用語 |
+| `BigQuery Dataset` | データセットのカタログエントリ |
+| `BigQuery Table` | テーブルのカタログエントリ |
+| `API Endpoint` | BigQuery 以外の資産のカタログエントリ |
+| `Reference` | 外部資料の写し |
+
+表示順は「定義 → 実行 → 解釈と規範 → カタログ資産 → 外部の写し」で、
+既存 7 型の相対順序は変えていない。
+
+0023 のすべての規則はそのまま生き続ける — 型は自由文字列、照合は
+大小文字非依存、保存は原表記、NFC 正規化、`/` 不可、128 バイト以内。
+**変わるのは推奨語彙の中身だけである。**
+
+### 4.1 `Skill` と `Playbook` は別の型である
+
+どちらも「手順」だが、**誰が従うかではなく、何に指されるかが違う**。
+`Skill` は `executor.resource` の指し先、すなわち Attested Computation の
+契約の一部として機械的に参照される。`Playbook` は何にも指されない —
+SPEC §4.4 がこれを「resource に紐づかない concept」の例として選んでいる
+とおりである。畳んで 1 つにすると、契約の指し先を検索で絞れなくなる。
+
+### 4.2 サーバーの振る舞いは 1 つも増えない
+
+足す 4 型に検証も特別扱いも付けない。0028 が引いた線
+(語彙は振る舞いのレジストリではない)はそのままで、型に schema を課す
+例外は 0036 §3.10 が定めた `Attested Computation` の `runtime` ただ 1 つに
+留まる。`Skill` に「手順が本文にあること」を課したくなるが、それは
+0036 §5 が閉じた話である。
+
+### 4.3 保存済みエントリは触らない
+
+**マイグレーションは書かない。** 0023 §3.5 が旧綴りについて定めた
+とおり、語彙から外れた型は**自由型としてそのまま生き続ける** —
+検索も export も import もリビジョンも更新も、これまでどおり動く。
+0005「自由型は第一級」がそのまま働くので、ここに特別扱いは要らない。
+
+型を機械的に `Attested Computation` へ改名する案は**採らない**。
+`runtime` は SPEC §10.2 で REQUIRED であり、書き込み経路の検証
+(`validateOKF`、0036 §3.9)は create と update の両方で空の `runtime` を
+400 にする。改名だけしたエントリは読めるが**次の更新で弾かれる**状態に
+なり、かといって ochakai が `bigquery` と埋めるのは「知らない事実を
+書き込む」ことで、0036 §3.4 の「再解釈は黙って行わない」に反する。
+runtime を知っているのは著者だけである。
+
+移行したい利用者は、通常の update で `type` と `runtime` を書き換えれば
+よい。それは知識の編集であって、サーバーの都合で走らせるものではない
+(0009「Your knowledge is yours」、0028 §5 と同じ線)。
+
+### 4.4 語彙を述べる場所を 1 つにする
+
+現状、語彙は**11 箇所にハードコードされ、長さが 3 通りに割れている** —
+`domain.Types` と補完 4 箇所と OpenAPI と Web UI の `TYPE_ICONS` と
+README が 9 型、MCP の `writeIn.Type` と Web UI のフォームヒントが 8 型
+(`Semantic Model` が欠落)、MCP の `search_knowledge` 説明と
+`searchIn` / `contextIn` が 7 型(`Attested Computation` も欠落)である。
+`domain.TypesHint()` はエラーメッセージ 2 箇所でしか使われていない。
+
+これは 0015(サーフェス整合)違反であり、本改訂で語彙を 2 方向に動かす
+以上、同じ穴をもう一度掘らないために直す:
+
+- **Go から出る文字列はすべて `domain.TypesHint()` 由来にする** —
+  MCP のツール説明、シェル補完 4 種。補完はクォートが要るので
+  `domain.TypesQuoted()` を足す。
+- `api/openapi.yaml`・`internal/webui/index.html`・MCP の
+  jsonschema タグは静的資産(構造体タグはコンパイル時定数)なので手で
+  揃え、**0035 の流儀で外から検査する** — 退役した綴りが推奨として
+  残っていないこと、現行 11 型が欠けていないことをテストで固定する。
+
+## 5. やらないこと
+
+- **`Policy` に「規範だから編集を制限する」ような振る舞い**(§4.2)。
+- **`attester.resource` 用の型を足すこと。** 指し先は `.py` などの
+  コードであり、concept ではなく添付である(§3.4)。
+- **`Skill` / `Playbook` を 1 つに畳むこと**(§4.1)。
+- **保存済みエントリの改名・削除・マイグレーション**(§4.3)。
+- **`Metric` を外すこと。** 0028 §5 のまま。コンパイルされなくても
+  メトリクスの定義は散文の知識として意味がある。
+- **型を閉じた集合にすること。** 0023 のまま、自由型は第一級。
+  語彙が 11 になっても、12 個目を利用者が書けることは変わらない。
+- **段階的な deprecation。** 消えるのはヒントだけで、旧綴りの型は
+  エラーにならず自由型として通る。0.15.0 で一度に落とす。
+
+## 6. 壊れるもの
+
+**保存済みデータと wire 形式は変わらない。** 型は自由文字列のままなので、
+`type: Golden Query` を送る既存クライアントは今までどおり通る。
+
+- 補完・ヒント・スキーマ説明から 2 つの綴りが消え、4 つ増える。
+  `--type 'Golden Query'` は**エラーにならず、その型のエントリを返す** —
+  自由型として照合されるだけである。
+- `domain.TypeModels` と `domain.TypeQueries` の定数が消える
+  (Go API を直接使う組み込みホスト向けの破壊的変更)。
+- **推奨語彙が 11 に増えることで、エージェントに渡るツール説明が長くなる。**
+  0015 が言うとおりツールスキーマはエージェントのコンテキスト予算を食う。
+  それでも列挙する価値があるのは、型が `get_context` と検索フィルタの
+  一語の絞り込み手段だからである(0036 §3.6 と同じ理由)。
+- `docs/guides/golden-query-canary.md` のカナリア手順が
+  `Attested Computation` を軸に書き直される。既存のゴールデンクエリで
+  回している利用者は `--type` の値だけ変えれば従来どおり動く。

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -53,7 +53,8 @@ PR の中に残る。
   違いは §2.2)と、引用元からの逆引き `source` フィルタ(+ GIN index)。
 - [0036 OKF のスキーマを真とする](0036-okf-schema-first.md) — **Accepted**
   (実装済み、次のリリース 0.14.0 で出る)。**OKF 互換領域の現行ドキュメント**
-  (§5 の 2 項目は 0037 が撤回して実装した)。
+  (§5 の 2 項目は 0037 が撤回して実装した。§3.6 の型の一覧は 0038 が
+  11 型に組み替えた — 型の語彙は「ナレッジモデル」節の 0038 が現行)。
   SPEC が定義するキーは封筒に持つ、と基準を引き直し、§5.1(`sources` /
   `usage_window`)と §10.2(`runtime` / `parameters` / `computation` /
   `executor` / `attester`)を attrs から封筒フィールドへ。trust/lifecycle の
@@ -80,8 +81,14 @@ PR の中に残る。
 - [0022 ファイル名が名前](0022-filename-as-name.md) — **Accepted**。
   title の任意化、ID の検索対象化、NFC 正規化。
 - [0023 型の語彙を OKF に一本化する](0023-okf-type-vocabulary.md) —
-  **Accepted**(§3.1 の一覧に 0036 が `Attested Computation` を追加)。
-  内部スラグと OKF 表示名の二重語彙を廃止し、型の値は OKF の綴りそのものに。
+  **Superseded by 0038**(改訂の履歴: §3.1 の一覧に 0036 が
+  `Attested Computation` を追加)。内部スラグと OKF 表示名の二重語彙を
+  廃止し、型の値は OKF の綴りそのものに。
+- [0038 推奨型の語彙を OKF の証拠に合わせ直す](0038-type-vocabulary-realignment.md)
+  — **Accepted**。**型の語彙領域の現行ドキュメント**。`Semantic Model` と
+  `Golden Query` を外し、`Skill` / `Playbook` / `Policy` / `API Endpoint` を
+  足して 11 型に(退役した綴りは自由型として存続、マイグレーションなし)。
+  語彙を述べる 11 箇所を `domain.TypesHint()` と外側のテストで固定する。
 - [0024 リンクは本文から導出する](0024-links-from-body.md) —
   **Accepted**。構造化 `links` フィールドを廃止し、リンクは本文
   markdown から導出する。
@@ -154,11 +161,12 @@ PR の中に残る。
 ## セマンティックモデルと compile
 
 - [0018 import-ossie の廃止](0018-semantic-model-as-knowledge.md) —
-  **Accepted**(compile 面と書き込み時検証は 0028 が撤去)。
-  セマンティックモデルは専用機構を持たず、通常のナレッジエントリ。
+  **Accepted**(compile 面と書き込み時検証は 0028 が撤去、推奨タイプ
+  `Semantic Model` は 0038 が語彙から外した)。セマンティックモデルは
+  専用機構を持たず、通常のナレッジエントリ。
 - [0028 compile_sql とセマンティックモデル面の撤去](0028-retire-compile-sql.md)
-  — **Accepted**。決定的 SQL コンパイルとその周辺(API・MCP・CLI・UI)を
-  すべて撤去。
+  — **Accepted**(§3 の「`Semantic Model` を語彙に残す」は 0038 が覆した)。
+  決定的 SQL コンパイルとその周辺(API・MCP・CLI・UI)をすべて撤去。
 
 ## MCP OAuth コネクタ(撤去済み)
 

--- a/docs/guides/golden-query-canary.md
+++ b/docs/guides/golden-query-canary.md
@@ -8,6 +8,15 @@ result back — the practice OpenAI's in-house data agent runs continuously
 against its golden queries, and the execution-accuracy metric text-to-SQL
 evaluation uses.
 
+**Golden queries are stored as `Attested Computation` entries.** ochakai
+has no type of its own for them (design doc
+[0038](../design/0038-type-vocabulary-realignment.md)): OKF SPEC §10 already
+defines the concept, so a golden query is an Attested Computation whose
+`runtime` says where the SQL runs, whose `# Computation` body fence holds
+the SQL, and whose `attrs.question` carries the question it answers. If
+your base predates this, entries typed `Golden Query` keep working as free
+types — substitute that spelling in the `--type` filters below.
+
 **ochakai does not execute SQL.** The canary runs on your side — a CI job
 or a scheduled agent — and the warehouse credentials stay there. ochakai
 supplies the material and records what you found.
@@ -17,12 +26,12 @@ supplies the material and records what you found.
 ### 1. List — least recently verified first
 
 ```sh
-ochakai search --sort verified_at --type 'Golden Query' --status verified --limit 100 --json \
-  | jq -r '.hits[] | [.id, .verified_at, .attrs.sql] | @tsv'
+ochakai search --sort verified_at --type 'Attested Computation' --status verified --limit 100 --json \
+  | jq -r '.hits[] | [.id, .verified_at, .attrs.question] | @tsv'
 ```
 
 Straight REST is
-`GET /api/v1/knowledge?type=Golden%20Query&status=verified&sort=verified_at&limit=100`;
+`GET /api/v1/knowledge?type=Attested%20Computation&status=verified&sort=verified_at&limit=100`;
 over MCP, `search_knowledge` with `sort: "verified_at"` returns the same
 feed. `sort=verified_at` orders by verification time, oldest first, with
 unverified entries last. "Verified queries not re-checked in 90 days" is
@@ -31,8 +40,11 @@ where a canary run starts. Checking out an OKF export
 
 ### 2. Run — with your own credentials
 
-Execute each entry's `attrs.sql` against the warehouse (`bq query` for
-BigQuery). ochakai takes no part in this step.
+Execute each entry's `# Computation` fence against the warehouse
+(`bq query` for BigQuery), reading `runtime` to know which warehouse that
+is. The fence is the computation — SPEC §10.2 puts it there rather than in
+`attrs`, so there is exactly one copy for an attester to canonicalize a
+run against. ochakai takes no part in this step.
 
 ### 3. Judge
 
@@ -95,12 +107,12 @@ jobs:
         run: |
           TOKEN=$(gcloud auth print-identity-token --audiences="$OCHAKAI_URL")
           curl -s -H "Authorization: Bearer $TOKEN" \
-            "$OCHAKAI_URL/api/v1/knowledge?type=Golden%20Query&status=verified&sort=verified_at&limit=50" \
+            "$OCHAKAI_URL/api/v1/knowledge?type=Attested%20Computation&status=verified&sort=verified_at&limit=50" \
           | jq -c '.hits[]' | while read -r hit; do
               id=$(jq -r .id <<<"$hit")
-              sql=$(jq -r .attrs.sql <<<"$hit")
+              sql=$(jq -r '.body | split("```sql\n")[1] | split("\n```")[0]' <<<"$hit")
               if ! bq query --nouse_legacy_sql --dry_run "$sql" >/dev/null 2>&1; then
-                echo "::error::golden query $id no longer compiles against the warehouse"
+                echo "::error::computation $id no longer compiles against the warehouse"
                 curl -s -X POST -H "Authorization: Bearer $TOKEN" \
                   -H 'Content-Type: application/json' \
                   -d '{"outcome":"failed","note":"canary: dry-run failed"}' \

--- a/examples/claude-code/CLAUDE.md
+++ b/examples/claude-code/CLAUDE.md
@@ -12,16 +12,16 @@ service-account ADC; there are no tokens to configure:
 it is reachable.
 -->
 
-ochakai holds metric definitions, verified golden queries, interpretation
-knowledge (how to read a metric), glossary terms, and table catalog
-entries. Search it before writing analytics SQL; write learnings back.
+ochakai holds metric definitions, attested computations (sanctioned SQL,
+including verified golden queries), interpretation knowledge (how to read
+a metric), glossary terms, and table catalog entries. Search it before writing analytics SQL; write learnings back.
 
 - `ochakai context "<question>"` — the one call to make before answering
   a data question: prints the full entries behind the top hits (verified
   entries rank higher), expanded one hop through links so the insight
   explaining a metric arrives with it. Start here; use search/get below
   for precise lookups.
-- `ochakai search "<question or keyword>" [--type Metric|'Golden Query'|Insight|'Glossary Term'|'BigQuery Dataset'|'BigQuery Table'|Reference] [--status verified]`
+- `ochakai search "<question or keyword>" [--type Metric|'Attested Computation'|Skill|Playbook|Insight|Policy|'Glossary Term'|'BigQuery Dataset'|'BigQuery Table'|'API Endpoint'|Reference] [--status verified]`
   — one hit per line: score, uri, status, title. Trust `verified` entries;
   judge `draft` entries by their provenance (`--json` shows `created_by`).
 - `ochakai get <id>` — full entry as markdown (YAML frontmatter +
@@ -37,7 +37,7 @@ entries. Search it before writing analytics SQL; write learnings back.
   attachment, write it into the body with `ochakai update` — knowledge
   locked in pixels is invisible to search.
 - `ochakai report <id> worked|failed [--note "what went wrong"]`
-  — after acting on knowledge (running a golden query, running SQL you
+  — after acting on knowledge (running an attested computation, running SQL you
   wrote from a metric definition), report whether the result was actually correct. `failed` reports
   flag verified entries for re-verification, so the next agent doesn't
   trust a stale entry blind. Always report `failed` when a verified entry
@@ -54,5 +54,6 @@ IDs may be hierarchical (`queries/sales/monthly-revenue`) to group
 related knowledge.
 
 When a query you wrote turns out to be correct and useful,
-save it: `type: Golden Query` with `attrs.question` (the natural-language
-question) and `attrs.sql`. A human can promote it to `verified` later.
+save it: `type: Attested Computation` with `runtime` (where the SQL runs),
+the SQL in a `# Computation` fence in the body, and `attrs.question` (the
+natural-language question). A human can promote it to `verified` later.

--- a/examples/claude-code/hooks/ochakai-write-back.sh
+++ b/examples/claude-code/hooks/ochakai-write-back.sh
@@ -28,5 +28,5 @@ grep -qiE 'SELECT|ochakai|bigquery|warehouse' "$transcript" || exit 0
 
 jq -n '{
   decision: "block",
-  reason: "Before finishing: this session did data work. If a query you wrote proved correct and reusable, or you learned how to read a metric (a baseline, a seasonality, a caveat), write it back to ochakai — search first (including --status rejected) to avoid re-proposing, then `ochakai create <path>` (type \"Golden Query\" with attrs.question + attrs.sql, or type \"Insight\"). If nothing durable was learned, finish now without creating anything — do not invent knowledge."
+  reason: "Before finishing: this session did data work. If a query you wrote proved correct and reusable, or you learned how to read a metric (a baseline, a seasonality, a caveat), write it back to ochakai — search first (including --status rejected) to avoid re-proposing, then `ochakai create <path>` (type \"Attested Computation\" with runtime, the SQL in a # Computation fence, and attrs.question; or type \"Insight\"). If nothing durable was learned, finish now without creating anything — do not invent knowledge."
 }'

--- a/examples/golden-query.md
+++ b/examples/golden-query.md
@@ -1,20 +1,25 @@
 ---
-type: Golden Query
+type: Attested Computation
 title: Monthly recognized revenue
 description: Monthly revenue from completed orders (example)
 status: draft
+runtime: bigquery
 question: What is our monthly revenue this year?
-sql: |
-  SELECT
-    DATE_TRUNC(o.created_at, MONTH) AS month,
-    SUM(o.total_price)              AS revenue
-  FROM `myproject.shop.orders` AS o
-  WHERE o.status = 'completed'
-    AND o.created_at >= DATE_TRUNC(CURRENT_DATE(), YEAR)
-  GROUP BY month
-  ORDER BY month
 tags: [sales, revenue]
 ---
+
+# Computation
+
+```sql
+SELECT
+  DATE_TRUNC(o.created_at, MONTH) AS month,
+  SUM(o.total_price)              AS revenue
+FROM `myproject.shop.orders` AS o
+WHERE o.status = 'completed'
+  AND o.created_at >= DATE_TRUNC(CURRENT_DATE(), YEAR)
+GROUP BY month
+ORDER BY month
+```
 
 # Caveats
 

--- a/internal/apiclient/apiclient_test.go
+++ b/internal/apiclient/apiclient_test.go
@@ -60,7 +60,7 @@ func TestSearchSortSendsSortParam(t *testing.T) {
 		got = r.URL.Query()
 		// The verified_at feed returns entries without scores.
 		_ = json.NewEncoder(w).Encode(map[string]any{"hits": []domain.Knowledge{
-			{Type: domain.TypeQueries, ID: "monthly-revenue", Title: "月次売上"},
+			{Type: domain.TypeComputations, ID: "monthly-revenue", Title: "月次売上"},
 		}})
 	})
 	hits, err := c.Search(context.Background(), SearchParams{Sort: "verified_at", Limit: 100})

--- a/internal/apiclient/wire_test.go
+++ b/internal/apiclient/wire_test.go
@@ -22,7 +22,7 @@ func TestBrowseResultMatchesServerWire(t *testing.T) {
 	server := service.BrowseResult{
 		Dirs: []store.DirCount{{Name: "sales", Count: 4}},
 		Entries: []store.BrowseEntry{
-			{Type: domain.TypeQueries, ID: "sales/monthly-revenue", Title: "月次売上",
+			{Type: domain.TypeComputations, ID: "sales/monthly-revenue", Title: "月次売上",
 				Description: "月次の確定売上", Status: domain.StatusVerified, UpdatedAt: when},
 		},
 		Truncated: true,
@@ -38,7 +38,7 @@ func TestBrowseResultMatchesServerWire(t *testing.T) {
 	want := BrowseResult{
 		Dirs: []BrowseDir{{Name: "sales", Count: 4}},
 		Entries: []BrowseEntry{
-			{Type: "Golden Query", ID: "sales/monthly-revenue", Title: "月次売上",
+			{Type: "Attested Computation", ID: "sales/monthly-revenue", Title: "月次売上",
 				Description: "月次の確定売上", Status: domain.StatusVerified, UpdatedAt: when},
 		},
 		Truncated: true,

--- a/internal/domain/knowledge.go
+++ b/internal/domain/knowledge.go
@@ -23,20 +23,23 @@ import (
 type Type string
 
 const (
-	TypeModels       Type = "Semantic Model"       // Apache Ossie semantic model, spec verbatim in attrs.spec (design doc 0018; unvalidated since 0028)
-	TypeMetrics      Type = "Metric"               // semantic metric definition (Apache Ossie)
-	TypeQueries      Type = "Golden Query"         // golden query: question + verified SQL
+	TypeMetrics      Type = "Metric"               // semantic metric definition, synonyms
 	TypeComputations Type = "Attested Computation" // sanctioned computation and the means to check a run of it (OKF SPEC §10, design doc 0036 §3.6)
+	TypeSkills       Type = "Skill"                // the procedure an executor.resource points at (OKF SPEC §10.2)
+	TypePlaybooks    Type = "Playbook"             // an operational procedure people and agents follow (OKF SPEC §4.4)
 	TypeInsights     Type = "Insight"              // how to read a metric: baselines, caveats
+	TypePolicies     Type = "Policy"               // the rule that decides a number; what a sources[].resource cites
 	TypeTerms        Type = "Glossary Term"        // glossary term
 	TypeDatasets     Type = "BigQuery Dataset"     // dataset: a container grouping tables
 	TypeTables       Type = "BigQuery Table"       // table catalog entry
+	TypeEndpoints    Type = "API Endpoint"         // catalog entry for an asset that is not a BigQuery one
 	TypeReferences   Type = "Reference"            // mirror of external material (enums, licenses, schema docs)
 )
 
-// Types lists the recommended (built-in) knowledge types, in display order
-// (containers before their contents: models define metrics, datasets
-// group tables).
+// Types lists the recommended (built-in) knowledge types, in display order:
+// definitions, then the things you run, then interpretation and the rules
+// behind it, then catalog assets (containers before their contents), then
+// mirrors of outside material.
 //
 // No server behavior hangs off any of them — the list is a vocabulary, not
 // a registry (design doc 0028 §3). Attested Computation is the clearest
@@ -45,7 +48,21 @@ const (
 // acting on it — executing the computation and checking the receipt belong
 // to the consumer (OKF SPEC §10.5), which is the same line design doc 0028
 // drew when compile_sql went away.
-var Types = []Type{TypeModels, TypeMetrics, TypeQueries, TypeComputations, TypeInsights, TypeTerms, TypeDatasets, TypeTables, TypeReferences}
+//
+// What earns a place is SPEC §4.1's one requirement of a producer — that
+// the spelling be descriptive and self-explanatory — read against what OKF
+// itself spells out (design doc 0038). "Semantic Model" and "Golden Query"
+// left on the first count: the one carried its meaning in a foreign spec
+// rather than in its spelling, and the other is what an Attested
+// Computation with a runtime already is. Skill, Playbook, Policy and API
+// Endpoint joined on the second — Skill and Policy are what an entry's own
+// executor.resource and sources[].resource point at, so leaving them out
+// left both ends of an edge ochakai already stores without a name.
+//
+// The retired spellings stay first-class as free types; only the
+// recommendation is gone.
+var Types = []Type{TypeMetrics, TypeComputations, TypeSkills, TypePlaybooks, TypeInsights,
+	TypePolicies, TypeTerms, TypeDatasets, TypeTables, TypeEndpoints, TypeReferences}
 
 // TypesHint renders the recommended vocabulary for help and error text,
 // so no surface keeps its own copy of the list to fall behind.
@@ -55,6 +72,22 @@ func TypesHint() string {
 		names[i] = string(t)
 	}
 	return strings.Join(names, ", ")
+}
+
+// TypesQuoted renders the recommended vocabulary as shell words, wrapping
+// the types that contain a space in q so the shell sees one word per type.
+// Completion scripts interpolate this rather than spelling the list out,
+// so the vocabulary has one home (design doc 0038 §4.4); q differs per
+// shell because each already uses the other quote around the whole list.
+func TypesQuoted(q string) string {
+	names := make([]string, len(Types))
+	for i, t := range Types {
+		names[i] = string(t)
+		if strings.Contains(names[i], " ") {
+			names[i] = q + names[i] + q
+		}
+	}
+	return strings.Join(names, " ")
 }
 
 // BuiltinType reports whether t is one of the recommended types, matched

--- a/internal/domain/knowledge_test.go
+++ b/internal/domain/knowledge_test.go
@@ -234,6 +234,17 @@ func TestValidType(t *testing.T) {
 	if BuiltinType("runbook") {
 		t.Error(`BuiltinType("runbook") = true, want false`)
 	}
+	// Retired from the vocabulary but still perfectly valid to write
+	// (design doc 0038): the narrowing must not have left either spelling
+	// half-in, recommended by one surface and unknown to the next.
+	for _, retired := range []Type{"Semantic Model", "Golden Query"} {
+		if BuiltinType(retired) {
+			t.Errorf("BuiltinType(%q) = true, want false: 0038 retired it", retired)
+		}
+		if !ValidType(retired) {
+			t.Errorf("ValidType(%q) = false: a retired type stays writable as a free type", retired)
+		}
+	}
 }
 
 // Filters match types case-insensitively so a caller need not reproduce
@@ -246,8 +257,8 @@ func TestTypeMatchingIsCaseInsensitive(t *testing.T) {
 	if EqualType("BigQuery Tables", TypeTables) {
 		t.Error("EqualType must not match a different type")
 	}
-	if !BuiltinType("golden query") {
-		t.Error(`BuiltinType("golden query") = false, want true`)
+	if !BuiltinType("attested computation") {
+		t.Error(`BuiltinType("attested computation") = false, want true`)
 	}
 	if got := CanonicalType("bigquery dataset"); got != TypeDatasets {
 		t.Errorf("CanonicalType = %q, want %q", got, TypeDatasets)

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -85,11 +85,13 @@ func requestCtx(ctx context.Context, cfg *config.Config, req extraProvider) (con
 
 func newServer(svc *service.Service, version string) *mcp.Server {
 	s := mcp.NewServer(&mcp.Implementation{Name: serverName, Version: version}, &mcp.ServerOptions{
-		Instructions: "ochakai is a context provider for data agents: semantic models, " +
-			"metric definitions, verified golden queries, interpretation knowledge (how to " +
-			"read a metric), glossary terms, dataset and table catalog entries, and references " +
+		Instructions: "ochakai is a context provider for data agents: metric definitions, " +
+			"attested computations (sanctioned SQL and other computations, including verified " +
+			"question-and-answer queries), interpretation knowledge (how to read a metric), " +
+			"glossary terms, dataset and table catalog entries, and references " +
 			"(mirrors of external material such as enum definitions or schema docs) — those " +
-			"types are recommendations, and any slug works as a type for your own document kinds. " +
+			"types are recommendations, and any single-line string works as a type for your own " +
+			"document kinds. " +
 			"An entry's id is its path: slash-separated segments (e.g. metrics/revenue, " +
 			"ga4/tables/orders) forming directories. Place together what should be read " +
 			"together; the type is metadata, not a location. " +
@@ -98,7 +100,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"entries in full, links expanded. " +
 			"Prefer verified knowledge and judge trust from provenance (created_by / updated_by / verified_by), " +
 			"and treat an entry whose stale_after has passed as due for re-checking, not as wrong. " +
-			"After acting on knowledge (running a golden query, writing SQL from a metric definition), report " +
+			"After acting on knowledge (running an attested computation, writing SQL from a metric definition), report " +
 			"whether it actually worked with report_outcome — failed reports are how stale " +
 			"verified knowledge gets caught. " +
 			"Write learnings back with create_knowledge; set status=verified only for knowledge " +
@@ -157,14 +159,14 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "search_knowledge",
 		Annotations: readOnly,
-		Description: "Search the knowledge base across all types (recommended: Metric, Golden Query, Insight, Glossary Term, BigQuery Dataset, BigQuery Table, Reference; custom types welcome). " +
+		Description: "Search the knowledge base across all types (recommended: " + domain.TypesHint() + "; custom types welcome). " +
 			"Verified entries rank higher. Filter with types/statuses/tags. Returns scored hits. " +
 			"Attachments count too — filenames and file contents — and a hit is always the owning entry. " +
 			"Rejected entries are excluded unless statuses includes \"rejected\" — filter for them " +
 			"to check whether a proposal was already rejected before creating similar knowledge. " +
 			"With sort=\"verified_at\" the tool lists entries by verification age instead of searching " +
 			"(oldest first, never-verified last; omit query, scores are 0) — the feed for " +
-			"golden-query canary runs and for finding stale verified knowledge. With sort=\"usage\" it " +
+			"canary runs and for finding stale verified knowledge. With sort=\"usage\" it " +
 			"lists by demand (most search_hits first, never-used drafts oldest-first at the bottom) and " +
 			"each hit carries its usage totals — the draft review/promotion feed. With sort=\"failed\" it " +
 			"lists entries callers reported wrong (report_outcome failed), worst first — the re-verification " +
@@ -225,8 +227,8 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 		Annotations: readOnly,
 		Description: "The one call to make before answering a data question: searches the knowledge " +
 			"base (verified entries rank higher), returns the full entries behind the top hits, " +
-			"and expands one hop through links so the insight explaining a metric and the golden " +
-			"query answering the question arrive together. Prefer this over search+get chains; " +
+			"and expands one hop through links so the insight explaining a metric and the " +
+			"computation answering the question arrive together. Prefer this over search+get chains; " +
 			"fall back to search_knowledge/get_knowledge for precise lookups. \"entries\" is the " +
 			"knowledge; \"hits\" is only the ranking behind it. Entries that do not fit the byte " +
 			"budget are listed under \"outline\" — fetch any of them by id with get_knowledge.",
@@ -285,13 +287,14 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"An \"Attested Computation\" entry records a sanctioned computation others must run instead of " +
 			"improvising: put the computation in a # Computation fence in body and the contract in the " +
 			"runtime, parameters, executor and attester fields. ochakai stores it and never runs it. " +
+			"A verified question-and-SQL pair is one of these: runtime says where the SQL runs, and " +
+			"attrs.question carries the natural-language question it answers. " +
 			"Cite the material an entry derives from in sources — each needs a resource, and an id lets " +
 			"markdown footnotes in body attribute single claims to it. " +
 			"Set stale_after when the knowledge has a known expiry date. " +
-			"A semantic model is a \"Semantic Model\" entry with the Apache Ossie model object in attrs.spec " +
-			"(one entry per model). Give each metric its own entry too (last id segment = the metric " +
-			"name, e.g. metrics/<name>) with attrs.expression holding the expression, so the " +
-			"definitions are searchable on their own; have table entries link to the Semantic Model entry from their body. " +
+			"Give each metric its own \"Metric\" entry (last id segment = the metric name, e.g. " +
+			"metrics/<name>) so definitions are searchable on their own, and have table entries link " +
+			"to it from their body. " +
 			"Links are never a field: write a markdown link to the other entry's path in body — " +
 			"[revenue](/metrics/revenue.md) — and it becomes a link both ways (the other entry gains a backlink). " +
 			"An id whose entry was deleted can be reused, which revives it as your draft — unless a human had " +
@@ -433,7 +436,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 		Name:        "report_outcome",
 		Annotations: nonDestructive,
 		Description: "Report whether knowledge you acted on actually worked — the last edge of the " +
-			"write-back loop. After running a golden query or SQL you wrote from an entry, report worked " +
+			"write-back loop. After running an attested computation or SQL you wrote from an entry, report worked " +
 			"(the result was correct) or failed (wrong or unusable; say what went wrong in note). " +
 			"Reports feed the entry's usage totals (get_knowledge_usage), where failed counts " +
 			"against verified entries flag them for re-verification. Your identity is recorded " +
@@ -491,7 +494,7 @@ type searchIn struct {
 	// rejects it — exactly one of query / sort must be set (the service
 	// rejects an empty search, the handler rejects the combination).
 	Query    string   `json:"query,omitempty" jsonschema:"search text; required unless sort is set (omit it then)"`
-	Types    []string `json:"types,omitempty" jsonschema:"filter by type (Metric, Golden Query, Insight, Glossary Term, BigQuery Dataset, BigQuery Table, Reference, or any custom type); matched case-insensitively"`
+	Types    []string `json:"types,omitempty" jsonschema:"filter by type (Metric, Attested Computation, Skill, Playbook, Insight, Policy, Glossary Term, BigQuery Dataset, BigQuery Table, API Endpoint, Reference, or any custom type); matched case-insensitively"`
 	Statuses []string `json:"statuses,omitempty" jsonschema:"filter by status: draft, verified, deprecated, rejected"`
 	Tags     []string `json:"tags,omitempty" jsonschema:"filter by tag"`
 	Source   string   `json:"source,omitempty" jsonschema:"only entries citing this resource, matched exactly against sources[].resource — the reverse lookup for \"this material changed, what derives from it?\"; a filter, so it combines with query or sort"`
@@ -511,7 +514,7 @@ type searchOut struct {
 // actually needs to bound a response is budget.
 type contextIn struct {
 	Query    string   `json:"query" jsonschema:"the data question to gather context for"`
-	Types    []string `json:"types,omitempty" jsonschema:"filter by type (Metric, Golden Query, Insight, Glossary Term, BigQuery Dataset, BigQuery Table, Reference, or any custom type); matched case-insensitively"`
+	Types    []string `json:"types,omitempty" jsonschema:"filter by type (Metric, Attested Computation, Skill, Playbook, Insight, Policy, Glossary Term, BigQuery Dataset, BigQuery Table, API Endpoint, Reference, or any custom type); matched case-insensitively"`
 	Statuses []string `json:"statuses,omitempty" jsonschema:"filter by status: draft, verified, deprecated, rejected"`
 	Tags     []string `json:"tags,omitempty" jsonschema:"filter by tag"`
 	Limit    int      `json:"limit,omitempty" jsonschema:"max primary entries: default 5, max 20 (out-of-range falls back to the default); linked companions share a 2x limit total cap"`
@@ -582,7 +585,7 @@ type deleteOut struct {
 }
 
 type writeIn struct {
-	Type        string              `json:"type" jsonschema:"what the entry is: the OKF type, one line; recommended: Metric, Golden Query, Attested Computation, Insight, Glossary Term, BigQuery Dataset, BigQuery Table, Reference — any custom type works"`
+	Type        string              `json:"type" jsonschema:"what the entry is: the OKF type, one line; recommended: Metric, Attested Computation, Skill, Playbook, Insight, Policy, Glossary Term, BigQuery Dataset, BigQuery Table, API Endpoint, Reference — any custom type works"`
 	ID          string              `json:"id" jsonschema:"where the entry lives: its full path, segments separated by / (e.g. metrics/revenue, 用語/売上); place together what should be read together; the last segment must not be \"index\" or \"log\""`
 	Title       string              `json:"title,omitempty" jsonschema:"display name; optional — when omitted, the id's last segment (the filename) is the name; set one only when the filename isn't enough"`
 	Description string              `json:"description,omitempty"`
@@ -598,7 +601,7 @@ type writeIn struct {
 	Computation string              `json:"computation,omitempty" jsonschema:"path to the file holding the computation; omit to put it inline in a # Computation fence in body"`
 	Executor    *domain.Executor    `json:"executor,omitempty" jsonschema:"how the computation is run and what a run must return as evidence: {resource, receipt}; ochakai records this and never runs it"`
 	Attester    *domain.Attester    `json:"attester,omitempty" jsonschema:"the deterministic checker for a run: {resource}; ochakai records the path and never executes it"`
-	Attrs       map[string]any      `json:"attrs,omitempty" jsonschema:"producer-defined extension keys, e.g. question/sql for a query; the keys OKF itself defines are fields of their own above and are rejected here"`
+	Attrs       map[string]any      `json:"attrs,omitempty" jsonschema:"producer-defined extension keys, e.g. question/sql for an Attested Computation holding a verified query; the keys OKF itself defines are fields of their own above and are rejected here"`
 	Body        string              `json:"body,omitempty" jsonschema:"markdown body; link to other entries by writing a markdown link to their path — [revenue](/metrics/revenue.md) — and those links become the entry's links"`
 }
 

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -426,7 +426,7 @@ func TestContextHitsCarryRankingNotKnowledge(t *testing.T) {
 	body := strings.Repeat("x", 4000)
 	hits := []domain.SearchHit{{
 		Knowledge: domain.Knowledge{
-			Type: domain.TypeQueries, ID: "queries/monthly-revenue",
+			Type: domain.TypeComputations, ID: "queries/monthly-revenue",
 			Status: domain.StatusVerified, Body: body,
 			Attrs: map[string]any{"sql": "SELECT 1"},
 		},
@@ -551,5 +551,49 @@ func TestListSortsAreTheSameEverywhere(t *testing.T) {
 	}
 	if domain.ValidListSort("stale") {
 		t.Error("ValidListSort accepts a value no surface implements")
+	}
+}
+
+// TestToolSchemasCarryTheTypeVocabulary pins what an agent actually sees.
+// The tool descriptions interpolate domain.TypesHint(), but the jsonschema
+// struct tags cannot — they are compile-time constants — so their copy of
+// the vocabulary drifts silently. It already had: before design doc 0038
+// the search filters listed seven types, create listed eight, and the
+// server's own instructions listed nine. An agent picks its --type value
+// from these strings, so a missing type is a type nobody filters on and a
+// retired one is a type nobody has (design doc 0038 §4.4).
+func TestToolSchemasCarryTheTypeVocabulary(t *testing.T) {
+	cs := connect(t)
+	res, err := cs.ListTools(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	// Only the tools that take a type: the read filters and the writes.
+	want := map[string]bool{"search_knowledge": true, "get_context": true,
+		"create_knowledge": true, "update_knowledge": true}
+	seen := 0
+	for _, tool := range res.Tools {
+		if !want[tool.Name] {
+			continue
+		}
+		seen++
+		raw, err := json.Marshal(tool.InputSchema)
+		if err != nil {
+			t.Fatalf("marshal %s schema: %v", tool.Name, err)
+		}
+		text := tool.Description + string(raw)
+		for _, ty := range domain.Types {
+			if !strings.Contains(text, string(ty)) {
+				t.Errorf("%s never names the recommended type %q", tool.Name, ty)
+			}
+		}
+		for _, retired := range []string{"Semantic Model", "Golden Query"} {
+			if strings.Contains(text, retired) {
+				t.Errorf("%s still recommends %q, retired by design doc 0038", tool.Name, retired)
+			}
+		}
+	}
+	if seen != len(want) {
+		t.Errorf("checked %d type-taking tools, want %d", seen, len(want))
 	}
 }

--- a/internal/okf/attachment_test.go
+++ b/internal/okf/attachment_test.go
@@ -147,7 +147,7 @@ func TestFromBundleNamespaceAttribution(t *testing.T) {
 // is its full canonical path, not just one segment deep.
 func TestFromBundleNamespaceHierarchicalID(t *testing.T) {
 	files := map[string][]byte{
-		"queries/sales/monthly.md":           []byte("---\ntype: Golden Query\ntitle: monthly\n---\n"),
+		"queries/sales/monthly.md":           []byte("---\ntype: Attested Computation\ntitle: monthly\n---\n"),
 		"queries/sales/monthly/expected.txt": []byte("month,revenue\n2026-01,100\n"),
 	}
 	_, atts, skipped, _ := FromBundle(files)

--- a/internal/okf/bundle_test.go
+++ b/internal/okf/bundle_test.go
@@ -56,9 +56,9 @@ func writeTarGz(t *testing.T, w io.Writer, files map[string][]byte, modTime time
 func TestBundleNestedDirectories(t *testing.T) {
 	now := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
 	entries := []domain.Knowledge{
-		{Type: domain.TypeQueries, ID: "queries/sales/monthly-revenue", Title: "月次売上",
+		{Type: domain.TypeComputations, ID: "queries/sales/monthly-revenue", Title: "月次売上",
 			CreatedBy: domain.Actor{Kind: "human", Name: "na0"}, Status: domain.StatusDraft, UpdatedAt: now},
-		{Type: domain.TypeQueries, ID: "queries/sales/refunds/by-region", Title: "地域別返金",
+		{Type: domain.TypeComputations, ID: "queries/sales/refunds/by-region", Title: "地域別返金",
 			CreatedBy: domain.Actor{Kind: "human", Name: "na0"}, Status: domain.StatusDraft, UpdatedAt: now},
 		{Type: "runbook", ID: "ops/restore", Title: "リストア手順",
 			CreatedBy: domain.Actor{Kind: "human", Name: "na0"}, Status: domain.StatusDraft, UpdatedAt: now},
@@ -95,7 +95,7 @@ func TestBundleRoundTrip(t *testing.T) {
 		{Type: "Data Contract", ID: "contracts/orders", Title: "注文契約", Status: domain.StatusDraft,
 			CreatedBy: domain.Actor{Kind: "human", Name: "na0"},
 			Attrs:     map[string]any{"owner": "sales"}, UpdatedAt: now},
-		{Type: domain.TypeQueries, ID: "queries/sales/monthly-revenue", Title: "月次売上", Status: domain.StatusVerified,
+		{Type: domain.TypeComputations, ID: "queries/sales/monthly-revenue", Title: "月次売上", Status: domain.StatusVerified,
 			Description: "月ごとの売上",
 			CreatedBy:   domain.Actor{Kind: "human", Name: "na0"},
 			Tags:        []string{"sales"},

--- a/internal/okf/fuzz_test.go
+++ b/internal/okf/fuzz_test.go
@@ -22,7 +22,7 @@ import (
 // been told the entry came from a parser.
 func FuzzParse(f *testing.F) {
 	f.Add([]byte("---\ntype: Metric\ntitle: Revenue\n---\n\nThe headline number.\n"))
-	f.Add([]byte("---\ntype: Golden Query\nstatus: stable\nverified:\n  - by: human:a@b.c\n---\n"))
+	f.Add([]byte("---\ntype: Attested Computation\nstatus: stable\nverified:\n  - by: human:a@b.c\n---\n"))
 	f.Add([]byte("---\ntype: Insight\nstale_after: 2026-12-31\ntags: [sales, orders]\n---\nbody"))
 	f.Add([]byte("---\ntype: Insight\ntags: sales, orders\nstatus: nonsense\n---\n"))
 	f.Add([]byte("---\ntype: Reference\nsources:\n  - last_modified: 2026-01-02\n---\n"))
@@ -91,7 +91,7 @@ func FuzzParse(f *testing.F) {
 // about them. Worth extending when someone next touches them.
 func FuzzDocumentRoundTrip(f *testing.F) {
 	f.Add("Metric", "Revenue", "The headline number", "sales,orders", "verified", "2026-12-31", "Body text.")
-	f.Add("Golden Query", "", "", "", "draft", "", "")
+	f.Add("Attested Computation", "", "", "", "draft", "", "")
 	f.Add("Attested Computation", "T", "D", "one", "rejected", "", "- a list\n- of things")
 	f.Add("カスタム型", "タイトル", "説明", "タグ", "deprecated", "", "本文です。")
 	f.Add("Insight", "  padded  ", "", "a,,b", "", "not-a-date", "  \n  ")

--- a/internal/okf/parse_test.go
+++ b/internal/okf/parse_test.go
@@ -53,10 +53,11 @@ func TestParseRoundTrip(t *testing.T) {
 
 func TestParseAcceptsRawTypeAndHandWrittenDoc(t *testing.T) {
 	k, _, err := Parse([]byte(`---
-type: Golden Query
+type: Attested Computation
 id: monthly-revenue
 title: 月次売上
 status: draft
+runtime: bigquery
 question: 月ごとの売上は？
 sql: SELECT 1
 ---
@@ -66,7 +67,7 @@ Body text here.
 	if err != nil {
 		t.Fatal(err)
 	}
-	if k.Type != domain.TypeQueries || k.ID != "monthly-revenue" {
+	if k.Type != domain.TypeComputations || k.ID != "monthly-revenue" {
 		t.Errorf("got %s/%s", k.Type, k.ID)
 	}
 	if k.Attrs["sql"] != "SELECT 1" {

--- a/internal/restapi/openapi_test.go
+++ b/internal/restapi/openapi_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/pb33f/libopenapi"
 	validator "github.com/pb33f/libopenapi-validator"
 	valerrors "github.com/pb33f/libopenapi-validator/errors"
+
+	"github.com/na0fu3y/ochakai/internal/domain"
 )
 
 const specPath = "../../api/openapi.yaml"
@@ -184,4 +186,37 @@ func reportSpecErrors(t *testing.T, what string, r *http.Request, errs []*valerr
 		}
 	}
 	t.Errorf("%s %s: %s does not match api/openapi.yaml:%s", r.Method, r.URL.RequestURI(), what, b.String())
+}
+
+// TestOpenAPITypeVocabularyMatchesDomain pins the Type schema against
+// domain.Types. The spec is a static document, so its copy of the
+// vocabulary can only drift, and a free-type model means drift is silent:
+// a retired spelling left in `examples` goes on recommending itself to
+// every reader of the public wire surface without failing anything
+// (design doc 0038 §4.4).
+func TestOpenAPITypeVocabularyMatchesDomain(t *testing.T) {
+	raw, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	spec := string(raw)
+	i := strings.Index(spec, "    Type:\n")
+	if i < 0 {
+		t.Fatal("the Type schema is gone from api/openapi.yaml")
+	}
+	// Up to the next sibling schema (four-space key), which is Status.
+	block := spec[i:]
+	if end := strings.Index(block, "\n    Status:"); end >= 0 {
+		block = block[:end]
+	}
+	for _, ty := range domain.Types {
+		if !strings.Contains(block, string(ty)) {
+			t.Errorf("the Type schema never mentions the recommended type %q", ty)
+		}
+	}
+	for _, retired := range []string{"Semantic Model", "Golden Query"} {
+		if strings.Contains(block, retired) {
+			t.Errorf("the Type schema still lists %q, retired by design doc 0038", retired)
+		}
+	}
 }

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -39,7 +39,7 @@ func Handler(svc *service.Service) http.Handler {
 
 	// GET /api/v1/knowledge?q=...&type=...&status=...&tag=...&source=...&limit=...
 	// With sort=verified_at, lists by verification age (oldest first)
-	// instead of searching — the feed for golden query canary runs.
+	// instead of searching — the feed for canary runs.
 	// source narrows to the entries citing one resource — the reverse of
 	// sources[].resource (design doc 0037 §2.3) — and composes with a
 	// query or with any sort.

--- a/internal/service/context_integration_test.go
+++ b/internal/service/context_integration_test.go
@@ -59,7 +59,7 @@ func TestContextIntegration(t *testing.T) {
 		{Type: domain.TypeMetrics, ID: metricID, Title: id + "-revenue metric",
 			Status: domain.StatusVerified,
 			Body:   "Answered by [the monthly query](/" + queryID + ".md)."},
-		{Type: domain.TypeQueries, ID: queryID, Title: "monthly numbers"},
+		{Type: domain.TypeComputations, ID: queryID, Title: "monthly numbers"},
 		{Type: domain.TypeInsights, ID: insightID, Title: "how to read it",
 			Body: "Explains ochakai://" + metricID + "."},
 		{Type: domain.TypeInsights, ID: rejectedID, Title: "bad take",

--- a/internal/service/context_integration_test.go
+++ b/internal/service/context_integration_test.go
@@ -59,7 +59,10 @@ func TestContextIntegration(t *testing.T) {
 		{Type: domain.TypeMetrics, ID: metricID, Title: id + "-revenue metric",
 			Status: domain.StatusVerified,
 			Body:   "Answered by [the monthly query](/" + queryID + ".md)."},
-		{Type: domain.TypeComputations, ID: queryID, Title: "monthly numbers"},
+		// A verified query is an Attested Computation, and SPEC §10.2 makes
+		// runtime required on that type — the one schema the write path
+		// enforces (design doc 0036 §3.10).
+		{Type: domain.TypeComputations, ID: queryID, Title: "monthly numbers", Runtime: "bigquery"},
 		{Type: domain.TypeInsights, ID: insightID, Title: "how to read it",
 			Body: "Explains ochakai://" + metricID + "."},
 		{Type: domain.TypeInsights, ID: rejectedID, Title: "bad take",

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -679,12 +679,12 @@ func (s *Service) Context(ctx context.Context, req ContextRequest) (*ContextResu
 // both. budget <= 0 means no cap.
 //
 // Entries are atomic: an entry is delivered whole or not at all. Cutting a
-// body mid-way would be worse than dropping it — half of a Golden Query's
-// attrs.sql still looks executable, and half a semantic model spec is not
-// a spec. Nothing downstream can tell a truncated field from a short one.
+// body mid-way would be worse than dropping it — half of an attested
+// computation's SQL still looks executable, and half a model spec is not a
+// spec. Nothing downstream can tell a truncated field from a short one.
 //
 // Packing is greedy rather than a prefix cut: one oversized entry high in
-// the ranking (a Semantic Model carries its entire spec in attrs) would
+// the ranking (a model entry carries its entire spec in attrs) would
 // otherwise starve everything below it. An entry larger than the whole
 // budget always becomes an outline row, even at rank 1 — the caller sees
 // its size and can fetch it deliberately.
@@ -771,8 +771,8 @@ func outlineRow(k *domain.Knowledge, size int) domain.ContextOutline {
 }
 
 // serializedSize is what the entry costs on the wire — attrs included. A
-// body-only measure would miss the largest payload in the base, a
-// Semantic Model's attrs.spec.
+// body-only measure would miss the largest payload in the base, the spec
+// a model entry keeps in attrs.
 func serializedSize(k *domain.Knowledge) int {
 	b, err := json.Marshal(k)
 	if err != nil {

--- a/internal/service/service_integration_test.go
+++ b/internal/service/service_integration_test.go
@@ -194,7 +194,7 @@ func TestRefuseIfCuratedIntegration(t *testing.T) {
 
 	t.Run("drafts stay writable", func(t *testing.T) {
 		id := "queries/" + uid("guard-draft")
-		k, err := svc.Create(ctx, &domain.Knowledge{Type: domain.TypeQueries, ID: id, Title: "draft"}, actor)
+		k, err := svc.Create(ctx, &domain.Knowledge{Type: domain.TypeMetrics, ID: id, Title: "draft"}, actor)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -221,7 +221,7 @@ func TestRefuseIfCuratedIntegration(t *testing.T) {
 		t.Run(string(status)+" is refused", func(t *testing.T) {
 			id := "queries/" + uid("guard-"+string(status))
 			k, err := svc.Create(ctx, &domain.Knowledge{
-				Type: domain.TypeQueries, ID: id, Title: string(status),
+				Type: domain.TypeMetrics, ID: id, Title: string(status),
 				StatusNote: "because the numbers were wrong",
 			}, actor)
 			if err != nil {
@@ -255,7 +255,7 @@ func TestRefuseIfCuratedIntegration(t *testing.T) {
 	t.Run("a rejection cannot be laundered into a draft", func(t *testing.T) {
 		id := "queries/" + uid("guard-launder")
 		k, err := svc.Create(ctx, &domain.Knowledge{
-			Type: domain.TypeQueries, ID: id, Title: "rejected proposal",
+			Type: domain.TypeMetrics, ID: id, Title: "rejected proposal",
 			StatusNote: "duplicate of an existing golden query",
 		}, actor)
 		if err != nil {
@@ -287,7 +287,7 @@ func TestRefuseIfCuratedIntegration(t *testing.T) {
 		} {
 			id := "queries/" + uid("guard-tomb-"+string(status))
 			k, err := svc.Create(ctx, &domain.Knowledge{
-				Type: domain.TypeQueries, ID: id, Title: "ruled on then deleted",
+				Type: domain.TypeMetrics, ID: id, Title: "ruled on then deleted",
 				StatusNote: "duplicate of an existing golden query",
 			}, actor)
 			if err != nil {
@@ -308,7 +308,7 @@ func TestRefuseIfCuratedIntegration(t *testing.T) {
 			}
 			// The human surfaces still revive it, ruling and all.
 			revived, err := svc.Create(ctx, &domain.Knowledge{
-				Type: domain.TypeQueries, ID: id, Title: "revived by a human"}, human)
+				Type: domain.TypeMetrics, ID: id, Title: "revived by a human"}, human)
 			if err != nil {
 				t.Fatalf("a human surface must still be able to reuse the id: %v", err)
 			}
@@ -321,7 +321,7 @@ func TestRefuseIfCuratedIntegration(t *testing.T) {
 	t.Run("a draft tombstone stays revivable", func(t *testing.T) {
 		id := "queries/" + uid("guard-tomb-draft")
 		if _, err := svc.Create(ctx, &domain.Knowledge{
-			Type: domain.TypeQueries, ID: id, Title: "abandoned draft"}, actor); err != nil {
+			Type: domain.TypeMetrics, ID: id, Title: "abandoned draft"}, actor); err != nil {
 			t.Fatal(err)
 		}
 		if err := svc.Delete(ctx, id, actor); err != nil {
@@ -331,7 +331,7 @@ func TestRefuseIfCuratedIntegration(t *testing.T) {
 			t.Fatalf("a deleted draft must stay revivable: %v", err)
 		}
 		if _, err := svc.Create(ctx, &domain.Knowledge{
-			Type: domain.TypeQueries, ID: id, Title: "second attempt"}, actor); err != nil {
+			Type: domain.TypeMetrics, ID: id, Title: "second attempt"}, actor); err != nil {
 			t.Fatal(err)
 		}
 		t.Cleanup(func() { _ = svc.Delete(ctx, id, actor) })
@@ -345,7 +345,7 @@ func TestRefuseIfCuratedIntegration(t *testing.T) {
 		}
 		id := "queries/" + uid("guard-tomb-live")
 		k, err := svc.Create(ctx, &domain.Knowledge{
-			Type: domain.TypeQueries, ID: id, Title: "live"}, actor)
+			Type: domain.TypeMetrics, ID: id, Title: "live"}, actor)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -370,7 +370,7 @@ func TestRefuseIfCuratedIntegration(t *testing.T) {
 		} {
 			id := "queries/" + uid("guard-live-"+string(status))
 			k, err := svc.Create(ctx, &domain.Knowledge{
-				Type: domain.TypeQueries, ID: id, Title: "ruled on",
+				Type: domain.TypeMetrics, ID: id, Title: "ruled on",
 				StatusNote: "duplicate of an existing golden query"}, actor)
 			if err != nil {
 				t.Fatal(err)
@@ -381,7 +381,7 @@ func TestRefuseIfCuratedIntegration(t *testing.T) {
 			}
 
 			_, err = svc.CreateKeepingCurated(ctx, &domain.Knowledge{
-				Type: domain.TypeQueries, ID: id, Title: "re-proposal"}, actor)
+				Type: domain.TypeMetrics, ID: id, Title: "re-proposal"}, actor)
 			if !errors.Is(err, store.ErrAlreadyExists) {
 				t.Fatalf("create over a live %s entry: got %v, want ErrAlreadyExists", status, err)
 			}

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -519,3 +519,30 @@ func (e *shrinkEmbedder) Embed(_ context.Context, _ embed.Task, texts []string) 
 	}
 	return [][]float32{{1, 0}}, nil
 }
+
+// TestRecommendedTypesAreWritable pins design doc 0038 §4.2: adding a type
+// to the vocabulary adds no server behavior. Every recommended type must
+// pass the write path carrying nothing but an id and a title — the sole
+// exception being the runtime SPEC §10.2 requires on an Attested
+// Computation (design doc 0036 §3.10).
+//
+// This is also the guard the vocabulary change itself needed. Swapping a
+// test fixture's type to Attested Computation without giving it a runtime
+// compiles, passes every unit test, and only fails where a real write
+// happens — which, for the entry types that live in integration tests, is
+// nowhere a developer without a database will see.
+func TestRecommendedTypesAreWritable(t *testing.T) {
+	for _, ty := range domain.Types {
+		k := &domain.Knowledge{Type: ty, ID: "probe/entry", Title: "probe"}
+		if ty == domain.TypeComputations {
+			k.Runtime = "bigquery"
+		}
+		if err := validate(k); err != nil {
+			t.Errorf("recommended type %q is not writable as-is: %v", ty, err)
+		}
+	}
+	bare := &domain.Knowledge{Type: domain.TypeComputations, ID: "probe/entry", Title: "probe"}
+	if err := validate(bare); err == nil {
+		t.Error("an Attested Computation without a runtime must still be refused")
+	}
+}

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -332,23 +332,31 @@ func TestExampleGoldenQueryRegisters(t *testing.T) {
 		t.Errorf("the shipped example should parse without reinterpretation: %v", notes)
 	}
 	k.ID = "queries/monthly-revenue"
-	if k.Type != domain.TypeQueries {
-		t.Errorf("type = %q, want %q", k.Type, domain.TypeQueries)
+	if k.Type != domain.TypeComputations {
+		t.Errorf("type = %q, want %q", k.Type, domain.TypeComputations)
 	}
 	if err := validate(k); err != nil {
 		t.Errorf("example entry rejected: %v", err)
 	}
 	if q, _ := k.Attrs["question"].(string); q == "" {
-		t.Error("attrs.question missing: a golden query without its question is not searchable as one")
+		t.Error("attrs.question missing: a verified query without its question is not searchable as one")
 	}
-	if sql, _ := k.Attrs["sql"].(string); !strings.Contains(sql, "SELECT") {
-		t.Errorf("attrs.sql = %q", k.Attrs["sql"])
+	// The computation belongs in the body fence, not in attrs: SPEC §10.2
+	// makes the fence the computation when no external file is named, and
+	// an attester canonicalizes what a run executed against it. Keeping a
+	// second copy under attrs.sql would leave a consumer no way to tell
+	// which of the two is authoritative (design doc 0038 §3.3).
+	if !strings.Contains(k.Body, "# Computation") || !strings.Contains(k.Body, "SELECT") {
+		t.Errorf("the computation must be a # Computation fence in the body, got %q", k.Body)
+	}
+	if _, ok := k.Attrs["sql"]; ok {
+		t.Error("attrs.sql duplicates the body fence: one computation, one home")
 	}
 }
 
 // packWithinBudget delivers whole entries or none: a body cut in half
-// still looks like a body, and half of a golden query's SQL still looks
-// executable.
+// still looks like a body, and half of an attested computation's SQL
+// still looks executable.
 func TestPackWithinBudgetKeepsEntriesWhole(t *testing.T) {
 	entry := func(id string, bodyBytes int) domain.Knowledge {
 		return domain.Knowledge{Type: domain.TypeInsights, ID: id, Title: id,
@@ -385,7 +393,7 @@ func TestPackWithinBudgetKeepsEntriesWhole(t *testing.T) {
 		}
 	})
 
-	// A Semantic Model carries its whole spec in attrs and can outweigh the
+	// A model entry carries its whole spec in attrs and can outweigh the
 	// entire budget. A prefix cut would let it starve everything below it;
 	// greedy packing keeps the rest and names the giant.
 	t.Run("an oversized leader does not starve the rest", func(t *testing.T) {
@@ -442,10 +450,10 @@ func TestPackWithinBudgetKeepsEntriesWhole(t *testing.T) {
 		}
 	})
 
-	// attrs, not just the body: a Semantic Model's spec is the largest
+	// attrs, not just the body: a semantic model's spec is the largest
 	// payload in the base and lives entirely in attrs.
 	t.Run("size counts attrs", func(t *testing.T) {
-		bare := domain.Knowledge{Type: domain.TypeModels, ID: "models/m"}
+		bare := domain.Knowledge{Type: domain.Type("Semantic Model"), ID: "models/m"}
 		withSpec := bare
 		withSpec.Attrs = map[string]any{"spec": strings.Repeat("y", 2000)}
 		if serializedSize(&withSpec) <= serializedSize(&bare)+1000 {

--- a/internal/store/browse_integration_test.go
+++ b/internal/store/browse_integration_test.go
@@ -42,13 +42,13 @@ func TestIntegrationBrowse(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	mk(domain.TypeQueries, "it-br-sales/monthly", domain.StatusVerified)
-	mk(domain.TypeQueries, "it-br-sales/regions/apac", domain.StatusDraft)
-	mk(domain.TypeQueries, "it-br-top", domain.StatusDraft)
-	mk(domain.TypeQueries, "it-br-rejected", domain.StatusRejected)
+	mk(domain.TypeComputations, "it-br-sales/monthly", domain.StatusVerified)
+	mk(domain.TypeComputations, "it-br-sales/regions/apac", domain.StatusDraft)
+	mk(domain.TypeComputations, "it-br-top", domain.StatusDraft)
+	mk(domain.TypeComputations, "it-br-rejected", domain.StatusRejected)
 	// "_" in the prefix must match literally, not as a LIKE wildcard:
 	// "it-br_x/deep" would match a LIKE pattern built from "it-br-…".
-	mk(domain.TypeQueries, "it-br_x/deep", domain.StatusDraft)
+	mk(domain.TypeComputations, "it-br_x/deep", domain.StatusDraft)
 	mk(domain.TypeMetrics, "it-br-revenue", domain.StatusDraft)
 
 	// The root is the top-level segments of the shared test DB; our
@@ -75,7 +75,7 @@ func TestIntegrationBrowse(t *testing.T) {
 	if len(dirs) != 1 || dirs[0].Name != "regions" || dirs[0].Count != 1 {
 		t.Errorf("dirs = %+v, want regions(1)", dirs)
 	}
-	if len(entries) != 1 || entries[0].ID != "it-br-sales/monthly" || entries[0].Type != domain.TypeQueries ||
+	if len(entries) != 1 || entries[0].ID != "it-br-sales/monthly" || entries[0].Type != domain.TypeComputations ||
 		entries[0].Title != "t:it-br-sales/monthly" || entries[0].Description != "d:it-br-sales/monthly" ||
 		entries[0].Status != domain.StatusVerified {
 		t.Errorf("entries = %+v", entries)

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -174,7 +174,7 @@ const hnswMaxDim = 2000
 // migrateVectorIndexes builds the HNSW indexes behind semantic search.
 // 0001 left them out on the grounds that an exact scan is fine at
 // knowledge-base scale — true at a few thousand rows, but a table
-// specification plus a glossary plus the Golden Queries and Insights the
+// specification plus a glossary plus the computations and insights the
 // write-back loop accumulates passes that within a year, and every search
 // reads every vector until it does not.
 //

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -226,7 +226,7 @@ func TestIntegration(t *testing.T) {
 	// the default filter.
 	oldAt := time.Now().UTC().Add(-365 * 24 * time.Hour)
 	older := &domain.Knowledge{
-		Type: domain.TypeQueries, ID: "it-old-query", Title: "古い検証済みクエリ",
+		Type: domain.TypeComputations, ID: "it-old-query", Title: "古い検証済みクエリ",
 		Status:     domain.StatusVerified,
 		CreatedBy:  domain.Actor{Kind: "human", Name: "test"},
 		VerifiedBy: &domain.Actor{Kind: "human", Name: "test"}, VerifiedAt: &oldAt,
@@ -314,7 +314,7 @@ func TestIntegration(t *testing.T) {
 	verifiedAt := time.Now().UTC().Add(-30 * 24 * time.Hour)
 	newFail := func(id, title string, status domain.Status, verified bool) *domain.Knowledge {
 		k := &domain.Knowledge{
-			Type: domain.TypeQueries, ID: id, Title: title, Tags: []string{failTag},
+			Type: domain.TypeComputations, ID: id, Title: title, Tags: []string{failTag},
 			Status: status, CreatedBy: domain.Actor{Kind: "agent", Name: "claude-code"},
 		}
 		if verified {
@@ -1641,7 +1641,7 @@ func TestIntegrationVerifyClearsTheReviewFeed(t *testing.T) {
 	}
 	human := domain.Actor{Kind: domain.ActorHuman, Name: "reviewer@example.com"}
 	agent := domain.Actor{Kind: domain.ActorAgent, Name: "claude-code"}
-	k := &domain.Knowledge{Type: domain.TypeQueries, ID: id, Title: "月次売上",
+	k := &domain.Knowledge{Type: domain.TypeComputations, ID: id, Title: "月次売上",
 		Status: domain.StatusDraft, CreatedBy: agent}
 	if err := s.Create(ctx, k, false); err != nil {
 		t.Fatal(err)

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -468,7 +468,7 @@ function esc(s) {
 // Keys are the OKF type vocabulary, which is what the server stores
 // (design doc 0023). Lookup is case-insensitive to match the server's
 // filter matching — the stored spelling is whatever the writer used.
-const TYPE_ICONS = { 'Semantic Model': '🧩', 'Metric': '📊', 'Golden Query': '🧾', 'Attested Computation': '🧮', 'Insight': '💡', 'Glossary Term': '📖', 'BigQuery Dataset': '🗂️', 'BigQuery Table': '🗃️', 'Reference': '🔖' };
+const TYPE_ICONS = { 'Metric': '📊', 'Attested Computation': '🧮', 'Skill': '🛠️', 'Playbook': '📘', 'Insight': '💡', 'Policy': '⚖️', 'Glossary Term': '📖', 'BigQuery Dataset': '🗂️', 'BigQuery Table': '🗃️', 'API Endpoint': '🔌', 'Reference': '🔖' };
 const ICON_BY_LOWER = new Map(Object.entries(TYPE_ICONS).map(([k, v]) => [k.toLowerCase(), v]));
 const icon = t => ICON_BY_LOWER.get(String(t ?? '').trim().toLowerCase()) || '📄';
 const KNOWN_TYPES = Object.keys(TYPE_ICONS);
@@ -1898,7 +1898,7 @@ async function viewEditor(id, prefix = '') {
           <label class="top" for="e-type">Type</label>
           <input type="text" id="e-type" list="type-list" value="${esc(entry.type)}" required>
           <datalist id="type-list">${KNOWN_TYPES.map(t => `<option value="${t}">`).join('')}</datalist>
-          <div class="hint">What the entry is: Metric, Golden Query, Attested Computation, Insight, Glossary Term, BigQuery Dataset, BigQuery Table, Reference — or any type of your own.</div>
+          <div class="hint">What the entry is: Metric, Attested Computation, Skill, Playbook, Insight, Policy, Glossary Term, BigQuery Dataset, BigQuery Table, API Endpoint, Reference — or any type of your own.</div>
         </div>
         ${idField}
       </div>
@@ -1970,8 +1970,8 @@ async function viewEditor(id, prefix = '') {
       <div class="field">
         <label class="top" for="e-attrs">Attributes (JSON)</label>
         <textarea id="e-attrs" rows="6" class="mono" placeholder='{"question": "…", "sql": "SELECT …"}'>${esc(attrsText)}</textarea>
-        <div class="hint">Anything OKF does not define, kept as written: <code>question</code>/<code>sql</code> for a Golden Query,
-          <code>spec</code> for a Semantic Model. The fields above have their own boxes — putting one here is refused rather than
+        <div class="hint">Anything OKF does not define, kept as written: <code>question</code>/<code>sql</code> for an Attested
+          Computation holding a verified query, <code>spec</code> for a semantic model. The fields above have their own boxes — putting one here is refused rather than
           stored where nothing reads it.</div>
       </div>
       <div id="editor-error"></div>

--- a/internal/webui/webui_test.go
+++ b/internal/webui/webui_test.go
@@ -3,6 +3,8 @@ package webui
 import (
 	"strings"
 	"testing"
+
+	"github.com/na0fu3y/ochakai/internal/domain"
 )
 
 // The page is plain JavaScript with no build step and no test runner, so
@@ -208,4 +210,47 @@ func TestStaleFeedSaysVerifyingDoesNotClearIt(t *testing.T) {
 	if !strings.Contains(page, "Verifying does <em>not</em> clear this one") {
 		t.Error("the stale feed banner no longer explains that verifying does not empty it")
 	}
+}
+
+// The page carries its own copy of the type vocabulary — an icon per type
+// and the hint under the new-entry form — because it is a static asset
+// with no build step to interpolate domain.Types into. That copy has
+// drifted before: when Attested Computation joined the vocabulary the
+// icons gained it and the form hint did not, and neither noticed. A
+// retired type is the worse direction, since free types mean the UI would
+// go on recommending a spelling nothing else does, forever, without
+// failing anything (design doc 0038 §4.4).
+func TestTypeVocabularyMatchesDomain(t *testing.T) {
+	page := string(Index)
+	icons := section(t, page, "const TYPE_ICONS = {", "};")
+	hint := section(t, page, "What the entry is:", "</div>")
+	for _, ty := range domain.Types {
+		if !strings.Contains(icons, "'"+string(ty)+"'") {
+			t.Errorf("TYPE_ICONS has no icon for %q", ty)
+		}
+		if !strings.Contains(hint, string(ty)) {
+			t.Errorf("the new-entry hint omits the recommended type %q", ty)
+		}
+	}
+	for _, retired := range []string{"Semantic Model", "Golden Query"} {
+		if strings.Contains(icons, retired) || strings.Contains(hint, retired) {
+			t.Errorf("the page still offers %q, retired by design doc 0038", retired)
+		}
+	}
+}
+
+// section returns the text between the first open and the next close, so a
+// guard reads one construct rather than the whole page.
+func section(t *testing.T, page, open, close string) string {
+	t.Helper()
+	i := strings.Index(page, open)
+	if i < 0 {
+		t.Fatalf("%q is gone from the page; the guard needs updating", open)
+	}
+	rest := page[i:]
+	end := strings.Index(rest, close)
+	if end < 0 {
+		t.Fatalf("%q never closes with %q", open, close)
+	}
+	return rest[:end]
 }


### PR DESCRIPTION
## Why

The recommended type vocabulary had drifted from OKF in both directions, and the list itself had drifted from ochakai: it was written out in **eleven places at three different lengths**, with `Semantic Model` already missing from four of them and nothing failing.

SPEC §4.1 registers no taxonomy and asks producers for exactly one thing — that a spelling be *descriptive and self-explanatory*. Its `BigQuery Table, BigQuery Dataset, API Endpoint, Metric, Playbook, Reference, Attested Computation` list is labelled **"Example values"**, not a recommended vocabulary; Google's own reference bundles use `Policy` and `Skill`, which appear nowhere in it. So "not in the SPEC's list" is not a reason to retire a type, and "in the list" is not by itself a reason to add one.

Applying the actual test against what OKF itself spells out — the spec's examples, its §4.4 worked example, and the reference bundles — moves the vocabulary in both directions. **9 types → 11.**

## Retired

| Type | Why |
|---|---|
| `Semantic Model` | Carried its meaning in a foreign spec (Apache Ossie), not in its spelling. Since 0.13.0 removed compile and its write-time validation, all that remained was a convention to put an Ossie object in `attrs.spec` that nothing on the server reads. Design doc 0028 §3 kept it by asking only whether behavior hung off it — the wrong test. |
| `Golden Query` | What an `Attested Computation` with a `runtime` already is. SPEC §10.2 requires only `runtime`, leaving `parameters`/`executor`/`attester` optional, so a golden query fits exactly: SQL in the `# Computation` fence, question in `attrs.question`. |

## Added

| Type | OKF's own evidence |
|---|---|
| `Skill` | Reference bundles (`acme_retail/skills/`), and SPEC §10.2 names it directly: "What sits behind a `resource` (a Skill, a script, a container)". |
| `Policy` | Reference bundles (`acme_retail/policies/`). |
| `Playbook` | SPEC §4.1 examples, and §4.4 writes one out in full as its example of a concept bound to no resource. |
| `API Endpoint` | SPEC §4.1 examples. |

`Skill` and `Policy` close a real gap rather than just padding the list: an entry's `executor.resource` points at a Skill and its `sources[].resource` cites a Policy, so since design doc 0036 put both in the envelope, ochakai has been **storing both ends of an edge while naming only one**.

No server behavior attaches to any of the four. The one type-specific rule stays the `runtime` requirement on an Attested Computation (0036 §3.10).

## No migration

The retired spellings stay valid to write and keep working as free types — matched, searched, exported, updated exactly as before (design doc 0005). The type is deliberately **not** renamed for anyone: `runtime` is REQUIRED on an Attested Computation and validated on both create and update, so a mechanical rename would leave entries readable but un-updatable, and filling in `bigquery` would be ochakai writing a fact it does not know (0036 §3.4 forbids silent reinterpretation). Only the author knows the runtime.

## The eleven places

Every list Go emits — the MCP tool descriptions and all three shell completions — now derives from `domain.TypesHint()`; completions gained `domain.TypesQuoted()` since each shell needs its own quoting. The static surfaces can't interpolate (OpenAPI and the Web UI have no build step; jsonschema struct tags are compile-time constants), so they're pinned by tests instead — one per owning package, each failing on a missing type or a still-recommended retired one. Free types are exactly why this needs a test: a stale recommendation never throws.

## Docs

- **New design doc [0038](docs/design/0038-type-vocabulary-realignment.md)**, written as a full replacement for the type-vocabulary area rather than a second partial amendment stacked on 0023 (CONTRIBUTING's chain rule). Supersedes 0023; amends 0028 §3 and 0036 §3.6; all Status headers and the index updated.
- `examples/golden-query.md` and the canary guide move onto `Attested Computation`. The example's SQL moves out of `attrs.sql` into its `# Computation` fence — SPEC §10.2 makes the fence the computation, and a second copy left a consumer no way to tell which an attester should canonicalize against.

## Breaking

- `domain.TypeModels` and `domain.TypeQueries` are gone from the Go API.
- Completions, hints and schema descriptions lose two spellings and gain four. `--type 'Golden Query'` still returns those entries.
- **Wire format and stored data are unchanged.**

## Verification

`gofmt`, `go vet`, `go test -race`, `CGO_ENABLED=0 go build -trimpath`, golangci-lint (0 issues) all pass locally.

The 43 store/service integration tests skip without a PostgreSQL and no Docker daemon was available in this environment — changes to those files are type-constant substitutions only (no schema, no migration), but CI is what actually exercises them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)