### PR TITLE
Render the CLI reference, and make version drift fail

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,18 @@ go test ./internal/okf/ -run XXX -fuzz FuzzDocumentRoundTrip -fuzztime 60s
 A failing input lands in `testdata/fuzz/` and becomes a permanent seed;
 commit it with the fix.
 
+Two checked-in files are generated, and the test that generates them
+fails when the copy is stale. [docs/cli.md](docs/cli.md) is the CLI's own
+help rendered — change a synopsis, a flag or an example and regenerate:
+
+```sh
+go test ./cmd/ochakai -run TestCLIReferenceIsCurrent -update
+```
+
+The other is the version number in `api/openapi.yaml`, checked against
+the newest release in `CHANGELOG.md` and the issue template's
+placeholder; see [Releases](#releases).
+
 The store integration test is skipped unless a real PostgreSQL is
 available (CI runs one as a service container):
 
@@ -130,9 +142,13 @@ release starts with a PR.
   leave a fresh empty `Unreleased` above it, and add the compare link at
   the bottom (`[x.y.z]: …/compare/v<prev>...vx.y.z`, and repoint
   `[Unreleased]` at the new tag).
-- `api/openapi.yaml` — `info.version`. It describes the wire surface, so
-  it drifts silently: nothing fails when it is stale.
+- `api/openapi.yaml` — `info.version`.
 - `.github/ISSUE_TEMPLATE/bug_report.yml` — the version placeholder.
+
+These three used to drift silently, since nothing fails when a version
+number is stale. `TestReleaseVersionsAgree` now does: it reads the newest
+dated heading in the changelog and requires the other two to say the same
+thing, so the prep PR is green only once all three have moved.
 
 While the major version is 0, a release with any **BREAKING** entry takes
 the minor, not the patch.

--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ ochakai ui                   # web UI at http://127.0.0.1:8098, acting as you (n
 it, so scripts and CI stay explicit. Tab completion:
 `source <(ochakai completion zsh)` (also bash, fish).
 
+Every command carries its own flags and worked examples in
+`ochakai <command> -h`. [docs/cli.md](docs/cli.md) is that same text
+rendered, for reading before you install anything.
+
 Then copy [examples/claude-code/CLAUDE.md](examples/claude-code/CLAUDE.md)
 into your project's CLAUDE.md — it teaches the agent the commands and the
 write-learnings-back habit. To make the loop automatic instead of

--- a/cmd/ochakai/clidocs_test.go
+++ b/cmd/ochakai/clidocs_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"maps"
+	"os"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// docs/cli.md is the CLI's own help, rendered. The help is generated from
+// the domain model where the values come from it (--type, --status), so a
+// hand-written copy would be a third spelling of something already spelled
+// twice — this keeps the copy derived and fails when it is stale, the way
+// the OpenAPI contract test does for the REST surface (design doc 0035).
+const cliDocsPath = "../../docs/cli.md"
+
+var updateCLIDocs = flag.Bool("update", false, "rewrite docs/cli.md from the CLI's own help")
+
+const cliDocsHeader = `<!-- Generated from the CLI's own help. Do not edit by hand:
+     go test ./cmd/ochakai -run TestCLIReferenceIsCurrent -update -->
+
+# CLI reference
+
+` + "`ochakai`" + ` is a thin client of the REST API — every client command
+below is one HTTP call against the server named by ` + "`--url`" + `, ` + "`$OCHAKAI_URL`" + `,
+or the ` + "`ochakai use`" + ` selection, in that order (design docs
+[0004](design/0004-cli.md), [0007](design/0007-api-only-cli.md)). ` + "`serve`" + `
+and ` + "`serve-ui`" + ` are the exception: they are the deployed services, and they
+take their configuration from the environment rather than from flags — the
+README's [Configuration](../README.md#configuration) table lists it.
+
+The same text is what ` + "`ochakai <command> -h`" + ` prints, so nothing here can
+disagree with the binary you are running.
+
+## Commands
+
+`
+
+// TestCLIReferenceIsCurrent regenerates docs/cli.md and compares it with
+// the checked-in copy.
+func TestCLIReferenceIsCurrent(t *testing.T) {
+	got := renderCLIDocs(t)
+	if *updateCLIDocs {
+		if err := os.WriteFile(cliDocsPath, []byte(got), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	want, err := os.ReadFile(cliDocsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(want) != got {
+		t.Errorf("docs/cli.md no longer matches the CLI's help; regenerate it:\n"+
+			"\tgo test ./cmd/ochakai -run TestCLIReferenceIsCurrent -update\n"+
+			"first difference at byte %d", firstDiff(string(want), got))
+	}
+}
+
+func firstDiff(a, b string) int {
+	for i := 0; i < len(a) && i < len(b); i++ {
+		if a[i] != b[i] {
+			return i
+		}
+	}
+	return min(len(a), len(b))
+}
+
+func renderCLIDocs(t *testing.T) string {
+	t.Helper()
+	// Without this the rendered --url default is whatever server this
+	// machine happens to have selected, and the file differs per developer.
+	t.Setenv("OCHAKAI_URL", "")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	var b strings.Builder
+	b.WriteString(cliDocsHeader)
+
+	var index strings.Builder
+	usage(&index)
+	fmt.Fprintf(&b, "```\n%s```\n", index.String())
+
+	for _, name := range slices.Sorted(maps.Keys(clientCommands)) {
+		fmt.Fprintf(&b, "\n## ochakai %s\n\n```\n%s```\n", name, helpFor(t, name))
+	}
+	return b.String()
+}
+
+// helpFor runs one command with -h and returns what it printed.
+func helpFor(t *testing.T, name string) string {
+	t.Helper()
+	var b bytes.Buffer
+	prev := helpOutput
+	helpOutput = &b
+	defer func() { helpOutput = prev }()
+
+	err := clientCommands[name](context.Background(), []string{"-h"})
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("`ochakai %s -h`: want flag.ErrHelp, got %v", name, err)
+	}
+	out := b.String()
+	if out == "" {
+		t.Fatalf("`ochakai %s -h` printed nothing", name)
+	}
+	if !strings.HasSuffix(out, "\n") {
+		out += "\n"
+	}
+	return out
+}

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -70,8 +70,15 @@ func runClient(name string, args []string) int {
 // errReported means the FlagSet already printed the problem.
 var errReported = errors.New("usage error")
 
+// helpOutput is where a command's own help goes. It is os.Stderr, which
+// is where the flag package would have put it anyway; naming it is what
+// lets docs/cli.md be generated from the help itself rather than written
+// beside it (cmd/ochakai/clidocs_test.go).
+var helpOutput io.Writer = os.Stderr
+
 func newBareFlagSet(synopsis, examples string) *flag.FlagSet {
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	fs.SetOutput(helpOutput)
 	fs.Usage = func() {
 		fmt.Fprintf(fs.Output(), "%s\n\nFlags:\n", synopsis)
 		fs.PrintDefaults()

--- a/cmd/ochakai/release_version_test.go
+++ b/cmd/ochakai/release_version_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"os"
+	"regexp"
+	"testing"
+)
+
+// Three files carry a version number that tagging does not update, and
+// CONTRIBUTING.md's release checklist is the only thing that has kept them
+// together — "it describes the wire surface, so it drifts silently:
+// nothing fails when it is stale" was true of api/openapi.yaml until this
+// test. They are all set in the same release-prep PR, so they either agree
+// or one of them was forgotten (design doc 0035: check the invariant from
+// outside rather than trust the convention).
+func TestReleaseVersionsAgree(t *testing.T) {
+	changelog := versionIn(t, "../../CHANGELOG.md",
+		`(?m)^## \[(\d+\.\d+\.\d+)\] - \d{4}-\d{2}-\d{2}$`)
+	spec := versionIn(t, "../../api/openapi.yaml",
+		`(?m)^  version: (\d+\.\d+\.\d+)$`)
+	template := versionIn(t, "../../.github/ISSUE_TEMPLATE/bug_report.yml",
+		`(?m)^      placeholder: "(\d+\.\d+\.\d+)"$`)
+
+	if spec != changelog {
+		t.Errorf("api/openapi.yaml says %s; the newest release in CHANGELOG.md is %s. "+
+			"The spec's info.version is bumped in the release PR (CONTRIBUTING.md, Releases)",
+			spec, changelog)
+	}
+	if template != changelog {
+		t.Errorf(".github/ISSUE_TEMPLATE/bug_report.yml suggests %s; the newest release is %s. "+
+			"A stale placeholder invites bug reports against a version nobody runs",
+			template, changelog)
+	}
+}
+
+// versionIn returns the first capture of re in the named file. The first
+// match is the newest entry in every file this is used on: CHANGELOG.md is
+// newest-first, and the other two carry one version each.
+func versionIn(t *testing.T, path, re string) string {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	m := regexp.MustCompile(re).FindSubmatch(content)
+	if m == nil {
+		t.Fatalf("%s carries no version matching %s — the file's shape changed, "+
+			"and this check now guards nothing", path, re)
+	}
+	return string(m[1])
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,8 +33,10 @@ types, and every environment variable.
 - [Connecting an MCP client](guides/mcp-clients.md) — the URL or the
   `mcp-stdio` bridge, per client, with the config file each one reads and
   the ones that cannot reach an IAM-restricted deployment at all.
-- `ochakai <command> -h` — every command carries its flags and worked
-  examples, generated from the domain model where the values come from it.
+- [CLI reference](cli.md) — every command's synopsis, flags and worked
+  examples. It is `ochakai <command> -h` rendered, and a test fails when
+  the two disagree, so it is readable before you have a binary and cannot
+  go stale after you do.
 
 ## For someone changing it
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,651 @@
+<!-- Generated from the CLI's own help. Do not edit by hand:
+     go test ./cmd/ochakai -run TestCLIReferenceIsCurrent -update -->
+
+# CLI reference
+
+`ochakai` is a thin client of the REST API — every client command
+below is one HTTP call against the server named by `--url`, `$OCHAKAI_URL`,
+or the `ochakai use` selection, in that order (design docs
+[0004](design/0004-cli.md), [0007](design/0007-api-only-cli.md)). `serve`
+and `serve-ui` are the exception: they are the deployed services, and they
+take their configuration from the environment rather than from flags — the
+README's [Configuration](../README.md#configuration) table lists it.
+
+The same text is what `ochakai <command> -h` prints, so nothing here can
+disagree with the binary you are running.
+
+## Commands
+
+```
+ochakai — context provider for data agents
+
+Client commands (talk to a server; --url > $OCHAKAI_URL > "use" selection):
+  use [name | url]        pick the server for later commands (saved locally)
+  whoami                  print target server, identity, and reachability
+  search [query]          search knowledge; verified entries rank higher
+  browse [prefix]         list one level of the ID hierarchy (folder view)
+  context <question>      the one-call read before a data question (full entries)
+  get <id>                print one entry as an OKF document
+  create [id] [-f file]   create an entry from OKF markdown or JSON
+  update <id>             replace an entry (every change kept as a revision)
+  verify <id>             record a verification (re-affirms a verified entry too)
+  delete <id>             soft-delete an entry (history retained)
+  purge <id>              hard-delete a soft-deleted entry, freeing its id
+  reembed                 embed entries missing a vector for the current model
+  move <id> <new-id>      move (rename) an entry; references are rewritten
+  attach <id> <file...>   attach files to an entry (png/jpeg/webp/pdf/text)
+  detach <id> <name>      remove an attachment
+  usage <id>              show usage totals (search hits, fetches, outcomes)
+  report <id> <outcome>   report an outcome: worked | failed (--note for why)
+  revisions <id>          list an entry's change history (newest first)
+  backlinks <id>          list entries whose links point at this one
+  export <dir | ->        download the knowledge base as an OKF bundle
+  import <dir | tgz | ->  upload an OKF bundle (any producer's, not just ours)
+  ui                      serve the web UI locally, acting as you (no deploy)
+  mcp-stdio               speak MCP on stdin/stdout, forwarding to the server
+                          (for clients that cannot open an HTTP MCP endpoint)
+
+Server commands (run as deployed services, configured by environment):
+  serve                   start the MCP + REST server (runs next to the database)
+  serve-ui                serve the team web UI, proxying to $OCHAKAI_URL as the
+                          service identity (same image as serve: --args=serve-ui)
+
+  version                 print the version
+  completion <shell>      print a completion script (zsh, bash, fish)
+
+Run "ochakai <command> -h" for flags and examples.
+```
+
+## ochakai attach
+
+```
+Usage: ochakai attach [flags] <id> <file...>
+
+Attach files to a knowledge entry (png, jpeg, webp, pdf, plain
+text — the type is sniffed from the bytes; max 5 MiB each, 20 per
+entry). An attachment of the same name is replaced (the change is kept
+as a revision). Reference the file from the entry's body so its
+caption is searchable and it survives OKF export/import — the hint
+printed after attaching shows the canonical relative link. Requires
+the server to have GCS configured (OCHAKAI_GCS_BUCKET).
+
+Flags:
+  -json
+    	print the attachment metadata as JSON
+  -name string
+    	attachment name (default: the file's basename; single file only)
+  -url ochakai use
+    	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
+
+Examples:
+  ochakai attach insights/revenue-reading weekly.png
+  ochakai attach tables/orders seeds.txt
+  ochakai attach tables/orders er-diagram.png --name schema.png
+```
+
+## ochakai backlinks
+
+```
+Usage: ochakai backlinks [flags] <id>
+
+List live entries whose links point at this entry, most recently
+updated first — the reverse edge the web UI shows as "linked from"
+(context already follows it when packing companions).
+Output: uri, status, title — description (one entry per line).
+
+Flags:
+  -json
+    	print the raw JSON response
+  -limit int
+    	max entries (server default 20, max 100)
+  -url ochakai use
+    	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
+
+Examples:
+  ochakai backlinks metrics/revenue
+  ochakai backlinks metrics/revenue --json | jq '.entries[].id'
+```
+
+## ochakai browse
+
+```
+Usage: ochakai browse [flags] [prefix]
+
+List one level of the ID hierarchy (the folder view of design docs
+0014 and 0017, the CLI counterpart of the web UI's Browse tab).
+Without an argument, the top-level directories with their entry
+counts; with a prefix, the subdirectories and entries directly under
+it. Directories print as "name/	count", entries as
+"segment	type	status	title". Rejected entries are hidden, as in search.
+
+Flags:
+  -json
+    	print the raw JSON response
+  -url ochakai use
+    	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
+
+Examples:
+  ochakai browse
+  ochakai browse queries
+  ochakai browse ga4/tables
+```
+
+## ochakai completion
+
+```
+Usage: ochakai completion <zsh|bash|fish>
+
+Print a shell completion script. Load it with:
+
+  zsh:   source <(ochakai completion zsh)    # ~/.zshrc, after compinit
+  bash:  source <(ochakai completion bash)   # ~/.bashrc
+  fish:  ochakai completion fish | source    # ~/.config/fish/config.fish
+
+Or install it as a file the shell picks up by itself (what package
+managers do):
+
+Flags:
+
+Examples:
+  ochakai completion zsh > "${fpath[1]}/_ochakai"
+  ochakai completion fish > ~/.config/fish/completions/ochakai.fish
+```
+
+## ochakai context
+
+```
+Usage: ochakai context [flags] <question>
+
+Gather what to read before answering a data question, in one call:
+the full entries behind the top search hits (verified entries rank
+higher), expanded one hop through links so the insight explaining a
+metric travels with it. Markdown on stdout, ready for an agent's
+context window. No hits print nothing (exit 0).
+
+Flags:
+  -budget int
+    	cap the response at ~this many bytes (0 = no cap); the rendered output stops printing entries, --json asks the server to cap and list what did not fit under "outline"
+  -json
+    	print the raw JSON response
+  -limit int
+    	max full entries (server default 5, max 20)
+  -min-score float
+    	drop hits scoring below this; scores depend on the server's search mode (matched-fragment weight plus boosts vs RRF rank fusion), so calibrate before use (0 = off)
+  -status value
+    	filter by status: draft|verified|deprecated|rejected (repeatable)
+  -tag value
+    	filter by tag (repeatable)
+  -type value
+    	filter by type: Metric|Attested Computation|Skill|Playbook|Insight|Policy|Glossary Term|BigQuery Dataset|BigQuery Table|API Endpoint|Reference, or any custom type (repeatable)
+  -url ochakai use
+    	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
+
+Examples:
+  ochakai context "why did revenue drop in March?"
+  ochakai context "monthly revenue" --type 'Attested Computation' --status verified --json
+  ochakai context "$PROMPT" --budget 4000   # hooks: cap the injected bytes
+```
+
+## ochakai create
+
+```
+Usage: ochakai create [flags] [id]
+
+Create a knowledge entry from -f or stdin. Input is an OKF document
+(--- frontmatter with type, markdown body — the format `ochakai get`
+prints; title is optional, the id's last segment is the display name
+when it is absent) or JSON (see api/openapi.yaml). The id is the
+entry's path; pass it as the argument (it overrides an id in the
+input, and OKF documents carry none — the path is the id). Entries
+default to draft; provenance is recorded from your Google identity.
+
+Flags:
+  -f string
+    	input file (default: stdin)
+  -json
+    	print the created entry as JSON
+  -url ochakai use
+    	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
+
+Examples:
+  ochakai get insights/revenue-seasonality | sed s/40%/45%/ | ochakai create insights/revenue-seasonality-v2
+  ochakai create runbook/restore -f entry.md
+```
+
+## ochakai delete
+
+```
+Usage: ochakai delete [flags] <id>
+
+Soft-delete a knowledge entry (history is retained server-side).
+
+Flags:
+  -url ochakai use
+    	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
+
+Examples:
+  ochakai delete terms/obsolete-kpi
+```
+
+## ochakai detach
+
+```
+Usage: ochakai detach [flags] <id> <name>
+
+Remove an attachment from a knowledge entry (the change is kept as a
+revision; content-addressed bytes stay referenced by history).
+
+Flags:
+  -url ochakai use
+    	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
+
+Examples:
+  ochakai detach insights/revenue-reading weekly.png
+```
+
+## ochakai export
+
+```
+Usage: ochakai export [flags] <dir | ->
+
+Download the whole knowledge base as an OKF bundle (markdown + YAML
+frontmatter) into dir, or stream the tar.gz to stdout with "-".
+Your knowledge is yours.
+
+Flags:
+  -no-attachments
+    	export the markdown only, skipping attachment files
+  -url ochakai use
+    	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
+
+Examples:
+  ochakai export ./knowledge
+  ochakai export - > ochakai-okf.tar.gz
+  ochakai export --no-attachments - > entries.tar.gz   # bytes are in GCS; copy them from there
+```
+
+## ochakai get
+
+```
+Usage: ochakai get [flags] <id>
+
+Print one knowledge entry as an OKF document (YAML frontmatter +
+markdown body). The output round-trips through `ochakai update`.
+Attachment metadata is listed on stderr; --download saves the
+attachment files themselves (an agent can then read them from disk).
+
+Flags:
+  -download string
+    	save the entry's attachments into this directory
+  -json
+    	print JSON instead of the OKF document
+  -url ochakai use
+    	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
+
+Examples:
+  ochakai get metrics/revenue
+  ochakai get queries/monthly-revenue --json | jq -r '.attrs.sql'
+  ochakai get insights/revenue-reading --download ./img
+```
+
+## ochakai import
+
+```
+Usage: ochakai import [flags] <dir | file.tar.gz | ->
+
+Import an OKF bundle (a directory of markdown + YAML frontmatter, or
+a tar.gz of one; "-" reads the tar.gz from stdin). The inverse of
+`ochakai export`: each path names its entry (the path minus .md is
+the id), the frontmatter type key names the type (required — files
+without one are skipped and reported), reserved index.md / log.md
+files are skipped, unknown frontmatter keys are kept as attrs, and
+existing entries are replaced (kept as revisions; entries identical
+to what is stored are left untouched and reported as unchanged;
+entries the server rejects as invalid — e.g. one whose type is not a
+single line — are skipped and reported).
+Files referenced by an entry's body markdown links become its
+attachments, wherever they sit in the bundle (their location is
+preserved for re-export); unreferenced data files inside an entry's
+directory (<id>/<name>) attach to that entry. The packed shape is
+the structure: an archive wrapped in a single directory imports
+under that directory — the bundle keeps its own namespace. Works
+with any OKF bundle, not just ochakai's own.
+
+Flags:
+  -dry-run
+    	parse and list what would be written, write nothing
+  -url ochakai use
+    	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
+
+Examples:
+  ochakai import ./knowledge
+  ochakai import ga4-bundle.tar.gz --dry-run
+  ochakai export - | OCHAKAI_URL=https://other ochakai import -
+```
+
+## ochakai mcp-stdio
+
+```
+Usage: ochakai mcp-stdio [flags]
+
+Speak MCP over stdin/stdout, forwarding every message to the
+selected server's /mcp. For clients that cannot open an HTTP MCP
+endpoint themselves, and for any client talking to Cloud Run, where
+the request needs a Google ID token this resolves for you (the same
+way every other client command does) — so the client itself is
+configured with no credentials.
+
+stdout carries the protocol and nothing else; diagnostics go to
+stderr. Run it as the client's command, not by hand.
+
+Flags:
+  -url ochakai use
+    	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
+
+Examples:
+  ochakai mcp-stdio
+  ochakai mcp-stdio --url https://your-service.run.app
+
+  # Claude Desktop / any client taking a command, in its JSON config:
+  #   "ochakai": { "command": "ochakai", "args": ["mcp-stdio"] }
+  claude mcp add ochakai -- ochakai mcp-stdio
+```
+
+## ochakai move
+
+```
+Usage: ochakai move [flags] <id> <new-id>
+
+Move (rename) a knowledge entry to a new id. Revisions, usage, and
+attachments follow, and inbound references (link targets, attrs.model)
+are rewritten so nothing breaks.
+
+Flags:
+  -url ochakai use
+    	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
+
+Examples:
+  ochakai move insights/revenue-seasonality insights/sales/revenue-seasonality
+```
+
+## ochakai purge
+
+```
+Usage: ochakai purge [flags] <id>
+
+Hard-delete an already soft-deleted entry: the entry, its revisions,
+usage, and attachment metadata are erased and the id is freed for a
+move. History is gone — `ochakai delete` first, then purge. A live
+entry is refused.
+
+Flags:
+  -url ochakai use
+    	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
+
+Examples:
+  ochakai delete terms/obsolete-kpi
+  ochakai purge terms/obsolete-kpi
+```
+
+## ochakai reembed
+
+```
+Usage: ochakai reembed [flags]
+
+Embed entries that have no vector for the configured model — entries
+written before semantic search was enabled, or before the model was
+changed. Runs bounded passes until nothing is left, so it can be started
+once and left alone.
+
+Flags:
+  -json
+    	print the raw JSON response of each pass
+  -limit int
+    	max entries to embed per pass (server default 200)
+  -once
+    	run a single pass instead of continuing until nothing is left
+  -url ochakai use
+    	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
+
+Examples:
+  ochakai reembed
+  ochakai reembed --limit 50   # smaller passes, e.g. behind a short request timeout
+  ochakai reembed --once       # one pass, then report what is left
+```
+
+## ochakai report
+
+```
+Usage: ochakai report [flags] <id> <worked|failed>
+
+Report whether acting on an entry gave a correct result — the last
+edge of the write-back loop. After running an attested computation or SQL you
+wrote from an entry, report worked or failed (say what went wrong with
+--note); failed counts against verified entries flag them for
+re-verification. Prints the entry's updated usage totals.
+
+Flags:
+  -json
+    	print the updated usage totals as JSON
+  -note string
+    	context recorded with the report: what was run, what went wrong (max 2000 bytes)
+  -url ochakai use
+    	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
+
+Examples:
+  ochakai report queries/monthly-revenue worked
+  ochakai report queries/monthly-revenue failed --note "joins dropped 2024 rows after schema change"
+```
+
+## ochakai revisions
+
+```
+Usage: ochakai revisions [flags] <id>
+
+List an entry's change history, newest first: who changed it, how,
+and when — the audit surface behind "every change kept as a
+revision". Works for soft-deleted entries too. Full snapshots are in
+the JSON output (--json).
+
+Flags:
+  -json
+    	print the raw JSON response (includes full snapshots)
+  -limit int
+    	max revisions (server default 50, max 200)
+  -url ochakai use
+    	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
+
+Examples:
+  ochakai revisions metrics/revenue
+  ochakai revisions queries/monthly-revenue --json | jq '.revisions[0].snapshot'
+```
+
+## ochakai search
+
+```
+Usage: ochakai search [flags] [query]
+
+Search the knowledge base; verified entries rank higher.
+Output: score, uri, status, title — description (one hit per line).
+With --sort verified_at the command lists by verification age instead
+of searching (oldest first, never-verified last — the
+canary feed); output leads with verified_at. With --sort usage it lists
+by demand (most search_hits first, never-used oldest-first at the bottom
+— the draft review feed); output leads with the search_hits count.
+With --sort failed it lists entries whose failure reports (report_outcome
+failed) are still unanswered, worst first — the re-verification feed;
+output leads with the failed count. `ochakai verify` takes an entry out
+of it, so a base that is kept up shows an empty feed.
+With --sort stale_after it lists entries whose declared stale_after has
+passed, most overdue first; output leads with that date. Verifying does
+not empty this one — the date is the writer's declaration, so clearing it
+means editing the entry to re-declare an expiry.
+--source is a filter, not a mode: it narrows to the entries citing one
+resource (the reverse of sources[].resource) and combines with a query
+or with any --sort.
+
+Flags:
+  -json
+    	print the raw JSON response
+  -limit int
+    	max results (server default 10, max 50; with --sort: 100, max 1000)
+  -sort string
+    	list instead of search: "verified_at" = by verification age (oldest first), "usage" = by demand (most search_hits first), "failed" = by failed outcome reports (re-verification feed), "stale_after" = past their declared expiry, most overdue first
+  -source resource
+    	only entries citing this resource (exact match against sources[].resource) — what derives from one piece of material
+  -status value
+    	filter by status: draft|verified|deprecated|rejected (repeatable)
+  -tag value
+    	filter by tag (repeatable)
+  -type value
+    	filter by type: Metric|Attested Computation|Skill|Playbook|Insight|Policy|Glossary Term|BigQuery Dataset|BigQuery Table|API Endpoint|Reference, or any custom type (repeatable)
+  -url ochakai use
+    	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
+
+Examples:
+  ochakai search "gross margin" --type Metric --type 'Glossary Term' --status verified
+  ochakai search churn --json | jq '.hits[0].attrs'
+  ochakai search --sort verified_at --type 'Attested Computation' --status verified --limit 100
+  ochakai search --sort usage --status draft --limit 50   # review queue
+  ochakai search --sort failed --status verified            # re-verification queue
+  ochakai search --sort stale_after                         # past their declared expiry
+  ochakai search --source https://wiki.example/finance/revenue-recognition  # what cites this
+```
+
+## ochakai ui
+
+```
+Usage: ochakai ui [flags]
+
+Serve the web UI at http://127.0.0.1:<port> against the selected
+server. API calls are proxied with your own Google identity (resolved
+the same way as every other client command), so no deployment is
+needed and your edits are recorded as human:<you>. The proxy also
+exposes /mcp, so it doubles as an authenticated local MCP endpoint.
+For a team-shared UI on Cloud Run, deploy `ochakai serve-ui`.
+
+Flags:
+  -port int
+    	port to listen on (always bound to 127.0.0.1: whoever reaches the proxy acts as you) (default 8098)
+  -url ochakai use
+    	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
+
+Examples:
+  ochakai ui
+  ochakai ui --port 9000
+  claude mcp add --transport http ochakai http://127.0.0.1:8098/mcp
+```
+
+## ochakai update
+
+```
+Usage: ochakai update [flags] <id>
+
+Replace a knowledge entry from -f or stdin (OKF document or JSON;
+the id comes from the argument, the type from the input). Every
+change is kept as a revision server-side. With --if-match the update
+is conditional: it lands only if the entry still has the version you
+read, and fails instead of overwriting someone else's edit.
+
+Flags:
+  -f string
+    	input file (default: stdin)
+  -if-match version
+    	update only if the entry still has this version — its updated_at (`ochakai get <id> --json` prints it as .updated_at; a REST GET returns it as the ETag header); a stale version fails with a conflict instead of overwriting
+  -json
+    	print the updated entry as JSON
+  -url ochakai use
+    	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
+
+Examples:
+  ochakai get metrics/revenue | $EDITOR /dev/stdin | ochakai update metrics/revenue
+  ochakai update metrics/revenue -f revenue.md
+  ochakai update metrics/revenue -f revenue.md --if-match "$(ochakai get metrics/revenue --json | jq -r .updated_at)"
+```
+
+## ochakai usage
+
+```
+Usage: ochakai usage [flags] <id>
+
+Show how often an entry was actually used: appeared in search results,
+fetched individually, reported worked or failed — and when it was last
+used. The measure of the write-back loop: evidence for promoting a
+draft, and a staleness signal for verified entries nobody uses.
+
+Flags:
+  -json
+    	print JSON
+  -url ochakai use
+    	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
+
+Examples:
+  ochakai usage queries/monthly-revenue
+  ochakai usage metrics/revenue --json
+```
+
+## ochakai use
+
+```
+Usage: ochakai use [flags] [name | url]
+
+Pick the server later client commands talk to, saved to
+~/.config/ochakai/config.json ($XDG_CONFIG_HOME honored;
+%AppData%\ochakai on Windows).
+With a URL: save it (named by --name, default its host) and switch.
+With a name: switch to a saved server. With no argument: list.
+--url and $OCHAKAI_URL always override the saved selection.
+
+Flags:
+  -name string
+    	name to save the URL under (default: its host)
+
+Examples:
+  ochakai use http://localhost:8080 --name local
+  ochakai use https://ochakai-prod.run.app --name prod
+  ochakai use prod
+```
+
+## ochakai verify
+
+```
+Usage: ochakai verify [flags] <id>
+
+Record a verification against the entry as it stands: you become
+verified_by and verified_at is stamped now. Promotes a draft, and
+re-affirms an entry that is already verified — which is what takes it
+out of both review feeds (--sort verified_at, --sort failed). Verifying
+a rejected entry clears the rejection: the status becomes verified and
+rejected_by/rejected_at are dropped (the revision history keeps both).
+
+Flags:
+  -json
+    	print the verified entry as JSON
+  -url ochakai use
+    	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
+
+Examples:
+  ochakai verify metrics/revenue
+  ochakai verify metrics/revenue --json | jq -r .verified_at
+```
+
+## ochakai whoami
+
+```
+Usage: ochakai whoami [flags]
+
+Print which server client commands target and where that choice came
+from (--url / $OCHAKAI_URL / `ochakai use`), the identity your
+credentials present (the server's actor resolution is authoritative),
+and whether the server is reachable.
+
+Flags:
+  -json
+    	print JSON
+  -url ochakai use
+    	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
+
+Examples:
+  ochakai whoami
+  ochakai whoami --json
+```


### PR DESCRIPTION
## What and why

Closes #208. Two copies of things the repository already knew, neither of
them checked.

**`docs/cli.md` — the CLI's help, rendered.** `ochakai <command> -h` is
the most complete documentation this project has: a synopsis, flags and
worked examples per command, with the `--type` and `--status` enums coming
from `domain.TypesHint()` so they cannot drift. All of it is invisible
until you have a binary, which is backwards — the person deciding whether
to install is the one who cannot read it.

The file is generated, not written. `TestCLIReferenceIsCurrent` runs every
command in `clientCommands` with `-h`, renders the result under the
top-level `usage()` index, and fails when the checked-in copy disagrees:

```sh
go test ./cmd/ochakai -run TestCLIReferenceIsCurrent -update
```

The only production change is a named writer for a `FlagSet`'s output —
it was `os.Stderr` implicitly and is `os.Stderr` explicitly now. That is
the seam the generator writes through.

Rendering is machine-independent on purpose: the test clears
`$OCHAKAI_URL` and points `$XDG_CONFIG_HOME` at a temp dir, because
otherwise the `--url` default renders as whichever server the developer
had selected with `ochakai use` — a diff that would appear on somebody
else's machine and nowhere else.

**`TestReleaseVersionsAgree` — version drift.** CONTRIBUTING.md's release
checklist names three files that carry a version number tagging does not
update, and says of `api/openapi.yaml`: *"It describes the wire surface,
so it drifts silently: nothing fails when it is stale."* That sentence is
now false. The test reads the newest dated heading in `CHANGELOG.md` and
requires `info.version` and the bug-report template's placeholder to match
it. All three are set in the same release-prep PR, so agreeing is free and
disagreeing means one was forgotten.

This is design doc 0035's pattern rather than a new one: an invariant the
type system cannot carry, checked from outside, in a test that is already
part of `go test ./...`.

## Verified

Both checks were made to fail before committing, then restored:

```
$ printf '\nstray line\n' >> docs/cli.md
--- FAIL: TestCLIReferenceIsCurrent
    docs/cli.md no longer matches the CLI's help; regenerate it:
      go test ./cmd/ochakai -run TestCLIReferenceIsCurrent -update
    first difference at byte 23021

$ sed -i '' 's/^  version: 0.14.0$/  version: 0.15.0/' api/openapi.yaml
--- FAIL: TestReleaseVersionsAgree
    api/openapi.yaml says 0.15.0; the newest release in CHANGELOG.md is 0.14.0.
```

The generated file was also read rather than assumed: 651 lines, no
absolute paths, no machine-specific defaults, and the only `run.app` URLs
in it are the ones the help's own examples contain.

## Checks

- [x] `gofmt -l .` prints nothing; `go vet ./...`; `go test -race ./...` (with the store integration DB)
- [x] `CGO_ENABLED=0 go build -trimpath ./...`
- [x] golangci-lint (v2.12.2) — `0 issues.`; govulncheck — 0 affecting this code
- [x] Behavior changes come with tests — the change *is* the tests

## Surfaces and contract

- [x] No endpoint, tool or flag changed; `api/openapi.yaml`,
      `internal/restapi`, `internal/mcpserver` and `internal/apiclient` are
      untouched
- [x] Nothing new lands on a surface — this documents the CLI surface that
      design doc 0004 defines

## Design docs

- [x] Alters no accepted decision; it applies 0035's approach to two
      copies that were held together by a checklist
- [x] Commit messages and code comments are in English

No changelog entry: nothing an operator upgrading needs to know changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
