### PR TITLE
Put the tag message on the release page, not a bare tag

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -6,10 +6,10 @@ description: Cut an ochakai release — the version-bump PR, the annotated tag, 
 # Cutting an ochakai release
 
 A release is a tag. Everything else is automation — but three files carry
-a version number the tag does not update, the release body comes out
-empty unless someone writes it, and a pushed tag is permanent because the
-Go module proxy caches it forever. So the work is: a reviewed PR, then a
-tag, then verification.
+a version number the tag does not update, the release body is only as
+good as the tag message it is copied from, and a pushed tag is permanent
+because the Go module proxy caches it forever. So the work is: a reviewed
+PR, then a tag, then verification.
 
 [CONTRIBUTING.md](../../../CONTRIBUTING.md) is the reference; this skill
 is the running order and the traps.
@@ -66,22 +66,32 @@ Pushing runs [release.yaml](../../../.github/workflows/release.yaml): one
 job publishes the multi-arch image to GHCR with SBOM and provenance, the
 other runs goreleaser for the archives, `checksums.txt`, and provenance.
 
-## 3. Write the release body
+## 3. The release body
 
 **goreleaser's own changelog generation is disabled** (`.goreleaser.yaml`
-— notes are written by hand), so if goreleaser creates the release, the
-body comes out **empty**. Either create the release with its notes before
-pushing the tag, or fill it in after:
+— notes are written by hand), so the release it creates would come out
+with an **empty** body. The workflow fills it from the annotated tag's
+message, so the tag you wrote in step 2 is already on the Releases page —
+which is the real reason to write that message properly rather than
+leaving it for later.
+
+This is why the trap is upstream: a thin tag message is now a thin
+release page, immediately and publicly. Write for an operator upgrading —
+which migrations run, whether `updated_at` moves (held ETags,
+`generated.at`), whether re-embedding is needed, and what a client
+reading the old shape must change.
+
+To add upgrade and install sections on top of it, edit the release; the
+body is replaced wholesale, so start from what is already there:
 
 ```bash
 git tag -l --format='%(contents)' vX.Y.Z | tail -n +3 > notes.md
+# add the upgrade + install sections to notes.md
 gh release edit vX.Y.Z --notes-file notes.md
 ```
 
-Write for an operator upgrading: which migrations run, whether
-`updated_at` moves (held ETags, `generated.at`), whether re-embedding is
-needed, and what a client reading the old shape must change. Add upgrade
-and install notes.
+A release drafted with its body *before* the tag was pushed keeps that
+body — the workflow only writes into an empty one.
 
 ## 4. Verify what shipped
 
@@ -89,9 +99,13 @@ Do this rather than trusting the green check.
 
 ```bash
 gh release view vX.Y.Z --json assets -q '.assets[].name'
+gh release view vX.Y.Z --json body -q '.body' | head -5
 ```
 
-Expect **6 archives plus `checksums.txt`**. Then, in a scratch directory:
+Expect **6 archives plus `checksums.txt`**, and a body that is the tag
+message — an empty one means the copy step warned and skipped (a
+lightweight tag, or a message with nothing under its title line). Then,
+in a scratch directory:
 
 ```bash
 shasum -a 256 -c checksums.txt --ignore-missing

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,6 +78,34 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # goreleaser's own changelog generation is disabled (the notes are
+      # written by hand), so a release it creates has an empty body and
+      # the Releases page shows a bare tag until someone edits it. The
+      # notes already exist by then: this repo's habit is that the
+      # annotated tag's message *is* the release notes. Copy it over.
+      # A release drafted with its body before the tag was pushed keeps
+      # that body — `keep-existing` leaves it alone, and so does this.
+      - name: Fill an empty release body from the tag message
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [ -n "$(gh release view "$TAG" --json body --jq .body)" ]; then
+            echo "$TAG already has a release body; leaving it alone"
+            exit 0
+          fi
+          if [ "$(git tag -l --format='%(objecttype)' "$TAG")" != tag ]; then
+            echo "::warning::$TAG is not annotated, so it carries no message to copy"
+            exit 0
+          fi
+          # Line 1 is the title ("ochakai X.Y.Z") and line 2 is blank.
+          git tag -l --format='%(contents)' "$TAG" | tail -n +3 > "$RUNNER_TEMP/notes.md"
+          if [ ! -s "$RUNNER_TEMP/notes.md" ]; then
+            echo "::warning::$TAG's message is a title with nothing under it"
+            exit 0
+          fi
+          gh release edit "$TAG" --notes-file "$RUNNER_TEMP/notes.md"
       # The image carries provenance; the archives people actually
       # download should too.
       - uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,15 +196,22 @@ job publishes the multi-arch image to GHCR with SBOM and provenance, the
 other runs goreleaser for the archives, `checksums.txt`, and provenance
 over them.
 
-**3. Write the release body.** goreleaser creates the GitHub release when
-none exists, and because its own changelog generation is disabled
-(`.goreleaser.yaml` — the notes are written by hand) **the body comes out
-empty**. Either create the release with its notes before pushing the tag,
-or fill it in afterwards:
+**3. The release body arrives with the tag.** goreleaser creates the
+GitHub release when none exists, and because its own changelog generation
+is disabled (`.goreleaser.yaml` — the notes are written by hand) the body
+would come out empty. So the workflow fills an empty body from the
+annotated tag's message, which is where the notes already are, and the
+Releases page is never a bare tag. Two cases still want a person:
+
+- **A release drafted before the tag was pushed** keeps the body it was
+  given — the workflow only writes into an empty one.
+- **Anything beyond the tag message** — upgrade and install sections,
+  links into `CHANGELOG.md` — is still an edit, and it overwrites:
 
 ```sh
 git tag -l --format='%(contents)' v0.14.0 | tail -n +3 > notes.md
