### PR TITLE
Let the single source of truth generate the copies

### DIFF
--- a/cmd/ochakai/serveui.go
+++ b/cmd/ochakai/serveui.go
@@ -24,7 +24,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"os"
 	"os/signal"
@@ -35,7 +34,6 @@ import (
 
 	"github.com/na0fu3y/ochakai/internal/domain"
 	"github.com/na0fu3y/ochakai/internal/httpauth"
-	"github.com/na0fu3y/ochakai/internal/webui"
 )
 
 func serveUI(log *slog.Logger) error {
@@ -75,16 +73,10 @@ func serveUI(log *slog.Logger) error {
 // serveUIHandler serves the embedded page at / plus /health, and routes
 // /api/v1 and /mcp through proxy.
 func serveUIHandler(proxy http.Handler) http.Handler {
-	mux := http.NewServeMux()
+	mux := webUIMux(proxy)
 	mux.HandleFunc("GET /health", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte("ok"))
 	})
-	mux.HandleFunc("GET /{$}", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		_, _ = w.Write(webui.Index)
-	})
-	mux.Handle("/api/v1/", proxy)
-	mux.Handle("/mcp", proxy)
 	return mux
 }
 
@@ -93,49 +85,24 @@ func serveUIHandler(proxy http.Handler) http.Handler {
 // token in X-Serverless-Authorization, the header Cloud Run validates in
 // preference to Authorization.
 //
-// Both credential headers are dropped before that, whatever the browser
-// sent and whether or not a token is available, as `ochakai ui` drops
-// them. httpauth reads Authorization when X-Serverless-Authorization is
-// absent, so a token fetch that fails — the one moment the proxy has no
-// identity of its own — is exactly when a forwarded browser header would
-// get to name the actor instead.
-//
 // When iap is non-nil the request is additionally attributed to the
 // person driving the browser, taken from IAP's signed assertion (design
-// doc 0032). The delegation header is stripped either way: whatever the
-// browser sent is a claim about identity from the one party with no
-// standing to make it.
+// doc 0032). The inbound delegation header is stripped either way, before
+// the IAP identity may set a verified one.
 func newServiceProxy(target *url.URL, tokens serviceTokenSource, iap iapVerifier, log *slog.Logger) http.Handler {
-	// Rewrite rather than Director: it drops the browser's X-Forwarded-*
-	// headers instead of appending to them, which is what we want from a
-	// proxy that trusts nothing the page sends.
-	proxy := &httputil.ReverseProxy{Rewrite: func(r *httputil.ProxyRequest) {
-		r.SetURL(target) // also points the outbound Host at the target
-		// Whatever the browser sent, this proxy speaks as the service.
-		r.Out.Header.Del("Authorization")
-		r.Out.Header.Del("X-Serverless-Authorization")
+	proxy := newCredentialProxy(target, func(h http.Header) {
 		// Cloud Run service-to-service auth; harmless if unavailable
 		// (e.g. running locally against an unrestricted ochakai).
 		if tok, err := tokens.token(); err == nil {
-			r.Out.Header.Set("X-Serverless-Authorization", "Bearer "+tok)
+			h.Set("X-Serverless-Authorization", "Bearer "+tok)
 		} else {
 			log.Warn("no service identity token; forwarding without it", "error", err)
 		}
-	}}
+	})
 	if iap == nil {
 		return stripDelegation(proxy)
 	}
 	return stripDelegation(withIAPIdentity(proxy, iap, log))
-}
-
-// stripDelegation removes an inbound delegation header. It wraps the
-// handler that may legitimately set one, so it runs first and cannot
-// undo it.
-func stripDelegation(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		r.Header.Del(httpauth.OnBehalfOfHeader)
-		next.ServeHTTP(w, r)
-	})
 }
 
 // withIAPIdentity names the end user on each proxied request from IAP's

--- a/cmd/ochakai/ui.go
+++ b/cmd/ochakai/ui.go
@@ -7,21 +7,15 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"golang.org/x/oauth2"
-
-	"github.com/na0fu3y/ochakai/internal/httpauth"
-	"github.com/na0fu3y/ochakai/internal/webui"
 )
 
 func cmdUI(ctx context.Context, args []string) error {
@@ -52,63 +46,31 @@ func cmdUI(ctx context.Context, args []string) error {
 	}
 	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 	defer stop()
-	server := &http.Server{
-		Addr:              fmt.Sprintf("127.0.0.1:%d", *port),
-		Handler:           handler,
-		ReadHeaderTimeout: 10 * time.Second,
-	}
-	go func() {
-		<-ctx.Done()
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		_ = server.Shutdown(shutdownCtx)
-	}()
-
 	fmt.Printf("ochakai ui: http://127.0.0.1:%d → %s as %s (%s); Ctrl-C to stop\n",
 		*port, *target, identity, auth)
-	if err := server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
-		return err
-	}
-	return nil
+	return runServer(ctx, fmt.Sprintf("127.0.0.1:%d", *port), handler)
 }
 
 // uiHandler serves the embedded page at / and reverse-proxies /api/v1
