### PR TITLE
Catch the generated docs up with 0041

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -171,6 +171,8 @@ Flags:
     	max full entries (server default 5, max 20)
   -min-score float
     	drop hits scoring below this; scores depend on the server's search mode (matched-fragment weight plus boosts vs RRF rank fusion), so calibrate before use (0 = off)
+  -prefix path
+    	only entries under this path, e.g. teams/growth (repeatable, OR-ed); scopes the search, not the links it expands
   -status value
     	filter by status: draft|verified|deprecated|rejected (repeatable)
   -tag value
@@ -184,6 +186,7 @@ Examples:
   ochakai context "why did revenue drop in March?"
   ochakai context "monthly revenue" --type 'Attested Computation' --status verified --json
   ochakai context "$PROMPT" --budget 4000   # hooks: cap the injected bytes
+  ochakai context "activation rate" --prefix teams/growth --prefix company
 ```
 
 ## ochakai create
@@ -480,15 +483,19 @@ With --sort stale_after it lists entries whose declared stale_after has
 passed, most overdue first; output leads with that date. Verifying does
 not empty this one — the date is the writer's declaration, so clearing it
 means editing the entry to re-declare an expiry.
---source is a filter, not a mode: it narrows to the entries citing one
-resource (the reverse of sources[].resource) and combines with a query
-or with any --sort.
+--source and --prefix are filters, not modes: both combine with a query
+or with any --sort. --source narrows to the entries citing one resource
+(the reverse of sources[].resource); --prefix narrows to the entries
+living under a path, which is how a team's own knowledge is told apart
+from the company-wide vocabulary.
 
 Flags:
   -json
     	print the raw JSON response
   -limit int
     	max results (server default 10, max 50; with --sort: 100, max 1000)
+  -prefix path
+    	only entries under this path, e.g. teams/growth — matched on segment boundaries, so it does not reach teams/growth-archive (repeatable, OR-ed)
   -sort string
     	list instead of search: "verified_at" = by verification age (oldest first), "usage" = by demand (most search_hits first), "failed" = by failed outcome reports (re-verification feed), "stale_after" = past their declared expiry, most overdue first
   -source resource
@@ -510,6 +517,7 @@ Examples:
   ochakai search --sort failed --status verified            # re-verification queue
   ochakai search --sort stale_after                         # past their declared expiry
   ochakai search --source https://wiki.example/finance/revenue-recognition  # what cites this
+  ochakai search 活性化 --prefix teams/growth --prefix company   # our scope and the shared one
 ```
 
 ## ochakai ui

--- a/docs/design/README.en.md
+++ b/docs/design/README.en.md
@@ -98,6 +98,23 @@ For the shape of the system rather than the history of it, read
 
 ## The knowledge model — structure, ids, types, names, links
 
+- **[0041 Narrowing a search by address](0041-path-scoped-search.md)** —
+  *Accepted.* Carries 0017's "the path is the address" through to search
+  and `get_context`, which could filter by type, status, tag and source but
+  never by id. A repeatable `prefix` filter narrows to a subtree — the
+  prefix's own entry and everything under it — matched at segment
+  boundaries, so `prefix=metrics` does not reach `metrics-legacy/churn`.
+  It is a filter rather than a mode, so it combines with a query and with
+  any `sort`, and repeating it ORs the scopes together, because the
+  ordinary question is "my team's *and* the company's". No index and no
+  migration. The record is unusually candid that the demand for this was
+  weaker than for 0037, and that the feature only earns its place where
+  directories mean something a type cannot say — a team, a domain, a
+  tenant.
+  *For a user:* `--prefix` on the CLI, `prefix` on REST and MCP; scoping
+  by path stops meaning a second, parallel tagging scheme that drifts from
+  the tree.
+
 - **[0037 Making declared expiry and cited sources
   queryable](0037-stale-and-source-lookup.md)** — *Accepted, shipped in
   0.14.0.* `stale_after` and `sources` were writable but not askable.
@@ -145,8 +162,8 @@ For the shape of the system rather than the history of it, read
 
 - **[0017 The path is the address; the type is an
   attribute](0017-path-addressing.md)** — *Accepted; the id character set
-  was relaxed by 0019 §2 and the type vocabulary replaced by 0023 and
-  0038.* Removes the rule that a path's first segment names the type. The
+  was relaxed by 0019 §2, the type vocabulary replaced by 0023 and 0038,
+  and filtering by address added by 0041.* Removes the rule that a path's first segment names the type. The
   full path is the id and the sole address; the primary key becomes the id
   alone. A file with no frontmatter `type` is skipped and reported rather
   than having a type inferred from where it sits.


### PR DESCRIPTION
## What and why

**`main` is red right now**, and this fixes it. #221 and #226 landed two
guards over documentation that cannot fail to compile; #225 landed the
first change they exist to catch. The three were in flight at the same
time, so no branch saw the others:

```
--- FAIL: TestCLIReferenceIsCurrent
    docs/cli.md no longer matches the CLI's help; regenerate it:
      go test ./cmd/ochakai -run TestCLIReferenceIsCurrent -update
    first difference at byte 6844
--- FAIL: TestEnglishDesignIndexCoversEveryRecord
    docs/design/README.en.md never links 0041-path-scoped-search.md.
    Summarize it there, or an English reader hits a Japanese dead end
```

Both failures are the checks doing their job on the first real occasion —
which is a better outcome than the alternative, where `--prefix` quietly
never appears in the CLI reference and 0041 quietly never appears in
English.

- **`docs/cli.md` regenerated**, which adds `--prefix` and its examples to
  `search` and `context`, plus the sentence explaining that `--source` and
  `--prefix` are filters rather than modes.
- **`docs/design/README.en.md` gains 0041** — the prefix filter that
  carries 0017's "the path is the address" through to search and
  `get_context`: matched at segment boundaries so `prefix=metrics` does not
  reach `metrics-legacy/churn`, repeatable so one call can span a team's
  scope and the company's, and a filter rather than a mode so it combines
  with a query or a `sort`. The summary keeps the record's own candour
  about the demand for it being weaker than 0037's, and about it only
  earning its place where directories mean something a type cannot say.
- **0017's entry** now notes that 0041 added filtering by address, the way
  the Japanese index does.

No Go changed.

## Checks

- [x] `gofmt -l .` prints nothing; `go vet ./...`; `go test ./cmd/ochakai` — green again
- [x] `CGO_ENABLED=0 go build -trimpath ./...`
- [x] golangci-lint and govulncheck report nothing
- [x] Behavior changes come with tests — n/a; this is the tests being right

## Surfaces and contract

- [x] n/a — nothing changed on any surface; the CLI reference is now what
      the CLI actually prints
- [x] n/a

## Design docs

- [x] Alters no accepted decision; it records 0041 in the English index and
      updates the cross-reference on 0017, matching what the Japanese index
      already says
- [x] Commit messages and code comments are in English

## Worth knowing for next time

Both guards compare a checked-in file with something generated from the
code or the tree, so a branch that merges cleanly can still make `main`
red if another branch changed the source in between. That is the intended
trade — silent drift was the previous state — but it does mean a
parallel change to CLI help or a new design record needs a regenerate
before merge, not after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