-gh release edit v0.14.0 --notes-file notes.md   # add upgrade + install notes
+# then add the upgrade + install sections to notes.md
+gh release edit v0.14.0 --notes-file notes.md
 ```
 
 Say what an operator upgrading needs: which migrations run, whether


### PR DESCRIPTION
Closes the first bullet of #216 — and only that one. The other five are
adoption signals whose value depends on having adopters, reviewers, or a
citation, none of which exist yet; #216 was closed `not_planned` for that
reason and stays closed.

## What and why

goreleaser's changelog generation is disabled because the notes are written
by hand, so the release it creates on a tag push has an **empty body**.
Until someone runs `gh release edit`, the Releases page shows a bare tag —
a window that has opened on every release so far, because filling it in is
documented as a manual step *after* the tag is pushed.

The notes already exist by then. The repo's habit is that the annotated
tag's message **is** the release notes (`CONTRIBUTING.md` step 2), and step
3 was copying exactly that message across by hand. So the workflow now does
it: read the tag message, drop the title line, write it into the body.

What this deliberately does **not** do is generate the body from
`.github/release.yml`'s label grouping, which is the other reading of that
bullet. `.goreleaser.yaml` already says why — "a generator here would
compete with both" — and the generated `Added` / `Fixed` list would be a
downgrade from prose like *"migrations do not run, `updated_at` does not
move, held ETags are unaffected"*. `release.yml` stays where it is, as the
fallback behind GitHub's own generate-notes button.

Two cases are left alone rather than overwritten:

- **A release drafted with its notes before the tag was pushed.** That is
  the other documented path and goreleaser's `mode: keep-existing` already
  protects it; overwriting here would take the choice away. The step only
  writes into an empty body.
- **A lightweight tag.** `%(contents)` falls back to the *commit* message
  there, so `v0.7.0` would have published a commit message as release
  notes. The step checks `%(objecttype)` and warns instead.

`CONTRIBUTING.md` and the `release` skill said the body comes out empty and
told the maintainer to fill it. They now say where it comes from, and that
the manual edit is for what goes *beyond* the tag message — the upgrade and
install sections, which the copy step cannot invent (v0.14.0's body is the
example). The skill also names the trap that moves upstream with the
automation: a thin tag message is now a thin release page, immediately and
publicly.

## Checks

- [x] `scripts/check core` is clean (no store changes, so no `--db`); no Go
      code is touched
- [x] Behavior changes come with tests — n/a for Go, so the step's three
      paths were exercised directly against this repo's real tags with a
      stubbed `gh`: empty body → copies; body present → skips; lightweight
      tag (`v0.7.0`) → warns and skips.
      **The copy reproduces v0.15.0's hand-written body byte for byte**
      (3819 bytes, the 3835-byte tag message less its title line and the
      blank line under it).

## Surfaces and contract

- [x] n/a — no endpoint, tool, command or view changes; nothing in
      `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver` or
      `internal/apiclient` moves
- [x] n/a — release packaging is not a product surface under design doc 0015

## Design docs

- [x] Not applicable — no accepted decision changes. This automates a step
      `CONTRIBUTING.md` already prescribed, using the source it already
      named; the hand-written-notes decision in `.goreleaser.yaml` is
      preserved rather than replaced.
- [x] Commit messages and code comments are in English (the tag messages
      they carry stay Japanese, as before)

Not added to `CHANGELOG.md`: that file "keeps what an operator upgrading
needs to know", and this changes how the release page gets its text, not
anything shipped. Happy to add a line if you'd rather it be recorded.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVS8jFopG5K4fZLPEmZGRV)_