### PR TITLE
State the compatibility policy instead of implying it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to ochakai are recorded here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project
 follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) — while
 the major version is 0, a minor bump may break compatibility, and those
-breaks are marked **BREAKING** below.
+breaks are marked **BREAKING** below. Every interface is unstable at 0.x
+and only the latest release is supported:
+[docs/compatibility.md](docs/compatibility.md) states the policy in full.
 
 Dates are the tag dates (JST). Each released version also has a GitHub
 release with longer prose; this file keeps what an operator upgrading

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,8 @@
 Please report vulnerabilities privately via
 [GitHub Security Advisories](https://github.com/na0fu3y/ochakai/security/advisories/new)
 — do not open a public issue. You should receive a response within a few
-days. The latest release is the supported version.
+days. The latest release is the supported version — there is no support
+window and no backporting ([docs/compatibility.md](docs/compatibility.md)).
 
 ## Scope notes
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -38,6 +38,8 @@ Most answers are already written down, and the docs are short enough to check:
   which is usually the fastest answer to "why does it work like that".
 - [ROADMAP.md](ROADMAP.md) — what is being worked on, and what has been ruled
   out on purpose.
+- [docs/compatibility.md](docs/compatibility.md) — what may break between
+  releases, and which release is supported (one: the latest).
 
 When you do ask, the useful details are the same ones the bug form asks for:
 version (`ochakai version`), deployment (docker compose or Cloud Run),

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,9 @@ types, and every environment variable.
 - [Architecture](architecture.md) — how the pieces fit, what the data
   model is, and why there is no authorization layer. English summary of
   the decision records.
+- [Compatibility and support](compatibility.md) — every interface is
+  unstable at 0.x, there is no deprecation window, and only the latest
+  release is supported. Read this before building on ochakai.
 - [Roadmap](../ROADMAP.md) — what is being worked on, and what is
   deliberately refused.
 - [Changelog](../CHANGELOG.md) — what changed between releases.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,88 @@
+# Compatibility and support
+
+The short version, so nobody has to infer it:
+
+> **While the major version is 0, every interface is unstable.** REST, MCP,
+> the CLI and the stored shape may all change in a minor release. There is
+> no deprecation window. Only the latest release is supported.
+
+That is the actual policy, not a disclaimer. If you are deciding whether
+to build on ochakai, decide against *this*, not against what "SemVer"
+usually implies at 0.x.
+
+## What "unstable" covers
+
+Everything a client can touch:
+
+- **REST** — paths, request and response shapes, status codes. `0.13.0`
+  moved the knowledge out of `/context`'s `hits`; `0.14.0` moved seven
+  keys out of `attrs` into envelope fields.
+- **MCP** — tool names, arguments, and which tools exist at all.
+  `compile_sql` existed until `0.13.0` and does not now.
+- **The CLI** — commands, flags, and the shape of what they print.
+- **The stored data** — migrations run automatically at server start, and
+  they are one-way. There is no downgrade path.
+
+The OKF export format is the one part with an external anchor: it follows
+[OKF v0.2](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf),
+so it changes when the spec does or when ochakai's reading of it does —
+`0.14.0` changed the key order in exported frontmatter, which is a diff in
+anything that stores bundles in git.
+
+## What you get instead of stability
+
+Not a promise that nothing breaks. A promise that you are told what did:
+
+- **Every breaking change is marked `BREAKING` in
+  [the changelog](../CHANGELOG.md)**, with what an operator has to do about
+  it — which migration runs, whether `updated_at` moves, whether
+  re-embedding is needed, what a client reading the old shape must change.
+- **Changes arrive in batches.** A minor release usually carries several
+  at once rather than trickling them out, so upgrading is one reading of
+  one changelog entry rather than a standing tax. `0.15.0` landed five
+  design records together, including the type-vocabulary realignment and
+  two new deployment postures.
+- **Every removal has a design record** that says why, and what to use
+  instead. `compile_sql` went with
+  [0028](design/0028-retire-compile-sql.md), the OAuth connector with
+  [0012](design/0012-retire-mcp-oauth-connector.md). Features are removed
+  when they stop earning their place, and that is treated as maintenance
+  rather than as a failure.
+- **Your knowledge outlives any of it.** `ochakai export` writes an OKF
+  bundle that another tool can read, which is the guarantee the project
+  actually makes.
+
+## Support
+
+**Only the latest release.** There is no support window, no backporting,
+and no long-term branch: a fix ships in the next release, and the way to
+get it is to upgrade. This is also what
+[SECURITY.md](../SECURITY.md) means by "the latest release is the
+supported version" — it applies to security fixes too.
+
+Releases before `0.9.0` are
+[retracted](https://go.dev/ref/mod#go-mod-file-retract) in `go.mod` and
+unsupported.
+
+## Living with it
+
+If you are running ochakai anyway — and the project is used this way — the
+practices that make an unstable dependency survivable:
+
+- **Pin a version.** The deploy guide pins an image tag rather than
+  `:latest`, so a redeploy is a decision and an upgrade is a separate one.
+- **Read the changelog before upgrading**, and read the whole entry: the
+  breaking notes are written for the person doing exactly that.
+- **Keep an export.** `ochakai export` is both your backup and your exit
+  ([operating guide](guides/operating.md)).
+- **Run the [golden query canary](guides/golden-query-canary.md) from CI**,
+  so a knowledge base that quietly stopped matching reality says so
+  without waiting for someone to notice.
+- **Upgrade the CLI with the server.** They are versioned together, and a
+  client one minor behind may be reading a shape that moved.
+
+## 1.0
+
+Not scheduled, and no criteria have been set. When the interfaces stop
+moving, that will be a decision recorded like any other — until then,
+assume the paragraph at the top of this page.


### PR DESCRIPTION
## What and why

Closes #215, written from your comment on the issue.

Between the changelog's *"a minor bump may break compatibility"* and
SECURITY.md's *"the latest release is the supported version"*, there was
no answer to what somebody with a production dependency actually asks: is
REST stable within a minor, is there a deprecation window, how long is a
release supported, what would 1.0 mean.

[docs/compatibility.md](docs/compatibility.md) says it plainly, and the
plainness is the point:

> **While the major version is 0, every interface is unstable.** REST, MCP,
> the CLI and the stored shape may all change in a minor release. There is
> no deprecation window. Only the latest release is supported.

The rest of the page is what that means in practice:

- **What "unstable" covers**, with breaks that already happened as
  evidence rather than as warnings — 0.13.0 taking the knowledge out of
  `/context`'s `hits`, 0.14.0 moving seven keys out of `attrs` and
  reordering exported frontmatter, `compile_sql` existing until it did
  not. An adopter can calibrate on real history instead of on a
  disclaimer.
- **What you get instead of stability**, because "we may break anything"
  is only half a policy: every break marked `BREAKING` with what to do
  about it, changes batched into a release rather than trickled (0.15.0
  landed five design records at once), every removal carrying the design
  record that says why, and the OKF export as the guarantee that actually
  holds.
- **Support in one line** — only the latest, no backporting, and that
  includes security fixes, which is what SECURITY.md's sentence has always
  meant and now says.
- **Living with it** — pin a version, read the whole changelog entry,
  keep an export, run the canary from CI, upgrade the CLI with the server.
  This is the part that makes the policy survivable rather than only
  honest.
- **1.0** — not scheduled, no criteria set. Said as such rather than
  invented.

The changelog preamble, `SECURITY.md`, `SUPPORT.md` and the docs index
link it from where each already talks about versions or support.

## Checks

- [x] `go test ./cmd/ochakai` — the documentation guards pass
- [x] No Go changed
- [x] Every relative link in the five touched files resolves

## Surfaces and contract

- [x] n/a — nothing changed on any surface
- [x] n/a

## Design docs

- [x] Alters no accepted decision. It writes down a policy that existed
      only as practice; if you would rather it were a numbered record than
      a doc page, say so and I will move it
- [x] Commit messages and code comments are in English

Only the changelog's **preamble** is touched — no released entry is
edited.

## One thing to sanity-check

I wrote the "what unstable covers" examples from the changelog's own
BREAKING entries, but they are your releases and you will spot a
mischaracterization faster than I will. In particular I describe the
stored shape as one-way ("migrations run automatically and there is no
downgrade path") — true as far as I can tell from `internal/store/migrate.go`,
but worth your eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
