### PR TITLE
Say what ochakai requires, and fix the facts that went stale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,15 @@ last entry.
 - Request and response examples throughout `api/openapi.yaml`, which
   previously carried exactly one. Every example is validated against the
   schema it sits under.
+- `OCHAKAI_READ_ONLY` — serve knowledge without changing it. Every write
+  is a 403, the MCP surface does not offer the write tools at all, and
+  the web UI stops drawing the buttons that would only fail. For a
+  reference-only instance, a public demo, or freezing a base during a
+  migration. It is not authorization: it does not look at the caller, and
+  it refuses the operator too (design doc 0040). Usage recording
+  continues, being the server's own observation rather than a write a
+  caller asked for. Default: off, so nothing changes for a deployment
+  that does not set it.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -15,15 +15,16 @@ humans and agents together, and served to Claude Code and every other
 data agent over [MCP](https://modelcontextprotocol.io), REST, a CLI, and
 a bundled web UI. More at [ochak.ai](https://ochak.ai).
 
-[Quick start](#quick-start) · [Architecture](docs/architecture.md) ·
+[Quick start](#quick-start) · [Requirements](#requirements) ·
+[All docs](docs/README.md) · [Architecture](docs/architecture.md) ·
 [Deploy on Cloud Run](deploy/cloudrun/README.md) ·
 [REST API](api/openapi.yaml) · [Changelog](CHANGELOG.md) ·
 [Roadmap](ROADMAP.md) · [Support](SUPPORT.md) ·
 [Contributing](CONTRIBUTING.md)
 
 The whole thing is one Go binary and Postgres, deployable on Cloud Run +
-Cloud SQL for [about $10/month](deploy/cloudrun/README.md). Local
-development needs only Docker.
+Cloud SQL for [about $10/month](deploy/cloudrun/README.md). The local
+stack is Docker and nothing else.
 
 ![The draft review queue: entries agents wrote back, waiting for a human
 to verify or reject them](docs/images/webui-review.png)
@@ -31,6 +32,44 @@ to verify or reject them](docs/images/webui-review.png)
 This README describes `main`. For what is in the version you are running,
 see the [changelog](CHANGELOG.md) — features documented here may not have
 reached a tagged release yet.
+
+## Requirements
+
+**Running it for real means Google Cloud.** Cloud Run's IAM check decides
+who reaches a deployment and Cloud SQL authenticates the service account,
+which is how ochakai holds no secret of its own — and it is also why
+there is no supported way to run it on another cloud or on-prem (design
+docs [0002](docs/design/0002-authn-authz.md),
+[0003](docs/design/0003-gcp-only.md)). What is portable is the knowledge,
+not the runtime: it round-trips through OKF bundles, so leaving does not
+depend on what you are leaving. `deploy/compose.yaml` runs the same
+binary locally with authentication switched off — a development harness,
+not the small end of production.
+
+**There is no authorization.** Whoever can reach a deployment can read
+and write everything. If you need per-entry permissions, this is the
+wrong tool; see the [refusals](#why-ochakai) for what that buys.
+
+**PostgreSQL, plus `pg_trgm`.** The first migration creates the
+extension, so a database whose user may not `CREATE EXTENSION` needs an
+admin to create it once — that is what the deploy guide's bootstrap SQL
+is for. Turning embeddings on adds `vector` (pgvector) the same way;
+without them, plain PostgreSQL is enough. CI and the deploy guide both
+exercise Postgres 17.
+
+**The server needs Docker; the client commands need a binary.** The quick
+start below runs the CLI with `go run`, which wants the toolchain named
+in `go.mod` — Go 1.21 and newer download it for you. To stay
+toolchain-free, take a
+[release archive](https://github.com/na0fu3y/ochakai/releases) instead,
+or talk to the API directly, since that is all the CLI does:
+
+```sh
+curl -X POST http://localhost:8080/api/v1/knowledge \
+  -H 'content-type: application/json' \
+  -d '{"id": "metrics/revenue", "type": "Metric",
+       "body": "Completed orders only, net of refunds."}'
+```
 
 ## Quick start
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,23 +19,36 @@ if the proposal is concrete.
 
 ## Now
 
-- **Get 0.14.0 out.** The latest release is 0.13.0. Two accepted design docs
-  are implemented on `main` and unreleased:
-  [0036](docs/design/0036-okf-schema-first.md), which takes OKF v0.2's schema
-  as ochakai's own and moves the keys the spec defines (`sources`,
-  `usage_window`, and the Attested Computation contract) out of `attrs` and
-  into first-class fields, and
-  [0037](docs/design/0037-stale-and-source-lookup.md), which makes those keys
-  something you can ask for: the `sort=stale_after` feed of entries past the
-  expiry their author declared, and the `?source=<uri>` reverse lookup for
-  everything derived from a document that changed. The release baseline for
-  breaking changes is 0.13.0, not 0.12.
+- **Get 0.15.0 out.** The latest release is
+  [0.14.0](https://github.com/na0fu3y/ochakai/releases/tag/v0.14.0)
+  (2026-07-27), which shipped 0035, 0036 and 0037. What is implemented on
+  `main` and unreleased is listed in the changelog's
+  [Unreleased](CHANGELOG.md) section; the breaking one is
+  [0038](docs/design/0038-type-vocabulary-realignment.md), which realigns
+  the recommended type vocabulary to what OKF itself spells out — nine
+  spellings become eleven, with `Semantic Model` and `Golden Query`
+  retired to free types. No migration runs and no stored entry changes.
+  Beside it, [0039](docs/design/0039-mcp-stdio-bridge.md) gives
+  stdio-only MCP clients a way in (`ochakai mcp-stdio`) and
+  [0040](docs/design/0040-read-only-mode.md) adds `OCHAKAI_READ_ONLY`,
+  for a deployment that serves knowledge without changing it. The release
+  baseline for breaking changes is 0.14.0.
 - **Keep the invariant checks growing with the code**
   ([0035](docs/design/0035-verifiability.md)): exhaustiveness linting, the
   OpenAPI contract test that runs every REST integration request and response
   past `api/openapi.yaml`, and fuzzing on the OKF parser. This is maintenance,
   not a feature — but it is where new endpoints acquire an obligation, since an
   endpoint only comes under the contract check once it has an integration test.
+- **Make the project legible to somebody who has not read it.** An audit of
+  what a newcomer can learn from this repository found the writing good and
+  the way in poor: the runtime requirement is stated only in
+  `docs/architecture.md`, MCP setup exists for one client out of the several
+  the README names, the CLI's help is the best documentation here and is
+  invisible until you have a binary, and the design records that the English
+  prose calls authoritative are Japanese-only. That is now
+  [a set of issues](https://github.com/na0fu3y/ochakai/issues) rather than a
+  paragraph here. None of it is a feature, and it is the work most likely to
+  decide whether anyone else can use this.
 
 ## Next
 
@@ -52,11 +65,11 @@ if the proposal is concrete.
   embeddings is the current answer. A better lexical index has not been
   designed, and nothing here promises one.
 
-Beyond that this roadmap is thin, and honestly so. There are no open issues and
-no other proposed design docs at the time of writing; work has been arriving
-from use and from release reviews rather than from a plan. If something you
-need is missing from this list, that is a reason to say so, not a sign it was
-already considered.
+Beyond that this roadmap is thin, and honestly so. Work has been arriving from
+use and from release reviews rather than from a plan; the open issues are the
+current exception, and no design doc is proposed but unlanded except 0009. If
+something you need is missing from this list, that is a reason to say so, not a
+sign it was already considered.
 
 ## Considered and deliberately not doing
 

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -55,7 +55,7 @@ export IMAGE=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:$VERSION
 Pin a version rather than `:latest`, so a redeploy is a decision. Without
 the `gh` CLI, read the number off the
 [releases page](https://github.com/na0fu3y/ochakai/releases) and set it by
-hand — `export VERSION=0.13.0`.
+hand — `export VERSION=0.14.0`.
 
 (This guide assumes 0.9.0 or later; earlier releases are
 [retracted](https://go.dev/ref/mod#go-mod-file-retract) and unsupported —


### PR DESCRIPTION
## What and why

Closes #206. Documentation only; no Go changed.

**The README never said the supported runtime is Google Cloud.** It is in
[docs/architecture.md](docs/architecture.md) and implied by design docs
0002/0003, but an evaluator could read the pitch, the quick start and the
entire configuration table without learning there is no supported way to
run this on AWS or on-prem. That is the single biggest qualifier for
adoption, so a **Requirements** section now sits above the quick start
with the four things you have to know before trying it:

- the runtime is Google Cloud, and what *is* portable (the knowledge, via
  OKF bundles) versus what is not;
- there is no authorization — reachability is the whole access model;
- PostgreSQL needs `pg_trgm` (and `vector` once embeddings are on), which
  until now appeared only as bootstrap SQL inside the Cloud Run guide;
- the quick start's `go run` wants a Go toolchain, which the "local
  development needs only Docker" line three lines above it contradicted.
  The toolchain-free paths — a release archive, or plain HTTP — are named,
  and the HTTP one is shown.

**Stale facts.** `ROADMAP.md` still said the latest release was 0.13.0 and
that getting 0.14.0 out was the current work; 0.14.0 shipped the same day
this was written. Its Now section is rewritten around 0.15.0 and the design
docs that are actually unreleased (0038, 0039, 0040), and the closing
paragraph no longer claims there are no open issues, because there are now
eleven. `deploy/cloudrun/README.md` still used `export VERSION=0.13.0` as
its worked example.

**`OCHAKAI_READ_ONLY` was missing from the changelog.** #202 landed it in
the README, the architecture doc and a design record, but not in the file
an operator reads to decide whether to upgrade.

**`docs/README.md` was linked from nowhere** — not from the README, not
from `SUPPORT.md`, `CONTRIBUTING.md` or `docs/architecture.md`. The nav
line carries it now.

## Verified

The curl example is not asserted. Against a server built from this branch
(`OCHAKAI_INSECURE_DEV=true`, local Postgres):

```
POST /api/v1/knowledge  → 201, entry stored as draft, created_by human:anonymous
GET  /api/v1/knowledge?q=revenue → 1 hit, the entry just created
```

It deliberately sends no `title`: the id's last segment names the entry
(design doc 0022), so the shortest honest example is also the current one.

Every relative link added here resolves, and the `#why-ochakai` anchor
exists. Facts checked against the source rather than the prose:
`pg_trgm` is created by `internal/store/migrations/0001_init.sql`;
`vector` by `internal/store/migrate.go` and only when embeddings are
configured; Postgres 17 is what both `.github/workflows/ci.yaml` and the
deploy guide's `--database-version` use.

## Checks

- [x] `gofmt -l .` prints nothing; `go vet ./...`; `go test -race ./...` — no Go changed
- [x] `CGO_ENABLED=0 go build -trimpath ./...`
- [x] golangci-lint and govulncheck report nothing
- [x] Behavior changes come with tests — n/a, documentation only

## Surfaces and contract

- [x] n/a — no endpoint or tool changed
- [x] n/a

## Design docs

- [x] Alters no accepted decision: it writes down decisions 0002, 0003 and
      0040 where a user will find them
- [x] Commit messages and code comments are in English

Note for merge order: #204 edits the quick-start prose immediately below
the new section. The two do not touch the same lines, but merge whichever
is convenient and expect the second to need a glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