-// and /mcp to target, replacing any browser-supplied Authorization with
+// and /mcp to target, replacing any browser-supplied credentials with
 // a fresh ID token from tokens (nil = plain-http development server,
-// forward without credentials).
+// forward without credentials). The delegation header is stripped too:
+// this proxy has no verified source for one (serve-ui gets its from
+// IAP, design doc 0032), and a page that could set it would be forging
+// an author on a server where you are permitted to delegate.
 func uiHandler(target string, tokens oauth2.TokenSource) (http.Handler, error) {
 	u, err := url.Parse(target)
 	if err != nil {
 		return nil, fmt.Errorf("invalid server URL %q: %w", target, err)
 	}
-	// Rewrite rather than Director: it drops the browser's X-Forwarded-*
-	// headers instead of appending to them, which is what we want from a
-	// proxy that trusts nothing the page sends.
-	proxy := &httputil.ReverseProxy{Rewrite: func(r *httputil.ProxyRequest) {
-		r.SetURL(u) // also points the outbound Host at the target
-		// Never forward whatever the browser sent; the proxy's whole job
-		// is to substitute the CLI user's identity. That covers the
-		// delegation header too: this proxy has no verified source for
-		// one (serve-ui gets its from IAP, design doc 0032), and a page
-		// that could set it would be forging an author on a server where
-		// you are permitted to delegate.
-		r.Out.Header.Del("Authorization")
-		r.Out.Header.Del(httpauth.OnBehalfOfHeader)
+	proxy := newCredentialProxy(u, func(h http.Header) {
 		if tokens != nil {
 			if tok, err := tokens.Token(); err == nil {
-				r.Out.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+				h.Set("Authorization", "Bearer "+tok.AccessToken)
 			}
 		}
-	}}
-
-	mux := http.NewServeMux()
-	mux.HandleFunc("GET /{$}", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		_, _ = w.Write(webui.Index)
 	})
-	mux.Handle("/api/v1/", proxy)
-	mux.Handle("/mcp", proxy)
-	return localBrowserGuard(mux), nil
+	return localBrowserGuard(webUIMux(stripDelegation(proxy))), nil
 }
 
 // localBrowserGuard fends off the two ways a web page in the user's

--- a/cmd/ochakai/ui_test.go
+++ b/cmd/ochakai/ui_test.go
@@ -188,3 +188,39 @@ func TestUIHandlerStripsDelegationHeader(t *testing.T) {
 		t.Errorf("%s reached the server as %q, want it stripped", httpauth.OnBehalfOfHeader, v)
 	}
 }
+
+// X-Serverless-Authorization is the other credential header httpauth
+// reads, and it reads it *in preference to* Authorization. Forwarding
+// what the browser sent would therefore let a page override the very
+// identity this proxy exists to attach, so it is dropped alongside
+// Authorization rather than only instead of it.
+func TestUIHandlerStripsServerlessAuthorization(t *testing.T) {
+	var got http.Header
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Clone()
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer backend.Close()
+
+	h, err := uiHandler(backend.URL, oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "id-token"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	local := httptest.NewServer(h)
+	defer local.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, local.URL+"/api/v1/knowledge?q=x", nil)
+	req.Header.Set("X-Serverless-Authorization", "Bearer browser-supplied")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.ReadAll(resp.Body)
+	if v := got.Get("X-Serverless-Authorization"); v != "" {
+		t.Errorf("X-Serverless-Authorization reached the server as %q, want it stripped", v)
+	}
+	if auth := got.Get("Authorization"); auth != "Bearer id-token" {
+		t.Errorf("upstream Authorization = %q, want the CLI user's token", auth)
+	}
+}

