### PR TITLE
Spell the non-human actor kind the way OKF does: process (0043 §3.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,21 @@ last entry.
 
 ### Changed
 
+- **BREAKING**: the actor kind for anything that is not a person is
+  `process`, not `agent` — the spelling OKF SPEC §7 defines (design doc
+  [0043](docs/design/0043-document-first.md) §3.8). `agent` was never a
+  spelling the spec offered, and the distinction it drew is one nothing
+  in ochakai ever read: SPEC §5.3 derives trust from the `human:` prefix
+  alone. A client reading `actor.kind` must accept `process`, and
+  `X-Ochakai-On-Behalf-Of: agent:…` is now a 400 — send `process:…`.
+  Exported bundles write `generated: { by: process:… }` and
+  `created_by: process:…`, so the next export of a git-tracked bundle
+  shows that diff. Migration `0022` rewrites every stored actor kind and
+  every `via` (which holds a whole `kind:name` string), in the entries,
+  their revisions and revision snapshots, the usage events, the
+  attachments and the purge log. It moves no `updated_at`, so no held
+  ETag is invalidated and nothing needs re-embedding.
+
 - `api/openapi.yaml`'s examples stop teaching `type: Golden Query` with
   the SQL in `attrs`. 0.15.0 retired that spelling and rewrote the shipped
   example and the canary guide onto `Attested Computation`, but the spec's

--- a/README.md
+++ b/README.md
@@ -495,7 +495,7 @@ sources:
     author: human:jsmith@example.co.jp
     last_modified: "2026-06-15"
 usage_window: { from: "2026-06-01", to: "2026-06-30" }
-generated: { by: agent:analyst@example.iam.gserviceaccount.com, at: 2026-07-26T04:12:00Z }
+generated: { by: process:analyst@example.iam.gserviceaccount.com, at: 2026-07-26T04:12:00Z }
 verified:
   - { by: human:tanaka@example.co.jp, at: 2026-07-26T09:30:00Z }
 status: stable                 # draft | stable | deprecated
@@ -568,8 +568,8 @@ back fits what you asked for.
 | `OCHAKAI_GCS_BUCKET` | Bucket for attachment bytes (auth is ADC — no keys). Default: unset — the instance stores markdown entries only and attach operations return an error |
 | `OCHAKAI_VERTEX_PROJECT` | Set to enable hybrid semantic search via Vertex AI embeddings (default: off, lexical-only — ochakai calls no external API unless you opt in). Auth is ADC — no API keys. **Recommended for Japanese knowledge bases** (see below) |
 | `OCHAKAI_VERTEX_LOCATION` / `OCHAKAI_VERTEX_MODEL` / `OCHAKAI_EMBEDDING_DIM` | Embedding details (defaults: `us-central1`, `gemini-embedding-001`, 768). For image/PDF attachment search set model `gemini-embedding-2` with location `global` (or `us`/`eu`). Vectors are written when an entry is written, so enabling this on an existing base — or changing the model — leaves entries unembedded until you run `ochakai reembed` (design doc 0020). Dimensions above 2000 exceed pgvector's indexing limit, so those deployments fall back to an exact scan. Changing `OCHAKAI_EMBEDDING_DIM` on a base that already holds vectors is refused at startup, with the two ways out: put it back, or drop the vector tables and re-embed |
-| `OCHAKAI_DELEGATING_CALLERS` | Comma-separated caller identities allowed to forward an end user's identity with `X-Ochakai-On-Behalf-Of: human:tanaka@example.co.jp` (`*` for any authenticated caller). For applications that embed ochakai and serve many people — without it, every one of their users collapses into the application's one service account. Both identities are recorded (`human:tanaka@… via agent:app-sa@…`), never just the forwarded one. Default: empty, delegation off; a header from an unlisted caller is a 403, not a silent downgrade (design doc 0027) |
-| `OCHAKAI_IAP_AUDIENCE` | `ochakai serve-ui` only: the IAP JWT audience to verify, which turns browser edits from `agent:<webui-sa>` into the person signed in (`human:tanaka@… via agent:<webui-sa>`). Requires the webui's service account in the server's `OCHAKAI_DELEGATING_CALLERS`. Once set, a request IAP did not sign is refused rather than recorded as the service account. Default: empty, per-user provenance off (design doc 0032) |
+| `OCHAKAI_DELEGATING_CALLERS` | Comma-separated caller identities allowed to forward an end user's identity with `X-Ochakai-On-Behalf-Of: human:tanaka@example.co.jp` (`*` for any authenticated caller). For applications that embed ochakai and serve many people — without it, every one of their users collapses into the application's one service account. Both identities are recorded (`human:tanaka@… via process:app-sa@…`), never just the forwarded one. Default: empty, delegation off; a header from an unlisted caller is a 403, not a silent downgrade (design doc 0027) |
+| `OCHAKAI_IAP_AUDIENCE` | `ochakai serve-ui` only: the IAP JWT audience to verify, which turns browser edits from `process:<webui-sa>` into the person signed in (`human:tanaka@… via process:<webui-sa>`). Requires the webui's service account in the server's `OCHAKAI_DELEGATING_CALLERS`. Once set, a request IAP did not sign is refused rather than recorded as the service account. Default: empty, per-user provenance off (design doc 0032) |
 | `OCHAKAI_READ_ONLY` | `true` makes the deployment serve knowledge without changing it: every write is a 403, MCP does not offer the write tools at all, and the web UI stops drawing buttons that would only fail. For a reference-only instance or freezing a base during a migration; a *public* demo needs `OCHAKAI_PUBLIC_READ_ONLY` below, because read-only alone still refuses anonymous callers. It is not authorization — it does not look at the caller, and it refuses the operator too (design doc [0040](docs/design/0040-read-only-mode.md)). Usage telemetry still records, being the server's own observation. Default: off |
 | `OCHAKAI_PUBLIC_READ_ONLY` | `true` is the posture for a deployment anyone may reach — a demo, or a reference-only copy handed out. It **reads no identity at all**: the `Authorization` header is ignored (without Cloud Run IAM in front nothing verified its signature, so believing it would let any caller name any person), delegation is ignored, every caller is `human:anonymous`, and nobody is refused. It **implies** `OCHAKAI_READ_ONLY` and cannot be separated from it — not recording who asked is only defensible because nothing is written, so a publicly readable *and writable* ochakai is not a configuration this program accepts (design doc [0042](docs/design/0042-public-read-only.md)). Setting it together with `OCHAKAI_INSECURE_DEV` is refused at startup. Default: off |
 | `OCHAKAI_INSECURE_DEV` | Local development only: disables auth, everything acts as human:anonymous |
@@ -577,7 +577,7 @@ back fits what you asked for.
 
 Authentication has no configuration: ochakai reads the caller identity
 that Cloud Run forwards after its IAM check (`human:<email>` for people,
-`agent:<sa-email>` for service accounts) and records it as provenance.
+`process:<sa-email>` for service accounts) and records it as provenance.
 Reachability is Cloud Run IAM's job; ochakai does no authorization.
 
 The complete, cost-minimized deployment walkthrough (~$10/month) lives in

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -218,8 +218,8 @@ paths:
                         tags: [finance]
                         status: draft
                         stale_after: "2027-01-31"
