### PR TITLE
Answer the questions the shape of this project invites

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,6 +600,8 @@ local setup and the checks CI runs. A design doc in Japanese is the
 project's own habit, not a requirement: propose in whichever language you
 think in, and say so in the PR.
 
+- [docs/faq.md](docs/faq.md) — the questions this shape invites, and
+  [troubleshooting](docs/guides/troubleshooting.md) for the symptoms
 - [SUPPORT.md](SUPPORT.md) — where to ask a question
 - [ROADMAP.md](ROADMAP.md) — what is being worked on, and what is
   deliberately refused

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -22,6 +22,12 @@ public issue is the wrong place, and the private path exists for exactly that.
 
 Most answers are already written down, and the docs are short enough to check:
 
+- [docs/faq.md](docs/faq.md) — the questions this project's shape invites:
+  whether it runs outside Google Cloud, whether anything leaves your project,
+  what an agent may do to verified knowledge, what happens if you leave.
+- [docs/guides/troubleshooting.md](docs/guides/troubleshooting.md) — symptoms
+  and their causes on the local and client side, from an empty search to a
+  skipped import to a 412.
 - [README](README.md) — what ochakai is, the configuration table, and the
   things it deliberately does not do.
 - [deploy/cloudrun/README.md](deploy/cloudrun/README.md) — the full Cloud Run +

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,9 @@ types, and every environment variable.
 
 ## For someone evaluating ochakai
 
+- [FAQ](faq.md) — can it run outside Google Cloud, does anything leave
+  your project, how it differs from RAG and from a memory layer, what an
+  agent may do to verified knowledge, and what leaving looks like.
 - [Architecture](architecture.md) — how the pieces fit, what the data
   model is, and why there is no authorization layer. English summary of
   the decision records.
@@ -22,6 +25,10 @@ types, and every environment variable.
   and nothing else; no Google account needed.
 - [Golden query canary](guides/golden-query-canary.md) — running verified
   queries from CI so a knowledge base that has quietly gone wrong says so.
