### PR TITLE
Ship the catalog sync as an Attested Computation

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ And it stays small by refusing things:
 |---|---|
 | LLM | it returns human-verified golden queries verbatim, and the definitions and caveats around them. Interpretation is the client agent's job |
 | SQL execution | it holds no warehouse credentials. Your agent executes |
-| connector ingestion | knowledge is curated by humans and agents, not harvested by pipelines. Trust density over volume |
+| connector ingestion | knowledge is curated by humans and agents, not harvested by pipelines. Trust density over volume. A harvester in the server would also need warehouse credentials it does not hold — so when you do want a catalog projected in, it runs as an ordinary client under your own service account: [examples/bigquery-catalog](examples/bigquery-catalog) |
 | chat UI or dashboards | it feeds your agents; it doesn't compete with them. The bundled web UI is a curation surface, not a BI tool |
 | secrets | Cloud Run IAM decides who reaches it, callers are identified by their Google identity, and Cloud SQL authenticates the service account — nothing to issue or rotate |
 | authorization | reachability is the whole access model: **whoever can reach the deployment can read and write everything**. ochakai identifies the caller and records it as provenance, and stops there. Deciding who may reach it is Cloud Run IAM's job, and running it publicly invokable is a misconfiguration, not a deployment mode (design doc [0002](docs/design/0002-authn-authz.md)). If you need per-entry permissions, this is the wrong tool |

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,6 +2,9 @@
 
 - **[demo/](demo)** — a whole knowledge base, ten entries, importable in one
   command. Described below.
+- **[bigquery-catalog/](bigquery-catalog)** — a daily job that projects BigQuery
+  table metadata in, shipped as an Attested Computation with its Python beside
+  it. What connector ingestion looks like when it stays outside the server.
 - **[claude-code/](claude-code)** — the recall and write-back loop as Claude Code
   instructions and hooks.
 - **[golden-query.md](golden-query.md)** — one entry on its own, for

