### PR TITLE
Start the quick start from a knowledge base, not one entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ last entry.
 
 ### Added
 
+- `examples/demo` — a ten-entry knowledge base loaded with
+  `ochakai import examples/demo`, and now what the quick start registers.
+  Entries link to each other, two are drafts and one is past its declared
+  expiry, so `get_context`, backlinks, the review queue and the stale
+  feed all have something to show on a base that is a minute old.
 - `ochakai mcp-stdio` — speaks MCP on stdin/stdout and forwards to the
   selected server, for clients that can only launch a command and for any
   client against Cloud Run, where the request needs a Google ID token the

--- a/README.md
+++ b/README.md
@@ -39,15 +39,25 @@ git clone https://github.com/na0fu3y/ochakai && cd ochakai
 docker compose -f deploy/compose.yaml up
 ```
 
-Register the example golden query — a knowledge entry like any other —
-and try a search; everything goes through the API, so plain curl works
-too:
+Load the demo knowledge base — ten entries about one invented retail
+domain — and try a search; everything goes through the API, so plain curl
+works too:
 
 ```sh
 export OCHAKAI_URL=http://localhost:8080
-go run ./cmd/ochakai create queries/monthly-revenue -f examples/golden-query.md
+go run ./cmd/ochakai import examples/demo
 curl 'http://localhost:8080/api/v1/knowledge?q=revenue'
 ```
+
+[examples/demo](examples/demo) is a knowledge base rather than a sample
+file: metrics, attested computations, an insight on how to read the
+numbers, a glossary term the others depend on, a table catalog entry.
+They link to each other, so `get_context` and backlinks have something to
+expand; two are drafts, so the review queue is not empty; one is past the
+expiry its author declared, so the stale feed has an occupant. The
+numbers and table names are invented — it is there to be explored, not
+copied into your warehouse. For a single entry instead, there is
+[examples/golden-query.md](examples/golden-query.md).
 
 Every client command needs to know which server it is talking to. The
 environment variable is the explicit way and the right one for a trial;
@@ -157,8 +167,8 @@ proxy) on `localhost:8787`.
 ### Try a prompt
 
 Once an agent is connected, four prompts walk the whole loop. Run them
-against the quick start's knowledge base — the one entry it registered is
-enough to see the shape.
+against the quick start's knowledge base — the demo bundle has enough in
+it that each one comes back with something.
 
 **Recall.** Ask something the knowledge base can answer and watch the
 agent reach for it rather than guess:

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,10 @@ types, and every environment variable.
 - [api/openapi.yaml](../api/openapi.yaml) — the REST contract. It is
   checked rather than described: the integration tests validate every
   request and response against it, so an endpoint that drifts fails CI.
+- [examples/demo](../examples/demo) — a ten-entry knowledge base to import
+  and poke at (`ochakai import examples/demo`). Linked entries, mixed
+  statuses, and an entry past its declared expiry, so the feeds and
+  `get_context` have something to show.
 - [examples/claude-code](../examples/claude-code) — drop-in agent
   instructions and the recall / write-back hooks.
 - `ochakai <command> -h` — every command carries its flags and worked


### PR DESCRIPTION
Follow-up to #201, which landed the bundle with **nothing in the repo
pointing at it** — `grep -rn examples/demo` matched only the bundle's own
files, so it was undiscoverable.

Documentation only.

- **Quick start imports `examples/demo`** instead of creating one entry
  from `examples/golden-query.md`. Same one command.
- **`docs/README.md`** lists it under "for someone building against it".
- **Changelog** records it under Added.
- The Try-a-prompt section no longer has to say it is working from a
  single entry.
- `examples/golden-query.md` stays, named as the single-entry alternative.

## Why it matters

Before: first search returns one hit, the review queue is empty, the
stale feed is empty, backlinks expand nothing — on a README that spends
several sections describing exactly those things.

After, verified against a fresh database rather than asserted:

```
imported 10 entries (10 created, 0 updated, 0 unchanged, 0 attachments, 0 skipped)
search "revenue"            → 10 hits
--sort usage --status draft → 2 (repeat-purchase-rate, revenue-by-channel)
--sort stale_after          → 1 (revenue-by-channel, 2026-06-30)
backlinks metrics/revenue   → 4
context "why is revenue down?" → 19 entries expanded
```

Every claim the new paragraph makes about the bundle was checked against
that run. Note `0 skipped`: the merged bundle carries no README of its
own, so the import output stays clean.

`gofmt`, `go vet`, `go test ./...` clean; every relative link in README,
CHANGELOG and docs/README resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
