### PR TITLE
Let one deployment be public because it believes nobody

### DIFF
--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -641,7 +641,25 @@ go run ./cmd/ochakai import examples/demo    # $OCHAKAI_URL from above
 
 Those ten entries are recorded as `human:you@your-org.example` — the last
 provenance this base will ever receive, and after the flip the only
-`created_by` any visitor sees.
+`created_by` any visitor sees. (The sequence has been rehearsed against a
+local server: import writable — 10 created, 0 skipped — then restart with
+`OCHAKAI_PUBLIC_READ_ONLY=true`, after which reads serve anonymously and
+every write is refused. Cloud Run adds only the IAM binding.)
+
+### Checking the flip landed
+
+The demo is the one deployment where a plain `curl` is supposed to work, so
+it is also the one you can verify without a proxy:
+
+```sh
+curl -s -o /dev/null -w '%{http_code}\n' "$OCHAKAI_URL/api/v1/knowledge?q=revenue"  # 200, no token
+curl -s -o /dev/null -w '%{http_code}\n' -X DELETE "$OCHAKAI_URL/api/v1/knowledge/queries/monthly-revenue"  # 403
+```
+
+200 without a token proves the public grant and `OCHAKAI_PUBLIC_READ_ONLY`
+both landed (before the flip this is Google's 401); 403 on the write proves
+the implied read-only. Sending a bogus `Authorization` header changes
+neither answer — that is the property, not a side effect.
 
 If you want the demo to show **hybrid search** (§4), turn embeddings on
 *before* the import: vectors are written when an entry is written, and

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -19,8 +19,8 @@ slightly more; pick what matches your latency needs. Teardown commands are
 at the bottom.
 
 **Prefer infrastructure as code?**
-[deploy/terraform](../terraform) stands up §1–§4b (and §5b's web UI) as a
-Terraform module, so a deployment can be reviewed as a diff, reproduced per
+[deploy/terraform](../terraform) stands up §1–§4b (plus §5b's web UI and
+§5d's demo posture) as a Terraform module, so a deployment can be reviewed as a diff, reproduced per
 environment, and destroyed cleanly. This guide stays the reference: it
 explains why each piece is shaped the way it is, and covers the parts the
 module deliberately leaves out — §5c, §6's org-policy guardrails, and §8's
@@ -238,10 +238,12 @@ How this works:
   `agent:<sa-email>`. Nothing to issue, rotate, or revoke.
 - **Never make the service publicly invokable (`allUsers`)** — the
   identity headers ochakai reads are only trustworthy behind Cloud Run's
-  IAM check.
-- No `allUsers` grant is needed anywhere, so this is compatible with —
-  and a good reason to keep — the Domain Restricted Sharing org policy
-  (`iam.allowedPolicyMemberDomains`).
+  IAM check. The single exception is a deployment that reads no identity
+  and writes nothing at all (§5d's demo); for anything you can write to,
+  this rule has no exception.
+- No `allUsers` grant is needed for this deployment, so it is compatible
+  with — and a good reason to keep — the Domain Restricted Sharing org
+  policy (`iam.allowedPolicyMemberDomains`).
 - With `OCHAKAI_DB_IAM_AUTH` the `OCHAKAI_DATABASE_URL` contains no
   password, so there is nothing secret in the environment variables.
   (If you use password auth instead, put the URL in Secret Manager with
@@ -557,6 +559,145 @@ Notes:
   the header too (as `via human:anonymous`), so a malformed header fails
   on your machine instead of on first deploy.
 
+## 5d. Optional: a public read-only demo (the one public posture)
+
+Everything above says never `allUsers`, and that stays true for every
+deployment anyone can write to. A demo is the exception, and it is an
+exception only because of what it gives up. Two settings, and the second
+implies the first:
+
+- **`OCHAKAI_READ_ONLY=true`** — the deployment changes no knowledge (design
+  doc 0040). Writes are 403, MCP does not offer the write tools at all, and
+  the web UI stops drawing buttons that would only fail. Useful on its own,
+  private, for a reference-only copy or for freezing a base during a
+  migration.
+- **`OCHAKAI_PUBLIC_READ_ONLY=true`** — the deployment reads no identity
+  (design doc 0041). The `Authorization` header is ignored: without Cloud Run
+  IAM in front its signature is unverifiable, and a forged unsigned token
+  would otherwise be believed. `X-Ochakai-On-Behalf-Of` is ignored. Every
+  caller is `human:anonymous`, and nothing returns 401. It **implies
+  read-only** — the server refuses to start if it would be publicly readable
+  and writable, so the dangerous half of "public" has no configuration.
+
+That is the whole trade: a service that believes nobody is safe to open,
+because it records nobody and writes nothing.
+
+### The ordering problem
+
+**A read-only deployment cannot be seeded.** `ochakai import` is a
+client-side loop over the ordinary write endpoints (§5) — there is no bulk
+import path that bypasses the refusal. So the sequence is always: deploy
+**writable and private**, import, then flip. Getting this backwards is the
+one way to end up with an empty demo and no way to fill it.
+
+**Terraform** — [deploy/terraform](../terraform) has both variables:
+
+```sh
+cd deploy/terraform
+# 1. Normal private deployment: public_read_only stays false.
+#    (invoker_members = ["user:you@your-org.example"] is enough for a demo.)
+terraform apply
+export OCHAKAI_URL=$(terraform output -raw service_url)
+# ... the one-time schema bootstrap, as always (module README) ...
+
+# 2. Seed it while it is still private and writable — see below.
+
+# 3. Flip. This sets OCHAKAI_PUBLIC_READ_ONLY and grants allUsers in the
+#    same apply; the module has no way to do one without the other.
+terraform apply -var public_read_only=true
+terraform output -raw demo_url
+```
+
+**gcloud** — deploy per §3 (private, `--no-allow-unauthenticated`), seed,
+then flip in this order:
+
+```sh
+# 1. Stop believing identities and stop writing, while still private.
+gcloud run services update ochakai --region=$REGION \
+  --update-env-vars=OCHAKAI_PUBLIC_READ_ONLY=true
+
+# 2. Only then open it.
+gcloud run services add-iam-policy-binding ochakai --region=$REGION \
+  --member=allUsers --role=roles/run.invoker
+```
+
+The order is the point: between the two commands the service is harmless, and
+the reverse order leaves a window in which a public ochakai still believes
+whatever `Authorization` header a stranger sends. As everywhere in this guide,
+`--update-env-vars` — `--set-env-vars` would wipe `OCHAKAI_DATABASE_URL`.
+
+### Seeding
+
+[examples/demo](../../examples/demo) is a ten-entry knowledge base built to be
+read: linked entries, mixed types, and enough usage for `sort=usage` to mean
+something. Import it while the service is still private, where you
+authenticate exactly as in §5 — the CLI resolves a Google ID token from your
+gcloud login, nothing special:
+
+```sh
+git clone --depth 1 https://github.com/na0fu3y/ochakai && cd ochakai
+go run ./cmd/ochakai import examples/demo    # $OCHAKAI_URL from above
+```
+
+Those ten entries are recorded as `human:you@your-org.example` — the last
+provenance this base will ever receive, and after the flip the only
+`created_by` any visitor sees.
+
+If you want the demo to show **hybrid search** (§4), turn embeddings on
+*before* the import: vectors are written when an entry is written, and
+`ochakai reembed` is itself a write, so it is refused once read-only is on.
+The demo bundle has no attachments, so §4b's bucket is not needed for it.
+
+### Cost
+
+The same shape as the table at the top of this guide — a demo is one Cloud
+Run service and one `db-f1-micro`, with nothing extra to pay for. One
+difference in kind, not in the numbers: Cloud Run is request-billed and the
+requests no longer come only from your organization. `--max-instances=1`
+(§3) is what keeps that bounded; leave it in place.
+
+### What you give up, and why that is acceptable
+
+- **No identity, at all.** Nothing about a visitor is known or recorded.
+  `created_by` / `updated_by` on anything written through a public service
+  would be a value the server invented — which is precisely why nothing can
+  be written. Provenance is most of what ochakai sells; a public demo does
+  not weaken it, it declines to pretend.
+- **Everything in the base is public.** There is no 401 anywhere, so the
+  entries, their revisions, and their authors' email addresses are on the
+  open internet. Put a demo bundle in it. Never point this posture at a real
+  knowledge base because "it is only read-only".
+- **Delegation is gone** (§5c) — an embedding application cannot forward its
+  users' identities here, because none of it would be believed.
+- **Domain Restricted Sharing rejects the `allUsers` binding** (§6, §7). It
+  should. Lift it for a dedicated demo project if you want one, not for the
+  organization.
+
+**The demo database still grows.** Usage telemetry — search hits and fetch
+counts (design doc 0029) — keeps recording under read-only on purpose: it is
+the server's own observation rather than a caller's write, and switching it
+off would freeze the `sort=usage` feed that a demo most wants to show (design
+doc 0040 §2.2). Two consequences: the 10 GB disk is a hard ceiling with
+auto-growth off (§2), so watch it on a demo that gets attention; and those
+counts are driven by anonymous strangers, so treat them as a public
+popularity signal, never as evidence about the knowledge.
+
+### Taking it back down
+
+Full teardown is §9. To retract just the posture and keep the deployment,
+reverse the order it was set in — the public grant goes first, so the service
+is never open while it is anything but read-only:
+
+```sh
+gcloud run services remove-iam-policy-binding ochakai --region=$REGION \
+  --member=allUsers --role=roles/run.invoker
+gcloud run services update ochakai --region=$REGION \
+  --remove-env-vars=OCHAKAI_PUBLIC_READ_ONLY
+```
+
+With Terraform, `terraform apply -var public_read_only=false` does both, in
+that order.
+
 ## 6. Security hardening checklist
 
 The default §1–§5 deployment is already secret-zero and least-privilege:
@@ -590,8 +731,11 @@ live by trying one: `gcloud sql instances patch ochakai
 fast — `--clear-authorized-networks` and try again).
 
 Keep Domain Restricted Sharing (`iam.allowedPolicyMemberDomains`) on at
-the org level; nothing in this guide needs `allUsers` — every service,
-the IAP-fronted webui included, stays `--no-allow-unauthenticated`.
+the org level; nothing in a working deployment needs `allUsers` — every
+service, the IAP-fronted webui included, stays
+`--no-allow-unauthenticated`. §5d's public demo is the one thing this
+policy blocks, and it is a fair trade: exempt a dedicated demo project if
+you want one, and leave the org policy alone.
 
 **Remove the reachable database endpoint**: §2b (private IP only).
 
@@ -693,8 +837,10 @@ doesn't work as written.
 
 - **`allUsers` binding fails with "do not belong to a permitted customer"**:
   the org enforces Domain Restricted Sharing
-  (`iam.allowedPolicyMemberDomains`). Nothing in this guide needs
-  `allUsers` (the webui goes behind IAP, §5b), so keep the policy on.
+  (`iam.allowedPolicyMemberDomains`). No normal deployment needs
+  `allUsers` (the webui goes behind IAP, §5b), so keep the policy on — if
+  you hit this while setting up §5d's demo, exempt that project rather
+  than the organization.
 - **`run.app` returns Google's HTML 404 ("That's an error") even though
   the service is Ready**: before suspecting infrastructure, test a real
   application endpoint (e.g. `/api/v1/knowledge?q=x`) and check request

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -44,15 +44,21 @@ Two consequences worth knowing before you read further:
 - Terraform therefore cannot run the one-time schema bootstrap SQL — doing so
   would mean holding a password. That step stays manual; see below.
 
-### Never publicly invokable
+### Never publicly invokable, with one named exception
 
-`invoker_members` refuses `allUsers` and `allAuthenticatedUsers`, and no
-resource here grants them. This is not just about access: ochakai does no
-authorization of its own and reads the caller identity Cloud Run has already
-verified in order to record provenance. Without the IAM check in front, those
-headers would be forgeable, and every recorded author would be a guess. The
-same rule keeps the deployment compatible with the Domain Restricted Sharing
-org policy.
+`invoker_members` refuses `allUsers` and `allAuthenticatedUsers`. This is not
+just about access: ochakai does no authorization of its own and reads the
+caller identity Cloud Run has already verified in order to record provenance.
+Without the IAM check in front, those headers would be forgeable, and every
+recorded author would be a guess. The same rule keeps the deployment
+compatible with the Domain Restricted Sharing org policy.
+
+The exception is `public_read_only` (guide §5d, design doc 0041), which grants
+`allUsers` itself. It is one variable rather than two because public is only
+safe together with what it comes with: the deployment refuses every write and
+reads no identity at all, so there is no provenance to forge and no author to
+get wrong. A public *writable* ochakai therefore has no spelling in this
+module — not a check to remember, a state with no representation.
 
 ## Usage
 
@@ -112,6 +118,8 @@ from then on — no password on that path either.
 | `enable_vertex_embeddings` | §4 | `roles/aiplatform.user` + `OCHAKAI_VERTEX_PROJECT`. Search becomes hybrid. Entries written before this was on stay unembedded until `ochakai reembed`. |
 | `enable_gcs_attachments` | §4b | Bucket + `roles/storage.objectUser` + `OCHAKAI_GCS_BUCKET`. Without it, attach operations return 501. |
 | `enable_webui` | §5b | `serve-ui` as a second Cloud Run service behind IAP, same image, dedicated identity. `webui_records_browser_user` (default on) records the person in the browser rather than the UI's service account. |
+| `read_only` | §5d | `OCHAKAI_READ_ONLY`. Serves the base without changing it; still private. Seed the base *before* turning it on — a read-only deployment cannot be imported into. |
+| `public_read_only` | §5d | `OCHAKAI_PUBLIC_READ_ONLY` + the module's only `allUsers` grant. The public demo: no account needed, no identity read, nothing writable (implies `read_only`). Apply writable, `ochakai import examples/demo`, then re-apply with this on. |
 | `maintenance_users` | §6 | Cloud SQL IAM logins for people, no passwords. |
 | `database_backups` | §6 | Daily backups. Off by default for cost; turn it on for anything you care about. |
 

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -12,11 +12,16 @@
 #     change to this module ever needs a generated credential, the change is
 #     wrong for this project (design docs 0002, 0003).
 #
-#   * The service is never publicly invokable. ochakai performs no
-#     authorization of its own: it reads the caller identity Cloud Run has
-#     already verified and records it as provenance. Those headers only mean
-#     something behind Cloud Run's IAM check, so allUsers would not merely
-#     widen access, it would make provenance forgeable.
+#   * The service is not publicly invokable, with exactly one exception.
+#     ochakai performs no authorization of its own: it reads the caller
+#     identity Cloud Run has already verified and records it as provenance.
+#     Those headers only mean something behind Cloud Run's IAM check, so
+#     allUsers would not merely widen access, it would make provenance
+#     forgeable. The exception is var.public_read_only (design doc 0041),
+#     which grants allUsers only together with the flag that makes the
+#     deployment refuse every write and stop reading identity altogether —
+#     there is then no provenance to forge and no author to get wrong. A
+#     public binding from anywhere else in this module is a bug.
 
 data "google_project" "this" {
   project_id = var.project_id
@@ -49,6 +54,13 @@ locals {
 
   iap_audience = "/projects/${data.google_project.this.number}/locations/${var.region}/services/${local.webui_name}"
 
+  # Public read-only implies read-only (design doc 0041): the server refuses
+  # to start if it would be publicly readable and writable. The module states
+  # the implication in the environment rather than leaving it to be
+  # discovered from a crash loop, so the deployed configuration reads the
+  # same way the posture does.
+  read_only = var.read_only || var.public_read_only
+
   server_env = merge(
     {
       # No password appears here, and none exists to appear. This is what
@@ -62,6 +74,8 @@ locals {
         "&user=${local.db_service_account_user}",
       ])
     },
+    local.read_only ? { OCHAKAI_READ_ONLY = "true" } : {},
+    var.public_read_only ? { OCHAKAI_PUBLIC_READ_ONLY = "true" } : {},
     var.enable_gcs_attachments ? { OCHAKAI_GCS_BUCKET = local.gcs_bucket_name } : {},
     var.enable_vertex_embeddings ? { OCHAKAI_VERTEX_PROJECT = var.project_id } : {},
     var.enable_vertex_embeddings && var.vertex_model != null ? { OCHAKAI_VERTEX_MODEL = var.vertex_model } : {},
@@ -402,9 +416,9 @@ resource "google_cloud_run_v2_service" "ochakai" {
   ]
 }
 
-# The only thing that decides who can reach ochakai. There is no allUsers
-# binding anywhere in this module, which is also what keeps the deployment
-# compatible with the Domain Restricted Sharing org policy.
+# The only thing that decides who can reach ochakai. allUsers cannot be named
+# here — the variable refuses it — which is also what keeps the default
+# deployment compatible with the Domain Restricted Sharing org policy.
 resource "google_cloud_run_v2_service_iam_member" "invokers" {
   for_each = toset(var.invoker_members)
 
@@ -413,6 +427,37 @@ resource "google_cloud_run_v2_service_iam_member" "invokers" {
   name     = google_cloud_run_v2_service.ochakai.name
   role     = "roles/run.invoker"
   member   = each.value
+}
+
+# The public read-only demo, and the only allUsers grant in this module
+# (design doc 0041). It is deliberately not something an operator can compose
+# out of parts: the same variable that opens the service is the one that makes
+# it refuse every write and stop reading identity, so "public" and "believes
+# nobody" cannot drift apart. A public writable ochakai would record authors
+# it has no way to know, which is worse than recording none.
+#
+# Domain Restricted Sharing (guide §6) rejects this binding, as it should —
+# a demo project is the place to lift it, not the org.
+resource "google_cloud_run_v2_service_iam_member" "public_demo" {
+  count = var.public_read_only ? 1 : 0
+
+  project  = var.project_id
+  location = var.region
+  name     = google_cloud_run_v2_service.ochakai.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+
+  lifecycle {
+    # Reads the environment the service actually carries rather than the
+    # variable that set it. Today the two cannot disagree; this exists for
+    # the edit that separates them, and it fails at plan time — an allUsers
+    # binding must never outlive the posture that justifies it, not even for
+    # the length of an apply.
+    precondition {
+      condition     = lookup(local.server_env, "OCHAKAI_PUBLIC_READ_ONLY", "") == "true"
+      error_message = "Refusing to grant allUsers: the service is not running with OCHAKAI_PUBLIC_READ_ONLY=true. Public is only safe while ochakai writes nothing and reads no identity (design doc 0041)."
+    }
+  }
 }
 
 # --- 5b. Optional: the team web UI behind IAP -----------------------------

--- a/deploy/terraform/outputs.tf
+++ b/deploy/terraform/outputs.tf
@@ -1,6 +1,26 @@
 output "service_url" {
-  description = "URL of the ochakai service. Not reachable without an identity: a plain curl gets Google's 401, which is the point."
+  description = "URL of the ochakai service. Not reachable without an identity: a plain curl gets Google's 401, which is the point — unless var.public_read_only is on, in which case see demo_url."
   value       = google_cloud_run_v2_service.ochakai.uri
+}
+
+output "demo_url" {
+  description = <<-EOT
+    The public read-only demo URL — anyone with this link can read the whole
+    knowledge base, with no Google account and no token — or null when
+    var.public_read_only is false. It is the same service as service_url; the
+    output exists so that "is this one public?" is answerable from
+    `terraform output` alone, without reading the IAM policy.
+  EOT
+  value       = var.public_read_only ? google_cloud_run_v2_service.ochakai.uri : null
+}
+
+output "posture" {
+  description = "One line naming what this deployment will and will not do, so that a flip between demo and normal shows up in the output diff as well as the plan."
+  value = (var.public_read_only
+    ? "public read-only: anyone with the URL can read; no identity is read, every caller is human:anonymous, and nothing can be written (design doc 0041)"
+    : local.read_only
+    ? "private read-only: only invoker_members can reach it, and nothing can be written (design doc 0040)"
+  : "private read-write: only invoker_members can reach it, and whoever reaches it can read and write everything (design doc 0002)")
 }
 
 output "use_command" {

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -32,6 +32,20 @@ invoker_members = [
 # enable_webui      = true
 # webui_iap_members = ["domain:your-org.example"]
 
+# Serve the base without changing it: every write is a 403, MCP hides the
+# write tools, the UI stops drawing buttons that would only fail. Still
+# private, still records who reached it. Note the ordering — a read-only
+# deployment cannot be seeded, so import first and set this afterwards.
+# read_only = true
+
+# The public read-only demo, and the only posture in which this module grants
+# allUsers (guide §5d, design doc 0041). Anyone with the URL reads the base
+# with no Google account. Safe only because of what comes with it: writes are
+# refused (this implies read_only) and no identity is read at all — the
+# Authorization header is ignored, every caller is human:anonymous. Do not use
+# it to share a real knowledge base; deploy writable, import, then flip.
+# public_read_only = true
+
 # People who need to connect to the database directly for maintenance. They
 # get an IAM login (cloud-sql-proxy --auto-iam-authn), never a password.
 # maintenance_users = ["you@your-org.example"]

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -69,9 +69,59 @@ variable "invoker_members" {
     # behind Cloud Run's IAM check. A public service would let any caller
     # claim to be anyone, so this state is made unrepresentable rather than
     # merely discouraged (deploy/cloudrun/README.md §3).
+    #
+    # There is exactly one posture where public is intended, and it is not
+    # reachable from here: var.public_read_only grants allUsers itself, and
+    # only together with the flag that stops the service believing anyone.
+    # Keeping the two in one variable is what makes "public and writable"
+    # unrepresentable instead of merely checked.
     condition     = !contains(var.invoker_members, "allUsers") && !contains(var.invoker_members, "allAuthenticatedUsers")
-    error_message = "ochakai must never be publicly invokable: its provenance headers are only trustworthy behind Cloud Run IAM. Grant a domain, group, user or service account instead."
+    error_message = "ochakai must never be publicly invokable by naming it here: its provenance headers are only trustworthy behind Cloud Run IAM. Grant a domain, group, user or service account instead — or, for the public read-only demo, set public_read_only = true, which grants allUsers itself and only alongside OCHAKAI_PUBLIC_READ_ONLY (deploy/cloudrun/README.md §5d)."
   }
+}
+
+# --- Posture: read-only, and the one intended public deployment -----------
+
+variable "read_only" {
+  description = <<-EOT
+    Serve the knowledge base without changing it (OCHAKAI_READ_ONLY, design
+    doc 0040): every write is a 403, MCP does not offer the write tools at
+    all, and the web UI stops drawing buttons that would only fail. For a
+    reference-only instance, or for freezing a base during a migration or an
+    audit. The service stays private and still records who reached it; this
+    is not the public demo below.
+
+    It is not authorization — it does not look at the caller, and it refuses
+    the operator too. Note the ordering it forces: a read-only deployment
+    cannot be seeded, so import first and set this afterwards
+    (deploy/cloudrun/README.md §5d).
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "public_read_only" {
+  description = <<-EOT
+    The public read-only demo (OCHAKAI_PUBLIC_READ_ONLY, design doc 0041).
+    This is the one posture where a publicly invokable ochakai is intended:
+    the module grants allUsers roles/run.invoker, so anyone with the URL can
+    read the base with no Google account and no token.
+
+    It is safe only because of the two things it gives up at once, and they
+    are one variable for that reason. Nothing can be written: this implies
+    var.read_only, and the server refuses to start if it would be publicly
+    readable and writable. And no identity is believed: the Authorization
+    header is not read at all — its signature is unverifiable without Cloud
+    Run IAM in front — X-Ochakai-On-Behalf-Of is ignored, and every caller is
+    human:anonymous. Provenance would be forgeable on a public service, so
+    none is read; nothing is written, so there is none to record.
+
+    Everything else in this module stays private. Do not reach for this to
+    "share a knowledge base more easily": for anything but a demo or a
+    reference-only copy, Cloud Run IAM is the answer.
+  EOT
+  type        = bool
+  default     = false
 }
 
 variable "delegating_callers" {


### PR DESCRIPTION
Terraform support and a guide section for the public read-only demo, so an
evaluator can try ochakai without deploying it.

**Depends on `OCHAKAI_PUBLIC_READ_ONLY` landing first** (branch
`claude/demo-posture`, design doc 0041). Nothing here works until that flag
exists: this PR only sets the environment variable and grants the IAM
binding. Merge that one first.

## Terraform

- `public_read_only` (default false) sets `OCHAKAI_PUBLIC_READ_ONLY=true` and
  grants `allUsers` `roles/run.invoker` — the only `allUsers` grant in the
  module.
- `read_only` (default false) sets `OCHAKAI_READ_ONLY=true` for the private
  reference-only case (0040). `public_read_only` implies it, in the module as
  well as in the server.
- Outputs: `demo_url` (null unless public), and `posture` — one line naming
  what the deployment will and will not do, so a flip shows up in the output
  diff too.

### How the unsafe state stays unrepresentable

The module pins `required_version = ">= 1.5.0"`, so cross-variable
`validation` (Terraform ≥1.9) is not available. Rather than pick a weaker
check, the guard is structural: `invoker_members` keeps its existing refusal
of `allUsers`/`allAuthenticatedUsers` (message now points at
`public_read_only`), and the public binding is a separate resource created
only by `public_read_only` — the same variable that sets the flag. **A public
writable ochakai has no spelling in this module**, so there is no combination
of inputs to reject.

On top of that, the public binding carries a `lifecycle.precondition` that
reads the environment the service actually carries, not the variable that set
it. It cannot fail today; it exists so that a future edit separating the
binding from the flag fails at plan time.

## Guide (§5d)

Covers the demo end to end, led by the ordering problem: `import` is a
client-side loop over the write endpoints, so a read-only deployment cannot
be seeded — deploy writable and private, import `examples/demo`, then flip.
Exact sequences for both Terraform and gcloud, and for gcloud the flip order
matters (flag first, then the binding: the reverse leaves a window where a
public ochakai still believes a stranger's `Authorization` header).

Also states what a public demo gives up — no identity, so `created_by` on
anything written there would be invented, which is exactly why nothing can be
written — and warns that the database still grows, because usage telemetry
keeps recording under read-only on purpose (0040 §2.2), on a 10 GB disk with
auto-growth off and with counts driven by anonymous strangers.

Cost is stated as the same shape as the guide's existing table rather than
new numbers, with one difference in kind noted: the request-billed half is no
longer bounded by your organization, and `--max-instances=1` is what bounds
it.

Three existing spots that said "nothing in this guide needs `allUsers`" (§3,
§6, §7) are qualified rather than left to contradict §5d.

## Validated vs reviewed by eye

Ran, with Terraform v1.5.6:

- `terraform fmt -check -recursive deploy/terraform` — clean.
- `terraform init -backend=false` + `terraform validate` — passes on the
  baseline and on the final tree.
- `terraform plan` on a scratch copy with `invoker_members = ["allUsers"]` —
  fails with the variable validation error at plan time. (The same plan also
  errors on credentials; note that `terraform validate` in 1.5 ignores
  variable values entirely, so this guard is plan-time, as it was before.)
- The demo posture cannot be planned against the real module without GCP
  credentials, so the guard logic was exercised in a **provider-free scratch
  module** (variables + locals + a `terraform_data` carrying the same
  precondition): defaults produce no public binding and no read-only vars;
  `public_read_only=true` produces one binding plus
  `OCHAKAI_PUBLIC_READ_ONLY=true` **and** `OCHAKAI_READ_ONLY=true`;
  `read_only=true` produces the read-only var and no binding; and a simulated
  edit that grants the binding without the flag fails the precondition at
  plan time.

Reviewed by eye, not executed: every `gcloud` command in §5d, the Cloud Run
plan output for the demo posture, and the two verification `curl`s. The
seeding order itself is not guesswork — it was rehearsed against a local
server (import writable, 10 created / 0 skipped, restart public read-only,
reads anonymous and writes refused); only the Cloud Run IAM binding on top is
untested.

**Nothing was applied.** No `terraform apply`, no `terraform import`, and no
`gcloud` command that creates, modifies or deletes anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)