### PR TITLE
Make the checks one command, and write the long procedures down

### DIFF
--- a/.claude/hooks/gofmt.sh
+++ b/.claude/hooks/gofmt.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# gofmt: PostToolUse hook — format Go files the agent just wrote.
+#
+# `gofmt -l .` is the first thing CI runs and the cheapest failure to
+# avoid, so this closes the loop at the edit rather than at the push.
+# It reformats in place and says so, because the agent's copy of the
+# file is now stale and it needs to re-read before editing again.
+#
+# Requires jq (the hook payload is JSON). Failures are silent: a hook
+# must never be the reason an edit appears to fail.
+set -eu
+
+command -v jq >/dev/null 2>&1 || exit 0
+command -v gofmt >/dev/null 2>&1 || exit 0
+
+payload=$(cat)
+file=$(printf '%s' "$payload" | jq -r '.tool_input.file_path // empty') || exit 0
+
+case $file in
+*.go) ;;
+*) exit 0 ;;
+esac
+[ -f "$file" ] || exit 0
+
+# Nothing to say when the file was already formatted, which is the
+# common case — keep the transcript quiet.
+[ -n "$(gofmt -l "$file" 2>/dev/null)" ] || exit 0
+
+gofmt -w "$file" 2>/dev/null || exit 0
+
+jq -nc --arg f "$file" '{
+	hookSpecificOutput: {
+		hookEventName: "PostToolUse",
+		additionalContext: ("gofmt reformatted \($f) in place. Re-read it before editing again — your copy is stale."),
+	},
+}'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "$comment": "Checked-in Claude Code settings for this repository. Hooks only — permissions are a personal choice and belong in the untracked settings.local.json.",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/gofmt.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/design-doc/SKILL.md
+++ b/.claude/skills/design-doc/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: design-doc
+description: Add a numbered design doc to docs/design and keep the index and older docs' Status headers truthful. Use when a change alters an accepted decision — a new interface, a new Google Cloud dependency, a change to the auth model or a surface.
+---
+
+# Adding a design doc
+
+`docs/design` holds decision records. They are **immutable** — once
+accepted, a doc is not rewritten. The incremental history lives in the
+docs and in PRs. What the repo must keep readable is the *current* state
+per area, and that is entirely the job of the `Status:` headers and
+[the index](../../../docs/design/README.md).
+
+So the deliverable is never just a new file. It is a new file **plus**
+every older doc it touches **plus** the index, in one PR.
+
+## When one is needed
+
+A change that alters an accepted decision: a new interface, a new
+dependency on a Google Cloud service, a change to the auth model, a
+change to what a surface carries. Small fixes and additions *within* an
+existing decision do not need one.
+
+Two decisions to check any proposal against first:
+
+- **No LLM inside, no SQL execution** (0001). Interpretation and
+  execution belong to the client agent.
+- **Google Cloud only, secret-zero** (0002, 0003). Cloud Run IAM + Cloud
+  SQL IAM; no tokens, no passwords.
+
+## Steps
+
+**1. Read the area first.** Open the index and read every doc for the
+area, following the `Status:` notes. You need to know exactly which
+decisions you are overturning before you can write the header.
+
+**2. Take the next free number.**
+
+```bash
+ls docs/design | tail -5
+```
+
+Gaps are fine — proposals that never landed stay in their PRs. Filename
+is `NNNN-kebab-case-slug.md`.
+
+**3. Write it.** Japanese is the maintainer's habit, not a rule — write
+in English if that is what you think in, and say so in the PR. The
+review cares that the decision **and its rejected alternatives** are
+legible. The `Status:` header names what this doc supersedes or amends:
+
+```
+# ochakai 設計ドキュメント NNNN: <題>
+
+Status: Accepted(YYYY-MM-DD)。[00XX](00XX-….md) を Superseded にし、
+[00YY](00YY-….md) §N の「…」を改訂する。
+Date: YYYY-MM-DD
+```
+
+Use 0038 or 0015 as models for the header style.
+
+**4. Update the older docs' `Status:` headers.** Every doc the new one
+supersedes or amends gets a line pointing at the new number. See 0011 or
+0018 for the style. This is the step that is easiest to forget and the
+one the whole scheme rests on.
+
+**5. Update the index.** Add the doc to its area with a one-line summary
+in the surrounding style (bold status, then what it decides), and adjust
+the status notes of the docs it amends.
+
+**6. Avoid amendment chains.** If this would be the *second* partial
+amendment stacked on the same doc, do not add another diff. Write a full
+replacement that states the area's whole current picture, and mark the
+older docs **Superseded**.
+
+## Surface consistency
+
+If the change adds or changes a feature, [0015](../../../docs/design/0015-surface-consistency.md)
+requires the PR to state, per surface, where it lands — **including the
+deliberate omissions**:
+
+- **REST** is the only contract. Everything lands on `/api/v1` or
+  nowhere; the other three are its clients.
+- **CLI**: yes by default — it is the completeness surface.
+- **MCP**: no by default. Tool schemas cost agent context, so tool count
+  is a budget. Yes only when an agent's loop needs it in one call.
+- **Web UI**: yes if human curation needs it. Not a BI tool.
+
+A new endpoint also needs an integration test, which is how it comes
+under the OpenAPI contract check (`internal/restapi/openapi_test.go`).
+Keep `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
+`internal/apiclient` in sync.
+
+## Before opening the PR
+
+Reread the index top to bottom and ask the question it exists to answer:
+can someone learn an area's current state by reading that area's docs and
+following the Status notes? If not, the index change is not done.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: release
+description: Cut an ochakai release — the version-bump PR, the annotated tag, the release body, and the post-tag verification. Use when asked to release, cut a version, tag, or prepare a release PR.
+---
+
+# Cutting an ochakai release
+
+A release is a tag. Everything else is automation — but three files carry
+a version number the tag does not update, the release body comes out
+empty unless someone writes it, and a pushed tag is permanent because the
+Go module proxy caches it forever. So the work is: a reviewed PR, then a
+tag, then verification.
+
+[CONTRIBUTING.md](../../../CONTRIBUTING.md) is the reference; this skill
+is the running order and the traps.
+
+## 0. Find out where you actually are
+
+Never infer the current version from `CHANGELOG.md` alone — it is what a
+PR *proposes*, not what is published.
+
+```bash
+gh release list --limit 5 && git fetch --tags && git log --oneline -5 origin/main
+```
+
+Then decide the number. While the major version is 0:
+
+- any **BREAKING** entry in the unreleased section → bump the **minor**
+- otherwise → bump the patch
+
+Check CI is green on `main` before starting. Do not prepare a release on
+top of a red main.
+
+## 1. The preparation PR
+
+Branch off `origin/main`. Three files, all of which drift silently —
+nothing fails when they are stale:
+
+1. **`CHANGELOG.md`**
+   - `## [Unreleased]` → `## [x.y.z] - YYYY-MM-DD` (tag date, JST)
+   - add a fresh empty `## [Unreleased]` above it
+   - at the bottom: add `[x.y.z]: …/compare/v<prev>...vx.y.z` and
+     repoint `[Unreleased]` at the new tag
+2. **`api/openapi.yaml`** — `info.version`
+3. **`.github/ISSUE_TEMPLATE/bug_report.yml`** — the version placeholder
+
+Read the unreleased entries as you go and confirm they match what
+actually landed (`git log v<prev>..origin/main --oneline`). A missing
+entry is much cheaper to fix now than after the tag.
+
+Run `scripts/check` and open the PR. Merge it before tagging.
+
+## 2. Tag the merged commit
+
+Annotated, and **the message is the release notes** — that is the repo's
+habit. Commits and code comments are English, but Japanese is fine in a
+tag message and release body.
+
+```bash
+git fetch origin && git checkout -B rel origin/main
+git tag -a vX.Y.Z -F -
+git push origin vX.Y.Z
+```
+
+Pushing runs [release.yaml](../../../.github/workflows/release.yaml): one
+job publishes the multi-arch image to GHCR with SBOM and provenance, the
+other runs goreleaser for the archives, `checksums.txt`, and provenance.
+
+## 3. Write the release body
+
+**goreleaser's own changelog generation is disabled** (`.goreleaser.yaml`
+— notes are written by hand), so if goreleaser creates the release, the
+body comes out **empty**. Either create the release with its notes before
+pushing the tag, or fill it in after:
+
+```bash
+git tag -l --format='%(contents)' vX.Y.Z | tail -n +3 > notes.md
+gh release edit vX.Y.Z --notes-file notes.md
+```
+
+Write for an operator upgrading: which migrations run, whether
+`updated_at` moves (held ETags, `generated.at`), whether re-embedding is
+needed, and what a client reading the old shape must change. Add upgrade
+and install notes.
+
+## 4. Verify what shipped
+
+Do this rather than trusting the green check.
+
+```bash
+gh release view vX.Y.Z --json assets -q '.assets[].name'
+```
+
+Expect **6 archives plus `checksums.txt`**. Then, in a scratch directory:
+
+```bash
+shasum -a 256 -c checksums.txt --ignore-missing
+./ochakai version
+gh attestation verify oci://ghcr.io/na0fu3y/ochakai:X.Y.Z -R na0fu3y/ochakai
+gh attestation verify ochakai_X.Y.Z_linux_amd64.tar.gz -R na0fu3y/ochakai
+curl -s https://proxy.golang.org/github.com/na0fu3y/ochakai/@latest
+```
+
+`./ochakai version` must print the tag — a mismatch means the ldflags
+wiring broke, and it is the one failure the automation cannot see.
+
+## Why the ceremony
+
+A tag is effectively permanent: the module proxy caches it forever and a
+bad one can only be retracted in `go.mod`, never withdrawn. That is why
+the prep is a reviewed PR rather than a push to `main`, and why the
+verification comes before announcing anything.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,12 +4,10 @@
 
 ## Checks
 
