### PR TITLE
Scope the question-search test to the corpus it plants

### DIFF
--- a/internal/service/service_integration_test.go
+++ b/internal/service/service_integration_test.go
@@ -509,47 +509,68 @@ func TestReembedReportsWhatIsLeft(t *testing.T) {
 	}
 
 	// A pass smaller than the corpus must say what it did not reach.
-	res, err := svc.Reembed(ctx, "", 2)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if res.Embedded > 2 {
-		t.Fatalf("bounded pass embedded %d, over its limit of 2", res.Embedded)
-	}
-	if res.Embedded < 2 {
+	//
+	// Attempted several times, because one attempt cannot tell drift from
+	// the bug. Missing is counted inside Reembed, between the two counts
+	// taken here, so an entry another package creates after the baseline
+	// and deletes before the one below lands in Missing and in neither of
+	// them: both measurements agree, the corpus looks still, and the
+	// equality fails on a row this test never saw. Bracketing it tighter
+	// is not possible from out here — the fix is repetition. Drift is a
+	// coincidence of timing and misses most attempts; the two-off this
+	// covers is in the arithmetic and misses every one.
+	var stable bool // an attempt whose corpus did hold still
+	var missing, left int
+	for range reembedPinAttempts {
+		base, err := svc.Store.CountUnembedded(ctx, model)
+		if err != nil {
+			t.Fatal(err)
+		}
+		res, err := svc.Reembed(ctx, "", 2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if res.Embedded > 2 {
+			t.Fatalf("bounded pass embedded %d, over its limit of 2", res.Embedded)
+		}
+		// Missing is a fresh count taken after the pass, so the assertion
+		// is an equality against a count taken the same way — not
+		// arithmetic on the baseline. The bug this covers is a two-off
+		// (subtracting the pass's work from a total that already excluded
+		// it), which no tolerance wide enough for the drift could catch.
+		after, err := svc.Store.CountUnembedded(ctx, model)
+		if err != nil {
+			t.Fatal(err)
+		}
 		// The pass takes the oldest unembedded entries in the whole
 		// database, so a parallel package deleting one of its own
-		// candidates mid-pass leaves this short. Nothing about the
-		// reporting is wrong; there is just nothing to pin it against.
-		t.Skipf("bounded pass embedded %d of 2; another package's entries moved under it", res.Embedded)
+		// candidates mid-pass leaves the pass short, and one writing
+		// entries moves the baseline under it. Neither says anything
+		// about the reporting, so that attempt measured nothing.
+		if res.Embedded < 2 || base-res.Embedded != after {
+			continue
+		}
+		stable, missing, left = true, res.Missing, after
+		if missing == left {
+			return
+		}
 	}
-	if res.Missing == 0 {
-		t.Error("a bounded pass over a larger corpus reported nothing left")
+	if !stable {
+		t.Skipf("the corpus moved under all %d attempts; the count Reembed reports "+
+			"cannot be pinned against a moving baseline", reembedPinAttempts)
 	}
-
-	// Missing is a fresh count taken after the pass, so the assertion is
-	// an equality against a count taken the same way — not arithmetic on
-	// the baseline above. The test database is shared by every package
-	// (CONTRIBUTING) and CountUnembedded counts live entries only, so
-	// between the baseline and the pass another package can both add
-	// entries and delete its own; the bug this covers is a two-off
-	// (subtracting the pass's work from a total that already excluded
-	// it), which no tolerance wide enough for that drift could catch.
-	//
-	// So: measure again, and only compare when nothing moved.
-	after, err := svc.Store.CountUnembedded(ctx, model)
-	if err != nil {
-		t.Fatal(err)
+	if missing == 0 {
+		t.Fatal("a bounded pass over a larger corpus reported nothing left")
 	}
-	if before-res.Embedded != after {
-		t.Skipf("another package changed the corpus during the pass (%d unembedded before, %d after, %d embedded); "+
-			"the count Reembed reports cannot be pinned against a moving baseline", before, after, res.Embedded)
-	}
-	if res.Missing != after {
-		t.Errorf("Missing = %d, want %d — the pass must report what is left, not what is left minus its own work",
-			res.Missing, after)
-	}
+	t.Errorf("Missing = %d, want %d — the pass must report what is left, not what is left minus its own work",
+		missing, left)
 }
+
+// reembedPinAttempts is how many times TestReembedReportsWhatIsLeft will
+// try for a measurement the shared database did not move under. Passing
+// needs one attempt to come back clean; failing needs all of them to
+// agree, which is what keeps a retry from hiding the bug it covers.
+const reembedPinAttempts = 5
 
 // newEmbeddingService is newIntegrationService plus the pgvector schema,
 // which exists only where an embedding dimension was configured. Reembed

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -1519,16 +1519,32 @@ func TestIntegrationLexicalSearchAnswersQuestions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer s.Close()
+	// Registered rather than deferred, and before the fixture cleanup
+	// below: a deferred Close runs before any t.Cleanup, which would leave
+	// the delete swallowing "pool closed" and the corpus in the database
+	// for every later run to search through. Cleanups are LIFO, so this
+	// one runs last.
+	t.Cleanup(s.Close)
 	if err := s.Migrate(ctx, 0); err != nil {
 		t.Fatal(err)
 	}
 	actor := domain.Actor{Kind: "human", Name: "test"}
 
-	const target, decoy = "it-q-target", "it-q-decoy"
+	// The corpus is the fixture: the assertions are about how these 22
+	// entries rank against each other, and a search over the whole table
+	// answers a different question. A database that other tests have run
+	// against holds hundreds of unrelated rows, and the English question —
+	// four common words — matches enough of them to push the subject past
+	// the limit, failing recall on a corpus the test never planted. So
+	// every entry carries a run tag and every search is scoped to it,
+	// which is what the rest of this file does (see the 0037 feeds).
+	run := fmt.Sprintf("it-q-%d", time.Now().UnixNano())
+	mine := Filter{Tags: []string{run}}
+
+	target, decoy := run+"/target", run+"/decoy"
 	ids := []string{target, decoy}
 	for i := range 20 {
-		ids = append(ids, fmt.Sprintf("it-q-filler-%d", i))
+		ids = append(ids, fmt.Sprintf("%s/filler-%d", run, i))
 	}
 	clean := func() {
 		for _, id := range ids {
@@ -1536,12 +1552,11 @@ func TestIntegrationLexicalSearchAnswersQuestions(t *testing.T) {
 			_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_revision WHERE id = $1`, id)
 		}
 	}
-	clean()
 	t.Cleanup(clean)
 	create := func(id, title, body string) {
 		t.Helper()
 		if err := s.Create(ctx, &domain.Knowledge{
-			Type: domain.TypeInsights, ID: id, Title: title,
+			Type: domain.TypeInsights, ID: id, Title: title, Tags: []string{run},
 			Status: domain.StatusDraft, CreatedBy: actor, Body: body,
 		}, false); err != nil {
 			t.Fatalf("create %s: %v", id, err)
@@ -1552,7 +1567,7 @@ func TestIntegrationLexicalSearchAnswersQuestions(t *testing.T) {
 	create(target, "売上の読み方", "売上は前年同期比で見ないと誤読する。monthly revenue by quarter.")
 	create(decoy, "棚卸の運用", "棚卸は毎月行っているのか、四半期ごとなのか。why is this down to the site?")
 	for i := range 20 {
-		create(fmt.Sprintf("it-q-filler-%d", i), fmt.Sprintf("運用メモ %d", i),
+		create(fmt.Sprintf("%s/filler-%d", run, i), fmt.Sprintf("運用メモ %d", i),
 			"これは毎日行っているのかを記録している。why is it down again, and is it down for long?")
 	}
 
@@ -1583,7 +1598,7 @@ func TestIntegrationLexicalSearchAnswersQuestions(t *testing.T) {
 		// embeddings — so here we require only that the subject is found.
 		{"why is revenue down", false, "English question: recall only"},
 	} {
-		hits, err := s.SearchLexical(ctx, tc.query, Filter{}, 50)
+		hits, err := s.SearchLexical(ctx, tc.query, mine, 50)
 		if err != nil {
 			t.Fatalf("SearchLexical(%q): %v", tc.query, err)
 		}
@@ -1601,7 +1616,7 @@ func TestIntegrationLexicalSearchAnswersQuestions(t *testing.T) {
 
 	// A query that shares nothing must still come back empty: fragment
 	// matching widens recall, it does not turn the floor off.
-	hits, err := s.SearchLexical(ctx, "zzzznothingmatchesthiszzzz", Filter{}, 50)
+	hits, err := s.SearchLexical(ctx, "zzzznothingmatchesthiszzzz", mine, 50)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## What and why

`TestIntegrationLexicalSearchAnswersQuestions` fails against a test database
that rows have accumulated in. Reproduced on one holding 1407 entries:

```
store_integration_test.go:1592: SearchLexical("why is revenue down") did not
    find it-q-target among 50 hits (English question: recall only)
```

Three defects, all in tests. No production code changes; the ranking and
reporting behaviour under test is unchanged.

### 1. The search was not scoped to the corpus the test plants

The assertions are about how 22 planted entries rank against each other, but
the call passed `Filter{}` — a search over the whole table. The English question
is four common words, so on a populated database it matches enough unrelated
rows to push the subject past the limit of 50, and recall fails on a corpus the
test never planted. Every entry now carries a run tag and every search is scoped
to it, the isolation this file already uses for the 0037 feeds. Document
frequency is computed over the candidate set, so a scoped search ranks exactly
as a whole-table search would if those entries were all that existed — which is
what the assertions assume, and what a fresh database happened to provide.

### 2. That test's fixture cleanup never ran

`defer s.Close()` executes before any `t.Cleanup`, so the deletes hit a closed
pool and their ignored errors hid it: 22 rows leaked per run. It self-healed
only because the ids were fixed and the test deleted them again on entry — an
accident the run-unique ids remove, which is why this has to be fixed here.
`s.Close` is registered ahead of the fixture cleanup instead, so LIFO runs the
delete first.

### 3. Fixing that leak broke `TestReembedReportsWhatIsLeft`

Which is the CI failure on the first push of this branch:

```
service_integration_test.go:549: Missing = 118, want 117 — the pass must report
    what is left, not what is left minus its own work
```

That test pins `Missing` against a baseline it measures itself, guarding the
shared database by comparing a count taken before the pass against one taken
after. But `Missing` is counted *inside* `Reembed`, in between those two — so an
entry another package creates after the baseline and deletes before the second
count lands in `Missing` and in neither measurement. Both agree, the corpus
looks still, and the equality fails over a row the test never saw. The CI
numbers say exactly that: before=119, embedded=2, after=117 (guard passes),
Missing=118.

The blind spot is not new — any package that creates fixtures and deletes them
can hit it, and the reembed pass already logs `internal/restapi` entries
disappearing under it. But until now `internal/store` leaked its question-search
corpus rather than cleaning it up, so its rows only ever *appeared*, which the
before/after guard does catch (as a skip). Fixing that cleanup made it a source
of the transient the guard is blind to.

Bracketing the count tighter is not possible from outside `Reembed`, so the
measurement is attempted up to 5 times instead. Drift is a coincidence of timing
and misses most attempts; the two-off this covers is in the arithmetic and
misses every one — so passing needs one clean attempt, failing needs all of
them, and the retry cannot hide the bug it exists for.

### Verification

Both faults were injected into `Reembed` to check the reworked test still
discriminates:

- **the two-off** (`res.Missing = missing + attMissing - res.Embedded`) → fails,
  off by exactly the pass's work, as before
- **a one-shot transient row** (`Missing++` on the first pass only) → the
  reworked test passes; the old test body fails with `Missing = 673, want 672`,
  reproducing the CI signature

### Reviewer notes

- The same `defer s.Close()`-before-`t.Cleanup` ordering exists at
  `store_integration_test.go:1770` and `:1948`. Those delete by fixed id prefix
  at test start, so at most one run's rows persist — latent, not failing, and
  left out to keep this PR to the reported failure. Happy to fix in a follow-up.
- The store test was verified against a database with 1407 accumulated rows and
  a fresh one; two consecutive runs leave the `it-q-%` row count unchanged,
  confirming the leak is closed.

## Checks

CI runs exactly this; make it pass locally first (CONTRIBUTING.md has the
context, including the store integration test and the fuzz targets).

- [x] `gofmt -l .` prints nothing; `go vet ./...`; `go test -race ./...`
      (integration tests against pgvector/pgvector:pg17 — a fresh database, and
      the accumulated one that reproduced the original failure; full suite run
      repeatedly to shake out the shared-database timing)
- [x] `CGO_ENABLED=0 go build -trimpath ./...`
- [ ] golangci-lint and govulncheck report nothing — **not run: neither is
      installed on this machine.** Both passed in CI on the first push; the
      second commit touches one test file and adds no new imports.
- [x] Behavior changes come with tests — these are the test changes

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing; a new endpoint has an
      integration test, which is what puts it under the OpenAPI contract check
      — not applicable, no wire surface touched
- [x] The change lands on every surface it belongs on — REST / MCP / CLI /
      Web UI — and what it stays off is deliberate (design doc 0015)
      — not applicable, test-only

## Design docs

- [x] Not applicable: no accepted decision is altered. The lexical test's own
      comment already records that English questions rank the grammar-only entry
      higher and that hybrid mode is the answer; this PR does not revisit that.
- [x] Commit messages and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)