--- a/cmd/ochakai/uicommon.go
+++ b/cmd/ochakai/uicommon.go
@@ -1,0 +1,62 @@
+// Plumbing shared by the two web-UI commands, `ochakai ui` and
+// `ochakai serve-ui` (design doc 0006). They stay separate commands so
+// neither can drift into the other's threat model; what they share is
+// the page layout and the rule that no inbound credential ever reaches
+// the upstream.
+package main
+
+import (
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+
+	"github.com/na0fu3y/ochakai/internal/httpauth"
+	"github.com/na0fu3y/ochakai/internal/webui"
+)
+
+// webUIMux serves the embedded page at / and routes /api/v1 and /mcp
+// through proxy. Callers add their own extras (serve-ui's /health) and
+// wrapping (ui's localBrowserGuard).
+func webUIMux(proxy http.Handler) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /{$}", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write(webui.Index)
+	})
+	mux.Handle("/api/v1/", proxy)
+	mux.Handle("/mcp", proxy)
+	return mux
+}
+
+// newCredentialProxy reverse-proxies to target, substituting the proxy's
+// own identity for whatever the browser sent. Both credential headers
+// httpauth reads — Authorization and X-Serverless-Authorization — are
+// dropped before setAuth attaches the outbound identity, whether or not
+// it attaches one: the moment the proxy has no identity of its own is
+// exactly when a forwarded browser header would get to name the actor
+// instead. The delegation header is the caller's business
+// (stripDelegation / withIAPIdentity), because serve-ui's IAP path
+// legitimately sets one after stripping the inbound claim.
+//
+// Rewrite rather than Director: it drops the browser's X-Forwarded-*
+// headers instead of appending to them, which is what we want from a
+// proxy that trusts nothing the page sends.
+func newCredentialProxy(target *url.URL, setAuth func(http.Header)) *httputil.ReverseProxy {
+	return &httputil.ReverseProxy{Rewrite: func(r *httputil.ProxyRequest) {
+		r.SetURL(target) // also points the outbound Host at the target
+		r.Out.Header.Del("Authorization")
+		r.Out.Header.Del("X-Serverless-Authorization")
+		setAuth(r.Out.Header)
+	}}
+}
+
+// stripDelegation removes an inbound delegation header: whatever the
+// browser sent is a claim about identity from the one party with no
+// standing to make it. It wraps any handler that may legitimately set
+// one, so it runs first and cannot undo it.
+func stripDelegation(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Header.Del(httpauth.OnBehalfOfHeader)
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/apiclient/token.go
+++ b/internal/apiclient/token.go
@@ -45,34 +45,43 @@ func (gcloudSource) Token() (*oauth2.Token, error) {
 	return &oauth2.Token{AccessToken: tok, Expiry: jwtExpiry(tok)}, nil
 }
 
-// jwtExpiry reads exp from the (Google-signed, already trusted) token so
-// ReuseTokenSource refreshes on time; unparseable tokens get a short TTL.
+// jwtClaims holds the payload claims the client reads from a
+// (Google-signed, already trusted) token — decoded, never verified.
+type jwtClaims struct {
+	Exp   int64  `json:"exp"`
+	Email string `json:"email"`
+}
+
+// parseJWTClaims decodes a token's payload; ok is false when it does not
+// parse as a JWT.
+func parseJWTClaims(tok string) (jwtClaims, bool) {
+	parts := strings.Split(tok, ".")
+	if len(parts) != 3 {
+		return jwtClaims{}, false
+	}
+	data, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return jwtClaims{}, false
+	}
+	var claims jwtClaims
+	if err := json.Unmarshal(data, &claims); err != nil {
+		return jwtClaims{}, false
+	}
+	return claims, true
+}
+
+// jwtExpiry reads exp from the token so ReuseTokenSource refreshes on
+// time; unparseable tokens get a short TTL.
 func jwtExpiry(tok string) time.Time {
-	if parts := strings.Split(tok, "."); len(parts) == 3 {
-		if data, err := base64.RawURLEncoding.DecodeString(parts[1]); err == nil {
-			var claims struct {
-				Exp int64 `json:"exp"`
-			}
-			if json.Unmarshal(data, &claims) == nil && claims.Exp > 0 {
-				return time.Unix(claims.Exp, 0)
-			}
-		}
+	if claims, ok := parseJWTClaims(tok); ok && claims.Exp > 0 {
+		return time.Unix(claims.Exp, 0)
 	}
 	return time.Now().Add(5 * time.Minute)
 }
 
-// jwtEmail reads the email claim from the (Google-signed, already
-// trusted) token; empty when absent or unparseable.
+// jwtEmail reads the email claim from the token; empty when absent or
+// unparseable.
 func jwtEmail(tok string) string {
-	if parts := strings.Split(tok, "."); len(parts) == 3 {
-		if data, err := base64.RawURLEncoding.DecodeString(parts[1]); err == nil {
-			var claims struct {
-				Email string `json:"email"`
-			}
-			if json.Unmarshal(data, &claims) == nil {
-				return claims.Email
-			}
-		}
-	}
-	return ""
+	claims, _ := parseJWTClaims(tok)
+	return claims.Email
 }

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -83,6 +83,23 @@ func requestCtx(ctx context.Context, cfg *config.Config, req extraProvider) (con
 	return httpauth.WithActor(ctx, actor), actor, nil
 }
 
+// tool adapts a handler to the shape mcp.AddTool takes, running requestCtx
+// first so the context the handler receives already carries the per-call
+// actor. Registering every tool through here is what makes the "handler
+// forgot requestCtx" failure impossible instead of merely convention.
+func tool[In, Out any](svc *service.Service,
+	fn func(ctx context.Context, actor domain.Actor, in In) (*mcp.CallToolResult, Out, error),
+) func(context.Context, *mcp.CallToolRequest, In) (*mcp.CallToolResult, Out, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in In) (*mcp.CallToolResult, Out, error) {
+		ctx, actor, err := requestCtx(ctx, svc.Config, req)
+		if err != nil {
+			var zero Out
+			return nil, zero, err
+		}
+		return fn(ctx, actor, in)
+	}
+}
+
 func newServer(svc *service.Service, version string) *mcp.Server {
 	s := mcp.NewServer(&mcp.Implementation{Name: serverName, Version: version}, &mcp.ServerOptions{
 		Instructions: "ochakai is a context provider for data agents: metric definitions, " +
@@ -177,11 +194,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"source is a filter rather than a mode: it narrows to the entries citing one resource — use it " +
 			"when a source document changed and you need everything derived from it — and combines with a " +
 			"query or with any sort.",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, in searchIn) (*mcp.CallToolResult, searchOut, error) {
-		ctx, _, err := requestCtx(ctx, svc.Config, req)
-		if err != nil {
-			return nil, searchOut{}, err
-		}
+	}, tool(svc, func(ctx context.Context, _ domain.Actor, in searchIn) (*mcp.CallToolResult, searchOut, error) {
 		f := store.Filter{
 			Types: domain.ToTypes(in.Types), Statuses: domain.ToStatuses(in.Statuses),
 			Tags: in.Tags, Source: in.Source,
@@ -191,7 +204,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			return nil, searchOut{}, err
 		}
 		return nil, searchOut{Hits: hits}, nil
-	})
+	}))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "get_context",
@@ -203,11 +216,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"fall back to search_knowledge/get_knowledge for precise lookups. \"entries\" is the " +
 			"knowledge; \"hits\" is only the ranking behind it. Entries that do not fit the byte " +
 			"budget are listed under \"outline\" — fetch any of them by id with get_knowledge.",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, in contextIn) (*mcp.CallToolResult, contextOut, error) {
-		ctx, _, err := requestCtx(ctx, svc.Config, req)
-		if err != nil {
-			return nil, contextOut{}, err
-		}
+	}, tool(svc, func(ctx context.Context, _ domain.Actor, in contextIn) (*mcp.CallToolResult, contextOut, error) {
 		budget := in.Budget
 		if budget <= 0 {
 			budget = defaultContextBudget
@@ -226,7 +235,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			Hits: res.Hits, Entries: res.Entries, Outline: res.Outline,
 			Truncated: res.Truncated, Hint: contextHint(res.Truncated),
 		}, nil
-	})
+	}))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "get_knowledge",
@@ -234,17 +243,13 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 		Description: "Get one knowledge entry by id, including its full markdown body, structured attrs, " +
 			"links, and attachment metadata (files the body references: images, PDFs, plain-text data — " +
 			"fetch bytes with get_attachment).",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, in getIn) (*mcp.CallToolResult, knowledgeOut, error) {
-		ctx, _, err := requestCtx(ctx, svc.Config, req)
-		if err != nil {
-			return nil, knowledgeOut{}, err
-		}
+	}, tool(svc, func(ctx context.Context, _ domain.Actor, in getIn) (*mcp.CallToolResult, knowledgeOut, error) {
 		k, err := svc.Get(ctx, in.ID)
 		if err != nil {
 			return nil, knowledgeOut{}, err
 		}
 		return nil, knowledgeOut{Knowledge: *k}, nil
-	})
+	}))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "create_knowledge",
@@ -271,17 +276,13 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"An id whose entry was deleted can be reused, which revives it as your draft — unless a human had " +
 			"ruled on it (verified, rejected, deprecated), in which case this surface refuses: propose at a " +
 			"different id instead.",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, in writeIn) (*mcp.CallToolResult, knowledgeOut, error) {
-		ctx, actor, err := requestCtx(ctx, svc.Config, req)
-		if err != nil {
-			return nil, knowledgeOut{}, err
-		}
+	}, tool(svc, func(ctx context.Context, actor domain.Actor, in writeIn) (*mcp.CallToolResult, knowledgeOut, error) {
 		k, err := svc.CreateKeepingCurated(ctx, in.toKnowledge(), actor)
 		if err != nil {
 			return nil, knowledgeOut{}, err
 		}
 		return nil, knowledgeOut{Knowledge: *k}, nil
-	})
+	}))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "update_knowledge",
@@ -297,11 +298,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"Setting status=verified records you as verified_by — " +
 			"do it only for knowledge you have actually validated. Setting status=rejected records you " +
 			"as rejected_by; put the reason in status_note (also useful when deprecating).",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, in writeIn) (*mcp.CallToolResult, knowledgeOut, error) {
-		ctx, actor, err := requestCtx(ctx, svc.Config, req)
-		if err != nil {
-			return nil, knowledgeOut{}, err
-		}
+	}, tool(svc, func(ctx context.Context, actor domain.Actor, in writeIn) (*mcp.CallToolResult, knowledgeOut, error) {
 		// MCP has no conditional-update channel, so it cannot opt into the
 		// If-Match precondition (nil) and writes are last-write-wins. That
 		// is tolerable for drafts and not for curated knowledge, so
@@ -319,7 +316,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			return nil, knowledgeOut{}, err
 		}
 		return nil, knowledgeOut{Knowledge: *k}, nil
-	})
+	}))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "delete_knowledge",
@@ -328,11 +325,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"create_knowledge on the same id revives it. Entries a human has ruled on — verified, " +
 			"rejected, or deprecated — cannot be deleted from this surface; deleting a rejected " +
 			"entry and recreating it would erase the record of why it was turned down.",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, in getIn) (*mcp.CallToolResult, deleteOut, error) {
-		ctx, actor, err := requestCtx(ctx, svc.Config, req)
-		if err != nil {
-			return nil, deleteOut{}, err
-		}
+	}, tool(svc, func(ctx context.Context, actor domain.Actor, in getIn) (*mcp.CallToolResult, deleteOut, error) {
 		// Delete has no precondition channel in the store, so a curation
 		// landing in the window between check and delete still wins. The
 		// window is a single round trip and the delete is revivable.
@@ -343,7 +336,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			return nil, deleteOut{}, err
 		}
 		return nil, deleteOut{Deleted: true, URI: uriScheme + in.ID}, nil
-	})
+	}))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "get_attachment",
@@ -355,11 +348,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"normal shape, an ER diagram, a seeds file). ochakai never interprets attachments; " +
 			"if you learn something from one, write it back into the entry's body with " +
 			"update_knowledge so the knowledge becomes searchable text.",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, in attachmentIn) (*mcp.CallToolResult, attachmentOut, error) {
-		ctx, _, err := requestCtx(ctx, svc.Config, req)
-		if err != nil {
-			return nil, attachmentOut{}, err
-		}
+	}, tool(svc, func(ctx context.Context, _ domain.Actor, in attachmentIn) (*mcp.CallToolResult, attachmentOut, error) {
 		att, data, err := svc.Attachment(ctx, in.ID, in.Name)
 		if err != nil {
 			return nil, attachmentOut{}, err
@@ -382,7 +371,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 		}
 		res := &mcp.CallToolResult{Content: []mcp.Content{content}}
 		return res, attachmentOut{Attachment: *att}, nil
-	})
+	}))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "get_knowledge_usage",
@@ -391,17 +380,13 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"was fetched individually, and how it was reported to have worked, with last_used_at. " +
 			"The measure of the write-back loop — evidence when deciding to promote a draft, " +
 			"and a staleness signal for verified entries that stopped being used.",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, in getIn) (*mcp.CallToolResult, usageOut, error) {
-		ctx, _, err := requestCtx(ctx, svc.Config, req)
-		if err != nil {
-			return nil, usageOut{}, err
-		}
+	}, tool(svc, func(ctx context.Context, _ domain.Actor, in getIn) (*mcp.CallToolResult, usageOut, error) {
 		u, err := svc.Usage(ctx, in.ID)
 		if err != nil {
 			return nil, usageOut{}, err
 		}
 		return nil, usageOut{Usage: *u}, nil
-	})
+	}))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "report_outcome",
@@ -412,11 +397,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"Reports feed the entry's usage totals (get_knowledge_usage), where failed counts " +
 			"against verified entries flag them for re-verification. Your identity is recorded " +
 			"with each report. Returns the entry's updated usage totals.",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, in outcomeIn) (*mcp.CallToolResult, usageOut, error) {
-		ctx, _, err := requestCtx(ctx, svc.Config, req)
-		if err != nil {
-			return nil, usageOut{}, err
-		}
+	}, tool(svc, func(ctx context.Context, _ domain.Actor, in outcomeIn) (*mcp.CallToolResult, usageOut, error) {
 		id := strings.TrimPrefix(in.Target, uriScheme)
 		if !domain.ValidID(id) {
 			return nil, usageOut{}, fmt.Errorf("invalid target %q (want the entry's id, e.g. queries/monthly-revenue)", in.Target)
@@ -426,7 +407,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			return nil, usageOut{}, err
 		}
 		return nil, usageOut{Usage: *u}, nil
-	})
+	}))
 
 	return s
 }