-CI runs exactly this; make it pass locally first (CONTRIBUTING.md has the
+CI runs the same script; make it pass locally first (CONTRIBUTING.md has the
 context, including the store integration test and the fuzz targets).
 
-- [ ] `gofmt -l .` prints nothing; `go vet ./...`; `go test -race ./...`
-- [ ] `CGO_ENABLED=0 go build -trimpath ./...`
-- [ ] golangci-lint and govulncheck report nothing
+- [ ] `scripts/check` is clean — add `--db` when the change touches the store
 - [ ] Behavior changes come with tests
 
 ## Surfaces and contract

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,15 +42,11 @@ jobs:
           restore-keys: |
             test-go-${{ hashFiles('go.sum') }}-
             test-go-
-      - run: test -z "$(gofmt -l .)" || { gofmt -l .; exit 1; }
-      - run: go vet ./...
-      # -count=1: with a warm build cache go would reuse cached test
-      # results, but the store tests talk to Postgres, which the test
-      # cache cannot see — make them run every time.
-      - run: go test -race -count=1 ./...
+      # gofmt, go vet, go test -race, and the CGO_ENABLED=0 build. Run
+      # through the script contributors run so the two cannot drift.
+      - run: scripts/check core
         env:
           OCHAKAI_TEST_DATABASE_URL: postgres://t:t@localhost:55433/t?sslmode=disable
-      - run: CGO_ENABLED=0 go build -trimpath ./...
       # Save only from main. A cache saved by a pull request run is
       # scoped to that pull request's merge ref and can only be restored
       # by re-runs of the same pull request, while every branch can
@@ -94,6 +90,9 @@ jobs:
       # three minutes, and the reason this job's cache was 586 MB. The
       # action installs a released binary instead. `args` is explicit
       # because the default set of packages is not documented.
+      #
+      # `scripts/check lint` reads the version below out of this file, so
+      # this is the one place it is written.
       - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: v2.12.2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 /ochakai
 *.test
 dist/
+
+# Claude Code. The shared settings and skills under .claude/ are tracked;
+# these are per-developer or per-session and are not.
+.claude/settings.local.json
+.claude/worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,24 +14,24 @@ first to find which docs describe the current state of an area; a
 superseded or amended doc says so in its `Status:` header.
 
 When a change alters an accepted decision, add a new numbered design
-doc in the same PR and keep the index truthful:
-
-1. Update the `Status:` header of every older doc the new one
-   supersedes or amends, linking to the new number.
-2. Update the index: add the new doc to its area with a one-line
-   summary, adjust the status notes of amended docs.
-3. Avoid amendment chains — if this would be the second partial
-   amendment stacked on the same doc, write a full replacement for the
-   area and mark the older docs Superseded instead.
+doc in the same PR and keep the index truthful — the `design-doc` skill
+has the full procedure (new number, older docs' `Status:` headers, the
+index entry, and why amendment chains get a replacement instead).
 
 ## Checks and conventions
 
-CI runs `gofmt -l .`, `go vet`, `go test -race`, a `CGO_ENABLED=0`
-build, golangci-lint, and govulncheck — see
-[CONTRIBUTING.md](CONTRIBUTING.md) for the exact commands and the store
-integration test setup. Linters are configured in
-[.golangci.yml](.golangci.yml) and chosen so a clean tree reports
-nothing ([docs/design/0035](docs/design/0035-verifiability.md)).
+Run the checks CI runs:
+
+```sh
+scripts/check          # everything; `scripts/check core` is CI's test job
+scripts/check --db     # plus a throwaway PostgreSQL for the store tests
+```
+
+CI calls the same script, so the two cannot drift. Linters are
+configured in [.golangci.yml](.golangci.yml) and chosen so a clean tree
+reports nothing ([docs/design/0035](docs/design/0035-verifiability.md));
+[CONTRIBUTING.md](CONTRIBUTING.md) explains the store test setup and
+fuzzing.
 
 - The public wire surface is [api/openapi.yaml](api/openapi.yaml); keep
   it, `internal/restapi`, `internal/mcpserver`, and `internal/apiclient`
@@ -40,3 +40,6 @@ nothing ([docs/design/0035](docs/design/0035-verifiability.md)).
   [docs/design/0015](docs/design/0015-surface-consistency.md)
   (REST / MCP / CLI / Web UI — including deliberate omissions).
 - Write commit messages and code comments in English.
+- Cutting a release is a reviewed PR, then a tag, then verification —
+  use the `release` skill rather than working from memory. A pushed tag
+  is permanent.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,16 +28,26 @@ config your everyday CLI reads.
 
 ## Tests and checks
 
-CI runs exactly this — make it pass locally before opening a PR:
+One command, and it is the one CI runs — make it pass before opening a
+PR:
 
 ```sh
-gofmt -l .          # must print nothing
-go vet ./...
-go test -race ./...
-CGO_ENABLED=0 go build -trimpath ./...
-go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...
-go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+scripts/check
 ```
+
+That is `gofmt -l .`, `go vet ./...`, `go test -race -count=1 ./...`, a
+`CGO_ENABLED=0 go build -trimpath ./...`, golangci-lint, and
+govulncheck, in that order. A step at a time when you are iterating:
+
+```sh
+scripts/check core   # the four fast ones — this is what CI's test job runs
+scripts/check lint
+scripts/check vuln
+```
+
+CI calls the same script for `core` and reads the pinned golangci-lint
+version out of [ci.yaml](.github/workflows/ci.yaml), so there is no
+second copy of any of this to keep in sync.
 
 The linters are configured in [.golangci.yml](.golangci.yml) and chosen so
 a clean tree reports nothing — a finding means new code, not a linter's
@@ -58,12 +68,29 @@ A failing input lands in `testdata/fuzz/` and becomes a permanent seed;
 commit it with the fix.
 
 The store integration test is skipped unless a real PostgreSQL is
-available (CI runs one as a service container):
+available (CI runs one as a service container). `scripts/check --db`
+starts one in Docker and removes it afterwards; by hand it is:
 
 ```sh
 docker run -d --rm -p 55433:5432 -e POSTGRES_PASSWORD=t -e POSTGRES_USER=t -e POSTGRES_DB=t pgvector/pgvector:pg17
 OCHAKAI_TEST_DATABASE_URL='postgres://t:t@localhost:55433/t?sslmode=disable' go test ./internal/store/
 ```
+
+## Working with Claude Code
+
+The repository checks in a `.claude/settings.json` with **hooks only** —
+currently one that runs `gofmt` on Go files as they are written, since
+that is the cheapest CI failure to avoid. Permissions are a personal
+choice and belong in `.claude/settings.local.json`, which is not tracked.
+
+`.claude/skills/` holds the procedures that are long enough to get wrong
+from memory: `release` and `design-doc`. They are the same procedures
+written out below and in [CLAUDE.md](CLAUDE.md); if you change one,
+change the other.
+
+Unrelated to any of this, `examples/claude-code/` is a *product* example
+— hooks that pull team knowledge out of a running ochakai and write back
+to it. It is not part of this repository's own setup.
 
 ## Design docs
 
@@ -122,7 +149,8 @@ Two decisions worth knowing before proposing features:
 
 A release is a tag. Everything else is automation, but three files carry
 a version number that the tag does not update on its own, so cutting a
-release starts with a PR.
+release starts with a PR. (Working with Claude Code: the `release` skill
+is this section as a running order.)
 
 **1. Prepare, in a PR.** With CI green on `main`:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -370,8 +370,10 @@ machines outside the code to check three specific things.
   replay under an ordinary `go test`, so CI needs no new shape.
 
 Alongside those, CI runs `gofmt -l .`, `go vet`, `go test -race`, a
-`CGO_ENABLED=0` build, and `govulncheck`; [CONTRIBUTING.md](../CONTRIBUTING.md)
-has the exact commands and the setup for the store integration tests.
+`CGO_ENABLED=0` build, and `govulncheck` — all of it through
+`scripts/check`, which is also what a contributor runs, so the two cannot
+drift. [CONTRIBUTING.md](../CONTRIBUTING.md) has the invocations and the
+setup for the store integration tests.
 Images are published with SBOM and SLSA provenance, and workflow actions
 are pinned by commit SHA.
 

--- a/scripts/check
+++ b/scripts/check
@@ -1,0 +1,136 @@
+#!/bin/sh
+# check: run the checks CI runs, in the order CI runs them.
+#
+#   scripts/check          everything (core, lint, vuln)
+#   scripts/check core     gofmt, go vet, go test -race, CGO_ENABLED=0 build
+#   scripts/check lint     golangci-lint
+#   scripts/check vuln     govulncheck
+#   scripts/check --db …   run a throwaway PostgreSQL for the store tests
+#
+# CI's test job runs `scripts/check core`, so those four stay identical by
+# construction. The lint and vuln jobs run their tools directly — lint via
+# the golangci-lint action, which installs a released binary instead of
+# building one from source — so this script takes the linter version from
+# ci.yaml rather than pinning a second copy of it.
+#
+# The store integration test is skipped unless a PostgreSQL is reachable.
+# `--db` starts one in Docker on port 55433 and removes it on exit;
+# without it, an already-exported OCHAKAI_TEST_DATABASE_URL is used as is.
+set -eu
+
+cd "$(git rev-parse --show-toplevel)"
+
+want_db=no
+steps=""
+for arg in "$@"; do
+	case $arg in
+	--db) want_db=yes ;;
+	core | lint | vuln) steps="$steps $arg" ;;
+	-h | --help)
+		awk 'NR > 1 && !/^#/ {exit} NR > 1 {sub(/^# ?/, ""); print}' "$0"
+		exit 0
+		;;
+	*)
+		echo "check: unknown argument: $arg" >&2
+		exit 2
+		;;
+	esac
+done
+[ -n "$steps" ] || steps="core lint vuln"
+
+step() { printf '\n\033[1m==> %s\033[0m\n' "$*" >&2; }
+
+start_db() {
+	if [ -n "${OCHAKAI_TEST_DATABASE_URL:-}" ]; then
+		echo "check: OCHAKAI_TEST_DATABASE_URL is already set — using it, not starting a container" >&2
+		return
+	fi
+	OCHAKAI_TEST_DATABASE_URL='postgres://t:t@localhost:55433/t?sslmode=disable'
+	export OCHAKAI_TEST_DATABASE_URL
+
+	# Reuse whatever already answers on the port. Running this twice, or
+	# alongside a database left up from an earlier session, should not be
+	# an error — and stopping someone else's container is worse.
+	if nc -z localhost 55433 >/dev/null 2>&1; then
+		step "reusing the PostgreSQL already on port 55433"
+		return
+	fi
+
+	command -v docker >/dev/null 2>&1 || {
+		echo "check: --db needs docker, or a PostgreSQL on port 55433" >&2
+		exit 2
+	}
+	step "starting PostgreSQL for the store tests"
+	cid=$(docker run -d --rm -p 55433:5432 --name ochakai-test-pg \
+		-e POSTGRES_USER=t -e POSTGRES_PASSWORD=t -e POSTGRES_DB=t \
+		pgvector/pgvector:pg17)
+	# shellcheck disable=SC2064 # $cid is meant to expand now, not at exit
+	trap "docker stop $cid >/dev/null" EXIT INT TERM
+	i=0
+	until docker exec "$cid" pg_isready -U t >/dev/null 2>&1; do
+		i=$((i + 1))
+		[ "$i" -lt 30 ] || {
+			echo "check: PostgreSQL did not become ready" >&2
+			exit 1
+		}
+		sleep 1
+	done
+}
+
+# The version the golangci-lint action installs in CI. Parsed rather than
+# duplicated: a pin that lives in two files is a pin that drifts.
+linter_version() {
+	awk '/golangci-lint-action/ {f = 1}
+	     f && $1 == "version:" {print $2; exit}' .github/workflows/ci.yaml
+}
+
+run_core() {
+	step "gofmt"
+	test -z "$(gofmt -l .)" || {
+		gofmt -l .
+		exit 1
+	}
+	step "go vet"
+	go vet ./...
+	step "go test -race"
+	if [ -z "${OCHAKAI_TEST_DATABASE_URL:-}" ]; then
+		echo "check: OCHAKAI_TEST_DATABASE_URL unset — store tests will skip (see --db)" >&2
+	fi
+	# -count=1 for the same reason CI passes it: the store tests talk to
+	# Postgres, which the test cache cannot see.
+	go test -race -count=1 ./...
+	step "CGO_ENABLED=0 go build"
+	CGO_ENABLED=0 go build -trimpath ./...
+}
+
+run_lint() {
+	v=$(linter_version)
+	case $v in
+	v*) ;;
+	*)
+		echo "check: could not read the golangci-lint version from .github/workflows/ci.yaml" >&2
+		exit 1
+		;;
+	esac
+	step "golangci-lint $v"
+	go run "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$v" run ./...
+}
+
+run_vuln() {
+	step "govulncheck"
+	# Unpinned, like CI: a new govulncheck release failing means a new
+	# vulnerability, not a new check.
+	go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+}
+
+if [ "$want_db" = yes ]; then start_db; fi
+
+for s in $steps; do
+	case $s in
+	core) run_core ;;
+	lint) run_lint ;;
+	vuln) run_vuln ;;
+	esac
+done
+
+step "ok"


