### PR TITLE
Summarize 0041 in the English index

### DIFF
--- a/docs/design/README.en.md
+++ b/docs/design/README.en.md
@@ -98,6 +98,24 @@ For the shape of the system rather than the history of it, read
 
 ## The knowledge model — structure, ids, types, names, links
 
+- **[0041 Scoping a search by address](0041-path-scoped-search.md)** —
+  *Accepted.* Carries 0017's "the path is the address" into search and
+  `get_context`, which could filter by type, status, tag and source but
+  never by id. Adds a repeatable `prefix` filter matching whole segments —
+  `metrics` covers `metrics/revenue` and `metrics` itself, never
+  `metrics-legacy/churn` — and combining with a query or any `sort`.
+  Repeatable because the ordinary question is "my team's scope *and* the
+  company's" and splitting it into two calls would merge two unrelated
+  rankings. No index and no migration; a scope layout like
+  `teams/<team>/…` stays a convention the server knows nothing about.
+  *For a user:* `?prefix=` on REST, `--prefix` on the CLI, a `prefixes`
+  argument on the existing MCP tools, and a filter plus a "search here"
+  action on the browse tree in the web UI. It is **not** an access
+  boundary: anyone may pass any prefix, and passing none returns
+  everything (0002 — separate deployments are still the answer for a
+  viewing boundary). It only helps where directories mean something a
+  `type` cannot say, such as a team or a tenant.
+
 - **[0037 Making declared expiry and cited sources
   queryable](0037-stale-and-source-lookup.md)** — *Accepted, shipped in
   0.14.0.* `stale_after` and `sources` were writable but not askable.
@@ -145,8 +163,9 @@ For the shape of the system rather than the history of it, read
 
 - **[0017 The path is the address; the type is an
   attribute](0017-path-addressing.md)** — *Accepted; the id character set
-  was relaxed by 0019 §2 and the type vocabulary replaced by 0023 and
-  0038.* Removes the rule that a path's first segment names the type. The
+  was relaxed by 0019 §2, the type vocabulary replaced by 0023 and 0038,
+  and filtering by address added by 0041.* Removes the rule that a path's
+  first segment names the type. The
   full path is the id and the sole address; the primary key becomes the id
   alone. A file with no frontmatter `type` is skipped and reported rather
   than having a type inferred from where it sits.


### PR DESCRIPTION
## What and why

`main` is red. #225 landed [0041](docs/design/0041-path-scoped-search.md) and #226 added `docs/design/README.en.md` together with `TestEnglishDesignIndexCoversEveryRecord`, which requires every numbered record to be summarized there. The two crossed, so the guard fails on `main` itself:

```
main_test.go:120: docs/design/README.en.md never links 0041-path-scoped-search.md.
Summarize it there, or an English reader hits a Japanese dead end
```

The guard is doing exactly its job — a citation to "design doc 0041" from English prose leads to a Japanese dead end — so this is the missing summary, not a change to the check.

The entry covers what the `prefix` filter is (whole-segment matching, repeatable, composable with `q` and `sort`), why it is repeatable (the ordinary question is "my team's scope *and* the company's", and two calls would merge two unrelated rankings), what it costs (no index, no migration, and scope layouts stay a convention the server knows nothing about), and — because this is the part most likely to be misread from outside — that it is **not** an access boundary.

It also notes on 0017 that filtering by address was added by 0041, the way that entry already notes the character set and the type vocabulary moving under it.

## Checks

- [x] `gofmt -l .` prints nothing; `go vet ./...`; `go test -race ./...`
- [x] `CGO_ENABLED=0 go build -trimpath ./...`
- [x] `TestEnglishDesignIndexCoversEveryRecord` passes; it fails on `main` without this

Documentation only — no Go changed.

## Surfaces and contract

- [x] Not applicable.

## Design docs

- [x] No decision is altered. `README.en.md` is explicitly not authoritative: the Japanese record stays the record, and this is the reading aid catching up with it.
- [x] Commit message is in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)