### PR TITLE
Cite 0042 for the public posture, and drop the refusal that never was

### DIFF
--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -577,12 +577,13 @@ implies the first:
   private, for a reference-only copy or for freezing a base during a
   migration.
 - **`OCHAKAI_PUBLIC_READ_ONLY=true`** — the deployment reads no identity
-  (design doc 0041). The `Authorization` header is ignored: without Cloud Run
+  (design doc 0042). The `Authorization` header is ignored: without Cloud Run
   IAM in front its signature is unverifiable, and a forged unsigned token
   would otherwise be believed. `X-Ochakai-On-Behalf-Of` is ignored. Every
   caller is `human:anonymous`, and nothing returns 401. It **implies
-  read-only** — the server refuses to start if it would be publicly readable
-  and writable, so the dangerous half of "public" has no configuration.
+  read-only** and cannot be separated from it — a publicly readable *and*
+  writable ochakai is not a configuration this program accepts, so the
+  dangerous half of "public" has no configuration.
 
 That is the whole trade: a service that believes nobody is safe to open,
 because it records nobody and writes nothing.

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -53,7 +53,7 @@ Without the IAM check in front, those headers would be forgeable, and every
 recorded author would be a guess. The same rule keeps the deployment
 compatible with the Domain Restricted Sharing org policy.
 
-The exception is `public_read_only` (guide §5d, design doc 0041), which grants
+The exception is `public_read_only` (guide §5d, design doc 0042), which grants
 `allUsers` itself. It is one variable rather than two because public is only
 safe together with what it comes with: the deployment refuses every write and
 reads no identity at all, so there is no provenance to forge and no author to

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -17,7 +17,7 @@
 #     identity Cloud Run has already verified and records it as provenance.
 #     Those headers only mean something behind Cloud Run's IAM check, so
 #     allUsers would not merely widen access, it would make provenance
-#     forgeable. The exception is var.public_read_only (design doc 0041),
+#     forgeable. The exception is var.public_read_only (design doc 0042),
 #     which grants allUsers only together with the flag that makes the
 #     deployment refuse every write and stop reading identity altogether —
 #     there is then no provenance to forge and no author to get wrong. A