### PR DESCRIPTION
## What and why

The six commands CI runs were written out in three places — `ci.yaml`, `CONTRIBUTING.md`, and `CLAUDE.md`. Three copies to keep in sync, and in practice one linter invocation everyone forgets to run.

**`scripts/check`** runs them, in CI's order. CI's test job now calls `scripts/check core` for the four it covers, so those cannot drift. The golangci-lint pin stays in `ci.yaml` alone and the script reads it from there — a pin in two files is a pin that drifts. The lint job keeps using the action, which installs a released binary instead of building one from source, and the caching commentary and job split are untouched.

```
scripts/check          # everything
scripts/check core     # gofmt, vet, test -race, CGO_ENABLED=0 build
scripts/check --db     # plus a pgvector container for the store tests
```

`--db` reuses a PostgreSQL already listening on 55433 rather than failing or stopping someone else's container.

**Two procedures move into `.claude/skills/`** because they are long enough to get wrong from memory and expensive when you do:

- `release` — three files carry a version the tag does not update, goreleaser leaves the release body empty because its changelog generation is disabled, and a pushed tag is permanent. It starts by checking `gh release list`, since `CHANGELOG.md` says what a PR proposes, not what is published.
- `design-doc` — the new number is the easy part; the `Status:` headers and the index are what keep the design docs readable. Carries 0015's surface table as the material for the REST/MCP/CLI/Web UI call.