-                        created_by: { kind: agent, name: analyst@example.iam.gserviceaccount.com }
-                        updated_by: { kind: agent, name: analyst@example.iam.gserviceaccount.com }
+                        created_by: { kind: process, name: analyst@example.iam.gserviceaccount.com }
+                        updated_by: { kind: process, name: analyst@example.iam.gserviceaccount.com }
                         links:
                           - { target: metrics/revenue, text: Revenue }
                         body: |
@@ -246,8 +246,8 @@ paths:
                         tags: [finance]
                         status: draft
                         stale_after: "2027-01-31"
-                        created_by: { kind: agent, name: analyst@example.iam.gserviceaccount.com }
-                        updated_by: { kind: agent, name: analyst@example.iam.gserviceaccount.com }
+                        created_by: { kind: process, name: analyst@example.iam.gserviceaccount.com }
+                        updated_by: { kind: process, name: analyst@example.iam.gserviceaccount.com }
                         links:
                           - { target: metrics/revenue, text: Revenue }
                         body: |
@@ -929,11 +929,11 @@ paths:
                     created_by:
                       kind: human
                       name: tanaka@example.co.jp
-                      via: agent:insightflow@example.iam.gserviceaccount.com
+                      via: process:insightflow@example.iam.gserviceaccount.com
                     updated_by:
                       kind: human
                       name: tanaka@example.co.jp
-                      via: agent:insightflow@example.iam.gserviceaccount.com
+                      via: process:insightflow@example.iam.gserviceaccount.com
                     links:
                       - { target: metrics/revenue, text: Revenue }
                     body: |
@@ -1288,8 +1288,8 @@ paths:
                     tags: [finance]
                     status: verified
                     stale_after: "2027-01-31"
-                    created_by: { kind: agent, name: analyst@example.iam.gserviceaccount.com }
-                    updated_by: { kind: agent, name: analyst@example.iam.gserviceaccount.com }
+                    created_by: { kind: process, name: analyst@example.iam.gserviceaccount.com }
+                    updated_by: { kind: process, name: analyst@example.iam.gserviceaccount.com }
                     verified_by: { kind: human, name: tanaka@example.co.jp }
                     verified_at: "2026-07-27T00:41:12.905337Z"
                     links:
@@ -1468,8 +1468,8 @@ paths:
                           tags: [finance]
                           status: verified
                           stale_after: "2027-01-31"
-                          created_by: { kind: agent, name: analyst@example.iam.gserviceaccount.com }
-                          updated_by: { kind: agent, name: analyst@example.iam.gserviceaccount.com }
+                          created_by: { kind: process, name: analyst@example.iam.gserviceaccount.com }
+                          updated_by: { kind: process, name: analyst@example.iam.gserviceaccount.com }
                           verified_by: { kind: human, name: tanaka@example.co.jp }
                           verified_at: "2026-07-27T00:41:12.905337Z"
                           links:
@@ -1482,7 +1482,7 @@ paths:
                           updated_at: "2026-07-27T00:41:12.905337Z"
                       - rev: 1
                         change: create
-                        changed_by: { kind: agent, name: analyst@example.iam.gserviceaccount.com }
+                        changed_by: { kind: process, name: analyst@example.iam.gserviceaccount.com }
                         changed_at: "2026-07-21T06:14:55.402881Z"
                         snapshot:
                           type: Insight
@@ -1492,8 +1492,8 @@ paths:
                           tags: [finance]
                           status: draft
                           stale_after: "2027-01-31"
-                          created_by: { kind: agent, name: analyst@example.iam.gserviceaccount.com }
-                          updated_by: { kind: agent, name: analyst@example.iam.gserviceaccount.com }
+                          created_by: { kind: process, name: analyst@example.iam.gserviceaccount.com }
+                          updated_by: { kind: process, name: analyst@example.iam.gserviceaccount.com }
                           links:
                             - { target: metrics/revenue, text: Revenue }
                           body: |
@@ -1560,8 +1560,8 @@ paths:
                         tags: [finance]
                         status: draft
                         stale_after: "2027-01-31"
-                        created_by: { kind: agent, name: analyst@example.iam.gserviceaccount.com }
-                        updated_by: { kind: agent, name: analyst@example.iam.gserviceaccount.com }
+                        created_by: { kind: process, name: analyst@example.iam.gserviceaccount.com }
+                        updated_by: { kind: process, name: analyst@example.iam.gserviceaccount.com }
                         links:
                           - { target: metrics/revenue, text: Revenue }
                         body: |
@@ -1892,7 +1892,7 @@ components:
       required: false
       description: >
         Delegated end-user identity (design doc 0027): "kind:identity",
-        kind human or agent, no whitespace in the identity, at most 320
+        kind human or process, no whitespace in the identity, at most 320
         bytes — e.g. "human:tanaka@example.co.jp". An application on the
         delegator allowlist (OCHAKAI_DELEGATING_CALLERS) forwards who it
         is acting for; the forwarded identity is recorded as the actor
@@ -1971,13 +1971,20 @@ components:
         Who acted. Resolved from the caller's Google identity, never from
         the request payload (design doc 0009).
       properties:
-        kind: { type: string, enum: [human, agent] }
+        kind:
+          description: >
+            The spellings OKF SPEC §7 defines (design doc 0043 §3.8).
+            Anything that is not a person is a process — §5.3 derives
+            trust from the human: prefix alone, so no finer distinction
+            is load-bearing. Service accounts are processes.
+          type: string
+          enum: [human, process]
         name: { type: string }
         via:
           description: >
             The delegating caller, when an application forwarded an end
             user's identity with X-Ochakai-On-Behalf-Of (design doc
