### PR TITLE
Give the release jobs the permissions they ask for

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,14 +7,18 @@ name: release
 on:
   push:
     tags: ["v*"]
+# Read-only by default, so a job added below starts with no write
+# permission it did not ask for. Each job declares what it needs.
 permissions:
   contents: read
-  packages: write
-  id-token: write
-  attestations: write
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout
+      packages: write # push the image to GHCR
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -52,7 +56,7 @@ jobs:
   binaries:
     runs-on: ubuntu-latest
     permissions:
-      # Narrower than the workflow default on purpose: this job needs to
+      # Deliberately not the same set as `publish`: this job needs to
       # write release assets, but has no business with packages.
       contents: write
       id-token: write


### PR DESCRIPTION
## What and why

`release.yaml` granted `packages: write`, `id-token: write`, and
`attestations: write` at the top level. `publish` declared no permissions of
its own, so it inherited all of them; `binaries` declared its own narrower set
with a comment saying it did so on purpose. The file already had the right
idea and applied it to one job out of two.

This drops the top level to `contents: read` and lets `publish` declare what it
actually needs. The release itself does not change — `publish` ends up with the
same effective permissions it had before. What changes is the default: the next
job added to this workflow starts with no write permission it did not ask for,
rather than silently receiving the ability to push to GHCR and sign
attestations.

The `binaries` comment said "narrower than the workflow default", which is no
longer true now that the default is read-only, so it is reworded to say what it
still means — that job writes release assets and has no business with packages.

Found by running OpenSSF Scorecard against a local checkout. Its
Token-Permissions check scores any top-level write permission as 0; with this
change the check reports 10 ("GitHub workflow tokens follow principle of least
privilege"). The score is the reason it was noticed, not the reason to make the
change — the workflow's own comment already argued for it.

Other Scorecard findings were looked at and deliberately left alone: the
Dockerfile base images are tag-pinned rather than digest-pinned (a judgment
call, not a defect), and the 0 scores for SAST and Signed-Releases come from
Scorecard not counting `golangci-lint` / `go vet` / `govulncheck` as SAST and
not reading GitHub's attestation store. Chasing either would raise a number
without improving anything.

## Checks

- [x] `scripts/check` is clean — add `--db` when the change touches the store

  Not run: this PR touches only `.github/workflows/release.yaml`, no Go code.
  The workflow was validated as YAML and re-checked with Scorecard's
  Token-Permissions check (0 → 10).
- [x] Behavior changes come with tests — no behavior change; `publish`'s
  effective permission set is identical

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — not applicable, no wire surface
      is touched
- [x] The change lands on every surface it belongs on — not applicable, this is
      CI configuration

## Design docs

- [x] Alters an accepted decision? No. Narrowing a workflow's default token
      permissions does not change a decision recorded under `docs/design`; no
      new numbered doc is needed
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYDD6DbDvhDXXqse4Hr168)_