@@ -54,11 +54,12 @@ locals {
 
   iap_audience = "/projects/${data.google_project.this.number}/locations/${var.region}/services/${local.webui_name}"
 
-  # Public read-only implies read-only (design doc 0041): the server refuses
-  # to start if it would be publicly readable and writable. The module states
-  # the implication in the environment rather than leaving it to be
-  # discovered from a crash loop, so the deployed configuration reads the
-  # same way the posture does.
+  # Public read-only implies read-only (design doc 0042): the server applies
+  # the implication itself and cannot be separated from it, so a publicly
+  # readable and writable ochakai is not a configuration it accepts. The
+  # module states the implication in the environment rather than leaving it
+  # to be read back off the running service, so the deployed configuration
+  # reads the same way the posture does.
   read_only = var.read_only || var.public_read_only
 
   server_env = merge(
@@ -430,7 +431,7 @@ resource "google_cloud_run_v2_service_iam_member" "invokers" {
 }
 
 # The public read-only demo, and the only allUsers grant in this module
-# (design doc 0041). It is deliberately not something an operator can compose
+# (design doc 0042). It is deliberately not something an operator can compose
 # out of parts: the same variable that opens the service is the one that makes
 # it refuse every write and stop reading identity, so "public" and "believes
 # nobody" cannot drift apart. A public writable ochakai would record authors
@@ -455,7 +456,7 @@ resource "google_cloud_run_v2_service_iam_member" "public_demo" {
     # the length of an apply.
     precondition {
       condition     = lookup(local.server_env, "OCHAKAI_PUBLIC_READ_ONLY", "") == "true"
-      error_message = "Refusing to grant allUsers: the service is not running with OCHAKAI_PUBLIC_READ_ONLY=true. Public is only safe while ochakai writes nothing and reads no identity (design doc 0041)."
+      error_message = "Refusing to grant allUsers: the service is not running with OCHAKAI_PUBLIC_READ_ONLY=true. Public is only safe while ochakai writes nothing and reads no identity (design doc 0042)."
     }
   }
 }

--- a/deploy/terraform/outputs.tf
+++ b/deploy/terraform/outputs.tf
@@ -17,7 +17,7 @@ output "demo_url" {
 output "posture" {
   description = "One line naming what this deployment will and will not do, so that a flip between demo and normal shows up in the output diff as well as the plan."
   value = (var.public_read_only
-    ? "public read-only: anyone with the URL can read; no identity is read, every caller is human:anonymous, and nothing can be written (design doc 0041)"
+    ? "public read-only: anyone with the URL can read; no identity is read, every caller is human:anonymous, and nothing can be written (design doc 0042)"
     : local.read_only
     ? "private read-only: only invoker_members can reach it, and nothing can be written (design doc 0040)"
   : "private read-write: only invoker_members can reach it, and whoever reaches it can read and write everything (design doc 0002)")

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -39,7 +39,7 @@ invoker_members = [
 # read_only = true
 
 # The public read-only demo, and the only posture in which this module grants
-# allUsers (guide §5d, design doc 0041). Anyone with the URL reads the base
+# allUsers (guide §5d, design doc 0042). Anyone with the URL reads the base
 # with no Google account. Safe only because of what comes with it: writes are
 # refused (this implies read_only) and no identity is read at all — the
 # Authorization header is ignored, every caller is human:anonymous. Do not use

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -102,18 +102,18 @@ variable "read_only" {
 
 variable "public_read_only" {
   description = <<-EOT
-    The public read-only demo (OCHAKAI_PUBLIC_READ_ONLY, design doc 0041).
+    The public read-only demo (OCHAKAI_PUBLIC_READ_ONLY, design doc 0042).
     This is the one posture where a publicly invokable ochakai is intended:
     the module grants allUsers roles/run.invoker, so anyone with the URL can
     read the base with no Google account and no token.
 
     It is safe only because of the two things it gives up at once, and they
     are one variable for that reason. Nothing can be written: this implies
-    var.read_only, and the server refuses to start if it would be publicly
-    readable and writable. And no identity is believed: the Authorization
-    header is not read at all — its signature is unverifiable without Cloud
-    Run IAM in front — X-Ochakai-On-Behalf-Of is ignored, and every caller is
-    human:anonymous. Provenance would be forgeable on a public service, so
+    var.read_only and cannot be separated from it, so a publicly readable
+    and writable ochakai is not a configuration the server accepts. And no
+    identity is believed: the Authorization header is not read at all — its
+    signature is unverifiable without Cloud Run IAM in front —
+    X-Ochakai-On-Behalf-Of is ignored, and every caller is human:anonymous. Provenance would be forgeable on a public service, so
     none is read; nothing is written, so there is none to record.
 
     Everything else in this module stays private. Do not reach for this to


### PR DESCRIPTION
Commit 7b1696c renumbered the public read-only record 0041 → 0042 (0041 is now path-scoped search) and left the `deploy/` tree pointing at the wrong record. Nine citations, in Terraform and in both deployment guides.

The worst of them was reachable. The precondition on the module's only `allUsers` grant prints its citation to whoever tripped it, so the operator who most needed the record — the one being told why their public binding was refused — was sent to a document about search scoping.

## The claim that was not true

Three of the same passages also said the server *refuses to start* if it would be publicly readable and writable. It does not, and never did. The implication is applied rather than checked ([`internal/config/config.go:102-109`](https://github.com/na0fu3y/ochakai/blob/main/internal/config/config.go#L102-L109)): `OCHAKAI_PUBLIC_READ_ONLY` forces `ReadOnly = true`, so the dangerous combination never exists to be rejected. Setting `OCHAKAI_READ_ONLY=false` alongside it does not turn writes back on. The only startup refusal in this area is `PUBLIC_READ_ONLY` together with `INSECURE_DEV`.

The wording now follows `README.md:574`, which had it right all along: the pairing is *not a configuration this program accepts*. That is the stronger promise, not the weaker one — a crash loop is a thing an operator can hit, and this is a thing that has no spelling.

## Changed

| File | |
|---|---|
| `deploy/terraform/main.tf` | 4 citations; the `local.read_only` comment and the precondition `error_message` |
| `deploy/terraform/variables.tf` | citation + the `public_read_only` description |
| `deploy/terraform/outputs.tf` | the `posture` output string (user-visible) |
| `deploy/terraform/terraform.tfvars.example` | citation — **not in the original report**, found by grep |
| `deploy/terraform/README.md` | citation |
| `deploy/cloudrun/README.md` | citation + §5d's implication paragraph |

Two edits go slightly past the literal citation. `main.tf`'s comment justified stating the implication in the environment "rather than leaving it to be discovered from a crash loop" — a clause that only made sense if the refusal were real, now "read back off the running service"; the point it was making is unchanged. And a few lines are reflowed to hold the wrap width, which widens the diff a little.

`docs/design/*` is untouched — those records are immutable. The ~20 remaining `0041` references elsewhere in the repo are all genuinely about path-scoped search; I checked each one rather than assuming.

## Verification

`scripts/check` passes — 0 lint issues, all tests ok. No behaviour changes: comments, descriptions, and two operator-visible strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)