### PR TITLE
Store the canonical document, and version entries by its hash (0043 §§3.1, 3.4, 3.7, 3.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,32 @@ last entry.
 
 ### Changed
 
+- **BREAKING**: the canonical OKF document is the stored form, and its
+  hash is the entry's version (design doc
+  [0043](docs/design/0043-document-first.md) §§3.1, 3.4, 3.7, 3.9).
+
+  - **The ETag is now `content_hash`**, the SHA-256 of the entry's
+    canonical document, also returned in the body. It is a hash of the
+    content alone, so verifying an entry, rejecting it, or attaching a
+    file to it no longer moves it — a held `If-Match` survives all three,
+    which the `updated_at` version could not manage because it was also
+    the row's write timestamp. Treat it as opaque: `If-Match` no longer
+    validates a format, so an unrecognized value is a `412` rather than a
+    `400`, and two entries that say the same thing carry the same version.
+  - **A revision carries `document` instead of `snapshot`**: the entry as
+    it stood, as an OKF document, rather than a JSON copy of the server's
+    own struct. A diff between two revisions is now a text diff.
+
+  Migration `0024` adds the columns; the server composes the documents
+  once at startup, right after migrating, because rendering a document
+  means writing YAML in the spelling the spec fixes and that is not
+  SQL's job. The pass is idempotent and resumable, holds the same
+  advisory lock the migrations do, and moves no `updated_at`. A revision
+  snapshot the current shape cannot read is replaced by a placeholder
+  document saying so; `knowledge_revision.snapshot` is kept (nullable)
+  until a later release drops it, since it is the only source the
+  backfill has.
+
 - **BREAKING**: `status` is OKF's lifecycle vocabulary and nothing else —
   `draft`, `stable`, `deprecated` (SPEC §5.4). The two values ochakai
   added were never lifecycle values, and both become ledgers (design doc

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1127,16 +1127,6 @@ paths:
                 properties:
                   error: { type: string }
               examples:
-                malformedIfMatch:
-                  summary: 'If-Match: "2026-07-14 02:33:41" — not an RFC3339Nano version'
-                  description: >
-                    The precondition is the entry's updated_at in
-                    RFC3339Nano, exactly as the ETag returned it. A value
-                    that is neither that nor "*" is refused rather than
-                    ignored: ignoring it would silently make the write
-                    unconditional.
-                  value:
-                    error: 'malformed If-Match: parsing time "2026-07-14 02:33:41" as "2006-01-02T15:04:05.999999999Z07:00": cannot parse " 02:33:41" as "T"'
                 invalidStaleAfter:
                   summary: A stale_after that is not an absolute date
                   value:
@@ -1531,7 +1521,8 @@ paths:
       description: >
         Every change — create, update, verify, delete, move, attach,
         detach — newest first, each with
-        who made it, when, and the full snapshot as of that change — the
+        who made it, when, and the whole entry as it stood, as an OKF
+        document — the
         read surface behind "every change kept as a revision". Works for
         soft-deleted entries too: the audit trail is most interesting
         exactly when the entry is gone.
@@ -1561,57 +1552,55 @@ paths:
                   description: >
                     Newest first, and never empty — the create is rev 1. Each
                     revision carries the whole entry as it stood after that
-                    change, so a diff is a comparison between two snapshots
-                    rather than a replay.
+                    change, as an OKF document, so a diff between two
+                    revisions is a text diff rather than a replay.
                   value:
                     revisions:
                       - rev: 2
                         change: verify
                         changed_by: { kind: human, name: tanaka@example.co.jp }
                         changed_at: "2026-07-27T00:41:12.905337Z"
-                        snapshot:
+                        document: |
+                          ---
                           type: Insight
-                          id: insights/revenue-seasonality
                           title: Reading revenue month over month
                           description: Why a December spike and a January drop are normal.
-                          tags: [finance]
+                          tags:
+                              - finance
+                          generated:
+                              by: process:analyst@example.iam.gserviceaccount.com
+                              at: "2026-07-27T00:41:12Z"
+                          verified:
+                              - by: human:tanaka@example.co.jp
+                                at: "2026-07-27T00:41:12Z"
                           status: stable
                           stale_after: "2027-01-31"
-                          created_by: { kind: process, name: analyst@example.iam.gserviceaccount.com }
-                          updated_by: { kind: process, name: analyst@example.iam.gserviceaccount.com }
-                          verifications:
-                            - by: { kind: human, name: tanaka@example.co.jp }
-                              at: "2026-07-27T00:41:12.905337Z"
-                          links:
-                            - { target: metrics/revenue, text: Revenue }
-                          body: |
-                            [Revenue](/metrics/revenue.md) is seasonal: December
-                            runs well above the trailing median and January falls
-                            back below it.
-                          created_at: "2026-07-21T06:14:55.402881Z"
-                          updated_at: "2026-07-27T00:41:12.905337Z"
+                          created_by: process:analyst@example.iam.gserviceaccount.com
+                          ---
+
+                          [Revenue](/metrics/revenue.md) is seasonal: December
+                          runs well above the trailing median and January falls
+                          back below it.
                       - rev: 1
                         change: create
                         changed_by: { kind: process, name: analyst@example.iam.gserviceaccount.com }
                         changed_at: "2026-07-21T06:14:55.402881Z"
-                        snapshot:
+                        document: |
+                          ---
                           type: Insight
-                          id: insights/revenue-seasonality
                           title: Reading revenue month over month
                           description: Why a December spike and a January drop are normal.
-                          tags: [finance]
+                          tags:
+                              - finance
+                          generated:
+                              by: process:analyst@example.iam.gserviceaccount.com
+                              at: "2026-07-21T06:14:55Z"
                           status: draft
                           stale_after: "2027-01-31"
-                          created_by: { kind: process, name: analyst@example.iam.gserviceaccount.com }
-                          updated_by: { kind: process, name: analyst@example.iam.gserviceaccount.com }
-                          links:
-                            - { target: metrics/revenue, text: Revenue }
-                          body: |
-                            [Revenue](/metrics/revenue.md) is seasonal: December
-                            runs well above the trailing median and January falls
-                            back below it.
-                          created_at: "2026-07-21T06:14:55.402881Z"
-                          updated_at: "2026-07-21T06:14:55.402881Z"
+                          created_by: process:analyst@example.iam.gserviceaccount.com
+                          ---
+
+                          [Revenue](/metrics/revenue.md) is seasonal.
         "400": { $ref: "#/components/responses/Error" }
         "403": { $ref: "#/components/responses/Forbidden" }
         "404": { $ref: "#/components/responses/Error" }
@@ -1964,9 +1953,15 @@ components:
   headers:
     ETag:
       description: >
-        The entry's version — its updated_at in RFC3339Nano, quoted. A
-        client echoes it in If-Match on a later update to write only if
-        nothing changed meanwhile (design doc 0030).
+        The entry's version — the hash of its canonical OKF document,
+        quoted, and the same value as the body's content_hash (design
+        doc 0043 §3.4). A client echoes it in If-Match on a later update
+        to write only if nothing changed meanwhile (design doc 0030).
+        It is a hash of the content alone, so it moves when the entry's
+        content moves and at no other time: verifying, rejecting or
+        attaching a file all leave a held precondition valid. Treat it as
+        opaque — two entries that say the same thing carry the same
+        version.
       schema: { type: string }
     ReadOnly:
       description: >
@@ -1988,14 +1983,16 @@ components:
       required: false
       description: >
         Optimistic-concurrency precondition (design doc 0030): the
