### PR TITLE
Name every listing mode when refusing a query-less search

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -267,7 +267,7 @@ paths:
                 noQuery:
                   summary: Neither q nor sort was given
                   value:
-                    error: search needs a query; use sort=verified_at, usage, or failed to list entries without one
+                    error: search needs a query; use sort=verified_at|usage|failed|stale_after to list entries without one, or source=URI to list what cites a resource
     post:
       operationId: createKnowledge
       summary: Create a knowledge entry

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -541,7 +541,11 @@ func (s *Service) Search(ctx context.Context, query string, f store.Filter, limi
 	// query into fragments and gets none, so guard here — once, for
 	// every surface — and point the caller at the listing modes.
 	if strings.TrimSpace(query) == "" {
-		return nil, Invalidf("search needs a query; use sort=verified_at, usage, or failed to list entries without one")
+		// The modes come from domain.ListSorts rather than a sentence:
+		// this message named three of them for as long as there were
+		// three, and stale_after (design doc 0037) never reached it.
+		return nil, Invalidf("search needs a query; use sort=%s to list entries without one, "+
+			"or source=URI to list what cites a resource", strings.Join(domain.ListSorts, "|"))
 	}
 	hits, err := s.search(ctx, query, f, limit)
 	if err != nil {

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -137,6 +137,14 @@ func TestSearchOrListValidation(t *testing.T) {
 		!strings.Contains(err.Error(), "needs a query") {
 		t.Errorf("neither query nor sort: got %v, want a needs-a-query InvalidInputError", err)
 	}
+	// The way out of that error is a listing mode, so the message has to
+	// name all of them. It named three for as long as there were three.
+	_, err = s.SearchOrList(ctx, "", "", store.Filter{}, 0)
+	for _, sort := range domain.ListSorts {
+		if !strings.Contains(err.Error(), sort) {
+			t.Errorf("the needs-a-query message never mentions sort=%s: %v", sort, err)
+		}
+	}
 }
 
 // TestReportOutcomeValidation pins the input checks that run before any


### PR DESCRIPTION
## What and why

A search with neither a query nor a sort is a 400, and that message is
where the caller learns the way out of it:

```
search needs a query; use sort=verified_at, usage, or failed to list entries without one
```

It named three modes for as long as there were three. Design doc 0037
added `stale_after`, and the sentence — being a sentence — did not notice.
The CLI's equivalent message was rewritten at the time and is current;
this one, which is what every REST and MCP caller sees, was not.

The modes already live in one place, `domain.ListSorts` — it is what
`ValidListSort` and the invalid-sort error read. The message now joins
that list rather than restating it, so the next listing mode arrives in
the error for free. It also names the `source` filter, which this path
never mentioned at all:

```
search needs a query; use sort=verified_at|usage|failed|stale_after to list entries without one, or source=URI to list what cites a resource
```

`source=URI` rather than `source=<uri>` because `encoding/json` escapes
the angle brackets — the REST body would have read `<uri>`.
Checked, not assumed.

`TestSearchOrListValidation` now requires the message to mention every
`domain.ListSorts` value, so a mode that reaches the vocabulary without
reaching this sentence fails. The `noQuery` example in `api/openapi.yaml`
is updated to what the server actually returns.

Found while writing the troubleshooting guide (#223), where the way out of
this error had to be documented correctly.

## Verified

Against a server built from this branch:

```
GET /api/v1/knowledge      → 400 search needs a query; use sort=verified_at|usage|failed|stale_after
                                  to list entries without one, or source=URI to list what cites a resource
GET /api/v1/knowledge?q=%20 → the same (a whitespace-only query is no query)
```

## Checks

- [x] `gofmt -l .` prints nothing; `go vet ./...`; `go test -race ./...` (with the store integration DB)
- [x] `CGO_ENABLED=0 go build -trimpath ./...`
- [x] golangci-lint and govulncheck report nothing
- [x] Behavior changes come with tests — the guard is in `TestSearchOrListValidation`

## Surfaces and contract

- [x] `api/openapi.yaml`'s example matches what `internal/restapi` returns;
      `internal/mcpserver` and `internal/apiclient` surface the same
      service error unchanged. No endpoint or tool shape changed
- [x] The message reaches every surface that calls `SearchOrList`, which is
      the point — one sentence, not four

## Design docs

- [x] Alters no accepted decision. It makes 0037 §2.5's "the listing modes
      live in one list" true of one more copy
- [x] Commit messages and code comments are in English

No changelog entry: an error message gaining two accurate words is not
something an operator upgrading needs to plan for. Say the word if you
would rather it had one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
