### PR TITLE
Hide the write affordances the web UI still showed when read-only

### DIFF
--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -1071,8 +1071,7 @@ function nodeHTML(prefix, label, count) {
   // The ＋ prefills the editor's ID with this directory — no retyping the
   // full path to create knowledge next to its neighbors.
   return `<details class="node" data-prefix="${esc(prefix)}" ${browse.open.has(prefix) ? 'open' : ''}>
-    <summary>${label}<span class="count">${count}</span><a class="node-new"
-      class="write-only"
+    <summary>${label}<span class="count">${count}</span><a class="node-new write-only"
       href="#/new/${prefix.split('/').filter(Boolean).map(encodeURIComponent).join('/')}/"
       title="New entry in ${esc(prefix)}">＋</a></summary>
     <div class="children"><div class="empty">…</div></div>
@@ -1084,13 +1083,16 @@ function nodeHTML(prefix, label, count) {
 // and full status ride in the tooltip. A directory's name is a link to
 // its index page (the ▸ marker and the rest of the row still toggle
 // expansion). Entries are draggable: dropping one on a directory moves
-// it there (references rewritten server-side).
+// it there (references rewritten server-side) — except on a read-only
+// deployment, where the move would only 403 (design doc 0040 §2.3). A
+// level is rendered from a browse response, so READ_ONLY is known by
+// the time this runs; the drag handlers check it again at drag time.
 function levelHTML(res, prefix) {
   const dirs = (res.dirs || []).map(dir => nodeHTML(prefix + dir.name + '/',
     `<span class="type-ico">📁</span><a class="dir-name mono" href="${dirHash(prefix + dir.name)}"
        title="Open the index of ${esc(prefix + dir.name)}/">${esc(dir.name)}/</a>`, dir.count)).join('');
   const entries = (res.entries || []).map(e => `
-    <a class="tree-entry" data-id="${esc(e.id)}" href="#/k/${idPath(e.id)}" draggable="true"
+    <a class="tree-entry" data-id="${esc(e.id)}" href="#/k/${idPath(e.id)}" draggable="${READ_ONLY ? 'false' : 'true'}"
        title="${esc(e.id)} · ${esc(e.status)}">
       <span class="type-ico" title="${esc(e.type)}">${icon(e.type)}</span>
       <span class="entry-title">${esc(displayTitle(e))}</span>
@@ -1233,6 +1235,13 @@ async function moveEntry(from, to) {
     tree.querySelectorAll('summary.drop-hover').forEach(s => s.classList.remove('drop-hover'));
   };
   tree.addEventListener('dragstart', e => {
+    // No drag ever starts on a read-only deployment, so dragId stays null
+    // and dragover/drop do nothing either: the move could only 403, and a
+    // gesture that always fails is the same lie as a button that always
+    // fails (design doc 0040 §2.3). Checked here rather than only on the
+    // rendered draggable attribute so a row rendered before the first
+    // response settled READ_ONLY cannot slip through.
+    if (READ_ONLY) { e.preventDefault(); return; }
     const entry = e.target.closest('.tree-entry');
     if (!entry) return;
     dragId = entry.dataset.id;
@@ -1596,19 +1605,19 @@ async function viewDetail(id) {
             <span class="mono">${esc(a.name)}</span>
             <span class="meta">${esc(a.media_type || '')} · ${fmtSize(a.size)}${a.created_by && a.created_by.name ? ' · ' + esc(actorStr(a.created_by)) : ''}${a.created_at ? ' · ' + esc(fmtDate(a.created_at)) : ''}</span>
             <span class="meta">body reference: <code>${ref}</code></span>
-            <button class="btn small danger" data-detach="${esc(a.name)}">Detach</button>
+            <button class="btn small danger write-only" data-detach="${esc(a.name)}">Detach</button>
           </div>
         </div>`;
       }).join('');
       return `
         ${cards || '<div class="empty">No attachments.</div>'}
-        <div class="toolbar" style="margin-top:1rem">
+        <div class="toolbar write-only" style="margin-top:1rem">
           <input type="file" id="att-file" accept="image/png,image/jpeg,image/webp,application/pdf,text/plain,.txt,.csv,.json" multiple hidden>
           <button class="btn small" id="att-choose">Choose files…</button>
           <span class="provenance" id="att-chosen" style="margin:0"></span>
           <button class="btn small primary" id="att-upload">Attach</button>
         </div>
-        <p class="provenance">png / jpeg / webp / pdf / plain text, max 5 MiB each, 20 per entry. Reference a file from the
+        <p class="provenance write-only">png / jpeg / webp / pdf / plain text, max 5 MiB each, 20 per entry. Reference a file from the
         body (<code>![alt](${esc(lastSeg)}/name.png)</code> or <code>[name](${esc(lastSeg)}/name.txt)</code>) so it is findable and survives OKF export.</p>`;
     },
     linked: () => '<div class="empty">…</div>',
@@ -2047,8 +2056,10 @@ async function viewEditor(id, prefix = '') {
           stored where nothing reads it.</div>
       </div>
       <div id="editor-error"></div>
+      <div class="read-only-note">This ochakai is read-only, so nothing here can be
+      saved. The form is what an editor on a writable deployment would fill in.</div>
       <p>
-        <button class="btn primary" type="submit">${editing ? 'Save' : 'Create draft'}</button>
+        <button class="btn primary write-only" type="submit">${editing ? 'Save' : 'Create draft'}</button>
         <a class="btn" href="${editing ? '#/k/' + idPath(entry.id) : '#/'}">Cancel</a>
       </p>
     </form>

--- a/internal/webui/webui_test.go
+++ b/internal/webui/webui_test.go
@@ -1,6 +1,7 @@
 package webui
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -236,6 +237,159 @@ func TestTypeVocabularyMatchesDomain(t *testing.T) {
 		if strings.Contains(icons, retired) || strings.Contains(hint, retired) {
 			t.Errorf("the page still offers %q, retired by design doc 0038", retired)
 		}
+	}
+}
+
+// A read-only deployment must not offer a control that can only ever 403:
+// a button that is pressed and always fails is a lie (design doc 0040
+// §2.3). The whole mechanism on this page is one CSS rule — a write
+// affordance is hidden exactly when the class `write-only` reaches it, on
+// the control itself or on a container.
+//
+// The tree's per-directory ＋ shipped visible on a read-only deployment
+// because it carried the class in a *second* class attribute: HTML keeps
+// the first `class` and drops the rest, so the rule never matched. Nothing
+// failed, because nothing on this page was checked for read-only at all.
+// This is that check: every affordance below writes through /api/v1, so
+// every one of them has to be gated.
+func TestWriteAffordancesAreHiddenOnAReadOnlyDeployment(t *testing.T) {
+	page := string(Index)
+	// The rule and the state that drives it. Renaming either without
+	// renaming the class everywhere would unhide the lot.
+	for _, want := range []string{
+		"body.read-only .write-only { display: none !important; }",
+		"Ochakai-Read-Only",
+		"classList.toggle('read-only', on)",
+	} {
+		if !strings.Contains(page, want) {
+			t.Fatalf("the read-only mechanism is gone: %q", want)
+		}
+	}
+
+	// Controls that carry the class themselves. Every link into the editor
+	// counts: the sidebar ＋, the tree's per-directory ＋, and the two the
+	// search view offers.
+	if n := strings.Count(page, `href="#/new`); n != 4 {
+		t.Errorf("the page has %d literal links to the editor, not the 4 this guard knows; gate the new one and update the count", n)
+	}
+	for _, i := range indexesOf(page, `href="#/new`) {
+		if _, tag := tagAt(t, page, i); !hidesOnReadOnly(tag) {
+			t.Errorf("a link to the editor is not hidden on a read-only deployment:\n%s", tag)
+		}
+	}
+	for _, aff := range []struct{ what, marker string }{
+		{"the directory view's New entry here", `href="${newHref}"`}, // the fifth, built as a variable
+		{"the status picker on an entry", `id="act-status"`},
+		{"Detach on an attachment", "data-detach="},
+		{"the editor's save button", `type="submit"`},
+	} {
+		if _, tag := tagAt(t, page, indexOf(t, page, aff.marker)); !hidesOnReadOnly(tag) {
+			t.Errorf("%s is not hidden on a read-only deployment:\n%s", aff.what, tag)
+		}
+	}
+
+	// Controls gated by the container they sit in: the entry's action bar
+	// and the review card's. Each marker must occur once, so a second copy
+	// added somewhere ungated fails here rather than shipping visible.
+	for _, aff := range []struct{ what, marker, open, close string }{
+		{"attaching a file", `id="att-upload"`, `<div class="toolbar write-only"`, "</div>"},
+		{"Edit", `href="#/edit/`, `<span class="actions write-only">`, "</span>"},
+		{"Re-verify", `id="act-reverify"`, `<span class="actions write-only">`, "</span>"},
+		{"Move…", `id="act-move"`, `<span class="actions write-only">`, "</span>"},
+		{"Delete…", `id="act-delete"`, `<span class="actions write-only">`, "</span>"},
+		{"Verify", `data-act="verify"`, `<span class="actions write-only" style="margin-left:auto`, "</span>"},
+		{"Reject", `data-act="reject"`, `<span class="actions write-only" style="margin-left:auto`, "</span>"},
+	} {
+		if n := strings.Count(page, aff.marker); n != 1 {
+			t.Errorf("%s appears %d times; every copy needs gating, so this guard needs updating", aff.what, n)
+			continue
+		}
+		if !strings.Contains(section(t, page, aff.open, aff.close), aff.marker) {
+			t.Errorf("%s is no longer inside an action bar that hides it on a read-only deployment", aff.what)
+		}
+	}
+
+	// Drag-to-move is a write affordance with no button: dropping an entry
+	// on a directory calls moveEntry, which can only 403 here. The rendered
+	// attribute stops the gesture being offered; the handler is what makes
+	// it impossible.
+	if !strings.Contains(page, `draggable="${READ_ONLY ? 'false' : 'true'}"`) {
+		t.Error("tree entries are draggable unconditionally, so a read-only deployment still invites a move")
+	}
+	if drag := section(t, page, "tree.addEventListener('dragstart'", "\n  });"); !strings.Contains(drag, "if (READ_ONLY)") {
+		t.Errorf("the dragstart handler does not check READ_ONLY, so a drag-to-move can still start:\n%s", drag)
+	}
+}
+
+// The ＋ above was hidden in review and still shipped visible, because the
+// class it was given was the second `class` attribute on the tag and the
+// browser had already taken the first. Nothing about that reads as wrong
+// in a diff, and it silences any guard written in terms of the class.
+func TestNoTagDeclaresClassTwice(t *testing.T) {
+	page := string(Index)
+	seen := map[int]bool{}
+	for _, i := range indexesOf(page, "class=") {
+		start, tag := tagAt(t, page, i)
+		if seen[start] {
+			continue
+		}
+		seen[start] = true
+		if n := strings.Count(tag, "class="); n > 1 {
+			t.Errorf("this tag declares class %d times; the browser keeps the first and drops the rest:\n%s", n, tag)
+		}
+	}
+}
+
+// hidesOnReadOnly reports whether a tag carries write-only in the class
+// the browser actually applies — the first class attribute, since a
+// second one is dropped rather than merged.
+func hidesOnReadOnly(tag string) bool {
+	i := strings.Index(tag, "class=")
+	if i < 0 {
+		return false
+	}
+	rest := tag[i+len("class="):]
+	if rest == "" || (rest[0] != '"' && rest[0] != '\'') {
+		return false
+	}
+	end := strings.IndexByte(rest[1:], rest[0])
+	if end < 0 {
+		return false
+	}
+	return slices.Contains(strings.Fields(rest[1:1+end]), "write-only")
+}
+
+// tagAt returns the tag enclosing offset i — from the "<" that opens it to
+// the ">" that closes it — with the offset it starts at.
+func tagAt(t *testing.T, page string, i int) (int, string) {
+	t.Helper()
+	start := strings.LastIndex(page[:i], "<")
+	end := strings.Index(page[i:], ">")
+	if start < 0 || end < 0 {
+		t.Fatalf("no tag encloses offset %d", i)
+	}
+	return start, page[start : i+end+1]
+}
+
+// indexOf finds the first marker, naming it when it is gone.
+func indexOf(t *testing.T, page, marker string) int {
+	t.Helper()
+	i := strings.Index(page, marker)
+	if i < 0 {
+		t.Fatalf("%q is gone from the page; the guard needs updating", marker)
+	}
+	return i
+}
+
+func indexesOf(page, marker string) []int {
+	var out []int
+	for i := 0; ; {
+		j := strings.Index(page[i:], marker)
+		if j < 0 {
+			return out
+		}
+		out = append(out, i+j)
+		i += j + len(marker)
 	}
 }
 


### PR DESCRIPTION
## What and why

Design doc [0040](docs/design/0040-read-only-mode.md) §2.3 says the Web UI
does not show Verify / Reject / Edit / New on a read-only deployment,
because *押せるが必ず失敗するボタンは嘘である*. Several of them were shown
anyway.

The tree's per-directory ＋ carried the hiding class in a **second** `class`
attribute:

```html
<a class="node-new"
   class="write-only"     <!-- HTML keeps the first class and drops this -->
```

so `body.read-only .write-only` never matched it and a read-only deployment
offered a New-entry button whose editor could only ever 403. Tree entries
were `draggable="true"` unconditionally too, and dropping one on a directory
calls `moveEntry` — the same lie without a button. Nothing failed, because
no write affordance on this page was under test at all.

- **The ＋** is one `class="node-new write-only"` now.
- **Drag-to-move** renders `draggable` from `READ_ONLY`, and `dragstart`
  refuses as well. The handler is the real gate: a row rendered before the
  first response settled `READ_ONLY` cannot slip through. `dragover`/`drop`
  were already inert once no drag starts.
- **Attachments** were ungated entirely — Detach, the upload toolbar, and
  the hint that teaches the body-reference notation, which is authoring
  instruction. Same violation, so they are gated here rather than left for
  the next reader to find.
- **The editor** stays reachable by typed hash once its links are hidden,
  so Save is hidden and a `read-only-note` says why, the way the review
  queue already does.

The guard is the point. `TestWriteAffordancesAreHiddenOnAReadOnlyDeployment`
walks an inventory of every write control and checks it is hidden, reading
`write-only` out of the *first* class attribute only — the one the browser
applies — so this exact bug fails rather than passes. `TestNoTagDeclaresClassTwice`
catches the shape of it anywhere on the page. Both were checked against the
code as it shipped: revert either fix and they fail.

Verified in a browser as well as in the tests: with `body.read-only` the ＋
computes `display: none`, and after `setReadOnly(true)` the rendered rows
are `draggable="false"` and a dispatched `dragstart` comes back cancelled.

## Checks

- [x] `scripts/check` is clean — no store change, so no `--db`
- [x] Behavior changes come with tests (two new guards in
      `internal/webui/webui_test.go`)

## Surfaces and contract

- [x] n/a — no endpoint, tool or client changed; this is the Web UI catching
      up with a decision the other three surfaces already implement
- [x] REST returns 403 with `Ochakai-Read-Only`, MCP omits the write tools,
      the CLI shows it in `whoami`; the Web UI hiding these controls is what
      0040 §2.3 asks of it (design doc 0015)

## Design docs

- [x] Alters no accepted decision — it implements 0040 as written
- [x] Commit messages and code comments are in English