-        entry's version — its updated_at in RFC3339Nano, as a prior read
-        or write returned it in the ETag response header (quotes
-        optional; the JSON body's updated_at field is the same value).
-        Every response carrying an entry carries the header. The write
-        happens only if the entry still has this version; an entry
-        changed since it was read is a 412 and nothing is written.
-        Absent or "*" means no precondition — last write wins. A value
-        that is neither is a 400.
+        entry's version, as a prior read or write returned it in the ETag
+        response header (quotes optional; the JSON body's content_hash
+        field is the same value). Every response carrying an entry
+        carries the header. The write happens only if the entry still has
+        this version; an entry changed since it was read is a 412 and
+        nothing is written. Absent or "*" means no precondition — last
+        write wins.
+        The version is opaque, so there is no format to reject: a value
+        that never matched anything fails the precondition with a 412,
+        which is what a merely stale one does too.
       schema: { type: string }
     OnBehalfOf:
       name: X-Ochakai-On-Behalf-Of
@@ -2344,6 +2341,16 @@ components:
           description: >
             The live ruling, absent when there is none. Written by
             POST /api/v1/reject/{id} and cleared by DELETE.
+        content_hash:
+          type: string
+          readOnly: true
+          description: >
+            The entry's version: the hash of its canonical OKF document,
+            and the same value the ETag header carries (design doc 0043
+            §3.4). Send it back as If-Match to write only if nothing
+            changed meanwhile. Opaque — it moves when the content moves
+            and at no other time, so a verification or an attachment
+            leaves a held precondition valid.
         links:
           type: array
           items: { $ref: "#/components/schemas/Link" }
@@ -2461,10 +2468,20 @@ components:
       type: object
       description: >
         One entry in a knowledge entry's change history: who changed it,
-        how, when, and the full snapshot as of that change.
+        how, when, and the whole entry as it stood, as an OKF document.
       properties:
         rev: { type: integer, description: 1-based, monotonically increasing per entry. }
-        change: { type: string, enum: [create, update, verify, delete, move, attach, detach] }
+        change: { type: string, enum: [create, update, verify, reject, unreject, delete, move, attach, detach] }
         changed_by: { $ref: "#/components/schemas/Actor" }
         changed_at: { type: string, format: date-time }
-        snapshot: { $ref: "#/components/schemas/Knowledge" }
+        document:
+          type: string
+          description: >
+            The entry as it stood after this change, as an OKF document
+            (design doc 0043 §3.9). It replaced a JSON snapshot of the
+            server's own struct: a record whose shape depends on the
+            reader knowing every past release is the distortion, not the
+            fidelity, and it also means a diff between two revisions
+            reads. The keys this instance owns are included — a revision
+            records what the entry was, and who had confirmed it then is
+            part of that.

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -551,10 +551,10 @@ func cmdReport(ctx context.Context, args []string) error {
 func cmdRevisions(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
 		"revisions",
-		"Usage: ochakai revisions [flags] <id>\n\nList an entry's change history, newest first: who changed it, how,\nand when — the audit surface behind \"every change kept as a\nrevision\". Works for soft-deleted entries too. Full snapshots are in\nthe JSON output (--json).",
-		"  ochakai revisions metrics/revenue\n  ochakai revisions queries/sales/monthly-revenue --json | jq '.revisions[0].snapshot'\n")
+		"Usage: ochakai revisions [flags] <id>\n\nList an entry's change history, newest first: who changed it, how,\nand when — the audit surface behind \"every change kept as a\nrevision\". Works for soft-deleted entries too. The whole entry as it\nstood, as an OKF document, is in the JSON output (--json), so a diff\nbetween two revisions is a text diff.",
+		"  ochakai revisions metrics/revenue\n  ochakai revisions queries/sales/monthly-revenue --json | jq -r '.revisions[0].document'\n")
 	limit := fs.Int("limit", 0, "max revisions (server default 50, max 200)")
-	asJSON := fs.Bool("json", false, "print the raw JSON response (includes full snapshots)")
+	asJSON := fs.Bool("json", false, "print the raw JSON response (includes each revision's document)")
 	id, _, err := idArgs(fs, args, 1)
 	if err != nil {
 		return err
@@ -788,9 +788,9 @@ func cmdUpdate(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
 		"update",
 		"Usage: ochakai update [flags] <id>\n\nReplace a knowledge entry from -f or stdin (OKF document or JSON;\nthe id comes from the argument, the type from the input). Every\nchange is kept as a revision server-side. With --if-match the update\nis conditional: it lands only if the entry still has the version you\nread, and fails instead of overwriting someone else's edit.",
-		"  ochakai get metrics/revenue | $EDITOR /dev/stdin | ochakai update metrics/revenue\n  ochakai update metrics/revenue -f revenue.md\n  ochakai update metrics/revenue -f revenue.md --if-match \"$(ochakai get metrics/revenue --json | jq -r .updated_at)\"\n")
+		"  ochakai get metrics/revenue | $EDITOR /dev/stdin | ochakai update metrics/revenue\n  ochakai update metrics/revenue -f revenue.md\n  ochakai update metrics/revenue -f revenue.md --if-match \"$(ochakai get metrics/revenue --json | jq -r .content_hash)\"\n")
 	file := fs.String("f", "", "input file (default: stdin)")
-	ifMatch := fs.String("if-match", "", "update only if the entry still has this `version` — its updated_at (`ochakai get <id> --json` prints it as .updated_at; a REST GET returns it as the ETag header); a stale version fails with a conflict instead of overwriting")
+	ifMatch := fs.String("if-match", "", "update only if the entry still has this `version` — its content hash (`ochakai get <id> --json` prints it as .content_hash; a REST GET returns it as the ETag header); a stale version fails with a conflict instead of overwriting. Verifying or rejecting an entry does not move it: only an edit does")
 	asJSON := fs.Bool("json", false, "print the updated entry as JSON")
 	id, _, err := idArgs(fs, args, 1)
 	if err != nil {
@@ -809,7 +809,7 @@ func cmdUpdate(ctx context.Context, args []string) error {
 	if err != nil {
 		var apiErr *apiclient.APIError
 		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusPreconditionFailed {
-			return fmt.Errorf("conflict: ochakai://%s changed since the version in --if-match — `ochakai get %s` again, redo the edit, and retry with the new updated_at", id, id)
+			return fmt.Errorf("conflict: ochakai://%s changed since the version in --if-match — `ochakai get %s` again, redo the edit, and retry with the new content_hash", id, id)
 		}
 		return err
 	}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -273,8 +273,9 @@ memory and flushed periodically, statistics are documented as
 best-effort, an overrun is dropped rather than backing up the request,
 and shutdown drains before a final flush (design doc
 [0029](design/0029-usage-recording-off-the-read-path.md)). Concurrent
-edits are handled by optional optimistic locking — `updated_at` as the
-version, exposed as an ETag with `If-Match` (design doc
+edits are handled by optional optimistic locking — the canonical
+document's hash as the version, exposed as an ETag with `If-Match`
+(design doc
 [0030](design/0030-optimistic-locking.md)).
 
 ## Search

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -478,12 +478,13 @@ Usage: ochakai revisions [flags] <id>
 
 List an entry's change history, newest first: who changed it, how,
 and when — the audit surface behind "every change kept as a
-revision". Works for soft-deleted entries too. Full snapshots are in
-the JSON output (--json).
+revision". Works for soft-deleted entries too. The whole entry as it
+stood, as an OKF document, is in the JSON output (--json), so a diff
+between two revisions is a text diff.
 
 Flags:
   -json
-    	print the raw JSON response (includes full snapshots)
+    	print the raw JSON response (includes each revision's document)
   -limit int
     	max revisions (server default 50, max 200)
   -url ochakai use
@@ -491,7 +492,7 @@ Flags:
 
 Examples:
   ochakai revisions metrics/revenue
-  ochakai revisions queries/sales/monthly-revenue --json | jq '.revisions[0].snapshot'
+  ochakai revisions queries/sales/monthly-revenue --json | jq -r '.revisions[0].document'
 ```
 
 ## ochakai search
@@ -594,7 +595,7 @@ Flags:
   -f string
     	input file (default: stdin)
   -if-match version
-    	update only if the entry still has this version — its updated_at (`ochakai get <id> --json` prints it as .updated_at; a REST GET returns it as the ETag header); a stale version fails with a conflict instead of overwriting
+    	update only if the entry still has this version — its content hash (`ochakai get <id> --json` prints it as .content_hash; a REST GET returns it as the ETag header); a stale version fails with a conflict instead of overwriting. Verifying or rejecting an entry does not move it: only an edit does
   -json
     	print the updated entry as JSON
   -url ochakai use
@@ -603,7 +604,7 @@ Flags:
 Examples:
   ochakai get metrics/revenue | $EDITOR /dev/stdin | ochakai update metrics/revenue
   ochakai update metrics/revenue -f revenue.md
-  ochakai update metrics/revenue -f revenue.md --if-match "$(ochakai get metrics/revenue --json | jq -r .updated_at)"
+  ochakai update metrics/revenue -f revenue.md --if-match "$(ochakai get metrics/revenue --json | jq -r .content_hash)"
 ```
 
 ## ochakai usage

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -90,9 +90,12 @@ curates from.
 ### What happens when two people edit the same entry?
 
 Last write wins, unless the client asks for better. Every `GET` and `PUT`
-returns an `ETag` — the entry's `updated_at` as a quoted RFC3339 stamp,
-e.g. `"2026-07-27T14:55:19.865822Z"` — and a `PUT` carrying `If-Match`
-with a stale value gets `412` and writes nothing (design doc 0030). MCP
+returns an `ETag` — the hash of the entry's canonical OKF document,
+quoted, and also in the body as `content_hash` — and a `PUT` carrying
+`If-Match` with a stale value gets `412` and writes nothing (design docs
+0030, 0043 §3.4). It is a hash of the content alone, so verifying or
+rejecting the entry, or attaching a file to it, leaves your precondition
+valid: only an edit invalidates it. MCP
 exposes no version field but uses the same mechanism internally to protect
 curated entries.
 

--- a/internal/domain/knowledge.go
+++ b/internal/domain/knowledge.go
@@ -541,6 +541,12 @@ type Knowledge struct {
 	Attachments []Attachment `json:"attachments,omitempty"`
 	CreatedAt   time.Time    `json:"created_at"`
 	UpdatedAt   time.Time    `json:"updated_at"`
+	// ContentHash is the entry's version: the SHA-256 of its canonical
+	// document (design doc 0043 §3.4), which is what the ETag carries and
+	// what If-Match is checked against. It is a hash of the content
+	// alone, so a verification, a rejection or an attachment leaves it
+	// where it was — only an edit moves it.
+	ContentHash string `json:"content_hash,omitempty"`
 }
 
 // EnvelopeKeys names every OKF frontmatter key the envelope owns, in the
@@ -694,10 +700,15 @@ func attrsEqual(a, b map[string]any) bool {
 // behind "every change kept as a revision".
 type Revision struct {
 	Rev       int       `json:"rev"`
-	Change    string    `json:"change"` // create | update | delete | attach | detach
+	Change    string    `json:"change"` // create | update | move | delete | verify | reject | unreject | attach | detach
 	ChangedBy Actor     `json:"changed_by"`
 	ChangedAt time.Time `json:"changed_at"`
-	Snapshot  Knowledge `json:"snapshot"`
+	// Document is the entry as it stood, as an OKF document (design doc
+	// 0043 §3.9). It replaced a JSON snapshot of the Go struct: a record
+	// whose shape depends on the reader knowing every past release is the
+	// distortion, not the fidelity, and OKF is an anchor that outlasts
+	// them. It also means a diff between two revisions reads.
+	Document string `json:"document"`
 }
 
 // validSegment reports whether s can be one ID path segment. OKF

--- a/internal/okf/okf.go
+++ b/internal/okf/okf.go
@@ -54,9 +54,9 @@ type frontmatter struct {
 	Tags        []text       `yaml:"tags,omitempty"`
 	Sources     []source     `yaml:"sources,omitempty"`
 	UsageWindow *usageWindow `yaml:"usage_window,omitempty"`
-	Generated   event        `yaml:"generated"`
-	Verified    []event      `yaml:"verified,omitempty"` // absent means unverified — the trust tier is read from this key's presence (SPEC §5.3)
-	Status      text         `yaml:"status"`             // OKF vocabulary: draft | stable | deprecated (design doc 0036 §3.4)
+	Generated   *event       `yaml:"generated,omitempty"` // omitted only by Canonical, which writes no server-owned key
+	Verified    []event      `yaml:"verified,omitempty"`  // absent means unverified — the trust tier is read from this key's presence (SPEC §5.3)
+	Status      text         `yaml:"status"`              // OKF vocabulary: draft | stable | deprecated (design doc 0036 §3.4)
 	StatusNote  text         `yaml:"status_note,omitempty"`
 	StaleAfter  text         `yaml:"stale_after,omitempty"`
 	Runtime     text         `yaml:"runtime,omitempty"`
@@ -64,7 +64,7 @@ type frontmatter struct {
 	Computation text         `yaml:"computation,omitempty"`
 	Executor    *executor    `yaml:"executor,omitempty"`
 	Attester    *attester    `yaml:"attester,omitempty"`
-	CreatedBy   text         `yaml:"created_by"` // ochakai extension: OKF records only who produced the current content
+	CreatedBy   text         `yaml:"created_by,omitempty"` // ochakai extension: OKF records only who produced the current content
 	RejectedBy  text         `yaml:"rejected_by,omitempty"`
 	RejectedAt  text         `yaml:"rejected_at,omitempty"`
 }
@@ -354,15 +354,32 @@ func sourcesOut(in []domain.Source) []source {
 	return out
 }
 
-// Document renders one knowledge entry as an OKF concept document.
+// Document renders one knowledge entry as an OKF concept document: the
+// canonical text the entry is stored as, plus the keys this instance
+// owns and only ever writes — generated and verified (SPEC §5.2), and
+// ochakai's created_by / rejected_* extensions. This is what an export
+// and a read hand out.
 //
-// The trust family follows SPEC §5.2: generated is who the content stands
-// by and when it last changed, verified is the list of confirmations (one,
-// for now — ochakai keeps the latest). status carries OKF's three-value
-// lifecycle, so "verified" leaves the status key entirely and becomes
-// stable plus a verified entry, which is where a v0.2 consumer looks for
-// it (design doc 0036 §3.4).
-func Document(k *domain.Knowledge) ([]byte, error) {
+// The trust family follows SPEC §5.2: generated is who the content
+// stands by and when it last changed, verified is every confirmation the
+// instance recorded. status carries OKF's three-value lifecycle and
+// nothing else — whether anyone confirmed the entry is the verified
+// key's business (§5.3, design doc 0043 §3.2).
+func Document(k *domain.Knowledge) ([]byte, error) { return render(k, true) }
+
+// Canonical renders the document without the server-owned keys: exactly
+// the text a writer authored, in one normal form. It is what the store
+// keeps and what the content hash is taken over (design doc 0043 §§3.4,
+// 3.7), and it is a pure function of the fields SameContent compares —
+// so two entries hash alike if and only if they say the same thing.
+//
+// Excluding the server-owned keys is what makes the hash a content hash
+// rather than a row hash: verifying an entry must not change its
+// version, or every confirmation would invalidate an editor's held
+// precondition.
+func Canonical(k *domain.Knowledge) ([]byte, error) { return render(k, false) }
+
+func render(k *domain.Knowledge, serverKeys bool) ([]byte, error) {
 	fm := frontmatter{
 		Type:        text(k.Type),
 		Resource:    text(k.Resource),
@@ -376,8 +393,11 @@ func Document(k *domain.Knowledge) ([]byte, error) {
 		StaleAfter:  text(k.StaleAfter),
 		Runtime:     text(k.Runtime),
 		Computation: text(k.Computation),
-		Generated:   actorEvent(&k.UpdatedBy, &k.UpdatedAt),
-		CreatedBy:   text(k.CreatedBy.String()),
+	}
+	if serverKeys {
+		g := actorEvent(&k.UpdatedBy, &k.UpdatedAt)
+		fm.Generated = &g
+		fm.CreatedBy = text(k.CreatedBy.String())
 	}
 	for _, p := range k.Parameters {
 		fm.Parameters = append(fm.Parameters, parameter{Name: text(p.Name), Type: text(p.Type), Required: p.Required})
@@ -392,9 +412,11 @@ func Document(k *domain.Knowledge) ([]byte, error) {
 	// as many entries as the instance recorded. The key's presence is what
 	// a v0.2 consumer reads the trust tier from (§5.3); its absence means
 	// unverified, so an entry with no verifications writes no key at all.
-	for i := range k.Verifications {
-		v := &k.Verifications[i]
-		fm.Verified = append(fm.Verified, actorEvent(&v.By, &v.At))
+	if serverKeys {
+		for i := range k.Verifications {
+			v := &k.Verifications[i]
+			fm.Verified = append(fm.Verified, actorEvent(&v.By, &v.At))
+		}
 	}
 	// A rejection is this instance's ruling and not a portable claim, so
 	// it stays an ochakai extension key that import never reads back
@@ -402,7 +424,7 @@ func Document(k *domain.Knowledge) ([]byte, error) {
 	// entry's real lifecycle value rather than deprecated, which is what
 	// the ruling used to be folded onto — an assertion ("this was once
 	// current") that a rejection specifically denies.
-	if k.Rejection != nil {
+	if serverKeys && k.Rejection != nil {
 		fm.RejectedBy = text(k.Rejection.By.String())
 		fm.RejectedAt = text(k.Rejection.At.UTC().Format(time.RFC3339))
 	}

--- a/internal/okf/okf_test.go
+++ b/internal/okf/okf_test.go
@@ -413,3 +413,62 @@ func TestDocumentKeepsBlockScalarsForProse(t *testing.T) {
 		t.Errorf("ordinary multi-line prose should stay a block scalar:\n%s", doc)
 	}
 }
+
+// Canonical is the stored form: the text a writer authored, with none of
+// the keys this instance owns. The content hash is taken over it (design
+// doc 0043 §§3.4, 3.7), so anything that leaks in here would make a
+// verification — or a rejection, or another instance's created_by —
+// change the entry's version and invalidate an editor's precondition.
+func TestCanonicalOmitsServerOwnedKeys(t *testing.T) {
+	at := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	k := domain.Knowledge{
+		Type: domain.TypeInsights, ID: "insights/seasonality", Title: "季節性",
+		Status: domain.StatusStable, Body: "12月は+40%。",
+		CreatedBy: domain.Actor{Kind: "human", Name: "na0"},
+		UpdatedBy: domain.Actor{Kind: "human", Name: "tanaka"},
+		Verifications: []domain.Verification{
+			{By: domain.Actor{Kind: "human", Name: "na0"}, At: at},
+		},
+		Rejection: &domain.Rejection{By: domain.Actor{Kind: "human", Name: "na0"}, At: at},
+		UpdatedAt: at,
+	}
+	canon, err := Canonical(&k)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, owned := range []string{"generated:", "verified:", "created_by:", "rejected_by:", "rejected_at:"} {
+		if strings.Contains(string(canon), owned) {
+			t.Errorf("canonical form carries the server-owned key %q:\n%s", owned, canon)
+		}
+	}
+	// What the writer wrote is all there.
+	for _, want := range []string{"type: Insight", "title: 季節性", "status: stable", "12月は+40%。"} {
+		if !strings.Contains(string(canon), want) {
+			t.Errorf("canonical form is missing %q:\n%s", want, canon)
+		}
+	}
+	// And it parses back as itself: the stored text is a valid document.
+	back, notes, err := Parse(canon)
+	if err != nil {
+		t.Fatalf("the canonical form does not parse: %v\n%s", err, canon)
+	}
+	if len(notes) != 0 {
+		t.Errorf("the canonical form was reinterpreted on read: %v", notes)
+	}
+	back.ID = k.ID
+	if !back.SameContent(&k) {
+		t.Errorf("canonical round trip changed the entry:\n got %+v\nwant %+v", back.Knowledge, k)
+	}
+
+	// A ruling must not move the hash. This is the invariant that lets
+	// verify leave a held If-Match alone.
+	bare := k
+	bare.Verifications, bare.Rejection = nil, nil
+	bareCanon, err := Canonical(&bare)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(bareCanon) != string(canon) {
+		t.Errorf("rulings changed the canonical form:\n%s\nvs\n%s", canon, bareCanon)
+	}
+}

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -184,11 +184,7 @@ func Handler(svc *service.Service) http.Handler {
 		// If-Match is an optional optimistic-concurrency precondition: its
 		// value is the ETag from a prior read. Absent means last-write-wins
 		// (design doc 0030); malformed is a client error.
-		ifMatch, err := parseIfMatch(r)
-		if err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "malformed If-Match: " + err.Error()})
-			return
-		}
+		ifMatch := parseIfMatch(r)
 		// The path is the address; the body carries the metadata — type
 		// included, always (no fill-in from the stored entry, design doc
 		// 0017 §4.5).
@@ -746,24 +742,28 @@ func writeError(w http.ResponseWriter, err error) {
 // etagOf renders an entry's version as an ETag: its updated_at in
 // RFC3339Nano, quoted. A client echoes it in If-Match to update
 // conditionally (design doc 0030).
+// etagOf renders the entry's version: the hash of its canonical document
+// (design doc 0043 §3.4). It moves when the entry's content moves and at
+// no other time — verifying, rejecting, or attaching a file all leave a
+// held precondition valid, which the updated_at version could not do
+// because it was also the row's write timestamp.
 func etagOf(k *domain.Knowledge) string {
-	return `"` + k.UpdatedAt.UTC().Format(time.RFC3339Nano) + `"`
+	return `"` + k.ContentHash + `"`
 }
 
-// parseIfMatch reads an optional If-Match precondition. Absent or "*" means
-// no version precondition (the update still requires the entry to exist).
-// A quoted value is our entry ETag — the RFC3339Nano updated_at. A value
-// that is neither is a client error.
-func parseIfMatch(r *http.Request) (*time.Time, error) {
+// parseIfMatch reads an optional If-Match precondition. Absent or "*"
+// means no version precondition (the update still requires the entry to
+// exist). Any other value is taken as an entry ETag, quoted or not: it is
+// an opaque token now, so there is no format to validate — a value that
+// never matched anything simply fails the precondition with a 412, which
+// is what a stale one does too.
+func parseIfMatch(r *http.Request) *string {
 	v := strings.TrimSpace(r.Header.Get("If-Match"))
 	if v == "" || v == "*" {
-		return nil, nil
+		return nil
 	}
-	t, err := time.Parse(time.RFC3339Nano, strings.Trim(v, `"`))
-	if err != nil {
-		return nil, err
-	}
-	return &t, nil
+	v = strings.Trim(v, `"`)
+	return &v
 }
 
 // queryInt and queryFloat parse optional numeric query parameters,

--- a/internal/restapi/restapi_integration_test.go
+++ b/internal/restapi/restapi_integration_test.go
@@ -122,7 +122,7 @@ func TestRESTIntegration(t *testing.T) {
 	}
 	getJSON(t, srv.URL+"/api/v1/revisions/"+typ+"/sales/orders", &revs)
 	if len(revs.Revisions) != 1 || revs.Revisions[0].Change != "create" ||
-		revs.Revisions[0].Snapshot.Title != "REST round trip" {
+		!strings.Contains(revs.Revisions[0].Document, "title: REST round trip") {
 		t.Errorf("revisions = %+v", revs.Revisions)
 	}
 
@@ -469,7 +469,7 @@ func TestRESTIntegrationVerify(t *testing.T) {
 	// A create returns the entry, so it returns the version with it: a
 	// client that creates and then updates conditionally should not have
 	// to GET the entry it just wrote to learn what to put in If-Match.
-	if got, want := resp.Header.Get("ETag"), `"`+created.UpdatedAt.Format(time.RFC3339Nano)+`"`; got != want {
+	if got, want := resp.Header.Get("ETag"), `"`+created.ContentHash+`"`; got != want || created.ContentHash == "" {
 		t.Errorf("create ETag = %q, want %q", got, want)
 	}
 

--- a/internal/restapi/restapi_test.go
+++ b/internal/restapi/restapi_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/na0fu3y/ochakai/internal/domain"
 	"github.com/na0fu3y/ochakai/internal/service"
@@ -150,25 +149,23 @@ func TestReportOutcomeBadRequests(t *testing.T) {
 	}
 }
 
-// TestETagRoundTrip pins the ETag/If-Match wire format: etagOf quotes the
-// updated_at, and parseIfMatch reads it (and "*", and absence) back — so a
-// value from a response header is accepted verbatim on the next request.
+// TestETagRoundTrip pins the ETag/If-Match wire format: etagOf quotes
+// the entry's content hash, and parseIfMatch reads it (and "*", and
+// absence) back — so a value from a response header is accepted verbatim
+// on the next request.
 func TestETagRoundTrip(t *testing.T) {
-	updated := time.Date(2026, 7, 24, 1, 2, 3, 456789000, time.UTC)
-	k := &domain.Knowledge{ID: "metrics/x", UpdatedAt: updated}
+	const hash = "9f2c1b0d4e5a6789abcdef0123456789abcdef0123456789abcdef0123456789"
+	k := &domain.Knowledge{ID: "metrics/x", ContentHash: hash}
 	etag := etagOf(k)
-	if etag != `"2026-07-24T01:02:03.456789Z"` {
+	if etag != `"`+hash+`"` {
 		t.Fatalf("etagOf = %s", etag)
 	}
 
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/knowledge/metrics/x", nil)
 	req.Header.Set("If-Match", etag)
-	got, err := parseIfMatch(req)
-	if err != nil {
-		t.Fatalf("parseIfMatch: %v", err)
-	}
-	if got == nil || !got.Equal(updated) {
-		t.Errorf("parseIfMatch(%s) = %v, want %v", etag, got, updated)
+	got := parseIfMatch(req)
+	if got == nil || *got != hash {
+		t.Errorf("parseIfMatch(%s) = %v, want %q", etag, got, hash)
 	}
 
 	// Absent and "*" carry no version precondition.
@@ -177,16 +174,20 @@ func TestETagRoundTrip(t *testing.T) {
 		if v != "" {
 			r.Header.Set("If-Match", v)
 		}
-		if p, err := parseIfMatch(r); err != nil || p != nil {
-			t.Errorf("parseIfMatch(If-Match:%q) = %v, %v; want nil, nil", v, p, err)
+		if p := parseIfMatch(r); p != nil {
+			t.Errorf("parseIfMatch(If-Match:%q) = %v; want nil", v, p)
 		}
 	}
 
-	// A non-ETag value is a client error, not a silent no-precondition.
+	// The version is an opaque token now, so there is no format to
+	// reject: a value that never matched anything fails the precondition
+	// with a 412, which is what a merely stale one does too. Rejecting it
+	// at parse time would only tell a client that its own ETag looked
+	// wrong to us, which is not something we can know.
 	r := httptest.NewRequest(http.MethodPut, "/x", nil)
-	r.Header.Set("If-Match", `"not-a-timestamp"`)
-	if _, err := parseIfMatch(r); err == nil {
-		t.Error("malformed If-Match must be an error")
+	r.Header.Set("If-Match", `"not-a-hash"`)
+	if p := parseIfMatch(r); p == nil || *p != "not-a-hash" {
+		t.Errorf("parseIfMatch of an unknown token = %v, want it passed through", p)
 	}
 }
 

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -11,7 +11,6 @@ import (
 	"log/slog"
 	"sort"
 	"strings"
-	"time"
 	"unicode/utf8"
 
 	"github.com/na0fu3y/ochakai/internal/config"
@@ -194,7 +193,7 @@ func (s *Service) create(ctx context.Context, k *domain.Knowledge, actor domain.
 // read, or in the read-modify-write window below — yields store.ErrConflict
 // rather than silently clobbering the other write. nil keeps the prior
 // last-write-wins behavior for callers that do not opt in.
-func (s *Service) Update(ctx context.Context, k *domain.Knowledge, actor domain.Actor, ifMatch *time.Time) (updated *domain.Knowledge, changed bool, err error) {
+func (s *Service) Update(ctx context.Context, k *domain.Knowledge, actor domain.Actor, ifMatch *string) (updated *domain.Knowledge, changed bool, err error) {
 	if err := s.readOnly(); err != nil {
 		return nil, false, err
 	}
@@ -209,7 +208,7 @@ func (s *Service) Update(ctx context.Context, k *domain.Knowledge, actor domain.
 	}
 	// The caller's version is already stale if the stored entry moved on
 	// between their read and ours — reject before doing any work.
-	if ifMatch != nil && !old.UpdatedAt.Equal(ifMatch.UTC()) {
+	if ifMatch != nil && old.ContentHash != *ifMatch {
 		return nil, false, store.ErrConflict
 	}
 	if k.Status == "" {
@@ -259,7 +258,7 @@ func (s *Service) Update(ctx context.Context, k *domain.Knowledge, actor domain.
 // tell agents to consult before re-proposing. Nobody notices: unlike a
 // deleted verified entry, a deleted rejection leaves nothing anyone was
 // using.
-func (s *Service) RefuseIfCurated(ctx context.Context, id, op string) (*time.Time, error) {
+func (s *Service) RefuseIfCurated(ctx context.Context, id, op string) (*string, error) {
 	k, err := s.Store.Get(ctx, domain.Normalize(id))
 	if err != nil {
 		return nil, err
@@ -278,7 +277,7 @@ func (s *Service) RefuseIfCurated(ctx context.Context, id, op string) (*time.Tim
 		instead = "Deprecated means it was correct and is no longer recommended. If it is worth " +
 			"reviving, create_knowledge a draft that says why."
 	default:
-		return &k.UpdatedAt, nil
+		return &k.ContentHash, nil
 	}
 	return nil, Invalidf("cannot %s %s from this surface: it is %s, and this surface has no "+
 		"If-Match precondition to replace curated knowledge safely. %s A human changes curated "+

--- a/internal/service/service_integration_test.go
+++ b/internal/service/service_integration_test.go
@@ -143,14 +143,14 @@ func TestUpdateIfMatchIntegration(t *testing.T) {
 	}
 
 	// Writer A updates against the current version — accepted.
-	v2, _, err := svc.Update(ctx, mk("v2"), actor, &base.UpdatedAt)
+	v2, _, err := svc.Update(ctx, mk("v2"), actor, &base.ContentHash)
 	if err != nil {
 		t.Fatalf("If-Match update on the current version: %v", err)
 	}
 
 	// Writer B still holds the pre-A version: its update must be rejected,
 	// not silently clobber A's write (the lost-update this fix closes).
-	if _, _, err := svc.Update(ctx, mk("v3-from-stale"), actor, &base.UpdatedAt); !errors.Is(err, store.ErrConflict) {
+	if _, _, err := svc.Update(ctx, mk("v3-from-stale"), actor, &base.ContentHash); !errors.Is(err, store.ErrConflict) {
 		t.Fatalf("stale If-Match: got %v, want ErrConflict", err)
 	}
 	// The stored content is still A's, untouched by B.
@@ -161,7 +161,7 @@ func TestUpdateIfMatchIntegration(t *testing.T) {
 	}
 
 	// After re-reading A's version, B can proceed.
-	if _, _, err := svc.Update(ctx, mk("v3"), actor, &v2.UpdatedAt); err != nil {
+	if _, _, err := svc.Update(ctx, mk("v3"), actor, &v2.ContentHash); err != nil {
 		t.Fatalf("If-Match update after re-read: %v", err)
 	}
 
@@ -238,8 +238,8 @@ func TestRefuseIfCuratedIntegration(t *testing.T) {
 			t.Fatalf("draft must be writable: %v", err)
 		}
 		// The guard hands back a usable precondition, not just a verdict.
-		if version == nil || !version.Equal(k.UpdatedAt) {
-			t.Errorf("version = %v, want the entry's updated_at %v", version, k.UpdatedAt)
+		if version == nil || *version != k.ContentHash {
+			t.Errorf("version = %v, want the entry's content hash %q", version, k.ContentHash)
 		}
 		// Promotion to stable is not restricted — 0002 stands.
 		setStatus(t, k, domain.StatusStable, actor)

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -3,11 +3,15 @@ package store
 import (
 	"context"
 	"embed"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
 
 	"github.com/jackc/pgx/v5"
+
+	"github.com/na0fu3y/ochakai/internal/domain"
+	"github.com/na0fu3y/ochakai/internal/okf"
 )
 
 //go:embed migrations/*.sql
@@ -86,6 +90,12 @@ func (s *Store) Migrate(ctx context.Context, embedDim int) error {
 		}
 	}
 
+	// Runs inside the advisory lock, like the SQL migrations, so several
+	// instances starting at once do not compose the same documents twice.
+	if err := s.backfillDocuments(ctx); err != nil {
+		return fmt.Errorf("backfill documents: %w", err)
+	}
+
 	if embedDim > 0 {
 		if err := s.migrateEmbedding(ctx, embedDim); err != nil {
 			return err
@@ -93,6 +103,143 @@ func (s *Store) Migrate(ctx context.Context, embedDim int) error {
 	}
 	return nil
 }
+
+// backfillDocuments composes the canonical document (and its hash) for
+// every entry and revision written before migration 0024 made the
+// document the stored form (design doc 0043 §§3.1, 3.9).
+//
+// It lives here rather than in the migration file because composing a
+// document means writing YAML in the spelling and key order the spec
+// fixes — the same renderer an export uses, which is Go. An empty doc is
+// the marker for "not yet composed", so this is idempotent: a run that
+// dies half-way resumes, and a database that has been through it does a
+// single counting query and returns.
+//
+// updated_at is deliberately not touched. Composing the stored form is a
+// change of representation, not of content.
+func (s *Store) backfillDocuments(ctx context.Context) error {
+	if err := s.backfillEntryDocuments(ctx); err != nil {
+		return err
+	}
+	return s.backfillRevisionDocuments(ctx)
+}
+
+func (s *Store) backfillEntryDocuments(ctx context.Context) error {
+	for {
+		rows, err := s.pool.Query(ctx,
+			`SELECT `+knowledgeSelect+` FROM knowledge WHERE doc = '' ORDER BY id LIMIT $1`,
+			backfillBatch)
+		if err != nil {
+			return err
+		}
+		batch, err := pgx.CollectRows(rows, scanKnowledge)
+		if err != nil {
+			return err
+		}
+		if len(batch) == 0 {
+			return nil
+		}
+		for i := range batch {
+			doc, hash, err := canonicalDoc(&batch[i])
+			if err != nil {
+				// A row the renderer cannot read is left with an empty
+				// doc rather than a wrong one, and named so somebody can
+				// look. Returning here would wedge every later start.
+				s.log.Warn("cannot compose the stored document", "id", batch[i].ID, "err", err)
+				continue
+			}
+			if _, err := s.pool.Exec(ctx,
+				`UPDATE knowledge SET doc = $2, content_hash = $3 WHERE id = $1`,
+				batch[i].ID, doc, hash); err != nil {
+				return err
+			}
+		}
+		// Rows the renderer refused keep doc = '' and would be selected
+		// again forever; stop once a batch converted nothing.
+		if !anyConverted(ctx, s, batch) {
+			return nil
+		}
+	}
+}
+
+// anyConverted reports whether any of the batch now has a document, so a
+// batch that failed wholesale ends the loop instead of repeating it.
+func anyConverted(ctx context.Context, s *Store, batch []domain.Knowledge) bool {
+	ids := make([]string, len(batch))
+	for i := range batch {
+		ids[i] = batch[i].ID
+	}
+	var n int
+	if err := s.pool.QueryRow(ctx,
+		`SELECT count(*) FROM knowledge WHERE id = ANY($1) AND doc <> ''`, ids).Scan(&n); err != nil {
+		return false
+	}
+	return n > 0
+}
+
+// backfillRevisionDocuments renders each stored snapshot as the document
+// that revision held. A snapshot the current shape cannot read loses what
+// it cannot express — design doc 0043 §3.9 accepts that in exchange for a
+// history whose shape does not depend on knowing every past release.
+func (s *Store) backfillRevisionDocuments(ctx context.Context) error {
+	for {
+		rows, err := s.pool.Query(ctx,
+			`SELECT id, rev, snapshot FROM knowledge_revision
+			 WHERE doc = '' AND snapshot IS NOT NULL ORDER BY id, rev LIMIT $1`, backfillBatch)
+		if err != nil {
+			return err
+		}
+		type row struct {
+			id       string
+			rev      int
+			snapshot []byte
+		}
+		batch, err := pgx.CollectRows(rows, func(r pgx.CollectableRow) (row, error) {
+			var v row
+			return v, r.Scan(&v.id, &v.rev, &v.snapshot)
+		})
+		if err != nil {
+			return err
+		}
+		if len(batch) == 0 {
+			return nil
+		}
+		for _, b := range batch {
+			doc := ""
+			var k domain.Knowledge
+			if err := json.Unmarshal(b.snapshot, &k); err != nil {
+				s.log.Warn("cannot read a revision snapshot", "id", b.id, "rev", b.rev, "err", err)
+			} else if rendered, err := okf.Document(&k); err != nil {
+				s.log.Warn("cannot compose a revision document", "id", b.id, "rev", b.rev, "err", err)
+			} else {
+				doc = string(rendered)
+			}
+			// An unreadable snapshot is marked with a placeholder rather
+			// than left empty: empty means "not yet converted", and the
+			// loop would come back to it every start.
+			if doc == "" {
+				doc = unreadableRevision
+			}
+			if _, err := s.pool.Exec(ctx,
+				`UPDATE knowledge_revision SET doc = $3 WHERE id = $1 AND rev = $2`,
+				b.id, b.rev, doc); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// backfillBatch bounds how much of the knowledge base the backfill holds
+// at once, the way the exporter batches for the same reason.
+const backfillBatch = 200
+
+// unreadableRevision stands in for a snapshot the current shape cannot
+// read. It is a valid OKF document, so every consumer of a revision gets
+// a document — and it says plainly that the content is gone rather than
+// pretending the revision was empty.
+const unreadableRevision = "---\ntype: Reference\nstatus: deprecated\n---\n\n" +
+	"This revision was written in a shape this release cannot read, and its\n" +
+	"content did not survive the move to document storage (design doc 0043 §3.9).\n"
 
 // migrateEmbedding sets up pgvector storage. Runs only when an embedding
 // provider is configured, keeping plain PostgreSQL sufficient by default.

--- a/internal/store/migrate_integration_test.go
+++ b/internal/store/migrate_integration_test.go
@@ -1061,3 +1061,109 @@ func TestMigrationActorProcess(t *testing.T) {
 		}
 	}
 }
+
+// The 0024 backfill composes the stored document for rows written before
+// the document was the stored form, and turns each revision snapshot into
+// the document that revision held (design doc 0043 §§3.1, 3.9). It runs
+// in Go rather than in SQL because composing a document means writing
+// YAML in the spelling the spec fixes.
+//
+// It runs against the real shared database rather than a scratch schema:
+// what is being tested is Migrate's own backfill pass, which reads
+// through the store's connection and cannot be pointed at a search_path
+// set for one transaction.
+func TestBackfillComposesStoredDocuments(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	actor := domain.Actor{Kind: domain.ActorHuman, Name: "test"}
+	id := fmt.Sprintf("it-backfill-%d", time.Now().UnixNano())
+	k := &domain.Knowledge{Type: domain.TypeInsights, ID: id, Title: "季節性",
+		Status: domain.StatusStable, Body: "12月は+40%。", CreatedBy: actor}
+	if err := s.Create(ctx, k, false); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge WHERE id = $1`, id)
+		_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_revision WHERE id = $1`, id)
+	})
+
+	// Put the row back into the pre-0024 shape: no document, no hash, and
+	// a revision carrying a JSON snapshot instead of a document.
+	snapshot, err := json.Marshal(k)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, q := range []struct {
+		sql  string
+		args []any
+	}{
+		{`UPDATE knowledge SET doc = '', content_hash = '' WHERE id = $1`, []any{id}},
+		{`UPDATE knowledge_revision SET doc = '', snapshot = $2 WHERE id = $1`, []any{id, snapshot}},
+	} {
+		if _, err := s.pool.Exec(ctx, q.sql, q.args...); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := s.backfillDocuments(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	var doc, hash string
+	var updatedAt time.Time
+	if err := s.pool.QueryRow(ctx,
+		`SELECT doc, content_hash, updated_at FROM knowledge WHERE id = $1`, id).
+		Scan(&doc, &hash, &updatedAt); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(doc, "title: 季節性") || !strings.Contains(doc, "12月は+40%。") {
+		t.Errorf("composed document does not carry the entry:\n%s", doc)
+	}
+	// The stored form carries no key this instance owns — that is what
+	// makes the hash a content hash (design doc 0043 §3.4).
+	for _, owned := range []string{"generated:", "created_by:"} {
+		if strings.Contains(doc, owned) {
+			t.Errorf("composed document carries the server-owned key %q:\n%s", owned, doc)
+		}
+	}
+	if hash == "" || !updatedAt.Equal(k.UpdatedAt) {
+		t.Errorf("hash = %q, updated_at = %v (want it unmoved from %v)", hash, updatedAt, k.UpdatedAt)
+	}
+
+	revs, err := s.ListRevisions(ctx, id, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(revs) == 0 || !strings.Contains(revs[0].Document, "title: 季節性") {
+		t.Errorf("revision was not composed into a document: %+v", revs)
+	}
+	// A revision keeps the keys this instance owns: it records what the
+	// entry was, and who had confirmed it then is part of that.
+	if !strings.Contains(revs[0].Document, "created_by:") {
+		t.Errorf("revision document dropped the provenance it is there to record:\n%s", revs[0].Document)
+	}
+
+	// Idempotent: a second pass over an already-composed base changes
+	// nothing, so a restart is free and a half-finished run resumes.
+	if err := s.backfillDocuments(ctx); err != nil {
+		t.Fatal(err)
+	}
+	var again string
+	if err := s.pool.QueryRow(ctx, `SELECT doc FROM knowledge WHERE id = $1`, id).Scan(&again); err != nil {
+		t.Fatal(err)
+	}
+	if again != doc {
+		t.Error("a second backfill pass rewrote an already-composed document")
+	}
+}

--- a/internal/store/migrations/0024_document_storage.sql
+++ b/internal/store/migrations/0024_document_storage.sql
@@ -1,0 +1,45 @@
+-- The canonical OKF document becomes the stored form (design doc 0043
+-- §§3.1, 3.7), and its hash becomes the entry's version (§3.4).
+--
+-- Until now an entry was a row of columns that an exporter re-rendered
+-- into a document on the way out, and its version was updated_at. Both
+-- had costs the design doc lays out: the render was a mapping to
+-- maintain against a spec that moves, and updated_at was doing three
+-- jobs at once — the ETag, OKF's generated.at, and "when was this row
+-- last touched" — which is why verifying an entry had to move a version
+-- that no editor's content had changed.
+--
+-- doc holds the document a writer authored, with none of the keys this
+-- instance owns; the columns beside it stay, as the derived index every
+-- query already reads (§3.1). content_hash is the SHA-256 of doc.
+--
+-- Neither column can be filled here: composing a document means writing
+-- YAML in the spelling and key order the spec fixes, which is Go's job,
+-- not SQL's. Both default to empty and the server backfills them once at
+-- startup, right after this migration (Store.backfillDocuments). An
+-- empty doc is the marker for "not yet composed", so the backfill is
+-- idempotent and a half-finished run simply resumes.
+--
+-- updated_at is untouched: composing the stored form is not a content
+-- change, and no held ETag may be invalidated by a representation
+-- change. (The ETag does move for every client here — but that is the
+-- version scheme changing, which the changelog states, not this
+-- migration silently editing entries.)
+
+ALTER TABLE knowledge ADD COLUMN IF NOT EXISTS doc          text NOT NULL DEFAULT '';
+ALTER TABLE knowledge ADD COLUMN IF NOT EXISTS content_hash text NOT NULL DEFAULT '';
+
+-- History gets the same treatment: a revision is the document as it stood
+-- (design doc 0043 §3.9), rather than a JSON snapshot of whatever the Go
+-- struct happened to look like that release. A record whose shape depends
+-- on the reader knowing every past generation of a struct is the
+-- distortion, not the fidelity — and OKF is an anchor that outlasts them.
+--
+-- snapshot is kept, not dropped: it is the only source the backfill has
+-- for the text of an existing revision. It loses NOT NULL because new
+-- revisions no longer write one, and a later release removes it once no
+-- deployment still has revisions to convert. Keeping a dead column for a
+-- release costs a little tidiness; dropping the only copy of the history
+-- before it has been read costs the history.
+ALTER TABLE knowledge_revision ADD COLUMN IF NOT EXISTS doc text NOT NULL DEFAULT '';
+ALTER TABLE knowledge_revision ALTER COLUMN snapshot DROP NOT NULL;

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4,6 +4,8 @@ package store
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -21,6 +23,7 @@ import (
 
 	"github.com/na0fu3y/ochakai/internal/blob"
 	"github.com/na0fu3y/ochakai/internal/domain"
+	"github.com/na0fu3y/ochakai/internal/okf"
 )
 
 // isUniqueViolation reports whether err is PostgreSQL's unique_violation
@@ -177,7 +180,7 @@ const knowledgeCols = `type, id, title, description, resource, tags, status, sta
 	sources, usage_window, runtime, parameters, computation, executor, attester,
 	created_by_kind, created_by_name, created_by_via,
 	updated_by_kind, updated_by_name, updated_by_via,
-	links, attrs, body, created_at, updated_at`
+	links, attrs, body, created_at, updated_at, doc, content_hash`
 
 // ledgerCols is the two instance ledgers — verifications and the
 // rejection — read as JSON beside the entry's own columns (design doc
@@ -208,11 +211,26 @@ func lastVerifiedAt(alias string) string {
 	return `(SELECT max(v.at) FROM knowledge_verification v WHERE v.id = ` + alias + `.id)`
 }
 
+// withoutDoc drops the stored document from a column list. A read does
+// not need it: the entry's own columns are the index derived from it
+// (design doc 0043 §3.1), and carrying the whole document beside the
+// body it contains would double every search result for nothing. Writes
+// keep it — they are what the index is derived from.
+func withoutDoc(cols string) string {
+	var kept []string
+	for _, c := range strings.Split(cols, ",") {
+		if t := strings.TrimSpace(c); t != "doc" && t != "k.doc" && t != "knowledge.doc" {
+			kept = append(kept, t)
+		}
+	}
+	return strings.Join(kept, ", ")
+}
+
 var (
 	// knowledgeSelect and knowledgeSelectK are what a read selects: the
-	// entry's columns plus its ledgers.
-	knowledgeSelect  = knowledgeCols + ", " + ledgerCols("knowledge")
-	knowledgeSelectK = knowledgeColsK + ", " + ledgerCols("k")
+	// entry's columns (minus the stored document) plus its ledgers.
+	knowledgeSelect  = withoutDoc(knowledgeCols) + ", " + ledgerCols("knowledge")
+	knowledgeSelectK = withoutDoc(knowledgeColsK) + ", " + ledgerCols("k")
 )
 
 // notCurated is Knowledge.Curated() as a SQL predicate, for the guards
@@ -289,7 +307,7 @@ func knowledgeDest(k *domain.Knowledge) (dests []any, finish func() error) {
 		&sources, &usageWindow, &k.Runtime, &parameters, &k.Computation, &executor, &attester,
 		&k.CreatedBy.Kind, &k.CreatedBy.Name, &k.CreatedBy.Via,
 		&k.UpdatedBy.Kind, &k.UpdatedBy.Name, &k.UpdatedBy.Via,
-		&links, &attrs, &k.Body, &k.CreatedAt, &k.UpdatedAt,
+		&links, &attrs, &k.Body, &k.CreatedAt, &k.UpdatedAt, &k.ContentHash,
 		&verifications, &rejection}
 	finish = func() error {
 		if staleAfter != nil {
@@ -317,6 +335,23 @@ func knowledgeDest(k *domain.Knowledge) (dests []any, finish func() error) {
 		return nil
 	}
 	return dests, finish
+}
+
+// canonicalDoc renders the entry's stored form and its version: the
+// canonical OKF document with no server-owned key in it, and the SHA-256
+// of exactly those bytes (design doc 0043 §§3.4, 3.7).
+//
+// The hash is taken over the canonical text rather than over the struct
+// so that the version means "what this entry says", not "how this
+// release happened to serialize it" — and so that a ruling, which writes
+// no key into the canonical form, cannot move it.
+func canonicalDoc(k *domain.Knowledge) (doc, hash string, err error) {
+	b, err := okf.Canonical(k)
+	if err != nil {
+		return "", "", err
+	}
+	sum := sha256.Sum256(b)
+	return string(b), hex.EncodeToString(sum[:]), nil
 }
 
 // staleAfterArg turns the entry's stale_after into a date argument: NULL
@@ -461,12 +496,17 @@ func (s *Store) Create(ctx context.Context, k *domain.Knowledge, keepCuratedTomb
 		if err != nil {
 			return err
 		}
+		doc, hash, err := canonicalDoc(k)
+		if err != nil {
+			return err
+		}
+		k.ContentHash = hash
 		args := []any{
 			k.Type, k.ID, k.Title, k.Description, k.Resource, k.Tags, k.Status, k.StatusNote, staleAfter,
 			j.sources, j.usageWindow, k.Runtime, j.parameters, k.Computation, j.executor, j.attester,
 			k.CreatedBy.Kind, k.CreatedBy.Name, k.CreatedBy.Via,
 			k.UpdatedBy.Kind, k.UpdatedBy.Name, k.UpdatedBy.Via,
-			j.links, j.attrs, k.Body, k.CreatedAt, k.UpdatedAt,
+			j.links, j.attrs, k.Body, k.CreatedAt, k.UpdatedAt, doc, hash,
 		}
 		tag, err := tx.Exec(ctx, `INSERT INTO knowledge (`+knowledgeCols+`)
 			VALUES (`+knowledgeParams+`)
@@ -508,7 +548,7 @@ func (s *Store) Create(ctx context.Context, k *domain.Knowledge, keepCuratedTomb
 // changed since the caller read it and returns ErrConflict, closing the
 // read-modify-write race that silently lost updates. A nil ifMatch keeps
 // the prior last-write-wins behavior for callers that do not opt in.
-func (s *Store) Update(ctx context.Context, k *domain.Knowledge, actor domain.Actor, ifMatch *time.Time) error {
+func (s *Store) Update(ctx context.Context, k *domain.Knowledge, actor domain.Actor, ifMatch *string) error {
 	k.UpdatedAt = NowStored()
 	return s.withTx(ctx, func(tx pgx.Tx) error {
 		j, err := marshalJSONFields(k)
@@ -519,20 +559,25 @@ func (s *Store) Update(ctx context.Context, k *domain.Knowledge, actor domain.Ac
 		if err != nil {
 			return err
 		}
+		doc, hash, err := canonicalDoc(k)
+		if err != nil {
+			return err
+		}
+		k.ContentHash = hash
 		cond := ""
 		args := []any{k.ID, k.Type, k.Title, k.Description, k.Resource, k.Tags, k.Status, k.StatusNote, staleAfter,
 			j.sources, j.usageWindow, k.Runtime, j.parameters, k.Computation, j.executor, j.attester,
 			k.UpdatedBy.Kind, k.UpdatedBy.Name, k.UpdatedBy.Via,
-			j.links, j.attrs, k.Body, k.UpdatedAt}
+			j.links, j.attrs, k.Body, k.UpdatedAt, doc, hash}
 		if ifMatch != nil {
-			args = append(args, ifMatch.UTC())
-			cond = fmt.Sprintf(" AND updated_at=$%d", len(args))
+			args = append(args, *ifMatch)
+			cond = fmt.Sprintf(" AND content_hash=$%d", len(args))
 		}
 		tag, err := tx.Exec(ctx, `UPDATE knowledge SET
 			type=$2, title=$3, description=$4, resource=$5, tags=$6, status=$7, status_note=$8, stale_after=$9,
 			sources=$10, usage_window=$11, runtime=$12, parameters=$13, computation=$14, executor=$15, attester=$16,
 			updated_by_kind=$17, updated_by_name=$18, updated_by_via=$19,
-			links=$20, attrs=$21, body=$22, updated_at=$23
+			links=$20, attrs=$21, body=$22, updated_at=$23, doc=$24, content_hash=$25
 			WHERE id=$1 AND deleted_at IS NULL`+cond, args...)
 		if err != nil {
 			return err
@@ -981,11 +1026,20 @@ func (s *Store) rewriteReferences(ctx context.Context, tx pgx.Tx, oldID string, 
 		// having filtered: rewriting a tombstone would plant a repaired
 		// body and a revision on an entry nobody can see, to resurface
 		// whenever someone revives it.
+		// The stored document and its hash are recomposed with the body:
+		// they are what the entry says, and the index columns beside them
+		// are derived from the same value (design doc 0043 §3.1).
+		doc, hash, err := canonicalDoc(r)
+		if err != nil {
+			return err
+		}
+		r.ContentHash = hash
 		tag, err := tx.Exec(ctx,
 			`UPDATE knowledge SET links=$2, attrs=$3, body=$4, updated_at=$5,
-			 updated_by_kind=$6, updated_by_name=$7, updated_by_via=$8
+			 updated_by_kind=$6, updated_by_name=$7, updated_by_via=$8,
+			 doc=$9, content_hash=$10
 			 WHERE id=$1 AND deleted_at IS NULL`,
-			r.ID, j.links, j.attrs, r.Body, r.UpdatedAt, actor.Kind, actor.Name, actor.Via)
+			r.ID, j.links, j.attrs, r.Body, r.UpdatedAt, actor.Kind, actor.Name, actor.Via, doc, hash)
 		if err != nil {
 			return err
 		}
@@ -1012,7 +1066,7 @@ func (s *Store) rewriteReferences(ctx context.Context, tx pgx.Tx, oldID string, 
 // trail is most interesting exactly when the entry is gone.
 func (s *Store) ListRevisions(ctx context.Context, id string, limit int) ([]domain.Revision, error) {
 	rows, err := s.pool.Query(ctx,
-		`SELECT rev, change, changed_by_kind, changed_by_name, changed_by_via, changed_at, snapshot
+		`SELECT rev, change, changed_by_kind, changed_by_name, changed_by_via, changed_at, doc
 		 FROM knowledge_revision WHERE id=$1 ORDER BY rev DESC LIMIT $2`,
 		id, limit)
 	if err != nil {
@@ -1020,11 +1074,7 @@ func (s *Store) ListRevisions(ctx context.Context, id string, limit int) ([]doma
 	}
 	revs, err := pgx.CollectRows(rows, func(row pgx.CollectableRow) (domain.Revision, error) {
 		var r domain.Revision
-		var snapshot []byte
-		if err := row.Scan(&r.Rev, &r.Change, &r.ChangedBy.Kind, &r.ChangedBy.Name, &r.ChangedBy.Via, &r.ChangedAt, &snapshot); err != nil {
-			return r, err
-		}
-		return r, json.Unmarshal(snapshot, &r.Snapshot)
+		return r, row.Scan(&r.Rev, &r.Change, &r.ChangedBy.Kind, &r.ChangedBy.Name, &r.ChangedBy.Via, &r.ChangedAt, &r.Document)
 	})
 	if err != nil {
 		return nil, err
@@ -1038,13 +1088,16 @@ func (s *Store) ListRevisions(ctx context.Context, id string, limit int) ([]doma
 }
 
 func (s *Store) addRevision(ctx context.Context, tx pgx.Tx, k *domain.Knowledge, change string, actor domain.Actor) error {
-	snapshot, err := json.Marshal(k)
+	// The full document, server-owned keys included: a revision records
+	// what the entry was, and who had confirmed it at the time is part of
+	// that (design doc 0043 §3.9).
+	doc, err := okf.Document(k)
 	if err != nil {
 		return err
 	}
-	_, err = tx.Exec(ctx, `INSERT INTO knowledge_revision (id, rev, change, changed_by_kind, changed_by_name, changed_by_via, snapshot)
+	_, err = tx.Exec(ctx, `INSERT INTO knowledge_revision (id, rev, change, changed_by_kind, changed_by_name, changed_by_via, doc)
 		VALUES ($1, (SELECT COALESCE(MAX(rev), 0) + 1 FROM knowledge_revision WHERE id=$1), $2, $3, $4, $5, $6)`,
-		k.ID, change, actor.Kind, actor.Name, actor.Via, snapshot)
+		k.ID, change, actor.Kind, actor.Name, actor.Via, string(doc))
 	return err
 }
 
@@ -1305,7 +1358,7 @@ func (s *Store) SearchVectorAttachments(ctx context.Context, vec []float32, mode
 	vecParam := len(args)
 	args = append(args, model) // this model's vectors only, as in SearchVector
 	q := fmt.Sprintf(`
-		SELECT `+knowledgeCols+", "+ledgerCols("best")+`, score FROM (
+		SELECT `+withoutDoc(knowledgeCols)+", "+ledgerCols("best")+`, score FROM (
 			SELECT DISTINCT ON (k.id) k.*, 1 - (e.embedding <=> $%d::vector) AS score
 			FROM knowledge k JOIN attachment_embedding e ON k.id = e.knowledge_id AND e.model = $%d
 			WHERE %s

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -1140,8 +1140,11 @@ func TestIntegrationListRevisions(t *testing.T) {
 	if revs[0].Rev != 3 || revs[2].Rev != 1 {
 		t.Errorf("revs = %d..%d, want 3..1", revs[0].Rev, revs[2].Rev)
 	}
-	if revs[1].Snapshot.Title != "v2" || revs[2].Snapshot.Title != "v1" {
-		t.Errorf("snapshot titles = %q, %q; want v2, v1", revs[1].Snapshot.Title, revs[2].Snapshot.Title)
+	// A revision is the document the entry was, so the title is read out
+	// of the frontmatter rather than off a struct field (design doc 0043
+	// §3.9).
+	if !strings.Contains(revs[1].Document, "title: v2") || !strings.Contains(revs[2].Document, "title: v1") {
+		t.Errorf("revision documents do not carry v2, v1:\n%s\n%s", revs[1].Document, revs[2].Document)
 	}
 	if revs[0].ChangedBy != actor {
 		t.Errorf("changed_by = %+v, want %+v", revs[0].ChangedBy, actor)
@@ -2006,15 +2009,11 @@ func TestIntegrationMoveSelfRewriteIsOneRevision(t *testing.T) {
 		}
 		t.Fatalf("revisions (newest first) = %v, want [move create] — the moved entry must not get its own trailing \"update\"", changes)
 	}
-	if revs[0].Snapshot.Body != stored.Body {
-		t.Errorf("move revision snapshot body %q contradicts the stored row %q", revs[0].Snapshot.Body, stored.Body)
+	if !strings.Contains(revs[0].Document, stored.Body) {
+		t.Errorf("move revision document contradicts the stored row %q:\n%s", stored.Body, revs[0].Document)
 	}
-	if !revs[0].Snapshot.UpdatedAt.Equal(stored.UpdatedAt) {
-		t.Errorf("move revision snapshot updated_at %v, stored row has %v", revs[0].Snapshot.UpdatedAt, stored.UpdatedAt)
-	}
-	if revs[0].Snapshot.UpdatedAt.Before(revs[1].Snapshot.UpdatedAt) {
-		t.Errorf("revision timestamps run backwards: rev %d has %v, rev %d has %v",
-			revs[1].Rev, revs[1].Snapshot.UpdatedAt, revs[0].Rev, revs[0].Snapshot.UpdatedAt)
+	if want := stored.UpdatedAt.UTC().Format(time.RFC3339); !strings.Contains(revs[0].Document, want) {
+		t.Errorf("move revision document does not carry generated.at %s:\n%s", want, revs[0].Document)
 	}
 	if revs[0].ChangedAt.Before(revs[1].ChangedAt) {
 		t.Errorf("revision changed_at runs backwards: rev %d at %v, rev %d at %v",
@@ -2030,8 +2029,8 @@ func TestIntegrationMoveSelfRewriteIsOneRevision(t *testing.T) {
 	if len(refRevs) != 2 || refRevs[0].Change != "update" {
 		t.Fatalf("referrer revisions = %+v, want an \"update\" on top of \"create\"", refRevs)
 	}
-	if !strings.Contains(refRevs[0].Snapshot.Body, "/"+dest+".md") {
-		t.Errorf("referrer's update snapshot still points at the old id: %q", refRevs[0].Snapshot.Body)
+	if !strings.Contains(refRevs[0].Document, "/"+dest+".md") {
+		t.Errorf("referrer's update revision still points at the old id:\n%s", refRevs[0].Document)
 	}
 }
 
@@ -2505,5 +2504,147 @@ func TestIntegrationMoveAndPurgeCarryTheLedgers(t *testing.T) {
 		if n != 0 {
 			t.Errorf("purge left %d row(s) in %s", n, table)
 		}
+	}
+}
+
+// The version is the content's, not the row's (design doc 0043 §3.4).
+// This is the invariant the whole change turns on: until 0.16 the ETag
+// was updated_at, so verifying an entry — or attaching a file to it —
+// moved a version whose content nobody had touched, and an editor's held
+// If-Match died for a reason unrelated to their edit.
+func TestIntegrationContentHashMovesOnlyWithContent(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	actor := domain.Actor{Kind: domain.ActorHuman, Name: "test"}
+	id := fmt.Sprintf("it-hash-%d", time.Now().UnixNano())
+	k := &domain.Knowledge{Type: domain.TypeTerms, ID: id, Title: "first",
+		Status: domain.StatusDraft, Body: "One.", CreatedBy: actor}
+	if err := s.Create(ctx, k, false); err != nil {
+		t.Fatal(err)
+	}
+	if k.ContentHash == "" {
+		t.Fatal("create returned no version")
+	}
+	original := k.ContentHash
+
+	for _, tc := range []struct {
+		what string
+		do   func() error
+	}{
+		{"verifying", func() error { _, err := s.Verify(ctx, id, actor); return err }},
+		{"rejecting", func() error { _, err := s.Reject(ctx, id, actor, "no"); return err }},
+		{"lifting a rejection", func() error { _, err := s.LiftRejection(ctx, id, actor); return err }},
+	} {
+		if err := tc.do(); err != nil {
+			t.Fatalf("%s: %v", tc.what, err)
+		}
+		read, err := s.Get(ctx, id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if read.ContentHash != original {
+			t.Errorf("%s moved the version %q -> %q; a ruling is not an edit",
+				tc.what, original, read.ContentHash)
+		}
+	}
+
+	// An edit does move it, and the old version stops matching.
+	read, err := s.Get(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	read.Body = "Two."
+	if err := s.Update(ctx, read, actor, &original); err != nil {
+		t.Fatalf("an update against the unchanged version must be accepted: %v", err)
+	}
+	if read.ContentHash == original {
+		t.Error("an edit left the version where it was")
+	}
+	stale := original
+	read.Body = "Three."
+	if err := s.Update(ctx, read, actor, &stale); !errors.Is(err, ErrConflict) {
+		t.Errorf("update with a stale version = %v, want ErrConflict", err)
+	}
+
+	// Two entries that say the same thing hash alike: the version is a
+	// statement about content, not about which row holds it.
+	twin := &domain.Knowledge{Type: domain.TypeTerms, ID: id + "-twin", Title: "first",
+		Status: domain.StatusDraft, Body: "One.", CreatedBy: domain.Actor{Kind: domain.ActorProcess, Name: "other"}}
+	if err := s.Create(ctx, twin, false); err != nil {
+		t.Fatal(err)
+	}
+	if twin.ContentHash != original {
+		t.Errorf("identical content hashed differently: %q vs %q", twin.ContentHash, original)
+	}
+}
+
+// The stored document and the columns beside it are one value written
+// twice: the columns are the index derived from the document (design doc
+// 0043 §3.1), so re-rendering what a read returns must reproduce exactly
+// what is stored. If these drift, the index is no longer derived.
+func TestIntegrationStoredDocumentMatchesTheIndex(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	actor := domain.Actor{Kind: domain.ActorHuman, Name: "test"}
+	id := fmt.Sprintf("it-storeddoc-%d", time.Now().UnixNano())
+	count := 7
+	k := &domain.Knowledge{
+		Type: domain.TypeComputations, ID: id, Title: "月次売上", Description: "説明",
+		Resource: "bq://p.d.t", Tags: []string{"finance", "core"},
+		Status: domain.StatusStable, StatusNote: "checked", StaleAfter: "2027-01-31",
+		Runtime: "bigquery", Computation: "queries/rev.sql",
+		Sources: []domain.Source{{Resource: "https://example.test/policy", ID: "pol",
+			UsageCount: &count, LastModified: "2026-05-30"}},
+		UsageWindow: &domain.UsageWindow{From: "2026-06-01", To: "2026-06-30"},
+		Parameters:  []domain.Parameter{{Name: "year", Type: "integer", Required: true}},
+		Executor:    &domain.Executor{Resource: "run.md", Receipt: []string{"job_id"}},
+		Attester:    &domain.Attester{Resource: "check.py"},
+		Attrs:       map[string]any{"question": "月次の売上は?", "owner": "finance"},
+		Body:        "本文。[売上](/metrics/revenue.md) を見る。", CreatedBy: actor,
+	}
+	if err := s.Create(ctx, k, false); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _, _ = s.pool.Exec(ctx, `DELETE FROM knowledge WHERE id = $1`, id) })
+
+	var stored string
+	if err := s.pool.QueryRow(ctx, `SELECT doc FROM knowledge WHERE id = $1`, id).Scan(&stored); err != nil {
+		t.Fatal(err)
+	}
+	read, err := s.Get(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rendered, hash, err := canonicalDoc(read)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rendered != stored {
+		t.Errorf("the index no longer reproduces the stored document:\n--- stored ---\n%s\n--- from the index ---\n%s", stored, rendered)
+	}
+	if hash != read.ContentHash {
+		t.Errorf("stored hash %q does not match the document's %q", read.ContentHash, hash)
 	}
 }

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -1723,8 +1723,8 @@ async function viewDetail(id) {
           <td class="k mono">#${r.rev}</td>
           <td>
             <div><strong>${esc(r.change)}</strong> · ${esc(actorStr(r.changed_by))} · ${esc(fmtDate(r.changed_at))}</div>
-            <details><summary style="cursor:pointer;color:var(--muted);font-size:.84rem">snapshot</summary>
-              <pre>${esc(JSON.stringify(r.snapshot, null, 2))}</pre></details>
+            <details><summary style="cursor:pointer;color:var(--muted);font-size:.84rem">document</summary>
+              <pre>${esc(r.document || '')}</pre></details>
           </td>
         </tr>`).join('');
       return () => `


### PR DESCRIPTION
<!-- Implements design doc 0043 §§3.1, 3.4, 3.7, 3.9. Third of the document-first implementation PRs, after #248 and #249. -->

## What and why

An entry was a row of columns that an exporter re-rendered into a document on the way out, and its version was `updated_at`. Both had costs [0043](docs/design/0043-document-first.md) lays out.

**The canonical OKF document becomes the stored form.** `okf.Canonical` renders the text a writer authored with none of the keys this instance owns; `okf.Document` is that plus `generated` / `verified` / `created_by` / `rejected_*`. The columns beside it stay as the index every query already reads (§3.1) — and a test pins that re-rendering what a read returns reproduces the stored bytes exactly, which is what makes the index legitimately *derived* rather than a second source of truth.

**Its hash becomes the version.** `updated_at` was doing three jobs at once — the ETag, OKF's `generated.at`, and "when was this row last touched" — which is why verifying an entry had to move a version whose content nobody had changed, killing an editor's held `If-Match` for a reason unrelated to their edit. Excluding the server-owned keys from the canonical form is exactly what makes the hash a *content* hash: a ruling writes no key into it, so verify, reject and attach all leave a precondition valid. `TestIntegrationContentHashMovesOnlyWithContent` states that invariant directly, with the corollary that two entries saying the same thing hash alike.

**Revisions become documents** (§3.9): a record whose shape depends on the reader knowing every past generation of a Go struct is the distortion, not the fidelity. A diff between two revisions now reads as text.

The backfill lives in Go rather than in the migration file, because composing a document means writing YAML in the spelling and key order the spec fixes. It runs inside the same advisory lock the SQL migrations hold, is idempotent and resumable (an empty `doc` is the marker for "not yet composed"), and moves no `updated_at`. A snapshot the current shape cannot read becomes a placeholder document saying so, rather than an empty string the backfill would revisit on every start.

## Checks

- [x] `scripts/check core` clean against a real PostgreSQL 16 + pgvector on 55433, so the store, service and REST integration tests **executed** — including migration 0024 and the backfill
- [x] Behavior changes come with tests — new: the hash holds still across verify/reject/lift and moves on an edit (with a stale-version `412`); the stored document and the column index agree byte-for-byte over an entry exercising every envelope family; `Canonical` omits every server-owned key and round-trips; the backfill composes entries and revisions from the pre-0024 shape, leaves `updated_at` alone, and is idempotent

⚠️ `scripts/check lint` still cannot run here (pinned golangci-lint built with go1.25 vs the module's 1.26.5; fails identically on a clean `main`). `go vet` is clean. I know #249 landed with lint findings you're fixing separately — happy to fold a fix in here if the same rule trips on this diff.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, `internal/apiclient` in sync: `Knowledge.content_hash`, `Revision.document` replacing `snapshot` (schema, description and both examples), the `ETag` header and `If-Match` parameter re-described, and the now-impossible `malformedIfMatch` 400 example removed
- [x] Per surface:
  - **REST** — `content_hash` on every entry, `ETag` is that value, `If-Match` is opaque (an unknown token is a `412`, not a `400`), revisions carry `document`
  - **CLI** — `--if-match` help and the `jq` recipe point at `.content_hash`; `revisions --json` documents the per-revision document
  - **MCP** — no schema change: the curation guard passes the version through internally, and MCP still exposes no version field (0030 §3.4)
  - **Web UI** — the revision drawer shows the document instead of pretty-printed JSON

**Breaking**: `ETag`/`If-Match` change format and meaning (opaque hash, no longer a timestamp), and `Revision.snapshot` becomes `Revision.document`. `knowledge_revision.snapshot` is kept nullable until a later release drops it — it is the only source the backfill has, and dropping the sole copy of the history before it has been read costs the history.

## Design docs

- [x] Alters an accepted decision? No new doc — 0043 (#247) specifies all of this; 0030's `Status:` header already records that §3.1's `updated_at` version was revised by 0043 §3.4
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcMFa1rh2cSHSQhEnARcov)_