### PR TITLE
Say that a path scope is not an access boundary

### DIFF
--- a/docs/design/README.en.md
+++ b/docs/design/README.en.md
@@ -127,7 +127,11 @@ For the shape of the system rather than the history of it, read
   migration. The record is unusually candid that the demand for this was
   weaker than for 0037, and that the feature only earns its place where
   directories mean something a type cannot say — a team, a domain, a
-  tenant.
+  tenant. It is emphatically **not an access boundary**: anyone may pass
+  any prefix, passing none returns everything, and reading stays bounded
+  by who can reach the service (0002). The record spends a paragraph on
+  that, because a scope filter and a read ACL look alike from outside and
+  running a deployment as though they were the same would hollow out 0002.
   *For a user:* `--prefix` on the CLI, `prefix` on REST and MCP; scoping
   by path stops meaning a second, parallel tagging scheme that drifts from
   the tree.


### PR DESCRIPTION
## What and why

Rewritten: #234 landed the renumber this branch was carrying, so
everything except one paragraph is gone. **The diff is now four lines in
`docs/design/README.en.md`.**

0041's own §4 opens by insisting that the prefix filter is **not
authorization**: anyone may pass any prefix, passing none returns
everything, and reading stays bounded by who can reach the service. The
record spends a paragraph on it, and says why — a scope filter and a read
ACL look alike from outside, and a deployment run as though they were the
same would hollow out 0002.

That is precisely the sentence an English reader needs, because the
summary without it describes a feature whose whole shape suggests access
control: narrow to a team's subtree, ask for one scope and not another.
The Go comment on `scopedFilter` already says it; the English index now
does too.

Credit to **#233**, which had this in its own version of the entry.

## What I checked while rewriting this

#234's renumber is correct, including the case that would have been easy
to get wrong: `internal/service/service.go:891` cites `0041 §4` on
`scopedFilter`, and §4 of the *prefix filter* is its own "this is not an
access check" section — it correctly stays 0041. `internal/config`,
`internal/httpauth` and `SECURITY.md` all moved to 0042, and no stray
0041 citation is left in a public-read-only context. `main` is green on
all three documentation guards.

## Checks

- [x] `go test ./cmd/ochakai` — `TestEnglishDesignIndexCoversEveryRecord` passes
- [x] No Go changed; documentation only

## Design docs

- [x] No decision altered; this restates one the record already makes
- [x] Commit message is in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)
