### PR TITLE
Say what the bridge needs before showing the config that needs it

### DIFF
--- a/docs/guides/mcp-clients.md
+++ b/docs/guides/mcp-clients.md
@@ -16,9 +16,8 @@ Locally that requirement disappears and the URL works directly.
 over stdio. For those, the bridge is the answer whatever the server is.
 
 So: **local server, capable client → the URL. Anything else → the
-bridge.** The bridge needs `ochakai` on `PATH`; see
-[when it does not connect](#when-it-does-not-connect) for the one way
-that reliably goes wrong.
+bridge** — which has prerequisites of its own, listed
+[below](#what-the-bridge-needs) before any of the configs.
 
 | Client | Local `docker compose` | Cloud Run | Config lives in |
 |---|---|---|---|
@@ -39,6 +38,33 @@ Claude Code and the bridge are what this project exercises. The rest is
 transcribed from each client's own documentation as of July 2026 and
 marked where nobody here has run it — a config that turns out to be wrong
 is worth an issue.
+
+## What the bridge needs
+
+Every config below that launches a command needs `ochakai` on the
+client's `PATH`. Against Cloud Run it needs two more things, and neither
+is present on a machine by default:
+
+- **The `gcloud` CLI**, which is where the ID token comes from. The
+  bridge tries service-account ADC first and otherwise shells out to
+  `gcloud auth print-identity-token` — a user's application-default
+  credentials cannot mint the audience-bound token Cloud Run wants, so
+  on a personal machine it is the `gcloud` path that runs.
+- **`gcloud auth login` having happened**, as a principal holding
+  `roles/run.invoker` on the service.
+
+"The client is configured with no credentials" is a claim about the
+config file, not about the machine. The credential exists; it lives in
+your gcloud session instead of in JSON, which is what keeps it out of
+the client's config and off disk in any form ochakai has to rotate.
+
+`ochakai whoami` is the check. It prints which server the CLI targets,
+as whom, and whether it answers — so run it in a terminal before editing
+any config below, because a client that launches a bridge with no
+identity usually reports it as "the server has no tools".
+
+None of this applies to a local `docker compose` server, which takes no
+token at all.
 
 ## Claude Code
 
@@ -85,6 +111,11 @@ editing.
 Use an absolute path for `command` (`which ochakai`). A desktop app does
 not inherit the `PATH` your shell has, which is the usual reason a config
 that looks right produces no tools.
+
+Against Cloud Run this config does nothing until the machine has gcloud
+and a login — [what the bridge needs](#what-the-bridge-needs). There is
+no way to supply that from inside the app, and no bundle or installer
+that removes it.
 
 Add `--url` when the server is not the one `ochakai use` selected:
 


### PR DESCRIPTION
Rebased onto `main` and narrowed to one commit. This PR originally also
fixed nine `design doc 0041` citations that should have said 0042;
[#240](https://github.com/na0fu3y/ochakai/pull/240) landed that
independently — with prose corrections beyond the number — so that commit
is dropped rather than merged. What is left touches one file.

## What and why

**`docs/guides/mcp-clients.md` stated the bridge's prerequisites as one
item and left the binding one for the bottom of the page.** The intro
said the client "ends up configured with no credentials, because there
are none to configure" and named `ochakai` on `PATH` as the requirement.
gcloud appeared only under *When it does not connect*, as a symptom to
look up after the connection had already failed.

It is not a symptom. Against Cloud Run the bridge takes its ID token
from `gcloud auth print-identity-token` — a user's ADC cannot mint the
audience-bound token Cloud Run wants (`internal/apiclient/token.go`) — so
the machine needs the gcloud CLI and a login by a principal holding
`roles/run.invoker`. That is a prerequisite of every Cloud Run row in the
client table, so it now has a **What the bridge needs** section between
the table and the first client, above the configs rather than below them.

The section also says what the no-credentials claim actually means: the
credential exists, it lives in the gcloud session rather than in JSON,
which is what keeps it out of the client's config. And it points at
`ochakai whoami` as the check to run first, since a bridge launched
without an identity surfaces as "the server has no tools" rather than as
an auth error. Claude Desktop gets the same note beside the absolute-path
one, because the table links there directly.

Context is in
[#213](https://github.com/na0fu3y/ochakai/issues/213#issuecomment-5099511844):
an `.mcpb` bundle would remove the binary install but not the gcloud
login, and the one deployment shape where it would remove the login
(`OCHAKAI_PUBLIC_READ_ONLY`) is reachable by a custom connector URL
without a bridge at all. Stating the prerequisite is the part of that
issue worth doing.

## Checks

- [x] `scripts/check` is clean — add `--db` when the change touches the store

  `scripts/check core` passes on the rebased tree. `lint` and `vuln`
  fail in my container on a toolchain mismatch — both tools are built
  with go1.25, the module targets go1.26 — which is environmental: both
  jobs pass in CI.
- [x] Behavior changes come with tests

  No behavior changes: one prose file.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and `internal/apiclient` say the same thing

  Untouched.
- [x] The change lands on every surface it belongs on — and what it stays off is deliberate (design doc 0015)

  Not applicable: no capability added or removed.

## Design docs

- [x] Alters an accepted decision? — it does not

  0039's bridge is described more completely, not changed.
- [x] Commit messages and code comments are in English
