### PR TITLE
Say so when a foreign bundle's stable lands as a draft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,18 @@ last entry.
   previously carried exactly one. Every example is validated against the
   schema it sits under.
 
+### Fixed
+
+- Importing an OKF bundle that declares `status: stable` with no
+  `verified` entry no longer demotes it to draft silently. ochakai has no
+  status meaning *stable and unverified*, so such an entry does land as a
+  draft and exports as one — that loss is real and unchanged — but the
+  import now reports it, the way every other reinterpretation already
+  did. Refusing to read `stable` as reviewed stays deliberate: OKF puts
+  human review in `verified` (SPEC §5.3). The README claimed the reverse
+  mapping "keeps the round-trip exact", which held for ochakai's own
+  exports and not for a foreign bundle; it now says which is which.
+
 ### Changed
 
 - **BREAKING** — the recommended type vocabulary is realigned to what OKF

--- a/README.md
+++ b/README.md
@@ -434,8 +434,17 @@ markdown footnote in the body can attribute a single claim to it.
 `verified` is who confirmed it — absent means unverified, and a `human:`
 entry is what makes it human-reviewed (SPEC §5.3). ochakai's `verified`
 status is exactly that: `stable` plus a verification, which is where a
-v0.2 consumer looks. The reverse mapping keeps the round-trip exact
-without treating a foreign bundle's `stable` as reviewed.
+v0.2 consumer looks, and reading it back the same way makes ochakai's own
+export round-trip exactly.
+
+A foreign bundle is where that mapping costs something. `stable` with no
+`verified` entry is not read as reviewed — OKF puts human review in
+`verified`, and `stable` alone only says the entry is fit to consume — but
+ochakai has no status meaning *stable and unverified*, so such an entry
+lands as a draft and exports as one. The lifecycle value its producer
+wrote does not survive the trip. Import says so rather than doing it
+quietly, and the content itself is untouched; adding a `verified` entry
+naming who checked it is what makes it verified here.
 
 ochakai **records** these; it never acts on them. It does not fetch a
 source's `resource`, score its credibility signals, or run an Attested

--- a/internal/okf/parse.go
+++ b/internal/okf/parse.go
@@ -204,9 +204,22 @@ func parseDoc(doc []byte) (*domain.Knowledge, string, []string, error) {
 		// A v0.1 document says the same thing with the flat keys.
 		_, hasVerified = raw["verified_at"]
 	}