--- a/internal/store/attachment.go
+++ b/internal/store/attachment.go
@@ -26,10 +26,16 @@ import (
 const attachmentCols = `a.name, b.media_type, b.size, a.sha256, a.okf_path,
 	a.created_by_kind, a.created_by_name, a.created_at`
 
+// attachmentDests returns the scan destinations matching attachmentCols,
+// in column order — the one place the two lists are paired.
+func attachmentDests(a *domain.Attachment) []any {
+	return []any{&a.Name, &a.MediaType, &a.Size, &a.SHA256, &a.OKFPath,
+		&a.CreatedBy.Kind, &a.CreatedBy.Name, &a.CreatedAt}
+}
+
 func scanAttachment(row pgx.CollectableRow) (domain.Attachment, error) {
 	var a domain.Attachment
-	err := row.Scan(&a.Name, &a.MediaType, &a.Size, &a.SHA256, &a.OKFPath,
-		&a.CreatedBy.Kind, &a.CreatedBy.Name, &a.CreatedAt)
+	err := row.Scan(attachmentDests(&a)...)
 	return a, err
 }
 
@@ -109,18 +115,7 @@ var errNoBlobStore = errors.New("attachments are not supported without GCS: set 
 // GetAttachment returns one attachment with its bytes. Attachments of
 // soft-deleted entries are gone with the entry.
 func (s *Store) GetAttachment(ctx context.Context, id, name string) (*domain.Attachment, []byte, error) {
-	rows, err := s.pool.Query(ctx, `SELECT `+attachmentCols+`
-		FROM attachment a
-		JOIN blob b ON b.sha256 = a.sha256
-		JOIN knowledge k ON k.id = a.knowledge_id AND k.deleted_at IS NULL
-		WHERE a.knowledge_id=$1 AND a.name=$2`, id, name)
-	if err != nil {
-		return nil, nil, err
-	}
-	att, err := pgx.CollectExactlyOneRow(rows, scanAttachment)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, nil, ErrNotFound
-	}
+	att, err := s.GetAttachmentMeta(ctx, id, name)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -131,7 +126,7 @@ func (s *Store) GetAttachment(ctx context.Context, id, name string) (*domain.Att
 	if err != nil {
 		return nil, nil, err
 	}
-	return &att, data, nil
+	return att, data, nil
 }
 
 // ListAttachments returns the metadata (no bytes) of a live entry's
@@ -165,8 +160,7 @@ func (s *Store) ListAttachmentsBatch(ctx context.Context, ids []string) (map[str
 	for rows.Next() {
 		var id string
 		var a domain.Attachment
-		if err := rows.Scan(&id, &a.Name, &a.MediaType, &a.Size, &a.SHA256, &a.OKFPath,
-			&a.CreatedBy.Kind, &a.CreatedBy.Name, &a.CreatedAt); err != nil {
+		if err := rows.Scan(append([]any{&id}, attachmentDests(&a)...)...); err != nil {
 			return nil, err
 		}
 		out[id] = append(out[id], a)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -166,6 +166,56 @@ const knowledgeCols = `type, id, title, description, resource, tags, status, sta
 	rejected_by_kind, rejected_by_name, rejected_by_via, rejected_at,
 	links, attrs, body, created_at, updated_at`
 
+// The SQL fragments that restate knowledgeCols are derived from it once,
+// so an envelope column is added by editing the list and knowledgeDest —
+// not by hunting down hand-written copies in each write path.
+var (
+	knowledgeColNames = func() []string {
+		cols := strings.Split(knowledgeCols, ",")
+		for i, c := range cols {
+			cols[i] = strings.TrimSpace(c)
+		}
+		return cols
+	}()
+
+	// knowledgeParams is the "$1,...,$N" placeholder list matching
+	// knowledgeCols; an argument past the columns is $len+1.
+	knowledgeParams = func() string {
+		params := make([]string, len(knowledgeColNames))
+		for i := range params {
+			params[i] = fmt.Sprintf("$%d", i+1)
+		}
+		return strings.Join(params, ",")
+	}()
+
+	// knowledgeExcluded assigns every column except the key from EXCLUDED,
+	// for Create's revive-in-place upsert. A column missing here would
+	// silently keep the tombstone's stale value on revival, with no error
+	// anywhere — which is why the list is derived rather than written out.
+	knowledgeExcluded = func() string {
+		var parts []string
+		for _, c := range knowledgeColNames {
+			if c == "id" {
+				continue
+			}
+			parts = append(parts, c+"=EXCLUDED."+c)
+		}
+		return strings.Join(parts, ", ")
+	}()
+
+	// knowledgeColsK is knowledgeCols with every column prefixed by "k",
+	// the alias every query that joins another table gives the knowledge
+	// table. Built once: the column list is fixed at compile time, so
+	// re-splitting it per query bought nothing.
+	knowledgeColsK = func() string {
+		cols := make([]string, len(knowledgeColNames))
+		for i, c := range knowledgeColNames {
+			cols[i] = "k." + c
+		}
+		return strings.Join(cols, ", ")
+	}()
+)
+
 // knowledgeDest returns the scan destinations for knowledgeCols targeting
 // k, plus a finish func that decodes the JSON columns and nullable actors
 // after the scan. Row shapes with trailing columns (score, usage totals)
@@ -328,7 +378,7 @@ func (s *Store) Create(ctx context.Context, k *domain.Knowledge, keepCuratedTomb
 	// instead of being erased by it.
 	revive := ""
 	if keepCuratedTombstones {
-		revive = ` AND knowledge.status <> ALL($36::text[])`
+		revive = fmt.Sprintf(` AND knowledge.status <> ALL($%d::text[])`, len(knowledgeColNames)+1)
 	}
 	return s.withTx(ctx, func(tx pgx.Tx) error {
 		j, err := marshalJSONFields(k)
@@ -358,26 +408,8 @@ func (s *Store) Create(ctx context.Context, k *domain.Knowledge, keepCuratedTomb
 			args = append(args, curated)
 		}
 		tag, err := tx.Exec(ctx, `INSERT INTO knowledge (`+knowledgeCols+`)
-			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,
-			        $26,$27,$28,$29,$30,$31,$32,$33,$34,$35)
-			ON CONFLICT (id) DO UPDATE SET
-				type=EXCLUDED.type,
-				title=EXCLUDED.title, description=EXCLUDED.description, resource=EXCLUDED.resource, tags=EXCLUDED.tags,
-				status=EXCLUDED.status, status_note=EXCLUDED.status_note, stale_after=EXCLUDED.stale_after,
-				sources=EXCLUDED.sources, usage_window=EXCLUDED.usage_window,
-				runtime=EXCLUDED.runtime, parameters=EXCLUDED.parameters, computation=EXCLUDED.computation,
-				executor=EXCLUDED.executor, attester=EXCLUDED.attester,
-				created_by_kind=EXCLUDED.created_by_kind, created_by_name=EXCLUDED.created_by_name,
-				created_by_via=EXCLUDED.created_by_via,
-				updated_by_kind=EXCLUDED.updated_by_kind, updated_by_name=EXCLUDED.updated_by_name,
-				updated_by_via=EXCLUDED.updated_by_via,
-				verified_by_kind=EXCLUDED.verified_by_kind, verified_by_name=EXCLUDED.verified_by_name,
-				verified_by_via=EXCLUDED.verified_by_via, verified_at=EXCLUDED.verified_at,
-				rejected_by_kind=EXCLUDED.rejected_by_kind, rejected_by_name=EXCLUDED.rejected_by_name,
-				rejected_by_via=EXCLUDED.rejected_by_via, rejected_at=EXCLUDED.rejected_at,
-				links=EXCLUDED.links, attrs=EXCLUDED.attrs, body=EXCLUDED.body,
-				created_at=EXCLUDED.created_at, updated_at=EXCLUDED.updated_at,
-				deleted_at=NULL
+			VALUES (`+knowledgeParams+`)
+			ON CONFLICT (id) DO UPDATE SET `+knowledgeExcluded+`, deleted_at=NULL
 			WHERE knowledge.deleted_at IS NOT NULL`+revive,
 			args...)
 		if err != nil {
@@ -1581,18 +1613,6 @@ func marshalJSONFields(k *domain.Knowledge) (knowledgeJSON, error) {
 	}
 	return j, nil
 }
-
-// knowledgeColsK is knowledgeCols with every column prefixed by "k", the
-// alias every query that joins another table gives the knowledge table.
-// Built once: the column list is fixed at compile time, so re-splitting it
-// per query bought nothing.
-var knowledgeColsK = func() string {
-	cols := strings.Split(knowledgeCols, ",")
-	for i, c := range cols {
-		cols[i] = "k." + strings.TrimSpace(c)
-	}
-	return strings.Join(cols, ", ")
-}()
 
 // escapeLike neutralizes the LIKE/ILIKE pattern metacharacters '%' and '_'
 // in a user query so it matches literally. PostgreSQL's default LIKE escape


### PR DESCRIPTION
<!-- Keep PRs small and focused. Link the issue or design doc, if there is one. -->

## What and why

Six places restated something the code already knew. Each restatement was a
place the copy could disagree with the original — none of them disagree
today, so this is about what it costs to keep it that way, not about a bug
being fixed. Net −67 lines.

Ranked by what the duplication was actually risking:

**`internal/store` — `Create`'s INSERT re-spelled `knowledgeCols` three
times.** The `VALUES ($1..$35)` placeholder list, an 18-line
`ON CONFLICT DO UPDATE SET … EXCLUDED` block, and the revive clause's
hardcoded `$36`. All three are derived from the column list now, the way
`knowledgeColsK` already was. Adding an envelope column went from ~7 edits
to ~3, and the nastiest of the seven is gone: a column missing from the
`EXCLUDED` list would have kept a tombstone's stale value when the entry
was revived, with no error anywhere.

**`internal/mcpserver` — ten handlers opened with the same four-line
`requestCtx` prologue.** The existing comment says why it is on every
handler and not just the recording ones: the failure is silent
misattribution. That made it load-bearing boilerplate enforced only by
convention. Handlers now register through a small generic `tool[In, Out]`
adapter that resolves the actor before the handler body runs, so
"forgot `requestCtx`" is no longer expressible.

**`internal/store` — `GetAttachment` was `GetAttachmentMeta` plus a blob
fetch, written out twice** (byte-identical query and `ErrNoRows` handling).
It calls it now. Separately, `ListAttachmentsBatch` hand-listed the eight
scan destinations `scanAttachment` already knew, so a change to
`attachmentCols` would have broken that one silently-by-position while the
other three call sites kept working; both go through `attachmentDests`.

**`cmd/ochakai` — `ochakai ui` had its own `http.Server` and shutdown
goroutine**, and returned as soon as `ListenAndServe` yielded
`ErrServerClosed` — which is when `Shutdown` is *called*, not when the
drain finishes. That is the exact mistake `serveAndDrain`'s doc comment
exists to explain, and `ui` was the only holdout (`serve-ui` already used
`runServer`). It goes through `runServer` now, so it waits for the drain
and shares `drainTimeout` instead of a second hardcoded `5s`.

**`cmd/ochakai` — `ui` and `serve-ui` each built the same page mux and the
same credential-stripping reverse proxy**, comment block included, and the
header lists had already drifted. `ui` dropped `Authorization` and the
delegation header but *not* `X-Serverless-Authorization` — the header
`httpauth` reads **in preference to** `Authorization`. A page could
therefore have overridden the very identity the proxy exists to attach.
New `cmd/ochakai/uicommon.go` holds `webUIMux`, `newCredentialProxy` and
`stripDelegation`; both credential headers are now dropped for both
commands. `serve-ui`'s IAP ordering is unchanged — the inbound delegation
claim is still stripped before `withIAPIdentity` may set a verified one.

**`internal/apiclient` — `jwtExpiry` and `jwtEmail` were the same decode
with a different claim.** Behavior unchanged.

### Reviewer notes

- No wire surface changes: `api/openapi.yaml`, REST, MCP and the CLI all
  say what they said before. No accepted decision is altered, so no new
  design doc.
- Two behavior changes, both alignments with intent the code already
  documented: the `ui` drain, and the `X-Serverless-Authorization` strip.
  The latter has a new test (`TestUIHandlerStripsServerlessAuthorization`),
  verified to fail when the `Del` is removed.
- The `Create` upsert is the highest-risk hunk. It is worth checking that
  the derived `EXCLUDED` list still covers all 34 non-`id` columns plus
  `deleted_at=NULL`; the store integration tests cover the revive path.
- Considered and deliberately left alone: the three curated-status advice
  switches in `internal/service` (tests assert on the prose, so it is not
  a mechanical change), the 125-line export handler in `internal/restapi`
  (no line reduction, worth its own PR), and the `idArgs`+`newClient`
  preamble in `client.go` (a helper would reorder stdin reads against
  token resolution for `create`/`update`).

## Checks

CI runs exactly this; make it pass locally first (CONTRIBUTING.md has the
context, including the store integration test and the fuzz targets).

- [x] `gofmt -l .` prints nothing; `go vet ./...`; `go test -race ./...`
- [x] `CGO_ENABLED=0 go build -trimpath ./...`
- [x] golangci-lint and govulncheck report nothing
- [x] Behavior changes come with tests

Store/service/restapi/mcpserver integration tests were also run against a
fresh `pgvector/pgvector:pg17` — all green.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing; a new endpoint has an
      integration test, which is what puts it under the OpenAPI contract check
- [x] The change lands on every surface it belongs on — REST / MCP / CLI /
      Web UI — and what it stays off is deliberate (design doc 0015)

Internal refactoring only; no surface gains or loses a feature. The one
cross-surface item is the credential-header strip, which now behaves the
same in `ui` and `serve-ui` rather than differing.

## Design docs

- [x] Alters an accepted decision? A new numbered doc under `docs/design` is in
      this PR, the `Status:` header of every doc it supersedes or amends links
      to it, and `docs/design/README.md` is updated — or: it does not, and this
      box is not applicable
- [x] Commit messages and code comments are in English

Not applicable: no accepted decision changes. The work implements what
0027 §5.2 (actor attribution), 0032 (delegation) and 0030 already decided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)