### PR TITLE
Catch the roadmap and the pasteable examples up with 0.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,9 @@ ochakai search "revenue" --type Metric --status verified
 ochakai search --sort stale_after   # past the expiry their author declared
 ochakai search --source https://wiki.example/revenue-policy  # what derives from this
 ochakai search "revenue" --prefix queries/sales   # only what lives under one subtree
-ochakai get queries/monthly-revenue
+ochakai get queries/sales/monthly-revenue
 ochakai verify metrics/revenue      # promotes a draft — and re-affirms a verified entry, clearing the review feeds
-ochakai attach insights/revenue-reading weekly.png   # files travel with the entry
+ochakai attach insights/reading-revenue weekly.png   # files travel with the entry
 ochakai export ./knowledge   # or: ochakai export - > okf.tar.gz
 ochakai import ./knowledge   # the inverse; works with any OKF bundle (a client-side loop — see below)
 ochakai ui                   # web UI at http://127.0.0.1:8098, acting as you (no deploy)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,36 +19,38 @@ if the proposal is concrete.
 
 ## Now
 
-- **Get 0.15.0 out.** The latest release is
-  [0.14.0](https://github.com/na0fu3y/ochakai/releases/tag/v0.14.0)
-  (2026-07-27), which shipped 0035, 0036 and 0037. What is implemented on
-  `main` and unreleased is listed in the changelog's
-  [Unreleased](CHANGELOG.md) section; the breaking one is
-  [0038](docs/design/0038-type-vocabulary-realignment.md), which realigns
-  the recommended type vocabulary to what OKF itself spells out — nine
-  spellings become eleven, with `Semantic Model` and `Golden Query`
-  retired to free types. No migration runs and no stored entry changes.
-  Beside it, [0039](docs/design/0039-mcp-stdio-bridge.md) gives
-  stdio-only MCP clients a way in (`ochakai mcp-stdio`) and
-  [0040](docs/design/0040-read-only-mode.md) adds `OCHAKAI_READ_ONLY`,
-  for a deployment that serves knowledge without changing it. The release
-  baseline for breaking changes is 0.14.0.
 - **Keep the invariant checks growing with the code**
   ([0035](docs/design/0035-verifiability.md)): exhaustiveness linting, the
   OpenAPI contract test that runs every REST integration request and response
   past `api/openapi.yaml`, and fuzzing on the OKF parser. This is maintenance,
   not a feature — but it is where new endpoints acquire an obligation, since an
   endpoint only comes under the contract check once it has an integration test.
+  0.15.0 extended the same habit to the documentation: the CLI reference is
+  generated from the commands' own help and the shell completions are read
+  from their FlagSets, so both fail CI rather than drifting quietly. Prose the
+  checks do not reach is where the drift now shows up — the OpenAPI examples
+  still teach the vocabulary 0038 retired, because the guard reads the `Type:`
+  schema block and never the examples (issue #222).
 - **Make the project legible to somebody who has not read it.** An audit of
   what a newcomer can learn from this repository found the writing good and
-  the way in poor: the runtime requirement is stated only in
-  `docs/architecture.md`, MCP setup exists for one client out of the several
-  the README names, the CLI's help is the best documentation here and is
-  invisible until you have a binary, and the design records that the English
-  prose calls authoritative are Japanese-only. That is now
-  [a set of issues](https://github.com/na0fu3y/ochakai/issues) rather than a
-  paragraph here. None of it is a feature, and it is the work most likely to
-  decide whether anyone else can use this.
+  the way in poor. Most of what it raised has landed: the quick start loads a
+  ten-entry knowledge base and says what ochakai requires before you need it,
+  every MCP client the README names has setup instructions
+  ([docs/guides/mcp-clients.md](docs/guides/mcp-clients.md)), the CLI's help —
+  still the best documentation here — is rendered into
+  [docs/cli.md](docs/cli.md) before you have a binary, every design record
+  carries an English abstract, and the half of the product that is not Cloud
+  Run has a [FAQ](docs/faq.md),
+  [troubleshooting](docs/guides/troubleshooting.md) and an
+  [operating guide](docs/guides/operating.md). What is left is
+  [open as issues](https://github.com/na0fu3y/ochakai/issues) rather than a
+  paragraph here: the compatibility policy the wire surfaces actually follow
+  is still unwritten (issue #215), and the two ways in that are missing for
+  somebody with no shell or no map — an installable bundle for desktop MCP
+  clients (issue #213) and a guided `ochakai tutorial` (issue #212, which
+  needs a design doc before code, and may be the first command whose purpose
+  is teaching) — are proposals, not plans. None of it is a feature, and it is
+  the work most likely to decide whether anyone else can use this.
 
 ## Next
 

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -452,7 +452,7 @@ func cmdUsage(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
 		"usage",
 		"Usage: ochakai usage [flags] <id>\n\nShow how often an entry was actually used: appeared in search results,\nfetched individually, reported worked or failed — and when it was last\nused. The measure of the write-back loop: evidence for promoting a\ndraft, and a staleness signal for verified entries nobody uses.",
-		"  ochakai usage queries/monthly-revenue\n  ochakai usage metrics/revenue --json\n")
+		"  ochakai usage queries/sales/monthly-revenue\n  ochakai usage metrics/revenue --json\n")
 	asJSON := fs.Bool("json", false, "print JSON")
 	id, _, err := idArgs(fs, args, 1)
 	if err != nil {
@@ -482,7 +482,7 @@ func cmdReport(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
 		"report",
 		"Usage: ochakai report [flags] <id> <worked|failed>\n\nReport whether acting on an entry gave a correct result — the last\nedge of the write-back loop. After running an attested computation or SQL you\nwrote from an entry, report worked or failed (say what went wrong with\n--note); failed counts against verified entries flag them for\nre-verification. Prints the entry's updated usage totals.",
-		"  ochakai report queries/monthly-revenue worked\n  ochakai report queries/monthly-revenue failed --note \"joins dropped 2024 rows after schema change\"\n")
+		"  ochakai report queries/sales/monthly-revenue worked\n  ochakai report queries/sales/monthly-revenue failed --note \"joins dropped 2024 rows after schema change\"\n")
 	note := fs.String("note", "", "context recorded with the report: what was run, what went wrong (max 2000 bytes)")
 	asJSON := fs.Bool("json", false, "print the updated usage totals as JSON")
 	id, rest, err := idArgs(fs, args, 2)
@@ -508,7 +508,7 @@ func cmdRevisions(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
 		"revisions",
 		"Usage: ochakai revisions [flags] <id>\n\nList an entry's change history, newest first: who changed it, how,\nand when — the audit surface behind \"every change kept as a\nrevision\". Works for soft-deleted entries too. Full snapshots are in\nthe JSON output (--json).",
-		"  ochakai revisions metrics/revenue\n  ochakai revisions queries/monthly-revenue --json | jq '.revisions[0].snapshot'\n")
+		"  ochakai revisions metrics/revenue\n  ochakai revisions queries/sales/monthly-revenue --json | jq '.revisions[0].snapshot'\n")
 	limit := fs.Int("limit", 0, "max revisions (server default 50, max 200)")
 	asJSON := fs.Bool("json", false, "print the raw JSON response (includes full snapshots)")
 	id, _, err := idArgs(fs, args, 1)
@@ -570,7 +570,7 @@ func cmdGet(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
 		"get",
 		"Usage: ochakai get [flags] <id>\n\nPrint one knowledge entry as an OKF document (YAML frontmatter +\nmarkdown body). The output round-trips through `ochakai update`.\nAttachment metadata is listed on stderr; --download saves the\nattachment files themselves (an agent can then read them from disk).",
-		"  ochakai get metrics/revenue\n  ochakai get queries/monthly-revenue --json | jq -r '.attrs.sql'\n  ochakai get insights/revenue-reading --download ./img\n")
+		"  ochakai get metrics/revenue\n  ochakai get queries/sales/monthly-revenue --json | jq -r '.attrs.sql'\n  ochakai get insights/reading-revenue --download ./img\n")
 	asJSON := fs.Bool("json", false, "print JSON instead of the OKF document")
 	download := fs.String("download", "", "save the entry's attachments into this directory")
 	id, _, err := idArgs(fs, args, 1)
@@ -624,7 +624,7 @@ func cmdAttach(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
 		"attach",
 		"Usage: ochakai attach [flags] <id> <file...>\n\nAttach files to a knowledge entry (png, jpeg, webp, pdf, plain\ntext — the type is sniffed from the bytes; max 5 MiB each, 20 per\nentry). An attachment of the same name is replaced (the change is kept\nas a revision). Reference the file from the entry's body so its\ncaption is searchable and it survives OKF export/import — the hint\nprinted after attaching shows the canonical relative link. Requires\nthe server to have GCS configured (OCHAKAI_GCS_BUCKET).",
-		"  ochakai attach insights/revenue-reading weekly.png\n  ochakai attach tables/orders seeds.txt\n  ochakai attach tables/orders er-diagram.png --name schema.png\n")
+		"  ochakai attach insights/reading-revenue weekly.png\n  ochakai attach tables/orders seeds.txt\n  ochakai attach tables/orders er-diagram.png --name schema.png\n")
 	name := fs.String("name", "", "attachment name (default: the file's basename; single file only)")
 	asJSON := fs.Bool("json", false, "print the attachment metadata as JSON")
 	pos, err := parseArgs(fs, args)
@@ -679,7 +679,7 @@ func cmdDetach(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
 		"detach",
 		"Usage: ochakai detach [flags] <id> <name>\n\nRemove an attachment from a knowledge entry (the change is kept as a\nrevision; content-addressed bytes stay referenced by history).",
-		"  ochakai detach insights/revenue-reading weekly.png\n")
+		"  ochakai detach insights/reading-revenue weekly.png\n")
 	id, rest, err := idArgs(fs, args, 2)
 	if err != nil {
 		return err

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -78,7 +78,7 @@ Flags:
     	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
 
 Examples:
-  ochakai attach insights/revenue-reading weekly.png
+  ochakai attach insights/reading-revenue weekly.png
   ochakai attach tables/orders seeds.txt
   ochakai attach tables/orders er-diagram.png --name schema.png
 ```
@@ -243,7 +243,7 @@ Flags:
     	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
 
 Examples:
-  ochakai detach insights/revenue-reading weekly.png
+  ochakai detach insights/reading-revenue weekly.png
 ```
 
 ## ochakai export
@@ -287,8 +287,8 @@ Flags:
 
 Examples:
   ochakai get metrics/revenue
-  ochakai get queries/monthly-revenue --json | jq -r '.attrs.sql'
-  ochakai get insights/revenue-reading --download ./img
+  ochakai get queries/sales/monthly-revenue --json | jq -r '.attrs.sql'
+  ochakai get insights/reading-revenue --download ./img
 ```
 
 ## ochakai import
@@ -436,8 +436,8 @@ Flags:
     	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
 
 Examples:
-  ochakai report queries/monthly-revenue worked
-  ochakai report queries/monthly-revenue failed --note "joins dropped 2024 rows after schema change"
+  ochakai report queries/sales/monthly-revenue worked
+  ochakai report queries/sales/monthly-revenue failed --note "joins dropped 2024 rows after schema change"
 ```
 
 ## ochakai revisions
@@ -460,7 +460,7 @@ Flags:
 
 Examples:
   ochakai revisions metrics/revenue
-  ochakai revisions queries/monthly-revenue --json | jq '.revisions[0].snapshot'
+  ochakai revisions queries/sales/monthly-revenue --json | jq '.revisions[0].snapshot'
 ```
 
 ## ochakai search
@@ -588,7 +588,7 @@ Flags:
     	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
 
 Examples:
-  ochakai usage queries/monthly-revenue
+  ochakai usage queries/sales/monthly-revenue
   ochakai usage metrics/revenue --json
 ```
 


### PR DESCRIPTION
Two post-release documentation fixes, one commit each.

## The roadmap still asked for 0.15.0

It shipped on 2026-07-28 with 0038 through 0042, and this file's own rule
is that an item stops being roadmap the moment it becomes a release — so
the bullet goes, and nothing replaces it as an item.

The two that stood before the release still stand, and both moved:

- **Invariant checks** grew a documentation half in 0.15.0 — the CLI
  reference is generated from the commands' own help and the completions
  are read from their FlagSets, so both fail CI rather than drifting.
  Issue #222 now sits with this bullet, because the guard that should have
  caught the OpenAPI examples reads the `Type:` schema block and never the
  examples.
- **Legibility** described a repository that no longer exists: it named
  four gaps that have since closed. It now says what landed — the
  demo-based quick start, the stated requirements, `docs/guides/mcp-clients.md`,
  the rendered `docs/cli.md`, an English abstract on every design record,
  and the FAQ, troubleshooting and operating guide — and names what is
  open: the compatibility policy (#215), the desktop bundle (#213), and
  the tutorial (#212), which needs a design doc before code.

## Two quick-start examples 404 against the bundle they tell you to import

The quick start imports `examples/demo` six lines above the command list,
and two ids in that list are not in it: the golden query is at
`queries/sales/monthly-revenue`, and the insight is
`insights/reading-revenue`. Both ids also run through the CLI's own help,
which is where `docs/cli.md` comes from, so the fix is in the help strings
and `docs/cli.md` is regenerated (`go test ./cmd/ochakai -run TestCLIReferenceIsCurrent -update`).

`client.go`'s create error message keeps `queries/monthly-revenue`: it is
an example of naming a *new* entry, and pointing it at a path the demo
occupies would teach a conflict.

## Left alone deliberately, both worth a decision

- `ochakai get queries/sales/monthly-revenue --json | jq -r '.attrs.sql'`
  now resolves to a real entry and prints `null` — 0038 moved the SQL into
  the `# Computation` fence and the demo entry follows that. Same drift as
  #222, one surface over.
- `ochakai attach tables/orders …` (two examples) still names an entry the
  bundle does not have; the demo's table entry is `tables/shop-orders`.

`scripts/check`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)