-            0027) — e.g. "agent:app@project.iam.gserviceaccount.com" on
+            0027) — e.g. "process:app@project.iam.gserviceaccount.com" on
             an entry whose actor is the person who used that application.
             Absent when the caller acted as itself. Recorded rather than
             replaced: a write made through an application must stay

--- a/cmd/ochakai/client_test.go
+++ b/cmd/ochakai/client_test.go
@@ -149,14 +149,14 @@ func TestRenderContext(t *testing.T) {
 			{
 				Type: domain.TypeComputations, ID: "queries/monthly-revenue", Status: domain.StatusVerified,
 				Title:      "Monthly revenue",
-				CreatedBy:  domain.Actor{Kind: domain.ActorAgent, Name: "claude"},
+				CreatedBy:  domain.Actor{Kind: domain.ActorProcess, Name: "claude"},
 				VerifiedBy: &human, VerifiedAt: &now,
 				Attrs: map[string]any{"question": "Revenue by month?", "sql": "SELECT 1\n"},
 				Body:  "Prefer this over writing new SQL.",
 			},
 			{
 				Type: domain.TypeInsights, ID: "insights/revenue-seasonality", Status: domain.StatusDraft,
-				Title: "Seasonality", CreatedBy: domain.Actor{Kind: domain.ActorAgent, Name: "claude"},
+				Title: "Seasonality", CreatedBy: domain.Actor{Kind: domain.ActorProcess, Name: "claude"},
 				Body: "Q4 peaks ~40% above baseline.",
 			},
 		},