**`.claude/settings.json` is checked in with hooks only** — `gofmt` on Go files as they are written, the cheapest CI failure to avoid. It is quiet when the file was already formatted, and says so when it reformats, because the agent's copy is then stale. Permissions are a personal choice and stay in the untracked `settings.local.json`, which `.gitignore` now covers along with `.claude/worktrees/`; both were relying on a maintainer's global gitignore until now.

`CLAUDE.md`, `CONTRIBUTING.md`, `docs/architecture.md`, and the PR template are updated to point at the script and the skills. `examples/claude-code/` is untouched and CONTRIBUTING now says why: it is a product example, not this repository's own setup.

## Checks

- [x] `scripts/check --db` is clean — including the store tests against a real pgvector, golangci-lint at 0 issues, and govulncheck
- [x] CI's `scripts/check core` path verified locally; `ci.yaml` still parses
- [x] The hook was exercised on formatted, unformatted, non-Go, and missing-path inputs

## Surfaces and contract

Not applicable — no wire surface, no CLI command, no server behavior changes. `scripts/check` is a developer entry point and is not shipped in any archive.

## Design docs

No new doc. This changes how the checks are invoked, not what they are, and adds no interface, no dependency on a Google Cloud service, and no change to the auth model or any surface — a change within the existing decisions rather than one that alters them.

No CHANGELOG entry either: nothing here is visible to an operator upgrading, which is what that file keeps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)