-	status, known := domain.StatusFromOKF(strings.TrimSpace(fm.status), hasVerified)
-	if !known {
+	rawStatus := strings.TrimSpace(fm.status)
+	status, known := domain.StatusFromOKF(rawStatus, hasVerified)
+	switch {
+	case !known:
 		notes = append(notes, fmt.Sprintf("status %q is not an OKF lifecycle value (draft, stable, deprecated); read as %s", fm.status, status))
+	case rawStatus == domain.OKFStatusStable && !hasVerified:
+		// Refusing to read stable as verified is deliberate: SPEC §5.3
+		// puts the trust tier in `verified`, and stable only means
+		// consumable (design doc 0036 §3.4). But ochakai has no status
+		// for "stable and unverified", so the entry lands as a draft and
+		// exports as one — the producer's lifecycle value does not
+		// survive the round trip. That is a reinterpretation, and 0036
+		// §3.4's own rule is that a reinterpretation is never silent.
+		notes = append(notes, "status \"stable\" with no verified entry: read as draft, because "+
+			"OKF puts human review in `verified` (SPEC §5.3) and stable alone does not assert it. "+
+			"The entry keeps its content; if it was reviewed, add a verified entry naming who checked it")
 	}
 	if !domain.ValidStaleAfter(fm.staleAfter) {
 		notes = append(notes, fmt.Sprintf("stale_after %q is not a YYYY-MM-DD date; dropped", fm.staleAfter))

--- a/internal/okf/parse_test.go
+++ b/internal/okf/parse_test.go
@@ -240,7 +240,12 @@ func TestParseStatusMapping(t *testing.T) {
 		wantNote          bool
 	}{
 		{"stable with a verification is verified", "status: stable\n" + verified, domain.StatusVerified, false},
-		{"stable alone is not a review", "status: stable\n", domain.StatusDraft, false},
+		// Reported, unlike the two rows around it: the value is understood,
+		// but its meaning is not preserved. ochakai has no status for
+		// "stable and unverified", so the entry lands as a draft and
+		// exports as one — a lifecycle demotion the producer never wrote.
+		// 0036 §3.4 says a reinterpretation is never silent.
+		{"stable alone is not a review, and says so", "status: stable\n", domain.StatusDraft, true},
 		{"a bare verified mapping counts too (SPEC §5.2)", "status: stable\nverified: { by: human:na0, at: 2026-07-01T00:00:00Z }\n", domain.StatusVerified, false},
 		{"draft stays draft", "status: draft\n", domain.StatusDraft, false},
 		{"deprecated stays deprecated", "status: deprecated\n", domain.StatusDeprecated, false},
@@ -518,5 +523,45 @@ func TestDocumentDoesNotReExportShadowedEnvelopeAttrs(t *testing.T) {
 	}
 	if strings.Contains(string(out), "ghost.md") {
 		t.Errorf("a shadowed attr must not be re-exported:\n%s", out)
+	}
+}
+
+// A foreign bundle that declares OKF's stable lifecycle without a
+// verification does not survive a round trip through ochakai: there is no
+// ochakai status for "stable and unverified", so it lands as a draft and
+// exports as a draft. Refusing to read stable as verified is deliberate
+// (SPEC §5.3 puts human review in `verified`), but the demotion of the
+// lifecycle value is a real loss, and this test exists so that it is a
+// known and reported one rather than a surprise. If ochakai ever gains
+// somewhere to keep the producer's lifecycle, this is the test that
+// should start failing.
+func TestStableWithoutVerificationIsDemotedButReported(t *testing.T) {
+	const in = "---\ntype: Metric\ntitle: Average order value\nstatus: stable\n---\n\nThe average revenue per order.\n"
+	k, notes, err := Parse([]byte(in))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if k.Status != domain.StatusDraft {
+		t.Fatalf("status = %q, want draft", k.Status)
+	}
+	var reported bool
+	for _, n := range notes {
+		if strings.Contains(n, "stable") && strings.Contains(n, "draft") {
+			reported = true
+		}
+	}
+	if !reported {
+		t.Errorf("the demotion was silent; notes = %v", notes)
+	}
+
+	out, err := Document(k)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(out), "status: draft") {
+		t.Errorf("re-export should show the demotion plainly; got:\n%s", out)
+	}
+	if strings.Contains(string(out), "status: stable") {
+		t.Errorf("stable came back without a verification, which would assert a review nobody made:\n%s", out)
 	}
 }


### PR DESCRIPTION
Found while writing the demo bundle. Reproduced before changing anything:

```
in : status: stable          (no verified entry)
     ↓ Parse
     status = draft          notes = []      ← silent
     ↓ Document
out: status: draft
```

A producer's *"fit to consume"* comes back out of ochakai as *"not
finished"*, and nothing mentioned it.

## What is not wrong

**Refusing to read `stable` as verified is correct and unchanged.** OKF
puts human review in `verified` (SPEC §5.3); `stable` alone does not
assert it. Reading it as verified would manufacture a review nobody
performed — much the worse error. Design doc 0036 §3.4 argues this well
and I am not touching it.

## What is wrong

It was **silent**. Import already reports far smaller reinterpretations —
`sources[0].usage_count is not a non-negative whole number; dropped`, a
source with no `resource`, a malformed `stale_after` — and 0036 §3.4
states the principle outright: *"再解釈は黙って行わない"* (a
reinterpretation is never silent). Its own table just omits this row. So
this is a bug against the accepted design rather than a change to it, and
needs no new design doc.

## Note on an existing assertion I flipped

`TestParseStatusMapping` pinned `wantNote: false` for this case. There is
no comment justifying it, and the rows that *do* carry notes are the ones
where the status value could not be understood — the pattern looks like
"note when we did not understand" rather than a decision that this
particular reinterpretation should stay quiet. I changed the row and left
a comment explaining why, rather than quietly matching the test to the
code. **Flag it if you disagree** — it is the one judgement call here.

## The loss itself is unchanged

ochakai has no status meaning *stable and unverified*, so there is
nowhere to keep the producer's value. Closing that needs a fifth status
(blast radius: the `exhaustive` switches, filters, the Web UI, the MCP
descriptions, the OpenAPI enum) or a new field — a design decision, not a
bug fix. `TestStableWithoutVerificationIsDemotedButReported` pins the
current behaviour and says in its comment that it is the test that should
start failing if that ever changes.

Also fixes the README, which claimed the reverse mapping *"keeps the
round-trip exact"* — true of ochakai's own exports, false of a foreign
bundle.

## Verification

`gofmt`, `go vet`, `go test -race ./...` clean with
`OCHAKAI_TEST_DATABASE_URL` set. Checked the note does not become noise:
`examples/demo` still imports **10 created, 0 skipped, no notes**, because
all seven of its `status: stable` entries carry a `verified` block — and
ochakai's own exports never emit stable without one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