@@ -167,7 +167,7 @@ func TestRenderContext(t *testing.T) {
 	s := out.String()
 	for _, want := range []string{
 		"## ochakai://queries/monthly-revenue (verified) — Monthly revenue",
-		"verified by human:na0 on 2026-06-01; created by agent:claude",
+		"verified by human:na0 on 2026-06-01; created by process:claude",
 		"Q: Revenue by month?",
 		"```sql\nSELECT 1\n```",
 		"Prefer this over writing new SQL.",

--- a/cmd/ochakai/serveui.go
+++ b/cmd/ochakai/serveui.go
@@ -5,7 +5,7 @@
 // service's identity token in X-Serverless-Authorization for Cloud Run
 // service-to-service auth. The ochakai deployment therefore stays
 // IAM-restricted, and browser users are recorded as this service's
-// identity (agent:<sa-email>). Same image as `serve`: deploy it with
+// identity (process:<sa-email>). Same image as `serve`: deploy it with
 // `--args=serve-ui` (deploy guide §5b).
 //
 // OCHAKAI_URL is required: the page always talks to its own origin

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,7 +95,7 @@ What ochakai does with an identity is *record* it. Cloud Run performs the
 IAM check and forwards the verified caller identity in a header; ochakai
 reads that header for one purpose — deciding whose name goes on the
 entry. An email ending in `.gserviceaccount.com` becomes
-`agent:<sa-email>`, anything else `human:<email>`. Nothing else consults
+`process:<sa-email>`, anything else `human:<email>`. Nothing else consults
 it. Promotion to `verified` is not restricted either: who verified an
 entry is always recorded, so the decision about whether to trust it is
 made by whoever reads the provenance, not by a gate at the write. The
@@ -112,7 +112,7 @@ The consequences to plan around:
   app that calls ochakai with its own service account records every one
   of its users as that service account. `X-Ochakai-On-Behalf-Of` fixes
   this for callers you list in `OCHAKAI_DELEGATING_CALLERS`; both
-  identities are then recorded (`human:… via agent:…`), never just the
+  identities are then recorded (`human:… via process:…`), never just the
   forwarded one, and a delegation header from an unlisted caller is
   refused rather than quietly downgraded (design doc
   [0027](design/0027-delegated-provenance.md)). The team web UI does the

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -137,7 +137,7 @@ last curl went to. Its startup line and `ochakai whoami` both say which.
 loopback. A deployed `ochakai serve-ui` records the service account
 instead, unless `OCHAKAI_IAP_AUDIENCE` is set and the webui's service
 account is listed in the server's `OCHAKAI_DELEGATING_CALLERS`, which is
-what turns browser edits into `human:you via agent:webui-sa` (design doc
+what turns browser edits into `human:you via process:webui-sa` (design doc
 0032).
 
 ## Startup

--- a/internal/apiclient/apiclient.go
+++ b/internal/apiclient/apiclient.go
@@ -51,7 +51,7 @@ func (c *Client) TokenSource() oauth2.TokenSource { return c.tokens }
 
 // Identity resolves, locally, the identity this client would present:
 // the ID token's email, prefixed the way the server maps actors (design
-// doc 0002) — service accounts to agent:, everyone else to human:.
+// doc 0002) — service accounts to process:, everyone else to human:.
 // Plain-http development servers see human:anonymous. The server's actor
 // resolution is authoritative; this is the client's best-effort view.
 func (c *Client) Identity() (actor, auth string, err error) {
@@ -66,9 +66,9 @@ func (c *Client) Identity() (actor, auth string, err error) {
 	if email == "" {
 		return "", c.auth, fmt.Errorf("ID token carries no email claim")
 	}
-	prefix := "human:"
+	prefix := domain.ActorHuman + ":"
 	if strings.HasSuffix(email, ".gserviceaccount.com") {
-		prefix = "agent:"
+		prefix = domain.ActorProcess + ":"
 	}
 	return prefix + email, c.auth, nil
 }

--- a/internal/apiclient/identity_test.go
+++ b/internal/apiclient/identity_test.go
@@ -39,8 +39,8 @@ func TestIdentityPlainHTTPIsAnonymous(t *testing.T) {
 func TestIdentityPrefixesActors(t *testing.T) {
 	for email, want := range map[string]string{
 		"someone@example.com":                 "human:someone@example.com",
-		"robot@proj.iam.gserviceaccount.com":  "agent:robot@proj.iam.gserviceaccount.com",
-		"ochakai@appspot.gserviceaccount.com": "agent:ochakai@appspot.gserviceaccount.com",
+		"robot@proj.iam.gserviceaccount.com":  "process:robot@proj.iam.gserviceaccount.com",
+		"ochakai@appspot.gserviceaccount.com": "process:ochakai@appspot.gserviceaccount.com",
 	} {
 		c := &Client{
 			tokens: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: fakeJWT(`{"email":"` + email + `"}`)}),

--- a/internal/domain/knowledge.go
+++ b/internal/domain/knowledge.go
@@ -359,14 +359,14 @@ type Usage struct {
 // delegation becomes indistinguishable from a forgery. Empty for the
 // ordinary case, where the caller acted as itself.
 type Actor struct {
-	Kind string `json:"kind"` // "human" | "agent"
+	Kind string `json:"kind"` // "human" | "process"
 	Name string `json:"name"`
 	Via  string `json:"via,omitempty"` // the delegating caller's identity, "" when there is none
 }
 
 // String renders an actor the way every surface shows provenance:
 // "human:tanaka@example.co.jp", or "human:tanaka@example.co.jp via
-// agent:insightflow@example.iam.gserviceaccount.com" when the write came
+// process:insightflow@example.iam.gserviceaccount.com" when the write came
 // through a delegating application.
 func (a Actor) String() string {
 	s := a.Kind + ":" + a.Name
@@ -376,10 +376,27 @@ func (a Actor) String() string {
 	return s
 }
 
+// The actor kinds, spelled as OKF SPEC §7 spells them. ochakai wrote
+// "agent:" until 0.15 (design doc 0043 §3.8): the spelling was ochakai's
+// own, and the distinction it drew — an LLM agent rather than any other
+// automation — is one nothing in the system ever branched on, while SPEC
+// §5.3 lumps everything that is not human: into one machine-confirmed
+// tier. A distinction that costs conformance and buys nothing is not one
+// worth keeping.
+//
+// SPEC §7's third form, "<producer>/<version>", stays unused: ochakai's
+// non-human writers are IAM service accounts, which have no version, and
+// inventing one would make the provenance say something the server never
+// observed.
 const (
-	ActorHuman = "human"
-	ActorAgent = "agent"
+	ActorHuman   = "human"
+	ActorProcess = "process"
 )
+
+// ValidActorKind reports whether kind is one ochakai records.
+func ValidActorKind(kind string) bool {
+	return kind == ActorHuman || kind == ActorProcess
+}
 
 // Link is an edge to another knowledge entry, derived from a markdown
 // link in the body — never authored as a field (design doc 0024). Links

--- a/internal/httpauth/httpauth.go
+++ b/internal/httpauth/httpauth.go
@@ -161,9 +161,9 @@ func parseOnBehalfOf(v string) (domain.Actor, error) {
 	}
 	kind, name, ok := strings.Cut(v, ":")
 	name = strings.TrimSpace(name)
-	if !ok || name == "" || (kind != domain.ActorHuman && kind != domain.ActorAgent) {
+	if !ok || name == "" || !domain.ValidActorKind(kind) {
 		return domain.Actor{}, fmt.Errorf(
-			`%s: want "human:<identity>" or "agent:<identity>", got %q`, OnBehalfOfHeader, v)
+			`%s: want "human:<identity>" or "process:<identity>", got %q`, OnBehalfOfHeader, v)
 	}
 	if strings.ContainsAny(name, " \t") {
 		return domain.Actor{}, fmt.Errorf("%s: identity must not contain whitespace", OnBehalfOfHeader)
@@ -172,7 +172,7 @@ func parseOnBehalfOf(v string) (domain.Actor, error) {
 }
 
 // actorFromIDToken extracts provenance from ID token claims: the email is
-// the actor name; service accounts are agents, people are humans.
+// the actor name; service accounts are processes, people are humans.
 func actorFromIDToken(token string) (domain.Actor, error) {
 	if token == "" {
 		return domain.Actor{}, errors.New("no identity token; is the service non-public with Cloud Run IAM enforced? (for local development set OCHAKAI_INSECURE_DEV=true)")
@@ -193,7 +193,7 @@ func actorFromIDToken(token string) (domain.Actor, error) {
 	}
 	kind := domain.ActorHuman
 	if strings.HasSuffix(claims.Email, ".gserviceaccount.com") {
-		kind = domain.ActorAgent
+		kind = domain.ActorProcess
 	}
 	return domain.Actor{Kind: kind, Name: claims.Email}, nil
 }
@@ -210,11 +210,11 @@ func WithActor(ctx context.Context, a domain.Actor) context.Context {
 	return context.WithValue(ctx, ctxKey{}, a)
 }
 
-// Actor returns the authenticated actor, defaulting to agent/unknown so a
-// missing context never grants human provenance.
+// Actor returns the authenticated actor, defaulting to process/unknown so
+// a missing context never grants human provenance.
 func Actor(ctx context.Context) domain.Actor {
 	if a, ok := ctx.Value(ctxKey{}).(domain.Actor); ok {
 		return a
 	}
-	return domain.Actor{Kind: domain.ActorAgent, Name: "unknown"}
+	return domain.Actor{Kind: domain.ActorProcess, Name: "unknown"}
 }

--- a/internal/httpauth/httpauth_test.go
+++ b/internal/httpauth/httpauth_test.go
@@ -37,7 +37,7 @@ func TestActorFromIDToken(t *testing.T) {
 		{
 			name:  "service account is an agent",
 			token: fakeIDToken(`{"email":"bot@myproj.iam.gserviceaccount.com"}`),
-			want:  domain.Actor{Kind: domain.ActorAgent, Name: "bot@myproj.iam.gserviceaccount.com"},
+			want:  domain.Actor{Kind: domain.ActorProcess, Name: "bot@myproj.iam.gserviceaccount.com"},
 		},
 		{name: "empty", token: "", wantErr: true},
 		{name: "not a jwt", token: "abc", wantErr: true},
@@ -115,7 +115,7 @@ func TestInsecureDevActsAsAnonymous(t *testing.T) {
 // application never reads like one tanaka wrote directly (design doc
 // 0027).
 func TestDelegate(t *testing.T) {
-	sa := domain.Actor{Kind: domain.ActorAgent, Name: "insightflow@example.iam.gserviceaccount.com"}
+	sa := domain.Actor{Kind: domain.ActorProcess, Name: "insightflow@example.iam.gserviceaccount.com"}
 	human := domain.Actor{Kind: domain.ActorHuman, Name: "na0@example.co.jp"}
 	allowed := []string{sa.Name}
 
@@ -148,7 +148,7 @@ func TestDelegate(t *testing.T) {
 		if got != want {
 			t.Errorf("actor = %+v, want %+v", got, want)
 		}
-		if !strings.Contains(got.String(), "via agent:insightflow@") {
+		if !strings.Contains(got.String(), "via process:insightflow@") {
 			t.Errorf("rendered provenance hides the delegation: %s", got)
 		}
 	})

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -479,7 +479,7 @@ func TestRequestActorUsesCallHeaders(t *testing.T) {
 // all there is — and correct, since such callers cannot share a session
 // across identities.
 func TestRequestActorFallsBackToContext(t *testing.T) {
-	want := domain.Actor{Kind: domain.ActorAgent, Name: "sa@example.gserviceaccount.com"}
+	want := domain.Actor{Kind: domain.ActorProcess, Name: "sa@example.gserviceaccount.com"}
 	ctx := httpauth.WithActor(context.Background(), want)
 	for _, req := range []*mcp.CallToolRequest{
 		{},

--- a/internal/okf/okf.go
+++ b/internal/okf/okf.go
@@ -319,12 +319,11 @@ func (d *dir) writeIndexes(files map[string][]byte, prefix string) {
 	}
 }
 
-// actorEvent renders one trust event. The actor's kind:name form already
-// matches SPEC §7 for people ("human:tanaka@example.co.jp"); agents keep
-// ochakai's "agent:" prefix rather than being dressed up as a versioned
-// producer or relabelled process, because §5.3 keys trust tiers off the
-// human: prefix alone and nothing else in the convention is load-bearing
-// (design doc 0036 §3.11).
+// actorEvent renders one trust event. The actor's kind:name form is SPEC
+// §7 verbatim on both kinds — "human:tanaka@example.co.jp" and
+// "process:sync@example.iam.gserviceaccount.com" (design doc 0043 §3.8).
+// The convention's third form, "<producer>/<version>", stays unused: a
+// service account has no version to name.
 func actorEvent(a *domain.Actor, at *time.Time) event {
 	var e event
 	if a != nil && (a.Kind != "" || a.Name != "") {

--- a/internal/okf/okf_test.go
+++ b/internal/okf/okf_test.go
@@ -22,8 +22,8 @@ func sample() []domain.Knowledge {
 			Title: "売上の季節性", Description: "12月は繁忙期",
 			Tags: []string{"sales"}, Status: domain.StatusVerified,
 			StaleAfter: "2026-12-31",
-			CreatedBy:  domain.Actor{Kind: "agent", Name: "claude-code"},
-			UpdatedBy:  domain.Actor{Kind: "agent", Name: "claude-code"},
+			CreatedBy:  domain.Actor{Kind: "process", Name: "claude-code"},
+			UpdatedBy:  domain.Actor{Kind: "process", Name: "claude-code"},
 			VerifiedBy: &domain.Actor{Kind: "human", Name: "na0"}, VerifiedAt: &verifiedAt,
 			Attrs:     map[string]any{"kind": "seasonality"},
 			Body:      "12月は+40%が通常。[売上](/metrics/revenue.md) の話である。",
@@ -33,7 +33,7 @@ func sample() []domain.Knowledge {
 			Type: domain.TypeTables, ID: "tables/orders",
 			Title: "orders", Status: domain.StatusDraft,
 			CreatedBy: domain.Actor{Kind: "human", Name: "na0"},
-			UpdatedBy: domain.Actor{Kind: "human", Name: "na0", Via: "agent:insightflow"},
+			UpdatedBy: domain.Actor{Kind: "human", Name: "na0", Via: "process:insightflow"},
 			Resource:  "myproject.shop.orders",
 			Attrs:     map[string]any{"model": "sales_analytics"},
 			UpdatedAt: verifiedAt,
@@ -68,7 +68,7 @@ func TestDocumentFrontmatterAndBody(t *testing.T) {
 		"title":       "売上の季節性",
 		"status":      "stable",
 		"stale_after": "2026-12-31",
-		"created_by":  "agent:claude-code",
+		"created_by":  "process:claude-code",
 	} {
 		if fm[key] != want {
 			t.Errorf("frontmatter %s = %v, want %v", key, fm[key], want)
@@ -80,7 +80,7 @@ func TestDocumentFrontmatterAndBody(t *testing.T) {
 		}
 	}
 	generated, _ := fm["generated"].(map[string]any)
-	if generated["by"] != "agent:claude-code" || generated["at"] != "2026-07-01T00:00:00Z" {
+	if generated["by"] != "process:claude-code" || generated["at"] != "2026-07-01T00:00:00Z" {
 		t.Errorf("generated = %v, want the last content author and change time", fm["generated"])
 	}
 	verified, _ := fm["verified"].([]any)
@@ -154,7 +154,7 @@ func TestDocumentDelegatedActor(t *testing.T) {
 		t.Fatal(err)
 	}
 	generated, _ := fm["generated"].(map[string]any)
-	if generated["by"] != "human:na0" || generated["via"] != "agent:insightflow" {
+	if generated["by"] != "human:na0" || generated["via"] != "process:insightflow" {
 		t.Errorf("generated = %v, want by and via kept apart", fm["generated"])
 	}
 }

--- a/internal/okf/parse_test.go
+++ b/internal/okf/parse_test.go
@@ -295,7 +295,7 @@ type: Insight
 title: 売上の季節性
 status: verified
 timestamp: '2026-05-28T22:51:43+00:00'
-created_by: 'agent:claude-code'
+created_by: 'process:claude-code'
 verified_by: 'human:na0'
 verified_at: '2026-06-01T00:00:00Z'
 ---

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -48,7 +48,7 @@ func TestRRFFuseBoostsVerified(t *testing.T) {
 func TestApplyVerificationStampsProvenance(t *testing.T) {
 	svc := &Service{}
 	human := domain.Actor{Kind: domain.ActorHuman, Name: "na0"}
-	agent := domain.Actor{Kind: domain.ActorAgent, Name: "claude-code"}
+	agent := domain.Actor{Kind: domain.ActorProcess, Name: "claude-code"}
 
 	verified := &domain.Knowledge{Status: domain.StatusVerified}
 	svc.applyVerification(verified, nil, human)

--- a/internal/store/migrate_integration_test.go
+++ b/internal/store/migrate_integration_test.go
@@ -917,3 +917,147 @@ func TestMigrationOKFFamiliesOutOfAttrs(t *testing.T) {
 		t.Errorf("attrs = %v, want the producer key untouched", attrs)
 	}
 }
+
+// TestMigrationActorProcess covers 0022: every stored actor kind of
+// "agent" becomes "process", the spelling OKF SPEC §7 defines (design doc
+// 0043 §3.8). The scratch schema carries one row per table that stores an
+// actor, including a delegation — a "via" holds the caller's whole
+// kind:name string, so a half-migration would leave "process:tanaka via
+// agent:app" on exactly the rows delegation exists to describe.
+func TestMigrationActorProcess(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck // rollback is the cleanup
+
+	for _, q := range []string{
+		`CREATE SCHEMA actor_scratch`,
+		`SET LOCAL search_path TO actor_scratch`,
+		`CREATE TABLE knowledge (
+			id text PRIMARY KEY,
+			created_by_kind text NOT NULL, created_by_name text NOT NULL, created_by_via text NOT NULL DEFAULT '',
+			updated_by_kind text NOT NULL, updated_by_name text NOT NULL, updated_by_via text NOT NULL DEFAULT '',
+			verified_by_kind text, verified_by_name text, verified_by_via text NOT NULL DEFAULT '',
+			rejected_by_kind text, rejected_by_name text, rejected_by_via text NOT NULL DEFAULT '',
+			updated_at timestamptz NOT NULL)`,
+		`CREATE TABLE knowledge_revision (
+			id text NOT NULL, rev int NOT NULL, change text NOT NULL,
+			changed_by_kind text NOT NULL, changed_by_name text NOT NULL,
+			changed_by_via text NOT NULL DEFAULT '', snapshot jsonb NOT NULL)`,
+		`CREATE TABLE knowledge_event (id text NOT NULL, actor_kind text NOT NULL, actor_name text NOT NULL)`,
+		`CREATE TABLE attachment (knowledge_id text NOT NULL, name text NOT NULL,
+			created_by_kind text NOT NULL, created_by_name text NOT NULL)`,
+		`CREATE TABLE knowledge_purge (id text NOT NULL,
+			purged_by_kind text NOT NULL, purged_by_name text NOT NULL, purged_by_via text NOT NULL DEFAULT '')`,
+		`INSERT INTO knowledge (id,
+			created_by_kind, created_by_name, created_by_via,
+			updated_by_kind, updated_by_name, updated_by_via,
+			verified_by_kind, verified_by_name, rejected_by_kind, rejected_by_name, updated_at) VALUES
+			('metrics/revenue', 'agent', 'claude-code', '',
+			 'human', 'tanaka', 'agent:app@x.iam.gserviceaccount.com',
+			 'human', 'na0', NULL, NULL, '2026-07-01T00:00:00Z'),
+			('metrics/human-only', 'human', 'na0', '', 'human', 'na0', '',
+			 NULL, NULL, 'agent', 'bot', '2026-07-01T00:00:00Z')`,
+		`INSERT INTO knowledge_revision (id, rev, change, changed_by_kind, changed_by_name, changed_by_via, snapshot) VALUES
+			('metrics/revenue', 1, 'create', 'agent', 'claude-code', '', '{
+				"created_by": {"kind": "agent", "name": "claude-code"},
+				"updated_by": {"kind": "human", "name": "tanaka", "via": "agent:app@x.iam.gserviceaccount.com"},
+				"body": "the literal {\"kind\": \"agent\"} in prose stays"
+			}'::jsonb)`,
+		`INSERT INTO knowledge_event (id, actor_kind, actor_name) VALUES ('metrics/revenue', 'agent', 'claude-code')`,
+		`INSERT INTO attachment (knowledge_id, name, created_by_kind, created_by_name)
+			VALUES ('metrics/revenue', 'chart.png', 'agent', 'claude-code')`,
+		`INSERT INTO knowledge_purge (id, purged_by_kind, purged_by_name, purged_by_via)
+			VALUES ('metrics/gone', 'agent', 'cleanup', 'agent:ops@x.iam.gserviceaccount.com')`,
+	} {
+		if _, err := tx.Exec(ctx, q); err != nil {
+			t.Fatalf("scratch setup: %v\n%s", err, q)
+		}
+	}
+
+	sql, err := migrationFS.ReadFile("migrations/0022_actor_process.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec(ctx, string(sql)); err != nil {
+		t.Fatalf("apply 0022: %v", err)
+	}
+
+	var created, updated, verified domain.Actor
+	var updatedAt time.Time
+	if err := tx.QueryRow(ctx, `SELECT created_by_kind, created_by_name, created_by_via,
+		updated_by_kind, updated_by_name, updated_by_via,
+		verified_by_kind, verified_by_name, updated_at
+		FROM knowledge WHERE id = 'metrics/revenue'`).
+		Scan(&created.Kind, &created.Name, &created.Via,
+			&updated.Kind, &updated.Name, &updated.Via,
+			&verified.Kind, &verified.Name, &updatedAt); err != nil {
+		t.Fatal(err)
+	}
+	if created.String() != "process:claude-code" {
+		t.Errorf("created_by = %q, want process:claude-code", created)
+	}
+	if updated.String() != "human:tanaka via process:app@x.iam.gserviceaccount.com" {
+		t.Errorf("updated_by = %q: the via half must migrate too", updated)
+	}
+	if verified.String() != "human:na0" {
+		t.Errorf("verified_by = %q: a human actor must be left alone", verified)
+	}
+	if !updatedAt.Equal(time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("updated_at moved to %v: it is the ETag version and generated.at", updatedAt)
+	}
+
+	var rejectedKind string
+	if err := tx.QueryRow(ctx,
+		`SELECT rejected_by_kind FROM knowledge WHERE id = 'metrics/human-only'`).Scan(&rejectedKind); err != nil {
+		t.Fatal(err)
+	}
+	if rejectedKind != "process" {
+		t.Errorf("rejected_by_kind = %q, want process", rejectedKind)
+	}
+
+	var revKind, revBody, snapCreated, snapVia string
+	if err := tx.QueryRow(ctx, `SELECT changed_by_kind,
+		snapshot ->> 'body', snapshot -> 'created_by' ->> 'kind', snapshot -> 'updated_by' ->> 'via'
+		FROM knowledge_revision WHERE id = 'metrics/revenue' AND rev = 1`).
+		Scan(&revKind, &revBody, &snapCreated, &snapVia); err != nil {
+		t.Fatal(err)
+	}
+	if revKind != "process" || snapCreated != "process" {
+		t.Errorf("revision actor = %q, snapshot created_by.kind = %q", revKind, snapCreated)
+	}
+	if snapVia != "process:app@x.iam.gserviceaccount.com" {
+		t.Errorf("snapshot updated_by.via = %q", snapVia)
+	}
+	// The rewrite is keyed, not textual: prose that happens to quote the
+	// old spelling is content and must survive untouched.
+	if !strings.Contains(revBody, `{"kind": "agent"}`) {
+		t.Errorf("snapshot body was rewritten: %q", revBody)
+	}
+
+	for _, tc := range []struct{ query, want, what string }{
+		{`SELECT actor_kind FROM knowledge_event`, "process", "knowledge_event"},
+		{`SELECT created_by_kind FROM attachment`, "process", "attachment"},
+		{`SELECT purged_by_kind FROM knowledge_purge`, "process", "knowledge_purge"},
+		{`SELECT purged_by_via FROM knowledge_purge`, "process:ops@x.iam.gserviceaccount.com", "purge via"},
+	} {
+		var got string
+		if err := tx.QueryRow(ctx, tc.query).Scan(&got); err != nil {
+			t.Fatalf("%s: %v", tc.what, err)
+		}
+		if got != tc.want {
+			t.Errorf("%s = %q, want %q", tc.what, got, tc.want)
+		}
+	}
+}

--- a/internal/store/migrations/0022_actor_process.sql
+++ b/internal/store/migrations/0022_actor_process.sql
@@ -1,0 +1,81 @@
+-- The actor kind ochakai writes for anything that is not a person becomes
+-- "process", the spelling OKF SPEC §7 defines (design doc 0043 §3.8).
+--
+-- ochakai wrote "agent" from 0001 onward. It was never a spelling the
+-- spec offered: §7 names human:<id>, process:<id>, and
+-- <producer>/<version>, and §5.3 derives trust from the human: prefix
+-- alone, lumping every other writer into one machine-confirmed tier. So
+-- the distinction "agent" drew — an LLM agent rather than any other
+-- automation — cost conformance and bought nothing: no query, no filter,
+-- and no branch in the server ever read it.
+--
+-- Every column that stores an actor kind is rewritten, and so is every
+-- "via" column, because a delegation is stored as the caller's whole
+-- kind:name string (design doc 0027). Leaving via behind would make an
+-- entry written through a delegating application say "process:tanaka via
+-- agent:app" — half migrated, and wrong in the half that names the
+-- machine.
+--
+-- updated_at is not touched anywhere here. The provenance spelling is not
+-- the entry's content: no held ETag is invalidated, no generated.at is
+-- misdated, and nothing needs re-embedding.
+
+-- 1. The entry's own provenance. Four actors per row.
+UPDATE knowledge SET
+    created_by_kind  = CASE WHEN created_by_kind  = 'agent' THEN 'process' ELSE created_by_kind  END,
+    updated_by_kind  = CASE WHEN updated_by_kind  = 'agent' THEN 'process' ELSE updated_by_kind  END,
+    verified_by_kind = CASE WHEN verified_by_kind = 'agent' THEN 'process' ELSE verified_by_kind END,
+    rejected_by_kind = CASE WHEN rejected_by_kind = 'agent' THEN 'process' ELSE rejected_by_kind END,
+    created_by_via   = CASE WHEN created_by_via  LIKE 'agent:%' THEN 'process:' || substring(created_by_via  from 7) ELSE created_by_via  END,
+    updated_by_via   = CASE WHEN updated_by_via  LIKE 'agent:%' THEN 'process:' || substring(updated_by_via  from 7) ELSE updated_by_via  END,
+    verified_by_via  = CASE WHEN verified_by_via LIKE 'agent:%' THEN 'process:' || substring(verified_by_via from 7) ELSE verified_by_via END,
+    rejected_by_via  = CASE WHEN rejected_by_via LIKE 'agent:%' THEN 'process:' || substring(rejected_by_via from 7) ELSE rejected_by_via END
+WHERE created_by_kind = 'agent' OR updated_by_kind = 'agent'
+   OR verified_by_kind = 'agent' OR rejected_by_kind = 'agent'
+   OR created_by_via LIKE 'agent:%' OR updated_by_via LIKE 'agent:%'
+   OR verified_by_via LIKE 'agent:%' OR rejected_by_via LIKE 'agent:%';
+
+-- 2. History. The revision row's own actor columns, and the actors inside
+--    the snapshot JSON — a revision read back must not show a spelling the
+--    program no longer writes. Design doc 0043 §3.9 withdraws 0036 §3.13's
+--    "history keeps the shape it had": a history whose shape depends on
+--    knowing every past generation of the struct is the distortion, not
+--    the fidelity.
+UPDATE knowledge_revision SET
+    changed_by_kind = CASE WHEN changed_by_kind = 'agent' THEN 'process' ELSE changed_by_kind END,
+    changed_by_via  = CASE WHEN changed_by_via LIKE 'agent:%' THEN 'process:' || substring(changed_by_via from 7) ELSE changed_by_via END
+WHERE changed_by_kind = 'agent' OR changed_by_via LIKE 'agent:%';
+
+-- The snapshot is rewritten key by key rather than by a text replace on
+-- the whole document: a body that quotes {"kind": "agent"} is content, and
+-- content must survive a provenance migration untouched.
+DO $$
+DECLARE
+    actor_key text;
+BEGIN
+    FOREACH actor_key IN ARRAY ARRAY['created_by', 'updated_by', 'verified_by', 'rejected_by'] LOOP
+        EXECUTE format($fmt$
+            UPDATE knowledge_revision
+               SET snapshot = jsonb_set(snapshot, ARRAY[%1$L, 'kind'], '"process"')
+             WHERE snapshot -> %1$L ->> 'kind' = 'agent'
+        $fmt$, actor_key);
+
+        EXECUTE format($fmt$
+            UPDATE knowledge_revision
+               SET snapshot = jsonb_set(snapshot, ARRAY[%1$L, 'via'],
+                       to_jsonb('process:' || substring(snapshot -> %1$L ->> 'via' from 7)))
+             WHERE snapshot -> %1$L ->> 'via' LIKE 'agent:%%'
+        $fmt$, actor_key);
+    END LOOP;
+END $$;
+
+-- 3. The remaining ledgers. knowledge_event has no via column by design
+--    (0017): its actor is the caller as observed, with no delegation.
+UPDATE knowledge_event SET actor_kind = 'process' WHERE actor_kind = 'agent';
+
+UPDATE attachment SET created_by_kind = 'process' WHERE created_by_kind = 'agent';
+
+UPDATE knowledge_purge SET
+    purged_by_kind = CASE WHEN purged_by_kind = 'agent' THEN 'process' ELSE purged_by_kind END,
+    purged_by_via  = CASE WHEN purged_by_via LIKE 'agent:%' THEN 'process:' || substring(purged_by_via from 7) ELSE purged_by_via END
+WHERE purged_by_kind = 'agent' OR purged_by_via LIKE 'agent:%';

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -1536,7 +1536,7 @@ func TestIntegrationDelegatedProvenance(t *testing.T) {
 	const id = "it-delegated"
 	_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge WHERE id = $1`, id)
 	_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_revision WHERE id = $1`, id)
-	via := "agent:insightflow@example.iam.gserviceaccount.com"
+	via := "process:insightflow@example.iam.gserviceaccount.com"
 	delegated := domain.Actor{Kind: domain.ActorHuman, Name: "tanaka@example.co.jp", Via: via}
 
 	if err := s.Create(ctx, &domain.Knowledge{
@@ -1752,7 +1752,7 @@ func TestIntegrationVerifyClearsTheReviewFeed(t *testing.T) {
 		}
 	}
 	human := domain.Actor{Kind: domain.ActorHuman, Name: "reviewer@example.com"}
-	agent := domain.Actor{Kind: domain.ActorAgent, Name: "claude-code"}
+	agent := domain.Actor{Kind: domain.ActorProcess, Name: "claude-code"}
 	k := &domain.Knowledge{Type: domain.TypeComputations, ID: id, Title: "月次売上",
 		Status: domain.StatusDraft, CreatedBy: agent}
 	if err := s.Create(ctx, k, false); err != nil {

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -524,7 +524,7 @@ function fmtDate(s) {
 // surface, so it is where the distinction has to be visible.
 function actorStr(a) {
   if (!a || !a.name) return '';
-  return (a.kind === 'agent' ? '🤖 ' : '👤 ') + a.name + (a.via ? ' via ' + a.via : '');
+  return (a.kind === 'human' ? '👤 ' : '🤖 ') + a.name + (a.via ? ' via ' + a.via : '');
 }
 // Whole days since an ISO timestamp (null for unparseable input).
 function daysSince(s) {

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -7,7 +7,7 @@
 //   - `ochakai ui` serves it on loopback and proxies with the caller's
 //     own Google identity (human:<email>);
 //   - `ochakai serve-ui` serves it as a deployed service (Cloud Run)
-//     and proxies with its service identity (agent:<sa-email>).
+//     and proxies with its service identity (process:<sa-email>).
 package webui
 
 import _ "embed"


### PR DESCRIPTION
<!-- Implements design doc 0043 §3.8. First of the document-first implementation PRs. -->

## What and why

Implements [0043](docs/design/0043-document-first.md) §3.8: the actor kind for anything that is not a person becomes `process`, the spelling OKF SPEC §7 defines.

ochakai wrote `agent` from 0001 onward. SPEC §7 names three actor forms — `human:<id>`, `process:<id>`, `<producer>/<version>` — and `agent` is none of them. The distinction it drew (an LLM agent rather than any other automation) is one nothing here ever read: SPEC §5.3 derives trust from the `human:` prefix alone, and no query, filter or branch consulted the difference. The third SPEC form stays unused — ochakai's non-human writers are IAM service accounts, which have no version, and inventing one would make provenance assert something the server never observed.

This is the first of the 0043 implementation PRs and is deliberately self-contained: no status, verification or storage change rides along.

**Migration 0022** rewrites every stored actor kind *and* every `via`, which holds a caller's whole `kind:name` string (0027) — leaving `via` behind would print `process:tanaka via agent:app` on exactly the rows delegation exists to describe. Covered: `knowledge` (4 actors + 4 vias), `knowledge_revision` (columns *and* snapshot JSON), `knowledge_event`, `attachment`, `knowledge_purge`. Snapshots are rewritten key by key rather than by a text replace, so a body quoting `{"kind": "agent"}` survives as the content it is (asserted in the test). **No `updated_at` moves** — no held ETag is invalidated, no `generated.at` is misdated, nothing needs re-embedding.

Note on `internal/store/migrate_integration_test.go`: the 0019 test keeps the legacy `agent` spelling in its fixture and expectations, because it rebuilds the schema of that era and applies only 0019.

## Checks

- [x] `scripts/check core` is clean, run with `--db` equivalent — a local PostgreSQL 16 + pgvector on 55433, so the store integration tests actually executed rather than skipping
- [x] Behavior changes come with tests — new `TestMigrationActorProcess` covers every table, the `via` half, the human-actor-untouched case, snapshot rewriting, and that `updated_at` does not move

⚠️ `scripts/check lint` could not run in this environment: the pinned golangci-lint is built with go1.25 while the module targets 1.26.5. **This fails identically on a clean `main` checkout** (verified by stashing), so it is a container toolchain mismatch, not something this branch introduces — CI's lint job installs a released binary and is unaffected. `go vet` (in `core`) is clean.

## Surfaces and contract

- [x] `api/openapi.yaml` (the `Actor.kind` enum, the `X-Ochakai-On-Behalf-Of` description, and every `kind: agent` example), `internal/restapi`, `internal/mcpserver` and `internal/apiclient` (`Identity()` now derives the prefix from the domain constants) all say `process`
- [x] Lands on every surface: REST (enum + delegation header), CLI/apiclient (identity resolution), web UI (`actorStr` now keys off `human` rather than off the machine kind, so it cannot silently mislabel a third kind), plus `docs/architecture.md`, `docs/guides/troubleshooting.md` and `README.md`. No surface is deliberately omitted — this is a vocabulary change, not a feature

**Breaking for clients**: `actor.kind` reads `process`, and `X-Ochakai-On-Behalf-Of: agent:…` is now a 400 (send `process:…`). No compatibility alias, per 0036 §2.4 / 0043 §2.4 — no shim for a spelling ochakai itself invented. Exported bundles write `generated: { by: process:… }`, so the next export of a git-tracked bundle carries that diff.

## Design docs

- [x] Alters an accepted decision? No new doc needed — 0043 landed in #247 and already records this decision (§3.8) and its migration (§3.10); the `Status:` headers it touches were updated there
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcMFa1rh2cSHSQhEnARcov)_