--- a/examples/bigquery-catalog/README.md
+++ b/examples/bigquery-catalog/README.md
@@ -1,0 +1,63 @@
+# BigQuery catalog sync
+
+A daily job that projects BigQuery table metadata into ochakai as
+`BigQuery Table` entries, so an agent asking about `shop.orders` finds the
+columns, the partition filter it must not forget, and whatever a human has
+since written underneath.
+
+**This is an example, not a feature.** ochakai has no connectors and is not
+getting any: a harvester living in the server would need warehouse
+credentials it deliberately does not hold, and knowledge here is curated
+rather than collected (README's refusal table, design doc
+[0001](../../docs/design/0001-architecture.md) §2). None of that stops
+*you* from filling a catalog — this one runs outside, as an ordinary client
+of the same REST API the CLI uses, under your own service account.
+
+## It ships as knowledge, not as a script in a folder
+
+`bundle/` is a two-entry OKF bundle. Import it and the job documents
+itself in the knowledge base it writes to:
+
+```sh
+ochakai import examples/bigquery-catalog/bundle
+```
+
+| Entry | Type | |
+|---|---|---|
+| [`jobs/sync-bigquery-catalog`](bundle/jobs/sync-bigquery-catalog.md) | Attested Computation | `runtime: python`, the parameters, the receipt, and every decision the projection makes |
+| [`skills/run-a-python-job`](bundle/skills/run-a-python-job.md) | Skill | what the `executor` points at: the identity to run as, the IAM roles, the receipt fields |
+
+[`sync-bigquery-catalog.py`](bundle/jobs/sync-bigquery-catalog.py) is the
+computation itself. It is named by the entry's `computation` key as a file
+rather than pasted into a `# Computation` fence — the form
+[OKF SPEC](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
+§10.2 gives for a computation too long to inline — and it travels with the
+entry as an attachment, so `ochakai get jobs/sync-bigquery-catalog
+--download .` brings back the code with the contract.
+
+That shape is the point as much as the sync is. An agent told to refresh
+the catalog gets a contract that says *supply these parameters and run this
+file*, and SPEC §10.3 says in as many words that it must not author the
+computation instead. A knowledge base whose own maintenance job is an entry
+inside it is one fewer thing living in a README nobody reads.
+
+The two entries import as **drafts**, on purpose. Verify them once you have
+run the job in your own project and the receipt came back clean — which is
+also the moment you would want to correct the IAM roles for how you
+actually granted them.
+
+## Try it without touching anything
+
+```sh
+pip install google-cloud-bigquery google-auth requests
+
+python bundle/jobs/sync-bigquery-catalog.py \
+  --project my-project --datasets shop \
+  --ochakai-url https://ochakai-<hash>.run.app --dry-run
+```
+
+`--dry-run` prints the entries it would write and needs no credentials for
+ochakai at all. Everything else — the daily schedule, the IAM grants, the
+ownership rule that keeps the job from flattening what a person wrote, and
+what is deliberately left out (Looker, a recommended-table flag, deletes) —
+is in the two entries.

--- a/examples/bigquery-catalog/bundle/jobs/sync-bigquery-catalog.md
+++ b/examples/bigquery-catalog/bundle/jobs/sync-bigquery-catalog.md
@@ -1,0 +1,149 @@
+---
+type: Attested Computation
+title: Sync the BigQuery catalog
+description: Project BigQuery table metadata into ochakai as BigQuery Table entries, daily
+tags: [bigquery, catalog, sync, python]
+generated: { by: human:na0fu3y, at: 2026-07-27T09:00:00Z }
+status: draft
+runtime: python
+parameters:
+  - { name: project, type: string, required: true }
+  - { name: datasets, type: array, required: true }
+  - { name: ochakai_url, type: string, required: true }
+  - { name: jobs_region, type: string }
+  - { name: usage_days, type: integer }
+  - { name: frequent_threshold, type: integer }
+  - { name: prefix, type: string }
+  - { name: dry_run, type: boolean }
+computation: /jobs/sync-bigquery-catalog.py
+executor:
+  resource: /skills/run-a-python-job.md
+  receipt: [sync_identity, tables_seen, written, skipped, failed]
+---
+
+The sanctioned way to get BigQuery table metadata into this knowledge base.
+Run [the script](/jobs/sync-bigquery-catalog.py) with parameter values; do
+not write a projection of your own instead. The computation lives in a file
+rather than a `# Computation` fence because it is a few hundred lines of
+Python (SPEC §10.2), and the rule around it is the same either way: an
+agent supplies parameters and **must not author or edit the computation**
+(SPEC §10.3).
+
+ochakai has no connectors and is not getting any — a harvester inside the
+server would need warehouse credentials it deliberately does not hold, and
+knowledge here is curated rather than collected. This runs outside it, as
+an ordinary client of the same REST API the CLI uses, under your own
+service account. Nothing in it is privileged; treat it as a starting point
+and change it.
+
+# What lands
+
+One entry per table and view, at
+`catalog/bigquery/<project>/<dataset>/<table>`:
+
+```yaml
+type: BigQuery Table
+resource: bigquery://my-project.shop.orders
+description: Raw orders            # BigQuery's own table description
+tags: [bigquery, shop, frequently-queried]
+sources:
+  - resource: bigquery://my-project.shop.orders
+    last_modified: "2026-07-26"
+    usage_count: 412
+usage_window: { from: "2026-06-27", to: "2026-07-27" }
+```
+
+with a body holding the columns (nested `RECORD` fields flattened to
+`items.sku`), the partitioning and clustering — including whether a
+partition filter is mandatory, which is the thing an agent most needs to
+know before it writes a query — the row count, the view SQL when it is a
+view, and an empty `# Caveats` section for a person to fill in.
+
+Three of those choices are load-bearing:
+
+- **No `title`.** The id's last segment is the display name, and that
+  segment is the table id already.
+- **The entry cites the table as its own source**, so
+  `ochakai search --source bigquery://my-project.shop.orders` returns the
+  catalog entry *and* every insight or computation written against the same
+  table. That reverse lookup only works if everyone spells the URI the same
+  way — pick the spelling once and keep it.
+- **Query counts go in `sources[].usage_count`, never into ochakai's usage
+  telemetry.** ochakai counts how often *its knowledge* was retrieved; this
+  counts how often *a table* was queried. Same word, two subjects, and
+  mixing them would corrupt the `--sort usage` review feed with numbers
+  that have nothing to do with the knowledge base.
+
+# Who owns an entry
+
+The obvious failure mode of any sync is that it flattens what a person
+wrote, the next morning, silently. This one writes an entry only while
+**it is still `draft` and the last writer was the sync account**, and the
+update is conditional, so an edit landing between the read and the write
+loses the race instead of being erased by it.
+
+A human takes an entry out of the sync by touching it, two ways that mean
+different things:
+
+- **`ochakai verify`** — "I checked this and it is right." The entry stops
+  being a projection and becomes curated knowledge.
+- **Editing the body** — enough on its own; the sync sees a different
+  writer and leaves it alone from then on.
+
+The cost is real: a frozen entry stops receiving schema changes, so a
+column added next month will not appear in it. If what you wrote is *about*
+the table rather than *of* it — a caveat, a baseline, the filter everyone
+forgets — the better home is a separate `Insight` that links to the catalog
+entry and cites the same source. Then the projection stays machine-owned
+and current, your knowledge stays yours, and one `get_context` call returns
+both, because links expand in each direction.
+
+This is also the answer to "can an entry be locked to its owner?" — it can,
+with no owner field and no authorization anywhere in the server. Status and
+provenance carry the whole rule.
+
+# The receipt, and what would attest it
+
+`executor.resource` points at
+[run a Python computation as a scheduled job](/skills/run-a-python-job.md),
+which says what identity a run needs and what it has to bring back. A run
+prints its receipt to stdout as JSON and its progress to stderr:
+
+```json
+{"sync_identity": "catalog-sync@my-project.iam.gserviceaccount.com",
+ "tables_seen": 84, "written": 3, "skipped": 12, "failed": 0}
+```
+
+There is no `attester` on this entry, which is the honest state of things:
+nothing checks these runs today. One would be easy and worth writing —
+`sync_identity` has to be the account you scheduled and no other, `failed`
+has to be zero, and `tables_seen` should not fall off a cliff between two
+nights, which is what a dataset silently losing read access looks like.
+Until that exists, a non-zero exit code and a red Cloud Scheduler run are
+the whole alarm.
+
+ochakai stores this contract and executes none of it: running the
+computation and checking the receipt belong to whoever runs the job
+(SPEC §10.5).
+
+# What this deliberately does not do
+
+- **No "recommended table" flag.** The script tags `frequently-queried`,
+  which is an observation, and stops there. Recommending a table is a
+  judgment; it belongs to the person who verifies the entry, in the words
+  they choose. A threshold would put the knowledge base's name on a claim
+  nobody made.
+- **No Looker, and no other API that needs a client secret.** A whole
+  deployment being secret-free is a property worth more than one more
+  connector. A Looker sync is perfectly writable as a sibling of this
+  script — but the secret is then yours to hold, in Secret Manager, and
+  that should be a decision rather than a side effect.
+- **No "sync everything".** `datasets` is required and has no default. A
+  warehouse has thousands of tables and a curated knowledge base does not:
+  the review feeds assume a person can empty them, and a few thousand
+  unreviewed machine drafts is how a queue stops being read. Sync the
+  datasets your agents actually query, and add more when that stops being
+  true.
+- **No deletes.** A table that disappears from BigQuery leaves its entry
+  behind. Removing knowledge is a human decision, and the entry may be the
+  only remaining record of what the table meant.

--- a/examples/bigquery-catalog/bundle/jobs/sync-bigquery-catalog.py
+++ b/examples/bigquery-catalog/bundle/jobs/sync-bigquery-catalog.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""Project BigQuery table metadata into ochakai as BigQuery Table entries.
+
+This is the `computation` of the Attested Computation entry beside it
+(sync-bigquery-catalog.md). An agent asked to refresh the catalog supplies
+parameter values and runs this file; per OKF SPEC §10.3 it must not author
+a projection of its own instead.
+
+ochakai has no connectors: a harvester inside the server would need
+warehouse credentials it deliberately does not hold. This runs outside,
+under your own service account, against the same REST API the CLI uses.
+
+Reads BigQuery, writes ochakai, and holds no secret: BigQuery is reached
+with Application Default Credentials, and ochakai with a Google-minted ID
+token for the Cloud Run service.
+
+    pip install google-cloud-bigquery google-auth requests
+
+The run prints a receipt to stdout as JSON — the fields the entry's
+executor declares — and progress to stderr.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import datetime
+import json
+import sys
+
+import google.auth
+import google.auth.transport.requests
+import google.oauth2.id_token
+import requests
+from google.cloud import bigquery
+
+TIMEOUT = 30
+
+
+# --------------------------------------------------------------- identity
+
+
+def id_token_for(audience: str) -> str:
+    """Mint a Google ID token for a private Cloud Run service.
+
+    Returns "" when the environment cannot mint one — a user's own ADC
+    cannot — which is fine against a local OCHAKAI_INSECURE_DEV server and
+    fatal against Cloud Run, where the server says so itself with a 403.
+    """
+    try:
+        request = google.auth.transport.requests.Request()
+        return google.oauth2.id_token.fetch_id_token(request, audience)
+    except Exception as err:  # noqa: BLE001 — any failure means "no token"
+        print(f"note: no ID token ({err}); sending unauthenticated", file=sys.stderr)
+        return ""
+
+
+def identity_from(token: str) -> str:
+    """Read the email claim out of our own ID token.
+
+    Not verified, and it does not need to be: we minted it a moment ago,
+    and it is used only to recognize our own past writes. The server does
+    verify — that is where the claim actually decides anything (design doc
+    0002 §2).
+    """
+    try:
+        payload = token.split(".")[1]
+        payload += "=" * (-len(payload) % 4)
+        return json.loads(base64.urlsafe_b64decode(payload)).get("email", "")
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+# --------------------------------------------------------------- document
+
+
+def flatten(fields, prefix: str = "") -> list[dict]:
+    """Flatten a BigQuery schema, so a RECORD's leaves read as items.sku."""
+    out: list[dict] = []
+    for f in fields:
+        name = prefix + f.name
+        out.append(
+            {
+                "name": name,
+                "type": f.field_type + ("[]" if f.mode == "REPEATED" else ""),
+                "required": f.mode == "REQUIRED",
+                "description": (f.description or "").replace("|", r"\|").replace("\n", " "),
+            }
+        )
+        out.extend(flatten(f.fields or (), name + "."))
+    return out
+
+
+def build_body(table, columns: list[dict], usage: dict | None, window: tuple[str, str]) -> str:
+    lines = ["# Columns", "", "| column | type | description |", "|---|---|---|"]
+    for c in columns:
+        kind = c["type"] + (" (required)" if c["required"] else "")
+        lines.append(f"| `{c['name']}` | {kind} | {c['description']} |")
+
+    lines += ["", "# Physical layout", ""]
+    part = table.time_partitioning
+    if part:
+        needs_filter = table.require_partition_filter or getattr(part, "require_partition_filter", False)
+        line = f"- **Partitioned** by `{part.field or '_PARTITIONTIME'}` ({part.type_})"
+        if needs_filter:
+            line += " — **a partition filter is required**; a query without one is rejected"
+        lines.append(line)
+    else:
+        lines.append("- Not partitioned")
+    if table.clustering_fields:
+        lines.append("- **Clustered** by " + ", ".join(f"`{f}`" for f in table.clustering_fields))
+    if table.num_rows is not None:
+        lines.append(f"- Rows: {table.num_rows} (observed {window[1]})")
+    if usage:
+        lines.append(
+            f"- Queried {usage['queries']} times by {usage['users']} accounts "
+            f"between {window[0]} and {window[1]}"
+        )
+
+    if table.view_query:
+        lines += ["", "# View definition", "", "```sql", table.view_query, "```"]
+
+    lines += [
+        "",
+        "# Caveats",
+        "",
+        "_Nothing recorded yet._ Write what an agent has to know before it",
+        "queries this table — the filter that is always required, the column",
+        "that lies, the timezone the timestamps are in. Then `ochakai verify`",
+        "this entry: the sync leaves verified entries alone, so your text will",
+        "not be overwritten tomorrow morning.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def build_document(table, fq: str, dataset: str, usage: dict | None,
+                   window: tuple[str, str], frequent: int) -> dict:
+    """The entry as ochakai's API takes it.
+
+    `status` is deliberately absent: create defaults it to draft, and
+    update leaves whatever is stored alone. `title` is absent too — the
+    id's last segment is the display name (design doc 0022), and that
+    segment is already the table id.
+    """
+    resource = f"bigquery://{fq}"
+    tags = ["bigquery", dataset]
+    if table.view_query:
+        tags.append("view")
+    if usage and usage["queries"] >= frequent:
+        tags.append("frequently-queried")
+
+    # The table cites itself: `ochakai search --source bigquery://…` then
+    # returns this entry together with every insight and computation
+    # someone wrote citing the same table (design doc 0037).
+    source: dict = {"resource": resource, "title": fq}
+    if table.modified:
+        source["last_modified"] = table.modified.date().isoformat()
+    if usage:
+        # Query counts belong here, never in ochakai's own usage
+        # telemetry: that counts how often *knowledge* was retrieved, this
+        # counts how often a *table* was queried. Mixing the two would
+        # corrupt the --sort usage review feed.
+        source["usage_count"] = usage["queries"]
+
+    doc = {
+        "type": "BigQuery Table",
+        "resource": resource,
+        "description": (table.description or "").split("\n")[0][:280],
+        "tags": tags,
+        "sources": [source],
+        "body": build_body(table, flatten(table.schema), usage, window),
+    }
+    if usage:
+        doc["usage_window"] = {"from": window[0], "to": window[1]}
+    return doc
+
+
+# ----------------------------------------------------------------- upsert
+
+
+class Ochakai:
+    def __init__(self, url: str, token: str):
+        self.url = url.rstrip("/")
+        self.headers = {"Authorization": f"Bearer {token}"} if token else {}
+
+    def get(self, entry_id: str) -> dict | None:
+        r = requests.get(f"{self.url}/api/v1/knowledge/{entry_id}",
+                         headers=self.headers, timeout=TIMEOUT)
+        if r.status_code == 404:
+            return None
+        r.raise_for_status()
+        return r.json()
+
+    def create(self, entry_id: str, doc: dict) -> None:
+        r = requests.post(f"{self.url}/api/v1/knowledge",
+                          json=dict(doc, id=entry_id),
+                          headers=self.headers, timeout=TIMEOUT)
+        r.raise_for_status()
+
+    def update(self, entry_id: str, doc: dict, version: str) -> None:
+        headers = dict(self.headers, **{"If-Match": f'"{version}"'})
+        r = requests.put(f"{self.url}/api/v1/knowledge/{entry_id}",
+                         json=doc, headers=headers, timeout=TIMEOUT)
+        r.raise_for_status()
+
+
+def upsert(api: Ochakai, entry_id: str, doc: dict, identity: str, counts: dict) -> None:
+    """Write the projection, unless a person has taken it over.
+
+    The rule, in full: write only while the entry is still draft and this
+    account was its last writer, and make the update conditional so an
+    edit landing between the read and the write loses the race instead of
+    being erased by it (design doc 0030). Verifying an entry — or simply
+    editing it — takes it out of the sync for good. That is the same line
+    design doc 0015 §3.1 draws for MCP, applied from outside: a machine
+    does not overwrite what a human ruled on. ochakai needs no owner field
+    and no authorization for this; status and provenance carry it.
+    """
+    existing = api.get(entry_id)
+    if existing is None:
+        api.create(entry_id, doc)
+        counts["written"] += 1
+        print(f"create {entry_id}", file=sys.stderr)
+        return
+
+    if existing["status"] != "draft":
+        counts["skipped"] += 1
+        print(f"skip   {entry_id} — {existing['status']}, a human ruled on it", file=sys.stderr)
+        return
+
+    writer = existing.get("updated_by", {}).get("name", "")
+    if identity and writer != identity:
+        counts["skipped"] += 1
+        print(f"skip   {entry_id} — last written by {writer}", file=sys.stderr)
+        return
+
+    # An update with identical content is a no-op server-side: no revision,
+    # no new updated_at. A daily run over an unchanged table leaves no trace.
+    api.update(entry_id, doc, existing["updated_at"])
+    counts["written"] += 1
+    print(f"sync   {entry_id}", file=sys.stderr)
+
+
+# -------------------------------------------------------------------- run
+
+
+def usage_counts(client: bigquery.Client, project: str, region: str, days: int) -> dict:
+    """Query counts per table from the job history.
+
+    Seeing anyone else's jobs needs bigquery.jobs.listAll
+    (roles/bigquery.resourceViewer). Without it this counts only the jobs
+    this account ran — which is worse than counting nothing, because the
+    numbers still look plausible.
+    """
+    sql = f"""
+        SELECT ref.dataset_id AS dataset_id,
+               ref.table_id   AS table_id,
+               COUNT(*)                     AS queries,
+               COUNT(DISTINCT j.user_email) AS users
+        FROM `region-{region}`.INFORMATION_SCHEMA.JOBS AS j,
+             UNNEST(j.referenced_tables) AS ref
+        WHERE j.creation_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {days} DAY)
+          AND j.job_type = 'QUERY'
+          AND j.state = 'DONE'
+          AND j.error_result IS NULL
+          AND ref.project_id = @project
+        GROUP BY dataset_id, table_id
+    """
+    config = bigquery.QueryJobConfig(
+        query_parameters=[bigquery.ScalarQueryParameter("project", "STRING", project)]
+    )
+    return {
+        f"{row.dataset_id}.{row.table_id}": {"queries": row.queries, "users": row.users}
+        for row in client.query(sql, job_config=config).result()
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--project", required=True, help="project holding the tables")
+    p.add_argument("--datasets", required=True, nargs="+",
+                   help="datasets to sync. There is no 'all datasets' default on "
+                        "purpose: scope is the one knob that keeps a curated base curated")
+    p.add_argument("--ochakai-url", required=True, help="e.g. https://ochakai-<hash>.run.app")
+    p.add_argument("--jobs-region", default="",
+                   help="region for INFORMATION_SCHEMA.JOBS, e.g. us or asia-northeast1. "
+                        "Unset skips the job history and writes no usage counts")
+    p.add_argument("--usage-days", type=int, default=30)
+    p.add_argument("--frequent-threshold", type=int, default=30,
+                   help="queries over the window at or above which the entry is "
+                        "tagged frequently-queried")
+    p.add_argument("--prefix", default="catalog/bigquery", help="id prefix")
+    p.add_argument("--sync-identity", default="",
+                   help="the account this runs as (default: the ID token's email claim)")
+    p.add_argument("--dry-run", action="store_true", help="print the documents instead of writing")
+    args = p.parse_args()
+
+    today = datetime.datetime.now(datetime.timezone.utc).date()
+    window = ((today - datetime.timedelta(days=args.usage_days)).isoformat(), today.isoformat())
+
+    token = "" if args.dry_run else id_token_for(args.ochakai_url)
+    identity = args.sync_identity or identity_from(token)
+    api = Ochakai(args.ochakai_url, token)
+    client = bigquery.Client(project=args.project)
+
+    usage = {}
+    if args.jobs_region:
+        print(f"reading job history for the last {args.usage_days} days "
+              f"in region-{args.jobs_region}", file=sys.stderr)
+        usage = usage_counts(client, args.project, args.jobs_region, args.usage_days)
+
+    counts = {"tables_seen": 0, "written": 0, "skipped": 0, "failed": 0}
+    for dataset in args.datasets:
+        for item in client.list_tables(dataset):
+            if item.table_type not in ("TABLE", "VIEW"):
+                continue
+            counts["tables_seen"] += 1
+            name = item.table_id
+            fq = f"{args.project}.{dataset}.{name}"
+            entry_id = f"{args.prefix}/{args.project}/{dataset}/{name}"
+            try:
+                table = client.get_table(f"{args.project}.{dataset}.{name}")
+                doc = build_document(table, fq, dataset,
+                                     usage.get(f"{dataset}.{name}"), window,
+                                     args.frequent_threshold)
+                if args.dry_run:
+                    print(f"=== {entry_id}")
+                    print(json.dumps(doc, indent=2, ensure_ascii=False))
+                    continue
+                upsert(api, entry_id, doc, identity, counts)
+            except Exception as err:  # noqa: BLE001 — one bad table is not a bad run
+                counts["failed"] += 1
+                print(f"FAIL   {entry_id} — {err}", file=sys.stderr)
+
+    # The receipt the entry's executor declares. Every field here is one a
+    # run has to bring back; checking them is the consumer's job, never
+    # ochakai's (OKF SPEC §10.5).
+    print(json.dumps({"sync_identity": identity, **counts}))
+    return 1 if counts["failed"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/bigquery-catalog/bundle/skills/run-a-python-job.md
+++ b/examples/bigquery-catalog/bundle/skills/run-a-python-job.md
@@ -1,0 +1,82 @@
+---
+type: Skill
+title: Run a Python computation as a scheduled job
+description: How to execute an Attested Computation with runtime python here — the identity it runs as, the roles it needs, and what a run has to bring back
+tags: [python, executor, cloud-run, runbook]
+generated: { by: human:na0fu3y, at: 2026-07-27T09:00:00Z }
+status: draft
+---
+
+The procedure the `runtime: python` entries in this bundle name as their
+`executor`. There is one so far:
+[sync the BigQuery catalog](/jobs/sync-bigquery-catalog.md).
+
+## Run it
+
+1. Take the file the entry's `computation` names — for the one above,
+   `sync-bigquery-catalog.py`, which travels with it as an attachment —
+   **verbatim**. Do not add a filter, a dataset, or a field. A rewritten
+   script is a different computation.
+2. Pass every entry in `parameters` as the matching `--flag`. `datasets`
+   takes several values; `dry_run` prints the documents instead of writing
+   them, which is how you check a change before it touches the base.
+3. Run it as a service account, not as yourself. A person's own credentials
+   cannot mint the ID token a private Cloud Run service wants, and — more
+   to the point — provenance should say a job wrote these entries, because
+   a job did.
+4. Return the receipt (below).
+
+```sh
+pip install google-cloud-bigquery google-auth requests
+
+python sync-bigquery-catalog.py \
+  --project my-project \
+  --datasets shop marketing \
+  --ochakai-url https://ochakai-<hash>.run.app \
+  --jobs-region asia-northeast1
+```
+
+A Cloud Run job on a Cloud Scheduler trigger is the obvious shape for the
+daily run; the script exits non-zero if any table failed, so a bad night
+shows red without anyone reading the log.
+
+## What it needs, and what it must not have
+
+Everything is IAM. There is no token, no password, and nothing to rotate —
+which is the property to protect when you extend this.
+
+| Grant | Why |
+|---|---|
+| `roles/bigquery.metadataViewer` on the datasets | list the tables and read their schemas |
+| `roles/bigquery.jobUser` | only with `jobs_region` — the job history is a query |
+| `roles/bigquery.resourceViewer` | only with `jobs_region` — without `bigquery.jobs.listAll` the query sees *only this account's own jobs*, and every count comes out wrong but plausible |
+| `roles/run.invoker` on the ochakai service | to write |
+
+Two things about the job history: the region has to match where the
+datasets live (`INFORMATION_SCHEMA.JOBS` is regional), and each run is a
+billed query — small, not free.
+
+## The receipt
+
+`receipt: [sync_identity, tables_seen, written, skipped, failed]`, printed
+to stdout as one JSON object. Progress goes to stderr, so a scheduler can
+capture the receipt on its own.
+
+| Field | Where it comes from |
+|---|---|
+| `sync_identity` | the email claim of the ID token the run used — who the entries will say wrote them |
+| `tables_seen` | tables and views considered, before any ownership check |
+| `written` | entries created or updated |
+| `skipped` | entries left alone because a person had verified or edited them |
+| `failed` | tables that errored; the run's exit code is non-zero when this is not 0 |
+
+`sync_identity` is the field worth checking hardest. The whole ownership
+rule rests on the job recognizing its own past writes, so a run under an
+unexpected account does not merely mislabel provenance — it stops seeing
+the entries as its own and skips the entire catalog, quietly.
+
+## What this is not
+
+Running the computation and checking the receipt belong to whoever runs the
+job. ochakai stores this procedure and the contract that points at it, and
+executes neither. No Python runs inside the knowledge base.


### PR DESCRIPTION
## What and why

An embedding host asked for BigQuery and Looker catalog sync **inside** ochakai: daily upsert, table metadata, usage inferred from job history, a recommended-table flag. Connector ingestion stays refused — a harvester in the server would need warehouse credentials it deliberately does not hold, and knowledge here is curated rather than collected. But that was the only row in the README's refusal table that did not name what to do instead.

So this names it, in the vocabulary the knowledge base already has. `examples/bigquery-catalog/bundle` is a two-entry OKF bundle:

| Entry | Type | |
|---|---|---|
| `jobs/sync-bigquery-catalog` | Attested Computation | `runtime: python`, the parameters, the receipt, and every decision the projection makes |
| `skills/run-a-python-job` | Skill | what the `executor` points at: the identity to run as, the IAM roles, the receipt fields |

`sync-bigquery-catalog.py` is named by the entry's `computation` key **as a file** rather than pasted into a `# Computation` fence — [SPEC](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) §10.2's form for a computation too long to inline, which #201's demo bundle had no occasion to show — and rides along as an attachment, so `ochakai get jobs/sync-bigquery-catalog --download .` brings the code back with the contract. An agent told to refresh the catalog then gets a contract saying *supply these parameters and run this file*, and SPEC §10.3 says in as many words that it must not author the computation instead.

The prose lives in the entries rather than in a README, which is the other half of the point: a knowledge base whose own maintenance job is an entry inside it is one fewer thing living in a file nobody reads.

### Three load-bearing choices in the projection

- **Query counts go in `sources[].usage_count` with a `usage_window`, never into ochakai's usage telemetry.** That telemetry counts how often *knowledge* was retrieved; this counts how often a *table* was queried. Same word, two subjects, and mixing them would corrupt the `--sort usage` review feed.
- **The job writes an entry only while it is still `draft` and the sync account was its last writer**, conditionally with `If-Match`. A human takes an entry out of the sync by verifying it or simply by editing it. That answers the reviewer's other request — "can an entry be locked to its owner?" — with status, provenance and 0030, rather than a server-side owner field and the authorization ochakai does not have (0002, [0015 §3.1](docs/design/0015-surface-consistency.md) draws the same line for MCP; this applies it from outside).
- **The machine tags `frequently-queried`, an observation, and stops there.** Recommending a table is a judgment and belongs to whoever verifies the entry.

### Deliberately absent, with the reasons in the entries

Looker (a client secret, which 0002/0003 keep out of the model — writable as a sibling script, but then the secret is the operator's), a sync-everything default (`datasets` is required; the review feeds of 0025 and 0037 assume a person can empty them), and deletes.

## Checks

No Go changed.

- [x] `gofmt -l .` prints nothing; `go vet ./...`
- [x] `CGO_ENABLED=0 go build -trimpath ./...`
- [x] `go test` over `internal/okf` and `internal/domain`

Bundle and script verified directly:

- `okf.FromBundle` over `examples/bigquery-catalog/bundle`: **2 entries, 1 attachment, 0 skipped, 0 notes**. The `.py` attaches to the computation entry only, and the two entries link to each other with both targets resolving.
- The document builder was exercised against stubbed BigQuery metadata — a partitioned, clustered table with a nested `RECORD` (flattened to `items.sku`, pipes escaped for the markdown table) and a view — and the resulting JSON decodes into `domain.Knowledge` with `status` empty, so create defaults it to `draft` and update leaves a stored status alone.
- `python3 -m py_compile` on the script.

Not run: the script against a real BigQuery project or a live server. It needs `google-cloud-bigquery`, IAM grants and a deployment, none of which exist in CI.

## Surfaces and contract

- [x] n/a — no endpoint, no wire change. The example uses `GET`/`POST`/`PUT /api/v1/knowledge` exactly as documented.

## Design docs

- [x] Not applicable: this implements an existing refusal rather than altering a decision. It does make the README's `connector ingestion` row name its alternative, the way the other rows do.
- [x] Commit message and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)