### PR TITLE
Read the completion flag check from the commands, not a copy of them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,14 @@ last entry.
   `--source` did not exist. The sort values now come from
   `domain.ListSorts`, so a new one fails the test until every script
   offers it.
+- The per-command flag list itself is no longer transcribed: it is read
+  from the commands' own FlagSets, so a flag cannot be missing from the
+  completions and from the list that checks them at the same time — which
+  is how `--source` stayed invisible for two releases with every test
+  passing. Adding a flag to a client command now fails the test until
+  zsh, bash and fish all offer it. `ochakai mcp-stdio --url`, which fish
+  had never offered because that command was absent from the old list
+  altogether, is the first thing this caught.
 
 ## [0.14.0] - 2026-07-27
 

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -76,8 +76,17 @@ var errReported = errors.New("usage error")
 // beside it (cmd/ochakai/clidocs_test.go).
 var helpOutput io.Writer = os.Stderr
 
-func newBareFlagSet(synopsis, examples string) *flag.FlagSet {
-	fs := flag.NewFlagSet("", flag.ContinueOnError)
+// commandFlagSets holds the FlagSet each command built, keyed by the
+// command name it was created under. Nothing at runtime reads it: it is
+// how the completion test enumerates what flags a command really has.
+// Every command registers its flags inside its own body, so they exist
+// only once the command has run — and a hand-copied list of them is
+// exactly what let `ochakai search --source` ship missing from all three
+// completion scripts.
+var commandFlagSets = map[string]*flag.FlagSet{}
+
+func newBareFlagSet(name, synopsis, examples string) *flag.FlagSet {
+	fs := flag.NewFlagSet("ochakai "+name, flag.ContinueOnError)
 	fs.SetOutput(helpOutput)
 	fs.Usage = func() {
 		fmt.Fprintf(fs.Output(), "%s\n\nFlags:\n", synopsis)
@@ -86,11 +95,12 @@ func newBareFlagSet(synopsis, examples string) *flag.FlagSet {
 			fmt.Fprintf(fs.Output(), "\nExamples:\n%s", examples)
 		}
 	}
+	commandFlagSets[name] = fs
 	return fs
 }
 
-func newFlagSet(synopsis, examples string) (*flag.FlagSet, *string) {
-	fs := newBareFlagSet(synopsis, examples)
+func newFlagSet(name, synopsis, examples string) (*flag.FlagSet, *string) {
+	fs := newBareFlagSet(name, synopsis, examples)
 	url := fs.String("url", defaultURL(), "ochakai server URL (default: $OCHAKAI_URL, else the `ochakai use` selection)")
 	return fs, url
 }
@@ -191,6 +201,7 @@ func parseRef(s string) (string, error) {
 
 func cmdSearch(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
+		"search",
 		"Usage: ochakai search [flags] [query]\n\nSearch the knowledge base; verified entries rank higher.\nOutput: score, uri, status, title — description (one hit per line).\nWith --sort verified_at the command lists by verification age instead\nof searching (oldest first, never-verified last — the\ncanary feed); output leads with verified_at. With --sort usage it lists\nby demand (most search_hits first, never-used oldest-first at the bottom\n— the draft review feed); output leads with the search_hits count.\nWith --sort failed it lists entries whose failure reports (report_outcome\nfailed) are still unanswered, worst first — the re-verification feed;\noutput leads with the failed count. `ochakai verify` takes an entry out\nof it, so a base that is kept up shows an empty feed.\nWith --sort stale_after it lists entries whose declared stale_after has\npassed, most overdue first; output leads with that date. Verifying does\nnot empty this one — the date is the writer's declaration, so clearing it\nmeans editing the entry to re-declare an expiry.\n--source and --prefix are filters, not modes: both combine with a query\nor with any --sort. --source narrows to the entries citing one resource\n(the reverse of sources[].resource); --prefix narrows to the entries\nliving under a path, which is how a team's own knowledge is told apart\nfrom the company-wide vocabulary.",
 		"  ochakai search \"gross margin\" --type Metric --type 'Glossary Term' --status verified\n  ochakai search churn --json | jq '.hits[0].attrs'\n  ochakai search --sort verified_at --type 'Attested Computation' --status verified --limit 100\n  ochakai search --sort usage --status draft --limit 50   # review queue\n  ochakai search --sort failed --status verified            # re-verification queue\n  ochakai search --sort stale_after                         # past their declared expiry\n  ochakai search --source https://wiki.example/finance/revenue-recognition  # what cites this\n  ochakai search 活性化 --prefix teams/growth --prefix company   # our scope and the shared one\n")
 	var types, statuses, tags, prefixes repeated
@@ -258,6 +269,7 @@ func cmdSearch(ctx context.Context, args []string) error {
 
 func cmdBrowse(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
+		"browse",
 		"Usage: ochakai browse [flags] [prefix]\n\nList one level of the ID hierarchy (the folder view of design docs\n0014 and 0017, the CLI counterpart of the web UI's Browse tab).\nWithout an argument, the top-level directories with their entry\ncounts; with a prefix, the subdirectories and entries directly under\nit. Directories print as \"name/\tcount\", entries as\n\"segment\ttype\tstatus\ttitle\". Rejected entries are hidden, as in search.",
 		"  ochakai browse\n  ochakai browse queries\n  ochakai browse ga4/tables\n")
 	asJSON := fs.Bool("json", false, "print the raw JSON response")
@@ -303,6 +315,7 @@ func cmdBrowse(ctx context.Context, args []string) error {
 
 func cmdContext(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
+		"context",
 		"Usage: ochakai context [flags] <question>\n\nGather what to read before answering a data question, in one call:\nthe full entries behind the top search hits (verified entries rank\nhigher), expanded one hop through links so the insight explaining a\nmetric travels with it. Markdown on stdout, ready for an agent's\ncontext window. No hits print nothing (exit 0).",
 		"  ochakai context \"why did revenue drop in March?\"\n  ochakai context \"monthly revenue\" --type 'Attested Computation' --status verified --json\n  ochakai context \"$PROMPT\" --budget 4000   # hooks: cap the injected bytes\n  ochakai context \"activation rate\" --prefix teams/growth --prefix company\n")
 	var types, statuses, tags, prefixes repeated
@@ -437,6 +450,7 @@ func renderEntry(k *domain.Knowledge) string {
 
 func cmdUsage(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
+		"usage",
 		"Usage: ochakai usage [flags] <id>\n\nShow how often an entry was actually used: appeared in search results,\nfetched individually, reported worked or failed — and when it was last\nused. The measure of the write-back loop: evidence for promoting a\ndraft, and a staleness signal for verified entries nobody uses.",
 		"  ochakai usage queries/monthly-revenue\n  ochakai usage metrics/revenue --json\n")
 	asJSON := fs.Bool("json", false, "print JSON")
@@ -466,6 +480,7 @@ func cmdUsage(ctx context.Context, args []string) error {
 
 func cmdReport(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
+		"report",
 		"Usage: ochakai report [flags] <id> <worked|failed>\n\nReport whether acting on an entry gave a correct result — the last\nedge of the write-back loop. After running an attested computation or SQL you\nwrote from an entry, report worked or failed (say what went wrong with\n--note); failed counts against verified entries flag them for\nre-verification. Prints the entry's updated usage totals.",
 		"  ochakai report queries/monthly-revenue worked\n  ochakai report queries/monthly-revenue failed --note \"joins dropped 2024 rows after schema change\"\n")
 	note := fs.String("note", "", "context recorded with the report: what was run, what went wrong (max 2000 bytes)")
@@ -491,6 +506,7 @@ func cmdReport(ctx context.Context, args []string) error {
 
 func cmdRevisions(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
+		"revisions",
 		"Usage: ochakai revisions [flags] <id>\n\nList an entry's change history, newest first: who changed it, how,\nand when — the audit surface behind \"every change kept as a\nrevision\". Works for soft-deleted entries too. Full snapshots are in\nthe JSON output (--json).",
 		"  ochakai revisions metrics/revenue\n  ochakai revisions queries/monthly-revenue --json | jq '.revisions[0].snapshot'\n")
 	limit := fs.Int("limit", 0, "max revisions (server default 50, max 200)")
@@ -519,6 +535,7 @@ func cmdRevisions(ctx context.Context, args []string) error {
 
 func cmdBacklinks(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
+		"backlinks",
 		"Usage: ochakai backlinks [flags] <id>\n\nList live entries whose links point at this entry, most recently\nupdated first — the reverse edge the web UI shows as \"linked from\"\n(context already follows it when packing companions).\nOutput: uri, status, title — description (one entry per line).",
 		"  ochakai backlinks metrics/revenue\n  ochakai backlinks metrics/revenue --json | jq '.entries[].id'\n")
 	limit := fs.Int("limit", 0, "max entries (server default 20, max 100)")
@@ -551,6 +568,7 @@ func cmdBacklinks(ctx context.Context, args []string) error {
 
 func cmdGet(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
+		"get",
 		"Usage: ochakai get [flags] <id>\n\nPrint one knowledge entry as an OKF document (YAML frontmatter +\nmarkdown body). The output round-trips through `ochakai update`.\nAttachment metadata is listed on stderr; --download saves the\nattachment files themselves (an agent can then read them from disk).",
 		"  ochakai get metrics/revenue\n  ochakai get queries/monthly-revenue --json | jq -r '.attrs.sql'\n  ochakai get insights/revenue-reading --download ./img\n")
 	asJSON := fs.Bool("json", false, "print JSON instead of the OKF document")
@@ -604,6 +622,7 @@ func cmdGet(ctx context.Context, args []string) error {
 
 func cmdAttach(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
+		"attach",
 		"Usage: ochakai attach [flags] <id> <file...>\n\nAttach files to a knowledge entry (png, jpeg, webp, pdf, plain\ntext — the type is sniffed from the bytes; max 5 MiB each, 20 per\nentry). An attachment of the same name is replaced (the change is kept\nas a revision). Reference the file from the entry's body so its\ncaption is searchable and it survives OKF export/import — the hint\nprinted after attaching shows the canonical relative link. Requires\nthe server to have GCS configured (OCHAKAI_GCS_BUCKET).",
 		"  ochakai attach insights/revenue-reading weekly.png\n  ochakai attach tables/orders seeds.txt\n  ochakai attach tables/orders er-diagram.png --name schema.png\n")
 	name := fs.String("name", "", "attachment name (default: the file's basename; single file only)")
@@ -658,6 +677,7 @@ func cmdAttach(ctx context.Context, args []string) error {
 
 func cmdDetach(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
+		"detach",
 		"Usage: ochakai detach [flags] <id> <name>\n\nRemove an attachment from a knowledge entry (the change is kept as a\nrevision; content-addressed bytes stay referenced by history).",
 		"  ochakai detach insights/revenue-reading weekly.png\n")
 	id, rest, err := idArgs(fs, args, 2)
@@ -677,6 +697,7 @@ func cmdDetach(ctx context.Context, args []string) error {
 
 func cmdCreate(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
+		"create",
 		"Usage: ochakai create [flags] [id]\n\nCreate a knowledge entry from -f or stdin. Input is an OKF document\n(--- frontmatter with type, markdown body — the format `ochakai get`\nprints; title is optional, the id's last segment is the display name\nwhen it is absent) or JSON (see api/openapi.yaml). The id is the\nentry's path; pass it as the argument (it overrides an id in the\ninput, and OKF documents carry none — the path is the id). Entries\ndefault to draft; provenance is recorded from your Google identity.",
 		"  ochakai get insights/revenue-seasonality | sed s/40%/45%/ | ochakai create insights/revenue-seasonality-v2\n  ochakai create runbook/restore -f entry.md\n")
 	file := fs.String("f", "", "input file (default: stdin)")
@@ -721,6 +742,7 @@ func cmdCreate(ctx context.Context, args []string) error {
 
 func cmdUpdate(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
+		"update",
 		"Usage: ochakai update [flags] <id>\n\nReplace a knowledge entry from -f or stdin (OKF document or JSON;\nthe id comes from the argument, the type from the input). Every\nchange is kept as a revision server-side. With --if-match the update\nis conditional: it lands only if the entry still has the version you\nread, and fails instead of overwriting someone else's edit.",
 		"  ochakai get metrics/revenue | $EDITOR /dev/stdin | ochakai update metrics/revenue\n  ochakai update metrics/revenue -f revenue.md\n  ochakai update metrics/revenue -f revenue.md --if-match \"$(ochakai get metrics/revenue --json | jq -r .updated_at)\"\n")
 	file := fs.String("f", "", "input file (default: stdin)")
@@ -764,6 +786,7 @@ func cmdUpdate(ctx context.Context, args []string) error {
 // an unchanged payload writes nothing and verified_at is carried over.
 func cmdVerify(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
+		"verify",
 		"Usage: ochakai verify [flags] <id>\n\nRecord a verification against the entry as it stands: you become\nverified_by and verified_at is stamped now. Promotes a draft, and\nre-affirms an entry that is already verified — which is what takes it\nout of both review feeds (--sort verified_at, --sort failed). Verifying\na rejected entry clears the rejection: the status becomes verified and\nrejected_by/rejected_at are dropped (the revision history keeps both).",
 		"  ochakai verify metrics/revenue\n  ochakai verify metrics/revenue --json | jq -r .verified_at\n")
 	asJSON := fs.Bool("json", false, "print the verified entry as JSON")
@@ -788,6 +811,7 @@ func cmdVerify(ctx context.Context, args []string) error {
 
 func cmdDelete(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
+		"delete",
 		"Usage: ochakai delete [flags] <id>\n\nSoft-delete a knowledge entry (history is retained server-side).",
 		"  ochakai delete terms/obsolete-kpi\n")
 	id, _, err := idArgs(fs, args, 1)
@@ -812,6 +836,7 @@ func cmdDelete(ctx context.Context, args []string) error {
 // forever (design doc 0021).
 func cmdPurge(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
+		"purge",
 		"Usage: ochakai purge [flags] <id>\n\nHard-delete an already soft-deleted entry: the entry, its revisions,\nusage, and attachment metadata are erased and the id is freed for a\nmove. History is gone — `ochakai delete` first, then purge. A live\nentry is refused.",
 		"  ochakai delete terms/obsolete-kpi\n  ochakai purge terms/obsolete-kpi\n")
 	id, _, err := idArgs(fs, args, 1)
@@ -835,6 +860,7 @@ func cmdPurge(ctx context.Context, args []string) error {
 // be rewritten.
 func cmdReembed(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
+		"reembed",
 		"Usage: ochakai reembed [flags]\n\nEmbed entries that have no vector for the configured model — entries\nwritten before semantic search was enabled, or before the model was\nchanged. Runs bounded passes until nothing is left, so it can be started\nonce and left alone.",
 		"  ochakai reembed\n  ochakai reembed --limit 50   # smaller passes, e.g. behind a short request timeout\n  ochakai reembed --once       # one pass, then report what is left\n")
 	limit := fs.Int("limit", 0, "max entries to embed per pass (server default 200)")
@@ -894,6 +920,7 @@ func cmdReembed(ctx context.Context, args []string) error {
 
 func cmdMove(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
+		"move",
 		"Usage: ochakai move [flags] <id> <new-id>\n\nMove (rename) a knowledge entry to a new id. Revisions, usage, and\nattachments follow, and inbound references (link targets, attrs.model)\nare rewritten so nothing breaks.",
 		"  ochakai move insights/revenue-seasonality insights/sales/revenue-seasonality\n")
 	id, rest, err := idArgs(fs, args, 2)
@@ -918,6 +945,7 @@ func cmdMove(ctx context.Context, args []string) error {
 
 func cmdExport(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
+		"export",
 		"Usage: ochakai export [flags] <dir | ->\n\nDownload the whole knowledge base as an OKF bundle (markdown + YAML\nfrontmatter) into dir, or stream the tar.gz to stdout with \"-\".\nYour knowledge is yours.",
 		"  ochakai export ./knowledge\n  ochakai export - > ochakai-okf.tar.gz\n  ochakai export --no-attachments - > entries.tar.gz   # bytes are in GCS; copy them from there\n")
 	noAtt := fs.Bool("no-attachments", false, "export the markdown only, skipping attachment files")
@@ -948,6 +976,7 @@ func cmdExport(ctx context.Context, args []string) error {
 
 func cmdImport(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
+		"import",
 		"Usage: ochakai import [flags] <dir | file.tar.gz | ->\n\nImport an OKF bundle (a directory of markdown + YAML frontmatter, or\na tar.gz of one; \"-\" reads the tar.gz from stdin). The inverse of\n`ochakai export`: each path names its entry (the path minus .md is\nthe id), the frontmatter type key names the type (required — files\nwithout one are skipped and reported), reserved index.md / log.md\nfiles are skipped, unknown frontmatter keys are kept as attrs, and\nexisting entries are replaced (kept as revisions; entries identical\nto what is stored are left untouched and reported as unchanged;\nentries the server rejects as invalid — e.g. one whose type is not a\nsingle line — are skipped and reported).\nFiles referenced by an entry's body markdown links become its\nattachments, wherever they sit in the bundle (their location is\npreserved for re-export); unreferenced data files inside an entry's\ndirectory (<id>/<name>) attach to that entry. The packed shape is\nthe structure: an archive wrapped in a single directory imports\nunder that directory — the bundle keeps its own namespace. Works\nwith any OKF bundle, not just ochakai's own.",
 		"  ochakai import ./knowledge\n  ochakai import ga4-bundle.tar.gz --dry-run\n  ochakai export - | OCHAKAI_URL=https://other ochakai import -\n")
 	dryRun := fs.Bool("dry-run", false, "parse and list what would be written, write nothing")

--- a/cmd/ochakai/completion.go
+++ b/cmd/ochakai/completion.go
@@ -28,6 +28,7 @@ var (
 
 func cmdCompletion(_ context.Context, args []string) error {
 	fs := newBareFlagSet(
+		"completion",
 		"Usage: ochakai completion <zsh|bash|fish>\n\nPrint a shell completion script. Load it with:\n\n  zsh:   source <(ochakai completion zsh)    # ~/.zshrc, after compinit\n  bash:  source <(ochakai completion bash)   # ~/.bashrc\n  fish:  ochakai completion fish | source    # ~/.config/fish/config.fish\n\nOr install it as a file the shell picks up by itself (what package\nmanagers do):",
 		"  ochakai completion zsh > \"${fpath[1]}/_ochakai\"\n  ochakai completion fish > ~/.config/fish/completions/ochakai.fish\n")
 	pos, err := parseArgs(fs, args)
@@ -272,7 +273,7 @@ complete -c ochakai -n __fish_use_subcommand -a serve -d 'start the MCP + REST s
 complete -c ochakai -n __fish_use_subcommand -a serve-ui -d 'serve the team web UI as a deployed service'
 complete -c ochakai -n __fish_use_subcommand -a version -d 'print the version'
 
-complete -c ochakai -n '__fish_seen_subcommand_from search browse context get create update verify delete purge reembed move attach detach usage report revisions backlinks export import whoami ui' -l url -x -d 'server URL'
+complete -c ochakai -n '__fish_seen_subcommand_from search browse context get create update verify delete purge reembed move attach detach usage report revisions backlinks export import whoami ui mcp-stdio' -l url -x -d 'server URL'
 complete -c ochakai -n '__fish_seen_subcommand_from ui' -l port -x -d 'port on 127.0.0.1'
 complete -c ochakai -n '__fish_seen_subcommand_from import' -l dry-run -d 'parse and list, write nothing'
 complete -c ochakai -n '__fish_seen_subcommand_from import' -F

--- a/cmd/ochakai/completion_test.go
+++ b/cmd/ochakai/completion_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"context"
+	"errors"
+	"flag"
+	"io"
 	"regexp"
 	"slices"
 	"strings"
@@ -60,38 +63,50 @@ func TestCompletionScriptsStayInSync(t *testing.T) {
 	}
 }
 
-// The canonical long-flag surface of every client command — the single
-// spec all three hand-written scripts are checked against, both ways
-// (a flag missing from one shell, and a flag a shell offers that the
-// command does not have). Short flags (-f) are outside the check.
+// commandLongFlags is the canonical long-flag surface of every client
+// command — the spec all three hand-written scripts are checked against,
+// both ways (a flag missing from one shell, and a flag a shell offers
+// that the command does not have). Short flags (-f) are outside the
+// check.
 //
-// This table is transcribed from the commands' flag registration by hand,
-// which is the one edge it does not cover: --source lived on `search` for
-// two releases while this table and all three scripts agreed it did not
-// exist. Adding a flag means editing here and in three scripts.
-var completionLongFlags = map[string][]string{
-	"search":    {"type", "status", "tag", "prefix", "source", "sort", "limit", "json", "url"},
-	"browse":    {"json", "url"},
-	"context":   {"type", "status", "tag", "prefix", "limit", "budget", "min-score", "json", "url"},
-	"get":       {"json", "download", "url"},
-	"create":    {"json", "url"},
-	"update":    {"if-match", "json", "url"},
-	"verify":    {"json", "url"},
-	"delete":    {"url"},
-	"purge":     {"url"},
-	"reembed":   {"limit", "once", "json", "url"},
-	"move":      {"url"},
-	"attach":    {"name", "json", "url"},
-	"detach":    {"url"},
-	"usage":     {"json", "url"},
-	"report":    {"note", "json", "url"},
-	"revisions": {"limit", "json", "url"},
-	"backlinks": {"limit", "json", "url"},
-	"export":    {"no-attachments", "url"},
-	"import":    {"dry-run", "url"},
-	"use":       {"name"},
-	"whoami":    {"json", "url"},
-	"ui":        {"port", "url"},
+// It is read from the commands rather than transcribed beside them. Each
+// one registers its flags inside its own body, so they exist only once
+// the command has run: "-h" runs it precisely that far — every command
+// parses before it acts — and leaves its FlagSet in commandFlagSets,
+// the same probe docs/cli.md is rendered by. A hand-copied list is what
+// let --source live on `search` for two releases while the table and all
+// three scripts agreed it did not exist.
+func commandLongFlags(t *testing.T) map[string][]string {
+	t.Helper()
+	// The --url default reads the CLI config: keep the probe off the
+	// developer's own. The help every -h prints is noise here.
+	t.Setenv("OCHAKAI_URL", "")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	prev := helpOutput
+	helpOutput = io.Discard
+	defer func() { helpOutput = prev }()
+
+	flags := map[string][]string{}
+	for name, cmd := range clientCommands {
+		delete(commandFlagSets, name)
+		if err := cmd(context.Background(), []string{"-h"}); !errors.Is(err, flag.ErrHelp) {
+			t.Errorf("`ochakai %s -h` = %v, want flag.ErrHelp: a command must register and parse its flags before it does anything", name, err)
+			continue
+		}
+		fs := commandFlagSets[name]
+		if fs == nil {
+			t.Errorf("%q registered no FlagSet under its own name; pass %q to newFlagSet/newBareFlagSet", name, name)
+			continue
+		}
+		var names []string
+		fs.VisitAll(func(f *flag.Flag) {
+			if len(f.Name) > 1 { // a one-letter name is a short flag (-f)
+				names = append(names, f.Name)
+			}
+		})
+		flags[name] = names
+	}
+	return flags
 }
 
 // caseArms parses the "label) ... ;;" arms of a shell case statement,
@@ -147,8 +162,8 @@ func fishFlags(script string) map[string]map[string]bool {
 }
 
 // Guard: each shell script offers exactly the long flags each command
-// has — per command, both directions — so a flag added to one script
-// (or to the command itself) cannot silently miss the other shells.
+// registers — per command, both directions — so a flag added to a
+// command (or to one script) cannot silently miss the other shells.
 func TestCompletionFlagsStayInSyncAcrossShells(t *testing.T) {
 	byShell := map[string]map[string]map[string]bool{
 		// zsh spells a flag "--name[help]", bash lists them in opts="...".
@@ -156,8 +171,9 @@ func TestCompletionFlagsStayInSyncAcrossShells(t *testing.T) {
 		"bash": armFlags(caseArms(bashCompletion), `--([a-z-]+)`),
 		"fish": fishFlags(fishCompletion),
 	}
+	longFlags := commandLongFlags(t)
 	for shell, byCmd := range byShell {
-		for cmd, want := range completionLongFlags {
+		for cmd, want := range longFlags {
 			for _, f := range want {
 				if !byCmd[cmd][f] {
 					t.Errorf("%s script misses --%s for %q", shell, f, cmd)

--- a/cmd/ochakai/instances.go
+++ b/cmd/ochakai/instances.go
@@ -109,6 +109,7 @@ func defaultURL() string {
 
 func cmdUse(_ context.Context, args []string) error {
 	fs := newBareFlagSet(
+		"use",
 		"Usage: ochakai use [flags] [name | url]\n\nPick the server later client commands talk to, saved to\n~/.config/ochakai/config.json ($XDG_CONFIG_HOME honored;\n%AppData%\\ochakai on Windows).\nWith a URL: save it (named by --name, default its host) and switch.\nWith a name: switch to a saved server. With no argument: list.\n--url and $OCHAKAI_URL always override the saved selection.",
 		"  ochakai use http://localhost:8080 --name local\n  ochakai use https://ochakai-prod.run.app --name prod\n  ochakai use prod\n")
 	name := fs.String("name", "", "name to save the URL under (default: its host)")
@@ -170,6 +171,7 @@ func cmdUse(_ context.Context, args []string) error {
 
 func cmdWhoami(ctx context.Context, args []string) error {
 	fs, target := newFlagSet(
+		"whoami",
 		"Usage: ochakai whoami [flags]\n\nPrint which server client commands target and where that choice came\nfrom (--url / $OCHAKAI_URL / `ochakai use`), the identity your\ncredentials present (the server's actor resolution is authoritative),\nand whether the server is reachable.",
 		"  ochakai whoami\n  ochakai whoami --json\n")
 	asJSON := fs.Bool("json", false, "print JSON")

--- a/cmd/ochakai/mcpstdio.go
+++ b/cmd/ochakai/mcpstdio.go
@@ -23,6 +23,7 @@ import (
 
 func cmdMCPStdio(ctx context.Context, args []string) error {
 	fs, target := newFlagSet(
+		"mcp-stdio",
 		"Usage: ochakai mcp-stdio [flags]\n\nSpeak MCP over stdin/stdout, forwarding every message to the\nselected server's /mcp. For clients that cannot open an HTTP MCP\nendpoint themselves, and for any client talking to Cloud Run, where\nthe request needs a Google ID token this resolves for you (the same\nway every other client command does) — so the client itself is\nconfigured with no credentials.\n\nstdout carries the protocol and nothing else; diagnostics go to\nstderr. Run it as the client's command, not by hand.",
 		"  ochakai mcp-stdio\n  ochakai mcp-stdio --url https://your-service.run.app\n\n  # Claude Desktop / any client taking a command, in its JSON config:\n  #   \"ochakai\": { \"command\": \"ochakai\", \"args\": [\"mcp-stdio\"] }\n  claude mcp add ochakai -- ochakai mcp-stdio\n")
 	pos, err := parseArgs(fs, args)

--- a/cmd/ochakai/ui.go
+++ b/cmd/ochakai/ui.go
@@ -20,6 +20,7 @@ import (
 
 func cmdUI(ctx context.Context, args []string) error {
 	fs, target := newFlagSet(
+		"ui",
 		"Usage: ochakai ui [flags]\n\nServe the web UI at http://127.0.0.1:<port> against the selected\nserver. API calls are proxied with your own Google identity (resolved\nthe same way as every other client command), so no deployment is\nneeded and your edits are recorded as human:<you>. The proxy also\nexposes /mcp, so it doubles as an authenticated local MCP endpoint.\nFor a team-shared UI on Cloud Run, deploy `ochakai serve-ui`.",
 		"  ochakai ui\n  ochakai ui --port 9000\n  claude mcp add --transport http ochakai http://127.0.0.1:8098/mcp\n")
 	port := fs.Int("port", 8098, "port to listen on (always bound to 127.0.0.1: whoever reaches the proxy acts as you)")


### PR DESCRIPTION
## What and why

`completionLongFlags` in `cmd/ochakai/completion_test.go` is a hand-transcribed table of every client command's long flags. All three completion scripts are checked against it in both directions, but nothing checks the table against the commands — so a flag can be missing from the scripts *and* from the table at once with every test passing. That is how `ochakai search --source` stayed invisible in zsh, bash and fish for two releases; #225 fixed the symptom and left the table with a comment naming the hole: "the one edge it does not cover". This closes it.

The table is gone. `newFlagSet`/`newBareFlagSet` now take the command name and record the FlagSet they build in `commandFlagSets`; nothing at runtime reads it. The test reads what it finds there after running each command with `-h` — the same probe `docs/cli.md` is rendered by since #221, which returns `flag.ErrHelp` after registration and before the command acts — and walks it with `VisitAll`. Adding a flag to a client command now fails the test until zsh, bash and fish all offer it, the same guarantee `TestCompletionScriptsStayInSync` already gives for enum values derived from `domain`.

Two guards keep the probe honest rather than quietly under-reporting: a command that acted before parsing fails with an error other than `ErrHelp`, and a command whose recorded name does not match its `clientCommands` key fails by name. Short flags (`-f`) stay outside the check, as before.

The alternative — splitting each of the 24 commands into a flag-registration function plus a run function — needs a per-command options struct to carry the typed pointers back, which is roughly the flag framework design doc 0004 §8 declines to have. The registry costs six lines of production code and reflects the real FlagSet exactly.

**What the derived check caught:** `ochakai mcp-stdio --url`, which fish had never offered. `mcp-stdio` and `completion` were absent from the hand-written table altogether, so their flags were checked in no shell at all.

Rebased onto main after #221/#224/#225 landed; `--source`, `--prefix` and `--sort stale_after` are main's fixes and are kept as they are.

## Checks

- [x] `scripts/check core` — one failure, `TestEnglishDesignIndexCoversEveryRecord`, which fails identically on a clean `origin/main` checkout (0041 is unsummarized in `docs/design/README.en.md`) and is what #235 is fixing. Everything else is green.
- [x] `gofmt -l .` prints nothing; `go vet ./...`; `CGO_ENABLED=0 go build -trimpath ./...`
- [ ] golangci-lint and govulncheck — not installed locally, left to CI
- [x] Behavior changes come with tests — the check is the change; I confirmed it bites by adding a throwaway flag to `cmdSearch` and watching all three shells fail, then reverting. `bash -n` and `zsh -n` pass on the emitted scripts, and `docs/cli.md` is unchanged (no help text moves).

## Surfaces and contract

- [x] No wire surface changes: no endpoint, no MCP tool, no schema. `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver` and `internal/apiclient` are untouched.
- [x] CLI-only by nature — this is the CLI's own completion surface catching up with flags that already exist on every other surface (design doc 0015).

## Design docs

- [x] Not applicable: no accepted decision is altered. Design doc 0004 §7 already says the scripts are hand-written and pinned by tests; this only widens what the test pins, from commands and enum values to flags.
- [x] Commit messages and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)