### PR TITLE
Give the two 0038s different numbers, and record what landed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,27 @@ last entry.
 
 ## [Unreleased]
 
+### Added
+
+- `ochakai mcp-stdio` — speaks MCP on stdin/stdout and forwards to the
+  selected server, for clients that can only launch a command and for any
+  client against Cloud Run, where the request needs a Google ID token the
+  client cannot mint. It resolves identity the way every other client
+  command does, so the client is configured with no credentials; it
+  listens on no port and copies JSON-RPC messages rather than holding a
+  second copy of the tool schemas (design doc 0039). No server surface is
+  added and the MCP tool count is unchanged.
+- A Terraform module at `deploy/terraform` for the deployment the Cloud
+  Run guide describes, so it can be reviewed as a diff, reproduced per
+  environment and destroyed cleanly. Private IP, Vertex embeddings, GCS
+  attachments and the IAP-fronted web UI are behind flags, all off by
+  default. It creates no password and cannot run the §3 bootstrap SQL —
+  `terraform output -raw database_bootstrap_sql` prints those statements
+  instead. The gcloud guide stays the reference.
+- Request and response examples throughout `api/openapi.yaml`, which
+  previously carried exactly one. Every example is validated against the
+  schema it sits under.
+
 ### Changed
 
 - **BREAKING** — the recommended type vocabulary is realigned to what OKF

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ claude mcp add ochakai -- ochakai mcp-stdio
 It listens on no port and holds no state; it copies JSON-RPC messages, so
 it carries whatever the server offers rather than a second copy of the
 tool list that could go stale (design doc
-[0038](docs/design/0038-mcp-stdio-bridge.md)). Add `--url` to point it at
+[0039](docs/design/0039-mcp-stdio-bridge.md)). Add `--url` to point it at
 a specific server. `ochakai ui` exposes the same authenticated `/mcp` over
 HTTP for clients that would rather have a URL, and
 `gcloud run services proxy` is the third way, documented in the

--- a/cmd/ochakai/mcpstdio.go
+++ b/cmd/ochakai/mcpstdio.go
@@ -1,6 +1,6 @@
 // `ochakai mcp-stdio`: bridge a stdio-only MCP client to the selected
 // server's /mcp, carrying the caller's own Google identity (design doc
-// 0038). ochakai's MCP is streamable HTTP only, so a client that speaks
+// 0039). ochakai's MCP is streamable HTTP only, so a client that speaks
 // nothing but stdio had no way in — and against Cloud Run no client can
 // mint the ID token the request needs. This process is the missing half:
 // it listens on no port, holds no state, and copies JSON-RPC messages
@@ -62,7 +62,7 @@ func cmdMCPStdio(ctx context.Context, args []string) error {
 // an MCP client and server pair. Enumerating the remote's tools and
 // re-registering them locally would put a second copy of every tool
 // schema here, to be updated whenever one gains an argument (design doc
-// 0038 §2.2). Copying means initialize, notifications, resources and
+// 0039 §2.2). Copying means initialize, notifications, resources and
 // anything added later pass through a bridge that never heard of them.
 //
 // tokens is nil for a plain-http development server, which is then

--- a/cmd/ochakai/mcpstdio_test.go
+++ b/cmd/ochakai/mcpstdio_test.go
@@ -43,7 +43,7 @@ func remoteMCP(t *testing.T) (base string, tools []string) {
 // The bridge carries whatever the remote offers. It must not hold a copy
 // of the tool list: what a client sees through it is what the server
 // said, including a tool the bridge has never heard of (design doc
-// 0038 §2.2, §3).
+// 0039 §2.2, §3).
 func TestBridgePassesMessagesThrough(t *testing.T) {
 	base, want := remoteMCP(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
@@ -93,7 +93,7 @@ func TestBridgePassesMessagesThrough(t *testing.T) {
 
 // In stdio mode stdout *is* the wire. One stray human-readable line
 // breaks the session, so the bridge must put every diagnostic on stderr
-// (design doc 0038 §2.4). Not parallel: it swaps the process's own
+// (design doc 0039 §2.4). Not parallel: it swaps the process's own
 // stdin and stdout.
 func TestBridgeStdoutCarriesOnlyProtocol(t *testing.T) {
 	base, _ := remoteMCP(t)

--- a/docs/design/0039-mcp-stdio-bridge.md
+++ b/docs/design/0039-mcp-stdio-bridge.md
@@ -1,4 +1,4 @@
-# ochakai 設計ドキュメント 0038: stdio しか話せないクライアントに橋を架ける
+# ochakai 設計ドキュメント 0039: stdio しか話せないクライアントに橋を架ける
 
 Status: Accepted(2026-07-27)。[0012](0012-retire-mcp-oauth-connector.md) が
 retire した「公開 OAuth コネクタ」を復活させずに同じ需要を満たす。

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -175,7 +175,7 @@ PR の中に残る。
   公開第二サービス。再実装時はこの設計が出発点。
 - [0012 MCP OAuth コネクタサービスの撤去](0012-retire-mcp-oauth-connector.md)
   — **Accepted**。同サービスの撤去。0002 §4 の「必要になったら」に回帰。
-- [0038 stdio クライアントへの橋](0038-mcp-stdio-bridge.md) —
+- [0039 stdio クライアントへの橋](0039-mcp-stdio-bridge.md) —
   **Accepted**。0012 が残した穴(stdio しか話せないクライアントに
   経路が無い)を、公開サービスではなく CLI の `mcp-stdio` で埋める。
   JSON-RPC をメッセージ単位で素通しするので、ツール定義を複製しない。


### PR DESCRIPTION
Two problems that only became visible once several parallel PRs had
landed. No behavior changes.

## There are two design doc 0038s on `main`

`docs/design/0038-type-vocabulary-realignment.md` (#196) and
`docs/design/0038-mcp-stdio-bridge.md` (#197). Each was written against a
`main` that did not yet contain the other, and both merged. The index
listed **0038 twice under different titles**, and every "design doc 0038"
citation was ambiguous — the changelog and `api/openapi.yaml` mean the
vocabulary, while the bridge's source and README mean the bridge.

The bridge merged second, so it takes the next free number, **0039**:
the file, its heading, the index entry, and the four citations in
`README.md`, `cmd/ochakai/mcpstdio.go` and `cmd/ochakai/mcpstdio_test.go`.
0038 stays with the type vocabulary, which a dozen tests, the changelog
and the OpenAPI description already cite — renumbering that one would
have been a much larger and riskier diff for no gain.

Worth noting the process cost this exposed: `CONTRIBUTING.md` says "take
the next free number", which is only unambiguous when one design doc is
in flight at a time. Nothing checks it. A test that fails on duplicate
numbers would be the natural fix, but that is a change to how design docs
are governed, so I have left it out of a correction PR — happy to add it
if you want it.

## The changelog missed four PRs

`[Unreleased]` recorded only the vocabulary change, having been written
before #193, #194, #197 and #198 landed. Adds an **Added** section for
the three that an operator or an adopter would want to know about:
`ochakai mcp-stdio`, the Terraform module (including that it creates no
password and cannot run the bootstrap SQL), and the OpenAPI examples.
#195 and #198 are internal/documentation and stay out.

## Verification

`gofmt`, `go vet`, and `go test -race ./...` clean — **with
`OCHAKAI_TEST_DATABASE_URL` set**, so the REST integration tests and the
OpenAPI contract check actually ran. No `0038` reference to the bridge
remains anywhere, both docs now have distinct numbers and headings, and
every relative link in the README, changelog, design index and
architecture doc resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
