### PR TITLE
Drop the period ST1005 flagged on the unruled-entry refusal

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -160,7 +160,7 @@ func (s *Service) explainOccupiedID(ctx context.Context, id string, err error) e
 			"reviving, create_knowledge a draft at a different id that says why."
 	default:
 		return fmt.Errorf("%w: %s is a live %s entry. Nobody has ruled on it: "+
-			"update_knowledge replaces it in place.", err, id, k.Status)
+			"update_knowledge replaces it in place", err, id, k.Status)
 	}
 	return fmt.Errorf("%w: %s is a live %s entry. %s", err, id, ruling, instead)
 }


### PR DESCRIPTION
## What and why

The lint job on #249 failed on one issue and it landed with main:

```
internal/service/service.go:162:10: ST1005: error strings should not end with punctuation or newlines (staticcheck)
```

`explainOccupiedID` builds the same two-sentence refusal in every branch, but only the `default` one spells its tail as a literal — the three ruling branches end in `%s`, which is why staticcheck could see the period here and nowhere else. Dropping the final period leaves the sentence reading the same, and nothing quotes the string: no test asserts on it and no doc reproduces it.

## Checks

- [x] `scripts/check lint` — golangci-lint v2.12.2, 0 issues (it does run on this host; the toolchain mismatch noted on #249 was the container's)
- [x] `go test ./internal/service/...` passes
- [x] No behavior change, so no new test

## Surfaces and contract

- [x] Wording inside one error message; the wire contract, MCP and CLI surfaces are untouched (0015 n/a)

## Design docs

- [x] Alters an accepted decision? No
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.com/claude-code)_