+- [Troubleshooting](guides/troubleshooting.md) — the local and client-side
+  half: an empty search, a skipped import, a 409 or 412, an empty web UI,
+  a server that refuses to start. Google Cloud symptoms stay in the deploy
+  guide's §7.
 
 ## For someone building against it
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,166 @@
+# FAQ
+
+Answers that the README implies but never states in one place. When a
+question is really about a symptom, it is in
+[troubleshooting](guides/troubleshooting.md) instead.
+
+### Can I run this without Google Cloud?
+
+Not in production. Cloud Run's IAM check is the access model and Cloud SQL
+IAM is the database credential, which together are why ochakai holds no
+secret of its own (design docs 0002, 0003) — a deployment elsewhere would
+have to invent both, and that is the thing the design refuses. Locally,
+`deploy/compose.yaml` runs the same binary against plain PostgreSQL with
+`OCHAKAI_INSECURE_DEV=true`, which disables authentication and records
+everyone as `human:anonymous`. That is a development harness, not the
+small end of production.
+
+What is portable is the knowledge: `ochakai export` writes an OKF bundle
+of markdown and YAML that any OKF consumer can read, so leaving does not
+depend on the runtime you are leaving.
+
+### Does my data leave my project?
+
+No. ochakai reports nothing anywhere — there is no telemetry, and so
+nothing to opt out of. The only hosts it ever contacts are Google Cloud
+APIs you turn on yourself: Cloud SQL always, plus GCS if you set
+`OCHAKAI_GCS_BUCKET` and Vertex AI if you set `OCHAKAI_VERTEX_PROJECT`.
+With neither set, an instance talks to its database and nothing else.
+
+Usage counts are rows in your own database. They exist so a reviewer can
+see which knowledge is earning its place, and they never leave it.
+
+### How is this different from RAG over our documents?
+
+RAG retrieves passages from documents somebody wrote for other reasons;
+what comes back is as right as whatever was in the wiki. ochakai returns
+entries a human marked `verified`, with provenance saying who wrote it,
+who checked it and when, and a feed that resurfaces knowledge which has
+gone too long unchecked or came back wrong. The unit is a reviewed claim,
+not a chunk.
+
+The other difference is direction. A RAG index is built from documents; a
+knowledge base here is written *by the agents using it* and promoted by a
+human — the write-back loop is the product, and a rejected proposal keeps
+its reason so agents stop re-proposing it.
+
+### How is it different from a memory layer (mem0, Zep, Letta)?
+
+Memory layers extract per-user memories with an LLM and inject them back
+unaudited: nobody reviews what got remembered, and a wrong memory persists
+quietly. ochakai is team-shared knowledge that passes through human
+review. They compose — preferences in your memory layer, verified data
+knowledge here.
+
+### Do I need embeddings?
+
+No. Search is lexical by default and calls no external API. Turn
+embeddings on (`OCHAKAI_VERTEX_PROJECT`) when your knowledge base is in
+Japanese, when questions arrive as sentences rather than keywords, or
+when you attach images and PDFs you want searchable by content.
+
+The reason Japanese is called out: PostgreSQL's full-text search does not
+tokenize it, so a Japanese query is matched by two-character windows
+against a stored haystack. That finds the right entry for a term, but it
+is a bag of words, and it is answered by scanning rather than from an
+index — about 16 ms across 5000 entries.
+
+### Can an agent overwrite or delete knowledge a human verified?
+
+Not over MCP. `create_knowledge`, `update_knowledge` and
+`delete_knowledge` all refuse an entry whose status is `verified`,
+`rejected` or `deprecated`, and the refusal says what to do instead:
+
+> cannot update metrics/revenue from this surface: it is verified, and
+> this surface has no If-Match precondition to replace curated knowledge
+> safely. If it is wrong, say so with report_outcome failed — that puts it
+> in the re-verification feed. If you have something better,
+> create_knowledge a new draft. A human changes curated entries from the
+> web UI or CLI.
+
+This is not authorization — a human on the same deployment can edit
+anything from REST, the CLI or the web UI. It is a surface rule: MCP has
+no way to carry the `If-Match` precondition that makes a safe replacement
+expressible (design docs 0015 §3.1, 0030). Reviving a curated entry's
+tombstone with `create` is refused on MCP for the same reason: it would
+put a fresh draft where a rejection's recorded reason used to be. On REST
+and the CLI that revival is allowed — those are the surfaces a human
+curates from.
+
+### What happens when two people edit the same entry?
+
+Last write wins, unless the client asks for better. Every `GET` and `PUT`
+returns an `ETag` — the entry's `updated_at` as a quoted RFC3339 stamp,
+e.g. `"2026-07-27T14:55:19.865822Z"` — and a `PUT` carrying `If-Match`
+with a stale value gets `412` and writes nothing (design doc 0030). MCP
+exposes no version field but uses the same mechanism internally to protect
+curated entries.
+
+### Who can read and write?
+
+Anyone who can reach the deployment. ochakai identifies the caller from
+what Cloud Run forwards, records it as provenance, and does no
+authorization at all — no roles, no per-entry permissions, no read-only
+users. Deciding who may reach it is Cloud Run IAM's job, and running the
+service publicly invokable is a misconfiguration rather than a deployment
+mode (design doc 0002).
+
+If you need a deployment that serves knowledge without changing it, that
+is `OCHAKAI_READ_ONLY` (design doc 0040) — a property of the deployment,
+not of the caller. It refuses the operator too.
+
+### What happens to my knowledge if I stop using ochakai?
+
+`ochakai export ./knowledge` writes the whole base as an OKF v0.2 bundle:
+one markdown file per entry with YAML frontmatter, attachments as plain
+files beside them, trust and lifecycle in the spec's own keys. It is a
+git-friendly directory that another OKF consumer reads without knowing
+ochakai exists. `ochakai import` is the inverse, and it accepts any
+producer's bundle, not just ours.
+
+Provenance is the one thing that does not travel: it is what an instance
+observed, not a claim a document can carry, so an import records the
+importer rather than replaying history (design doc 0009).
+
+### Is there a hosted version?
+
+No. ochakai is self-hosted per tenant; there is no service to sign up for
+today.
+
+### Does it connect to my warehouse, or run SQL?
+
+Neither. ochakai holds no warehouse credentials and executes nothing. It
+stores the sanctioned computation — the SQL in a `# Computation` fence,
+the contract in `runtime` / `parameters` / `executor` / `attester` — and
+hands it back verbatim. Your agent runs it. Even for an Attested
+Computation, which names how a run can be checked, ochakai records the
+contract and never fetches or executes any part of it.
+
+### How large a knowledge base does this hold?
+
+Nobody has measured a ceiling, and the honest answer is that ochakai is
+built for the scale a *curated* base reaches — thousands of entries, not
+millions, because every one of them passed a human. The only published
+figure is the search cost quoted above (about 16 ms per Japanese search
+across 5000 entries, against 0.2 ms for a latin word). If you are
+planning a deployment materially larger than that, say so in
+[Discussions](https://github.com/na0fu3y/ochakai/discussions) — it is the
+kind of thing that should be measured before it is promised.
+
+### Can I try it without installing a Go toolchain?
+
+Yes, two ways. Take a
+[release archive](https://github.com/na0fu3y/ochakai/releases) — linux,
+macOS and Windows on amd64 and arm64, with checksums and build provenance
+— or skip the client entirely and talk to the REST API, which is all the
+CLI does. The README's [Requirements](../README.md#requirements) section
+has a `curl` that creates an entry.
+
+### What is an "entry", exactly?
+
+One markdown document with YAML frontmatter, addressed by a path-like id
+(`queries/sales/monthly-revenue`). The id is the address and the type is
+an attribute, not a directory (design doc 0017). Relationships come from
+ordinary markdown links in the body — there is no links field to fill in
+(design doc 0024) — and a `title` is optional, because the last segment of
+the id already names the entry (design doc 0022).

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -1,0 +1,158 @@
+# Troubleshooting
+
+Symptoms on the local and client side. Google Cloud symptoms — the GFE
+intercepting `/healthz`, `NOT_AUTHORIZED`, IAM propagation delays — are
+[§7 of the deploy guide](../../deploy/cloudrun/README.md). MCP clients
+that will not connect at all are in
+[Connecting an MCP client](mcp-clients.md).
+
+Start with `ochakai whoami`. It prints the whole client-side situation in
+four lines — which server, from where that choice came, as whom, and
+whether the server answers:
+
+```
+server:    http://localhost:8080 ($OCHAKAI_URL)
+identity:  human:anonymous (plain http, no credentials)
+health:    ok
+mode:      read-write
+```
+
+## The CLI
+
+**`ochakai: unknown command "--url"`.** Flags go after the subcommand, not
+before it: `ochakai whoami --url http://localhost:8080`, never
+`ochakai --url … whoami`. The first word after `ochakai` is always a
+command.
+
+**`health: error: … connect: connection refused`.** The server named on
+the `server:` line is not listening. That line also says where the choice
+came from — `$OCHAKAI_URL`, `--url`, or the `ochakai use` selection — which
+is usually the actual bug: a shell that still exports `OCHAKAI_URL` from an
+earlier session overrides `ochakai use` every time.
+
+**Writes fail with 403 and `mode:` says `read-only`.** The deployment sets
+`OCHAKAI_READ_ONLY`. Every write is refused, including yours as the
+operator; it is a property of the deployment, not of the caller.
+
+## Search
+
+**`search needs a query`, HTTP 400.** A search wants either a query or a
+`sort` that lists without one (`verified_at`, `usage`, `failed`,
+`stale_after`), or a `--source` to list what cites a resource. Listing
+everything is deliberately not a mode.
+
+**Search returns nothing on a base that has entries.**
+
+- *A Japanese query of only hiragana returns no hits.* The lexical half
+  cuts Japanese into two-character windows and keeps only the ones
+  carrying a kanji or katakana, because an all-hiragana window is grammar
+  and would match nearly everything. Search for the noun, not the
+  particle — or turn embeddings on.
+- *An English question returns the wrong entries.* Lexical search is a bag
+  of words: an entry sharing three function words can outrank the one that
+  names the subject. This is the case embeddings fix
+  (`OCHAKAI_VERTEX_PROJECT`).
+- *Nothing matches a term you know is stored.* Rejected and soft-deleted
+  entries are excluded from default search, and `--status` narrows
+  further. Drop the filters before concluding the entry is missing.
+- *Embeddings are on but ranking did not change.* Vectors are written when
+  an entry is written, so entries that predate the setting have none. Run
+  `ochakai reembed`.
+
+**Scores look meaningless.** They are an ordering, not a measure, and they
+are not comparable between the lexical and hybrid modes. To bound a
+response, use `budget` rather than a score floor.
+
+## Writing entries
+
+**409 on create.** A live entry already has that id — including a
+`rejected` one. Use `update`, or pick another id. Creating over a
+*soft-deleted* entry revives it, with its prior history intact; over MCP,
+reviving one that was verified, rejected or deprecated before deletion is
+refused instead, because it would put a fresh draft where a recorded
+ruling used to be. REST and the CLI allow that revival: they are the
+surfaces a human curates from.
+
+**404 on update.** `update` replaces an entry that exists; it does not
+create one.
+
+**412 on update.** The `If-Match` you sent is not the entry's current
+`ETag` — somebody wrote in between. Re-read the entry, reapply your change
+and retry. Nothing was written.
+
+**`invalid type "…"`.** A type is one line, no `/`, up to 128 bytes. Any
+value that fits is legal — the recommended vocabulary is a recommendation,
+not a closed set — but a multi-line string is not.
+
+**An agent gets `cannot update … it is verified`.** Working as intended:
+MCP refuses to overwrite or delete curated entries. See the
+[FAQ](../faq.md#can-an-agent-overwrite-or-delete-knowledge-a-human-verified).
+
+## Import and export
+
+**`import` reports files skipped.** Every skip is printed to stderr with a
+`skip:` prefix and counted in the summary
+(`imported N entries (… , M skipped)`). The reasons:
+
+- the file has no `type` in its frontmatter — the type is never inferred
+  from the path (design doc 0017);
+- it is a reserved `index.md` or `log.md`, or a hidden path;
+- the server rejected it, in which case the message carries the server's
+  own complaint, and the rest of the bundle still imports;
+- it is an attachment whose entry was not imported.
+
+**Everything imported one directory deeper than expected.** The packed
+shape is the structure: an archive wrapped in a single directory imports
+under that directory, so a bundle keeps its own namespace. That is
+deliberate — unwrap the archive first if you did not want it.
+
+**Import says `unchanged`.** Entries identical to what is stored are left
+alone rather than rewritten, so a re-import does not fill the revision
+history with copies.
+
+## Attachments
+
+**501 on attach.** The instance has no `OCHAKAI_GCS_BUCKET`, so it stores
+markdown entries only. This is a whole-deployment setting, not a
+per-request one.
+
+**A file is refused.** The media type is decided by sniffing the bytes,
+never by what the client claims: png, jpeg, webp, pdf and plain text are
+accepted, and 5 MiB per file / 20 files per entry are the limits. HTML and
+SVG are refused on purpose — both can carry script into the web UI.
+
+**Attachment contents do not turn up in search.** Filenames match in every
+search, but contents join only when embeddings are on, and images and PDFs
+need a file-capable model (`gemini-embedding-2`, with
+`OCHAKAI_VERTEX_LOCATION` set to `global`, `us` or `eu`). Attachments that
+predate the setting are not backfilled — `ochakai reembed`.
+
+## The web UI
+
+**The UI is empty though the API has entries.** `ochakai ui` serves the UI
+against the server *it* selected, which is not necessarily the one your
+last curl went to. Its startup line and `ochakai whoami` both say which.
+
+**Edits are recorded as the wrong identity.** `ochakai ui` acts as you on
+loopback. A deployed `ochakai serve-ui` records the service account
+instead, unless `OCHAKAI_IAP_AUDIENCE` is set and the webui's service
+account is listed in the server's `OCHAKAI_DELEGATING_CALLERS`, which is
+what turns browser edits into `human:you via agent:webui-sa` (design doc
+0032).
+
+## Startup
+
+**The server refuses to start after an embedding change.** Changing
+`OCHAKAI_EMBEDDING_DIM` on a database that already holds vectors is
+refused rather than silently corrupting them. Put it back, or drop the
+vector tables and re-embed.
+
+**`pgvector extension is required for semantic search`.** The database
+user may not `CREATE EXTENSION`. Create `vector` once as an admin — the
+deploy guide's §3 bootstrap SQL does exactly this — or unset
+`OCHAKAI_VERTEX_PROJECT` and run lexical-only.
+
+**Logs say `attachments disabled` or `semantic search disabled`.** Those
+are the startup lines confirming which optional subsystems are off. They
+are informational, and they are the fastest way to check what a running
+instance actually has enabled.


### PR DESCRIPTION
## What and why

Closes #210. Documentation only; no Go changed.

Troubleshooting existed only as §7 of the deploy guide, and every symptom
in it is a Google Cloud one. Somebody whose `docker compose` came up and
whose search returns nothing had no page to land on.

**[docs/faq.md](docs/faq.md)** answers the questions the positioning
invites and the README answers only obliquely: can it run outside Google
Cloud, does anything leave your project, how it differs from RAG and from
a memory layer, do you need embeddings, what an agent may do to verified
knowledge, what happens when two people edit the same entry, who can read
and write, what leaving looks like, whether there is a hosted version, and
how large a knowledge base this holds — that last one answered with the
only measured figure that exists plus an admission that nothing else has
been measured, rather than a number invented for the occasion.

**[docs/guides/troubleshooting.md](docs/guides/troubleshooting.md)** is the
symptom half: the CLI, search, writing entries, import/export,
attachments, the web UI, startup. It routes Google Cloud symptoms to the
deploy guide and MCP connection failures to the client guide rather than
restating either.

`SUPPORT.md`'s "Before you ask" list and the docs index now point at both,
which is where somebody about to open a Discussion actually looks.

## Verified

Every behavior asserted was run against a server built from this branch
with `examples/demo` imported — none of it is recalled:

| Probe | Result |
|---|---|
| `GET /api/v1/knowledge` (no q, no sort) | `400 search needs a query` |
| `?q=なぜ` (hiragana only) | `{"hits":[]}` |
| `?sort=stale_after` alone | `200`, one overdue entry |
| `POST` over a live id | `409` |
| `PUT` a missing id | `404` |
| `PUT` with a stale `If-Match` | `412`, nothing written |
| `POST` with a multi-line type | `400`, quoting the one-line rule |
| `PUT /attachments/...` with no bucket | `501` |
| MCP `update_knowledge` on a verified entry | `isError`, with the refusal the FAQ quotes verbatim |
| `ochakai --url X whoami` | `unknown command "--url"` — flags go after the subcommand |
| `GET` an entry | `Etag: "2026-07-27T14:55:19.865822Z"` |

**One correction came out of that.** I had written that reviving a curated
entry's tombstone is refused, full stop. It is refused **on MCP only** —
deleting a `verified` entry over REST and re-creating it at the same id
succeeded and came back as a draft. Both documents now name the surface,
and say why the human surfaces are allowed to do it.

## Checks

- [x] `gofmt -l .` prints nothing; `go vet ./...`; `go test ./cmd/ochakai` — no Go changed
- [x] `CGO_ENABLED=0 go build -trimpath ./...`
- [x] golangci-lint and govulncheck report nothing
- [x] Behavior changes come with tests — n/a, documentation only

Every relative link in the new files resolves (checked programmatically;
the only miss in the whole set is the README's pre-existing
`[revenue](/metrics/revenue.md)`, which is a syntax example rather than a
link).

## Surfaces and contract

- [x] n/a — nothing changed on any surface
- [x] n/a

## Design docs

- [x] Alters no accepted decision. It writes down the consequences of
      0002, 0015 §3.1, 0017, 0022, 0024, 0030 and 0040 where somebody
      hitting them will look
- [x] Commit messages and code comments are in English

## Noticed while writing this

The server's own 400 for a query-less search still says
*"use sort=verified_at, usage, or failed"* — it never learned about
`stale_after` (0037) or `--source`. The CLI's equivalent message is
current. Small drift, fixed separately so this stays documentation-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
