### PR TITLE
Write knowledge as an OKF document, with PUT as the whole surface (0043 §§3.5, 3.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,36 @@ last entry.
 
 ### Changed
 
+- **BREAKING**: knowledge is written as an OKF document, and `PUT` is the
+  whole write surface (design doc
+  [0043](docs/design/0043-document-first.md) §§3.5, 3.11).
+
+  - `PUT /api/v1/knowledge/{id}` takes `text/markdown` — frontmatter and
+    body, the same text `ochakai get` prints and an export writes, so
+    read → edit → write is one loop with no translation in it. A JSON
+    body is a `415` naming the document form. Keys the server owns
+    (`generated`, `verified`, `created_by`, `rejected_*`) are ignored
+    rather than refused, which is what makes a served document sendable
+    back as it came.
+  - **`POST /api/v1/knowledge` is gone.** PUT is create-or-replace: a
+    document says what the entry should say and nothing about whether the
+    id was taken. `If-None-Match: *` writes only if the id is free (an
+    occupied one is a `409`), `If-Match` only if the entry still says
+    what you read. A create answers `201`, a replacement `200`.
+  - `GET /api/v1/knowledge/{id}` answers the document when asked with
+    `Accept: text/markdown`; JSON is still the default.
+  - Values the server read differently than they were written come back
+    as `Ochakai-Note` response headers instead of being applied in
+    silence.
+  - **MCP**: `create_knowledge` and `update_knowledge` take `{id,
+    document}`. The eighteen-field mirror of the envelope is gone — it
+    was a fourth place the field list was written out, and an agent that
+    trusted the enumeration could silently drop whatever it had fallen
+    behind on. Notes come back in the tool result.
+  - **CLI**: unchanged to use. `create` and `update` still read an OKF
+    document or JSON from `-f`/stdin; JSON is now rendered to a document
+    locally, so the server keeps one write format.
+
 - **BREAKING**: the canonical OKF document is the stored form, and its
   hash is the entry's version (design doc
   [0043](docs/design/0043-document-first.md) §§3.1, 3.4, 3.7, 3.9).

--- a/README.md
+++ b/README.md
@@ -65,11 +65,16 @@ toolchain-free, take a
 or talk to the API directly, since that is all the CLI does:
 
 ```sh
-curl -X POST http://localhost:8080/api/v1/knowledge \
-  -H 'content-type: application/json' \
-  -d '{"id": "metrics/revenue", "type": "Metric",
-       "body": "Completed orders only, net of refunds."}'
+curl -X PUT http://localhost:8080/api/v1/knowledge/metrics/revenue \
+  -H 'content-type: text/markdown' \
+  --data-binary $'---\ntype: Metric\n---\n\nCompleted orders only, net of refunds.\n'
 ```
+
+Knowledge is written as an OKF document — the frontmatter is the
+metadata, the markdown is the body, and the path is the address. It is
+the same text `ochakai get` prints and an export writes, so reading an
+entry, editing it and sending it back is one loop with no translation in
+it.
 
 ## Quick start
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -323,222 +323,6 @@ paths:
                   value:
                     error: search needs a query; use sort=verified_at|usage|failed|stale_after to list entries without one, or source=URI to list what cites a resource
         "403": { $ref: "#/components/responses/Forbidden" }
-    post:
-      operationId: createKnowledge
-      summary: Create a knowledge entry
-      description: >
-        Entries default to draft. status is the lifecycle value alone
-        (draft, stable, deprecated); confirming an entry is a separate
-        act with its own endpoint, POST /api/v1/verify/{id}, and anyone
-        who can reach ochakai may perform it — the ledger records who did
-        (provenance over authorization). A live entry with the same id is
-        a 409 — including rejected ones — but creating over a soft-deleted
-        entry revives it (its prior history stays in the revisions, and
-        its rulings do not carry over: a create is a new entry).
-      parameters:
-        - $ref: "#/components/parameters/OnBehalfOf"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema: { $ref: "#/components/schemas/Knowledge" }
-            examples:
-              goldenQuery:
-                summary: A golden query — an Attested Computation with a runtime
-                description: >
-                  This is the type a golden query has: SPEC §10.2 requires
-                  only runtime and leaves parameters, executor and attester
-                  optional, so the sanctioned query and the fully attested
-                  one are the same type at different levels of detail
-                  (design doc 0038). The SQL goes in the body's
-                  "# Computation" fence rather than in attrs, because a
-                  second copy leaves a consumer no way to tell which is
-                  authoritative. question is a producer key, so it stays in
-                  attrs. No title: the id's last segment names the entry
-                  (design doc 0022). Links are not sent — the body's
-                  markdown link to /metrics/revenue.md becomes one, while
-                  the one inside the fence is an example and is skipped.
-                value:
-                  type: Attested Computation
-                  id: queries/monthly-revenue
-                  description: Monthly net revenue for the last 12 complete months.
-                  tags: [finance]
-                  runtime: bigquery
-                  attrs:
-                    question: How much revenue did we make each month last year?
-                  body: |
-                    Answers the question above against
-                    [Revenue](/metrics/revenue.md). Completed orders only;
-                    the month boundary is `order_date`, not the settlement
-                    date.
-
-                    # Computation
-
-                    ```sql
-                    SELECT DATE_TRUNC(order_date, MONTH) AS month,
-                           SUM(net_amount) AS revenue
-                    FROM `example-analytics.shop.orders`
-                    WHERE status = 'completed'
-                      AND order_date >= DATE_TRUNC(DATE_SUB(CURRENT_DATE(), INTERVAL 12 MONTH), MONTH)
-                      AND order_date < DATE_TRUNC(CURRENT_DATE(), MONTH)
-                    GROUP BY month
-                    ORDER BY month
-                    ```
-              insightCaveat:
-                summary: An Insight — the caveat that keeps a metric from being misread
-                description: >
-                  stale_after dates the knowledge from the writer's side:
-                  the seasonal claim is worth re-checking once next January
-                  is in. sources cites the material it rests on.
-                value:
-                  type: Insight
-                  id: insights/revenue-seasonality
-                  title: Reading revenue month over month
-                  description: Why a December spike and a January drop are normal.
-                  tags: [finance]
-                  stale_after: "2027-01-31"
-                  sources:
-                    - id: fy2025-review
-                      resource: https://wiki.example.co.jp/finance/fy2025-review
-                      title: FY2025 revenue review
-                      author: human:sato@example.co.jp
-                      last_modified: "2026-04-08"
-                  body: |
-                    [Revenue](/metrics/revenue.md) is seasonal: December runs
-                    well above the trailing median and January falls back
-                    below it. Comparing either month with the one before it
-                    says nothing about the business[^fy2025-review].
-
-                    Compare year over year, or against the same month's
-                    three-year median. A month-over-month drop in January is
-                    not a regression to investigate.
-
-                    [^fy2025-review]: FY2025 revenue review.
-              attestedComputation:
-                summary: An Attested Computation — the contract as envelope fields
-                description: >
-                  runtime is required for this type and for no other (design
-                  doc 0036 §3.4); executor.receipt names what a run must hand
-                  back. ochakai records all of it and runs none of it.
-                value:
-                  type: Attested Computation
-                  id: computations/monthly-revenue
-                  description: Sanctioned monthly revenue run, with a checkable receipt.
-                  runtime: bigquery
-                  parameters:
-                    - { name: year, type: integer, required: true }
-                    - { name: currency, type: string }
-                  computation: computations/monthly-revenue.sql
-                  executor:
-                    resource: references/skills/run-on-bigquery.md
-                    receipt: [job_id, executed_sql, result]
-                  attester:
-                    resource: references/attesters/monthly-revenue.py
-                  body: |
-                    Runs the revenue figure the finance review quotes. Supply
-                    the parameters; do not edit the computation — an edited
-                    run is not the sanctioned one.
-      responses:
-        "201":
-          description: Created.
-          content:
-            application/json:
-              schema: { $ref: "#/components/schemas/Knowledge" }
-              examples:
-                goldenQuery:
-                  summary: The golden query above, as stored
-                  description: >
-                    Entries default to draft. created_by and updated_by come
-                    from the caller's identity, never from the payload, and
-                    links were derived from the body — one link, not two:
-                    the target inside the "# Computation" fence is an
-                    example rather than an edge (design doc 0024). The ETag
-                    response header carries the same value as updated_at.
-                  value:
-                    type: Attested Computation
-                    id: queries/monthly-revenue
-                    description: Monthly net revenue for the last 12 complete months.
-                    tags: [finance]
-                    status: draft
-                    runtime: bigquery
-                    created_by: { kind: human, name: tanaka@example.co.jp }
-                    updated_by: { kind: human, name: tanaka@example.co.jp }
-                    links:
-                      - { target: metrics/revenue, text: Revenue }
-                    attrs:
-                      question: How much revenue did we make each month last year?
-                    body: |
-                      Answers the question above against
-                      [Revenue](/metrics/revenue.md). Completed orders only;
-                      the month boundary is `order_date`, not the settlement
-                      date.
-
-                      # Computation
-
-                      ```sql
-                      SELECT DATE_TRUNC(order_date, MONTH) AS month,
-                             SUM(net_amount) AS revenue
-                      FROM `example-analytics.shop.orders`
-                      WHERE status = 'completed'
-                        AND order_date >= DATE_TRUNC(DATE_SUB(CURRENT_DATE(), INTERVAL 12 MONTH), MONTH)
-                        AND order_date < DATE_TRUNC(CURRENT_DATE(), MONTH)
-                      GROUP BY month
-                      ORDER BY month
-                      ```
-                    created_at: "2026-06-09T07:41:02.110945Z"
-                    updated_at: "2026-06-09T07:41:02.110945Z"
-          headers:
-            ETag: { $ref: "#/components/headers/ETag" }
-            Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
-        "400":
-          description: Error.
-          headers:
-            Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error: { type: string }
-              examples:
-                envelopeKeyInAttrs:
-                  summary: attrs carried a key OKF v0.2 defines
-                  description: >
-                    The key would have been dropped on export, where nothing
-                    would ever read it again, so the write is refused instead
-                    (design doc 0036 §3.5). Move the value to the top level
-                    of the payload.
-                  value:
-                    error: 'attrs must not carry "sources": it is an OKF envelope field, so write it at the top level of the payload instead'
-                missingRuntime:
-                  summary: An Attested Computation without a runtime
-                  value:
-                    error: "an Attested Computation needs a runtime (e.g. bigquery, postgres, dbt, python): it is what tells a consumer how to read the parameters"
-                sourceWithoutResource:
-                  summary: A source that names no artifact
-                  value:
-                    error: sources[0] needs a resource (the artifact it cites); id and title alone do not name one
-        "403": { $ref: "#/components/responses/Forbidden" }
-        "409":
-          description: Error.
-          headers:
-            Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error: { type: string }
-              examples:
-                alreadyExists:
-                  summary: A live entry already holds that id
-                  description: >
-                    Update it (PUT), or free the id with
-                    DELETE ...?purge=true if the entry there is already
-                    soft-deleted. Creating over a soft-deleted entry revives
-                    it rather than conflicting.
-                  value:
-                    error: knowledge already exists
   /api/v1/browse:
     get:
       operationId: browseKnowledge
@@ -875,6 +659,11 @@ paths:
     get:
       operationId: getKnowledge
       summary: Get one knowledge entry
+      description: >
+        Answers JSON by default. With "Accept: text/markdown" it answers
+        the OKF document instead — the same text an export writes, keys
+        the server owns included, which is what `ochakai get` hands to an
+        editor and what a PUT takes straight back (design doc 0043 §3.5).
       responses:
         "200":
           description: The entry.
@@ -882,6 +671,8 @@ paths:
             ETag: { $ref: "#/components/headers/ETag" }
             Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
           content:
+            text/markdown:
+              schema: { type: string }
             application/json:
               schema: { $ref: "#/components/schemas/Knowledge" }
               examples:
@@ -893,8 +684,8 @@ paths:
                     usage_count was counted over, the declared expiry, the
                     producer keys left in attrs, the links derived from the
                     body, and attachment metadata (the bytes are a separate
-                    fetch). The ETag header carries "2026-07-14T02:33:41.019778Z"
-                    — updated_at, quoted — for a later If-Match.
+                    fetch). The ETag header carries the same value as
+                    content_hash, quoted, for a later If-Match.
                   value:
                     type: Metric
                     id: metrics/revenue
@@ -997,63 +788,77 @@ paths:
                   value:
                     error: knowledge not found
     put:
-      operationId: updateKnowledge
-      summary: Update a knowledge entry (full replacement; revisions retained)
+      operationId: putKnowledge
+      summary: Write a knowledge entry from an OKF document
       description: >
-        The path is the address; the body carries the metadata — type
-        included, always (design doc 0016). With If-Match, the update is
-        conditional on the entry's version — see the parameter; without
-        it, last write wins.
+        The one way to write knowledge. The body is an OKF document —
+        YAML frontmatter, then markdown — which is what an entry is
+        (design doc 0043 §3.5): the path is the address, the document is
+        what the entry says, and there is no typed JSON write surface
+        beside it to drift from the format. A JSON body is a 415 naming
+        the document form.
+        It is create-or-replace, and a full replacement: what the document
+        omits is cleared, so send the entry as it should end up. A PUT
+        states what the entry should say; whether an entry already held
+        the id is not something the writer of a document is saying
+        anything about, which is why there is no separate create. The
+        preconditions are where existence is expressed — If-None-Match "*"
+        writes only if the id is free (an occupied one is a 409), and
+        If-Match a version writes only if the entry still says that.
+        A 201 means the entry was created, a 200 that it was replaced.
+        Keys the server owns (generated, verified, created_by,
+        rejected_by, rejected_at) are ignored if present, so a document
+        read back from ochakai can be edited and sent as it came. Values
+        read differently than they were written come back as
+        Ochakai-Note headers rather than being applied in silence.
       parameters:
         - $ref: "#/components/parameters/IfMatch"
+        - name: If-None-Match
+          in: header
+          required: false
+          description: >
+            "*" writes only if the id is free; an occupied id is a 409.
+            Any other value is ignored — ochakai has no conditional read,
+            and a caller that means "only if absent" says "*".
+          schema: { type: string, enum: ["*"] }
         - $ref: "#/components/parameters/OnBehalfOf"
       requestBody:
         required: true
         content:
-          application/json:
-            schema: { $ref: "#/components/schemas/Knowledge" }
-            examples:
-              fullReplacement:
-                summary: PUT /api/v1/knowledge/metrics/revenue, If-Match "2026-07-14T02:33:41.019778Z"
-                description: >
-                  A full replacement: what the payload omits is cleared, so
-                  send the entry as it should end up, not just the fields
-                  that changed. Here a second source is dropped and the
-                  declared expiry moved out a year. type is always required,
-                  even though the path already names the entry. Server-owned
-                  fields (created_by, verified_*, links, attachments) are
-                  ignored if sent.
-                value:
-                  type: Metric
-                  id: metrics/revenue
-                  title: Revenue
-                  description: Net revenue from completed orders, excluding tax, shipping, and gift wrapping.
-                  resource: bigquery://example-analytics.shop.orders
-                  tags: [finance, core]
-                  sources:
-                    - id: revenue-policy
-                      resource: https://wiki.example.co.jp/finance/revenue-recognition
-                      title: Revenue recognition policy (FY2027)
-                      author: human:finance@example.co.jp
-                      usage_count: 31
-                      last_modified: "2026-07-20"
-                  usage_window: { from: "2026-07-01", to: "2026-07-31" }
-                  status: stable
-                  stale_after: "2027-12-31"
-                  attrs: { unit: JPY, grain: order }
-                  body: |
-                    Revenue is the sum of `net_amount` over every
-                    [completed order](/glossary/completed-order.md) in
-                    [shop.orders](/tables/shop-orders.md). Tax, shipping, and
-                    gift wrapping are excluded.
+          text/markdown:
+            schema: { type: string }
+            example: |
+              ---
+              type: Metric
+              title: Revenue
+              description: Net revenue, refunds excluded.
+              tags:
+                  - finance
+              sources:
+                  - resource: https://wiki.example/finance/revenue-recognition
+                    id: rev-rec
+              status: stable
+              stale_after: "2027-06-30"
+              ---
 
-                    A refund is subtracted in the month it settles, not the
-                    month of the order it reverses[^revenue-policy].
-
-                    [^revenue-policy]: Revenue recognition policy (FY2027).
+              Net of refunds, per [revenue recognition](/policies/revenue-recognition.md).
       responses:
+        "201":
+          description: The id was free, so the entry was created.
+          headers:
+            ETag: { $ref: "#/components/headers/ETag" }
+            Ochakai-Note: { $ref: "#/components/headers/Note" }
+            Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Knowledge" }
+            text/markdown:
+              schema: { type: string }
+        # If-None-Match "*" was sent and the id is taken. Without that
+        # precondition the write would have replaced the entry.
+        "409": { $ref: "#/components/responses/Error" }
         "200":
-          description: Updated, or unchanged (see the Ochakai-Unchanged header).
+          description: Replaced, or unchanged (see the Ochakai-Unchanged header).
           headers:
             ETag: { $ref: "#/components/headers/ETag" }
             Ochakai-Unchanged:
@@ -1062,8 +867,11 @@ paths:
                 exactly, so nothing was written — no revision, no
                 updated_at bump. Absent on a real update.
               schema: { type: string, enum: ["true"] }
+            Ochakai-Note: { $ref: "#/components/headers/Note" }
             Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
           content:
+            text/markdown:
+              schema: { type: string }
             application/json:
               schema: { $ref: "#/components/schemas/Knowledge" }
               examples:
@@ -1962,6 +1770,14 @@ components:
         attaching a file all leave a held precondition valid. Treat it as
         opaque — two entries that say the same thing carry the same
         version.
+      schema: { type: string }
+    Note:
+      description: >
+        A value the server accepted but read differently than it was
+        written — an unrecognized status, a date it could not parse.
+        Repeatable, one per reinterpretation. A reinterpretation is never
+        silent (design doc 0036 §3.4), and there is no room for it in a
+        response whose body is the entry.
       schema: { type: string }
     ReadOnly:
       description: >

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -773,15 +773,41 @@ func cmdCreate(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	created, err := c.Create(ctx, k)
+	doc, err := documentOf(k)
 	if err != nil {
 		return err
 	}
+	// If-None-Match "*": create means create. A PUT with no precondition
+	// would replace an entry that is already there, which is what
+	// `ochakai update` is for.
+	created, _, _, notes, err := c.Put(ctx, k.ID, doc, "", true)
+	if err != nil {
+		return err
+	}
+	reportNotes(notes)
 	if *asJSON {
 		return printJSON(created)
 	}
 	fmt.Printf("created %s (%s)\n", created.URI(), created.Status)
 	return nil
+}
+
+// documentOf renders what the caller supplied as the OKF document the
+// server takes. Input that was already a document round-trips through
+// the same renderer the server stores, so what is sent is what will be
+// kept; JSON input is a local convenience that ends here (design doc
+// 0043 §5 — the server has one write format).
+func documentOf(k *domain.Knowledge) ([]byte, error) {
+	return okf.Canonical(k)
+}
+
+// reportNotes prints what the server read differently than it was
+// written. A reinterpretation is never silent (design doc 0036 §3.4),
+// and stderr keeps it out of a piped --json body.
+func reportNotes(notes []string) {
+	for _, n := range notes {
+		fmt.Fprintln(os.Stderr, "note:", n)
+	}
 }
 
 func cmdUpdate(ctx context.Context, args []string) error {
@@ -805,7 +831,11 @@ func cmdUpdate(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	updated, changed, err := c.Update(ctx, k, *ifMatch)
+	doc, err := documentOf(k)
+	if err != nil {
+		return err
+	}
+	updated, _, changed, notes, err := c.Put(ctx, id, doc, *ifMatch, false)
 	if err != nil {
 		var apiErr *apiclient.APIError
 		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusPreconditionFailed {
@@ -813,6 +843,7 @@ func cmdUpdate(ctx context.Context, args []string) error {
 		}
 		return err
 	}
+	reportNotes(notes)
 	if *asJSON {
 		return printJSON(updated)
 	}
@@ -1131,26 +1162,29 @@ func cmdImport(ctx context.Context, args []string) error {
 	for i := range entries {
 		d := &entries[i]
 		k := &d.Knowledge
-		if _, err := c.Create(ctx, k); err == nil {
-			created++
-			confirm(d)
-			fmt.Printf("created %s\n", k.URI())
-			continue
-		} else if isInvalid(err) {
+		doc, err := documentOf(k)
+		if err != nil {
 			skipEntry(k, err)
 			continue
-		} else if !isConflict(err) {
-			return fmt.Errorf("%s: %w", k.URI(), err)
 		}
-		// No If-Match: import deliberately replaces whatever is stored
-		// (the bundle is the source of truth for this loop).
-		_, changed, err := c.Update(ctx, k, "")
+		// One call per document, with no precondition: import deliberately
+		// replaces whatever is stored (the bundle is the source of truth
+		// for this loop), and whether the id was free is not something the
+		// bundle says anything about.
+		_, wasCreated, changed, notes, err := c.Put(ctx, k.ID, doc, "", false)
 		if err != nil {
 			if isInvalid(err) {
 				skipEntry(k, err)
 				continue
 			}
 			return fmt.Errorf("%s: %w", k.URI(), err)
+		}
+		reportNotes(notes)
+		if wasCreated {
+			created++
+			confirm(d)
+			fmt.Printf("created %s\n", k.URI())
+			continue
 		}
 		if !changed {
 			unchanged++

--- a/cmd/ochakai/client_test.go
+++ b/cmd/ochakai/client_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/na0fu3y/ochakai/internal/apiclient"
 	"github.com/na0fu3y/ochakai/internal/domain"
+	"github.com/na0fu3y/ochakai/internal/okf"
 )
 
 func TestParseArgsAllowsFlagsAfterPositionals(t *testing.T) {
@@ -217,16 +218,23 @@ func TestImportReportsUnchanged(t *testing.T) {
 	}
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /api/v1/knowledge", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusConflict)
-		_ = json.NewEncoder(w).Encode(map[string]string{"error": "already exists"})
-	})
 	mux.HandleFunc("PUT /api/v1/knowledge/{id...}", func(w http.ResponseWriter, r *http.Request) {
-		var k domain.Knowledge
-		if err := json.NewDecoder(r.Body).Decode(&k); err != nil {
-			t.Errorf("bad PUT payload: %v", err)
+		// The payload is a document now (design doc 0043 §3.5), and the
+		// import loop makes one call per entry rather than create-then-
+		// update: whether the id was free is not something a bundle says.
+		if ct := r.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/markdown") {
+			t.Errorf("Content-Type = %q, want text/markdown", ct)
 		}
-		if r.PathValue("id") == "metrics/same" {
+		body, _ := io.ReadAll(r.Body)
+		d, _, err := okf.Parse(body)
+		if err != nil {
+			t.Errorf("bad PUT payload: %v\n%s", err, body)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		k := d.Knowledge
+		k.ID = r.PathValue("id")
+		if k.ID == "metrics/same" {
 			w.Header().Set("Ochakai-Unchanged", "true")
 		}
 		_ = json.NewEncoder(w).Encode(k)

--- a/internal/apiclient/apiclient.go
+++ b/internal/apiclient/apiclient.go
@@ -310,45 +310,47 @@ func (c *Client) Get(ctx context.Context, id string) (*domain.Knowledge, error) 
 	return &k, nil
 }
 
-func (c *Client) Create(ctx context.Context, k *domain.Knowledge) (*domain.Knowledge, error) {
-	var created domain.Knowledge
-	if err := c.doJSON(ctx, http.MethodPost, "/api/v1/knowledge", nil, k, &created); err != nil {
-		return nil, err
-	}
-	return &created, nil
-}
-
-// Update replaces the entry at k.ID (full replacement; the server
-// keeps every change as a revision). changed=false reports the server
-// wrote nothing because the payload matched the stored content (the
-// Ochakai-Unchanged response header); servers predating the header
-// always report changed=true.
+// Put writes doc — an OKF document — to the entry at id, creating it
+// when the id is free (PUT /api/v1/knowledge/{id}). One call, because a
+// document says what the entry should say and nothing about whether it
+// already existed (design doc 0043 §3.5).
 //
 // A non-empty ifMatch is sent as the If-Match precondition: the entry's
-// version — its updated_at in RFC3339Nano, as a prior read returned it
-// (the ETag header, or the JSON body's updated_at field). The update
-// then lands only if the entry still has that version; a stale one is a
-// 412 APIError and nothing is written. "" means last write wins.
-func (c *Client) Update(ctx context.Context, k *domain.Knowledge, ifMatch string) (updated *domain.Knowledge, changed bool, err error) {
-	buf, err := json.Marshal(k)
-	if err != nil {
-		return nil, false, err
-	}
-	var hdr http.Header
+// version, as a prior read returned it (the ETag header, or the JSON
+// body's content_hash). The write then lands only if the entry still has
+// that version; a stale one is a 412 APIError and nothing is written. ""
+// means last write wins. onlyIfAbsent sends If-None-Match "*", which
+// makes an occupied id a 409 instead of a replacement.
+//
+// created reports which way it went; changed=false reports the server
+// wrote nothing because the document matched the stored content (the
+// Ochakai-Unchanged response header). notes carry values the server
+// accepted but read differently than they were written — a
+// reinterpretation is never silent (design doc 0036 §3.4).
+func (c *Client) Put(ctx context.Context, id string, doc []byte, ifMatch string, onlyIfAbsent bool) (
+	out *domain.Knowledge, created, changed bool, notes []string, err error) {
+	hdr := http.Header{}
 	if ifMatch != "" {
-		hdr = http.Header{"If-Match": {etagValue(ifMatch)}}
+		hdr.Set("If-Match", etagValue(ifMatch))
 	}
-	resp, err := c.doRaw(ctx, http.MethodPut, entryPath(k.ID), nil, "application/json", hdr, bytes.NewReader(buf))
+	if onlyIfAbsent {
+		hdr.Set("If-None-Match", "*")
+	}
+	resp, err := c.doRaw(ctx, http.MethodPut, entryPath(id), nil, documentMediaType, hdr, bytes.NewReader(doc))
 	if err != nil {
-		return nil, false, err
+		return nil, false, false, nil, err
 	}
 	defer resp.Body.Close()
-	var out domain.Knowledge
-	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-		return nil, false, err
+	var k domain.Knowledge
+	if err := json.NewDecoder(resp.Body).Decode(&k); err != nil {
+		return nil, false, false, nil, err
 	}
-	return &out, resp.Header.Get("Ochakai-Unchanged") != "true", nil
+	return &k, resp.StatusCode == http.StatusCreated,
+		resp.Header.Get("Ochakai-Unchanged") != "true", resp.Header.Values("Ochakai-Note"), nil
 }
+
+// documentMediaType is what an OKF concept document travels as.
+const documentMediaType = "text/markdown; charset=utf-8"
 
 // etagValue renders a version as an If-Match value: quoted, the way HTTP
 // spells an ETag, unless the caller already passed one (or "*").

--- a/internal/apiclient/apiclient_test.go
+++ b/internal/apiclient/apiclient_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"reflect"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/na0fu3y/ochakai/internal/domain"
@@ -212,20 +213,25 @@ func TestErrorResponsesBecomeAPIErrors(t *testing.T) {
 	}
 }
 
-func TestCreateSendsJSONBodyAndDelete204(t *testing.T) {
+func TestPutSendsADocumentAndDelete204(t *testing.T) {
+	const doc = "---\ntype: Metric\ntitle: 売上\n---\n\n本文。\n"
 	c := newTestPair(t, func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
-		case http.MethodPost:
-			if ct := r.Header.Get("Content-Type"); ct != "application/json" {
-				t.Errorf("Content-Type = %q", ct)
+		case http.MethodPut:
+			if ct := r.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/markdown") {
+				t.Errorf("Content-Type = %q, want text/markdown", ct)
 			}
-			var k domain.Knowledge
-			if err := json.NewDecoder(r.Body).Decode(&k); err != nil || k.ID != "revenue" {
-				t.Errorf("body decode: %v, k=%+v", err, k)
+			if got := r.Header.Get("If-None-Match"); got != "*" {
+				t.Errorf("If-None-Match = %q, want * for a create-only write", got)
 			}
-			k.Status = domain.StatusDraft
+			body, _ := io.ReadAll(r.Body)
+			if string(body) != doc {
+				t.Errorf("body = %q, want the document verbatim", body)
+			}
+			w.Header().Add("Ochakai-Note", "status \"retired\" is not an OKF lifecycle value")
 			w.WriteHeader(http.StatusCreated)
-			_ = json.NewEncoder(w).Encode(k)
+			_ = json.NewEncoder(w).Encode(domain.Knowledge{
+				Type: domain.TypeMetrics, ID: "metrics/revenue", Title: "売上", Status: domain.StatusDraft})
 		case http.MethodDelete:
 			if r.URL.Path != "/api/v1/knowledge/metrics/revenue" {
 				t.Errorf("path = %s", r.URL.Path)
@@ -233,12 +239,42 @@ func TestCreateSendsJSONBodyAndDelete204(t *testing.T) {
 			w.WriteHeader(http.StatusNoContent)
 		}
 	})
-	created, err := c.Create(context.Background(), &domain.Knowledge{Type: domain.TypeMetrics, ID: "revenue", Title: "売上"})
-	if err != nil || created.Status != domain.StatusDraft {
-		t.Fatalf("create: %v, %+v", err, created)
+	got, created, changed, notes, err := c.Put(context.Background(), "metrics/revenue", []byte(doc), "", true)
+	if err != nil || got.Status != domain.StatusDraft {
+		t.Fatalf("put: %v, %+v", err, got)
+	}
+	if !created || !changed {
+		t.Errorf("created = %v, changed = %v; a 201 is both", created, changed)
+	}
+	// A reinterpretation comes back rather than being swallowed.
+	if len(notes) != 1 {
+		t.Errorf("notes = %v, want the one the server reported", notes)
 	}
 	if err := c.Delete(context.Background(), "metrics/revenue"); err != nil {
 		t.Fatalf("delete: %v", err)
+	}
+}
+
+// An update is the same call without the create-only precondition, and a
+// server that wrote nothing says so in a header rather than in the body.
+func TestPutReportsAnUnchangedWrite(t *testing.T) {
+	c := newTestPair(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("If-Match"); got != `"abc123"` {
+			t.Errorf("If-Match = %q, want the quoted version", got)
+		}
+		if r.Header.Get("If-None-Match") != "" {
+			t.Error("an update must not send If-None-Match")
+		}
+		w.Header().Set("Ochakai-Unchanged", "true")
+		_ = json.NewEncoder(w).Encode(domain.Knowledge{ID: "metrics/revenue"})
+	})
+	_, created, changed, _, err := c.Put(context.Background(), "metrics/revenue",
+		[]byte("---\ntype: Metric\n---\n"), "abc123", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created || changed {
+		t.Errorf("created = %v, changed = %v; a 200 with Ochakai-Unchanged is neither", created, changed)
 	}
 }
 
@@ -398,11 +434,12 @@ func TestReportOutcomePostsAndDecodesTotals(t *testing.T) {
 	}
 }
 
-// Update's ifMatch becomes the If-Match precondition on the wire: absent
+// Put's ifMatch becomes the If-Match precondition on the wire: absent
 // when "", quoted into a valid ETag when the caller passes the bare
-// version (the updated_at a read returned), verbatim when already an
+// version (the content_hash a read returned), verbatim when already an
 // ETag. A stale version surfaces as a 412 APIError.
-func TestUpdateSendsIfMatchAndMapsConflict(t *testing.T) {
+func TestPutSendsIfMatchAndMapsConflict(t *testing.T) {
+	const stale = "0000000000000000000000000000000000000000000000000000000000000000"
 	var got []string
 	c := newTestPair(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPut || r.URL.Path != "/api/v1/knowledge/metrics/revenue" {
@@ -413,25 +450,25 @@ func TestUpdateSendsIfMatchAndMapsConflict(t *testing.T) {
 			v = []string{"(absent)"}
 		}
 		got = append(got, v[0])
-		if v[0] == `"2026-07-01T00:00:00.000000001Z"` {
+		if v[0] == `"`+stale+`"` {
 			w.WriteHeader(http.StatusPreconditionFailed)
 			_ = json.NewEncoder(w).Encode(map[string]string{"error": "knowledge changed since it was read"})
 			return
 		}
 		_ = json.NewEncoder(w).Encode(domain.Knowledge{Type: domain.TypeMetrics, ID: "metrics/revenue"})
 	})
-	k := &domain.Knowledge{Type: domain.TypeMetrics, ID: "metrics/revenue", Title: "売上"}
-	for _, ifMatch := range []string{"", "2026-06-30T00:00:00Z", `"2026-06-30T00:00:00Z"`} {
-		if _, _, err := c.Update(context.Background(), k, ifMatch); err != nil {
-			t.Fatalf("Update(ifMatch=%q): %v", ifMatch, err)
+	doc := []byte("---\ntype: Metric\ntitle: 売上\n---\n")
+	for _, ifMatch := range []string{"", "abc123", `"abc123"`} {
+		if _, _, _, _, err := c.Put(context.Background(), "metrics/revenue", doc, ifMatch, false); err != nil {
+			t.Fatalf("Put(ifMatch=%q): %v", ifMatch, err)
 		}
 	}
-	want := []string{"(absent)", `"2026-06-30T00:00:00Z"`, `"2026-06-30T00:00:00Z"`}
+	want := []string{"(absent)", `"abc123"`, `"abc123"`}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("If-Match on the wire = %q, want %q", got, want)
 	}
 
-	_, _, err := c.Update(context.Background(), k, "2026-07-01T00:00:00.000000001Z")
+	_, _, _, _, err := c.Put(context.Background(), "metrics/revenue", doc, stale, false)
 	var apiErr *APIError
 	if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusPreconditionFailed {
 		t.Fatalf("stale version: err = %v, want a 412 *APIError", err)

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -281,20 +281,24 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"ruled on it (verified, rejected, deprecated), in which case this surface refuses: propose at a " +
 			"different id instead.",
 	}, tool(svc, func(ctx context.Context, actor domain.Actor, in writeIn) (*mcp.CallToolResult, knowledgeOut, error) {
-		k, err := svc.CreateKeepingCurated(ctx, in.toKnowledge(), actor)
+		write, notes, err := in.toKnowledge()
 		if err != nil {
 			return nil, knowledgeOut{}, err
 		}
-		return nil, knowledgeOut{Knowledge: *k}, nil
+		k, err := svc.CreateKeepingCurated(ctx, write, actor)
+		if err != nil {
+			return nil, knowledgeOut{}, err
+		}
+		return nil, knowledgeOut{Knowledge: *k, Notes: notes}, nil
 	}))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "update_knowledge",
 		Annotations: nonDestructive,
-		Description: "Update a knowledge entry (full replacement of title/description/resource/tags/sources/usage_window/" +
-			"status/stale_after/runtime/parameters/computation/executor/attester/attrs/body — " +
-			"an omitted title clears it, making the filename the name, and omitted sources clear the citations). " +
-			"Links are not a field: they come from the markdown links in body, so keep the ones you want to keep. " +
+		Description: "Update a knowledge entry by replacing its document. The document you send is the " +
+			"whole entry: a key you leave out is cleared, so get_knowledge first, change what you mean " +
+			"to change, and send the rest back as it came. " +
+			"Links are not a key: they come from the markdown links in the body, so keep the ones you want to keep. " +
 			"Every change is kept as a revision; an update identical to the stored content writes nothing. " +
 			"Entries a human has ruled on — verified, rejected, or deprecated — cannot be updated from " +
 			"this surface: if a verified entry is wrong, report_outcome failed; otherwise create_knowledge " +
@@ -315,11 +319,15 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 		// entry curated in the window between the two is a conflict rather
 		// than a clobber — the surface has no If-Match channel of its own,
 		// but the check can supply one.
-		k, _, err := svc.Update(ctx, in.toKnowledge(), actor, version)
+		write, notes, err := in.toKnowledge()
 		if err != nil {
 			return nil, knowledgeOut{}, err
 		}
-		return nil, knowledgeOut{Knowledge: *k}, nil
+		k, _, err := svc.Update(ctx, write, actor, version)
+		if err != nil {
+			return nil, knowledgeOut{}, err
+		}
+		return nil, knowledgeOut{Knowledge: *k, Notes: notes}, nil
 	}))
 
 	mcp.AddTool(s, &mcp.Tool{
@@ -535,6 +543,11 @@ type getIn struct {
 
 type knowledgeOut struct {
 	Knowledge domain.Knowledge `json:"knowledge"`
+	// Notes carry what the server read differently than the document
+	// wrote it — a reinterpretation is never silent (design doc 0036
+	// §3.4), and an agent that gets one back can fix the document rather
+	// than discover the change on the next read.
+	Notes []string `json:"notes,omitempty"`
 }
 
 type attachmentIn struct {
@@ -561,46 +574,30 @@ type deleteOut struct {
 	URI     string `json:"uri"`
 }
 
+// writeIn is an id and a document. It was a field-by-field mirror of the
+// envelope until 0.16 — a fourth place the field list was written out,
+// which had to be found and extended every time OKF gained a key, and
+// which an agent that trusted the enumeration could use to silently drop
+// whatever the list had fallen behind on. A document has no list to fall
+// behind (design doc 0043 §3.11).
+//
+// It is also the shape an LLM handles best: frontmatter and markdown is
+// what the entries it reads look like, so editing one means returning it
+// changed rather than translating it into a schema and back.
 type writeIn struct {
-	Type        string              `json:"type" jsonschema:"what the entry is: the OKF type, one line; recommended: Metric, Attested Computation, Skill, Playbook, Insight, Policy, Glossary Term, BigQuery Dataset, BigQuery Table, API Endpoint, Reference — any custom type works"`
-	ID          string              `json:"id" jsonschema:"where the entry lives: its full path, segments separated by / (e.g. metrics/revenue, 用語/売上); place together what should be read together; the last segment must not be \"index\" or \"log\""`
-	Title       string              `json:"title,omitempty" jsonschema:"display name; optional — when omitted, the id's last segment (the filename) is the name; set one only when the filename isn't enough"`
-	Description string              `json:"description,omitempty"`
-	Resource    string              `json:"resource,omitempty" jsonschema:"canonical URI of the underlying asset (the table/dataset URI, or for references the external source URL); omit for abstract concepts"`
-	Tags        []string            `json:"tags,omitempty"`
-	Sources     []domain.Source     `json:"sources,omitempty" jsonschema:"the material this entry derives from: a list of {resource, id, title, author, usage_count, last_modified}; resource is required and names the artifact; give each an id so footnotes in body can attribute single claims to it"`
-	UsageWindow *domain.UsageWindow `json:"usage_window,omitempty" jsonschema:"the date range the sources' usage_count values were counted over: {from, to} as YYYY-MM-DD"`
-	Status      string              `json:"status,omitempty" jsonschema:"draft, verified, deprecated, or rejected; defaults to draft"`
-	StatusNote  string              `json:"status_note,omitempty" jsonschema:"free-form reason for the current status (why rejected/deprecated)"`
-	StaleAfter  string              `json:"stale_after,omitempty" jsonschema:"absolute date (YYYY-MM-DD) after which this entry should be re-checked, e.g. when the quarter it describes closes; omit when nothing dates it"`
-	Runtime     string              `json:"runtime,omitempty" jsonschema:"for an Attested Computation, the execution environment (bigquery, postgres, dbt, python...); required for that type because it is what tells a consumer how to read the parameters"`
-	Parameters  []domain.Parameter  `json:"parameters,omitempty" jsonschema:"an Attested Computation's declared inputs: a list of {name, type, required}; you supply values for these, never edits to the computation itself"`
-	Computation string              `json:"computation,omitempty" jsonschema:"path to the file holding the computation; omit to put it inline in a # Computation fence in body"`
-	Executor    *domain.Executor    `json:"executor,omitempty" jsonschema:"how the computation is run and what a run must return as evidence: {resource, receipt}; ochakai records this and never runs it"`
-	Attester    *domain.Attester    `json:"attester,omitempty" jsonschema:"the deterministic checker for a run: {resource}; ochakai records the path and never executes it"`
-	Attrs       map[string]any      `json:"attrs,omitempty" jsonschema:"producer-defined extension keys, e.g. question/sql for an Attested Computation holding a verified query; the keys OKF itself defines are fields of their own above and are rejected here"`
-	Body        string              `json:"body,omitempty" jsonschema:"markdown body; link to other entries by writing a markdown link to their path — [revenue](/metrics/revenue.md) — and those links become the entry's links"`
+	ID       string `json:"id" jsonschema:"where the entry lives: its full path, segments separated by / (e.g. metrics/revenue, 用語/売上); place together what should be read together; the last segment must not be \"index\" or \"log\""`
+	Document string `json:"document" jsonschema:"the entry as an OKF document: YAML frontmatter, then markdown. Frontmatter: type (required, one line — recommended: Metric, Attested Computation, Skill, Playbook, Insight, Policy, Glossary Term, BigQuery Dataset, BigQuery Table, API Endpoint, Reference; any custom type works), title (optional — the id's last segment is the name without one), description, tags, resource (the underlying asset's URI), status (draft, stable or deprecated; defaults to draft — whether anyone confirmed the entry is recorded separately and is not yours to set), status_note, stale_after (YYYY-MM-DD), sources (list of {resource, id, title, author, usage_count, last_modified} — the material this derives from), usage_window ({from, to}), and for an Attested Computation runtime (required), parameters (list of {name, type, required}), computation, executor ({resource, receipt}), attester ({resource}). Producer-defined keys go at the top level beside these and are kept as written. Link to other entries with a markdown link to their path in the body — [revenue](/metrics/revenue.md) — and those links become the entry's links. Keys the server owns (generated, verified, created_by, rejected_by, rejected_at) are ignored if present, so a document read back from ochakai can be edited and returned as-is"`
 }
 
-func (in writeIn) toKnowledge() *domain.Knowledge {
-	return &domain.Knowledge{
-		Type:        domain.Type(in.Type),
-		ID:          in.ID,
-		Title:       in.Title,
-		Description: in.Description,
-		Resource:    in.Resource,
-		Tags:        in.Tags,
-		Sources:     in.Sources,
-		UsageWindow: in.UsageWindow,
-		Status:      domain.Status(in.Status),
-		StatusNote:  in.StatusNote,
-		StaleAfter:  in.StaleAfter,
-		Runtime:     in.Runtime,
-		Parameters:  in.Parameters,
-		Computation: in.Computation,
-		Executor:    in.Executor,
-		Attester:    in.Attester,
-		Attrs:       in.Attrs,
-		Body:        in.Body,
+// toKnowledge parses the document. Notes — values read differently than
+// written — come back with it, for the tool to hand to the agent: a
+// reinterpretation is never silent (design doc 0036 §3.4).
+func (in writeIn) toKnowledge() (*domain.Knowledge, []string, error) {
+	d, notes, err := okf.Parse([]byte(in.Document))
+	if err != nil {
+		return nil, nil, service.Invalidf("%s", err.Error())
 	}
+	k := d.Knowledge
+	k.ID = in.ID
+	return &k, notes, nil
 }

--- a/internal/mcpserver/mcpserver_integration_test.go
+++ b/internal/mcpserver/mcpserver_integration_test.go
@@ -87,7 +87,7 @@ func TestIntegrationDelegatedActorFollowsEachCall(t *testing.T) {
 	id := fmt.Sprintf("mcpit%d/delegation", time.Now().UnixNano())
 	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
 		Name:      "create_knowledge",
-		Arguments: map[string]any{"id": id, "type": "glossary", "body": "written on behalf of bob"},
+		Arguments: map[string]any{"id": id, "document": "---\ntype: glossary\n---\n\nwritten on behalf of bob\n"},
 	})
 	if err != nil {
 		t.Fatalf("create_knowledge: %v", err)

--- a/internal/restapi/readonly_test.go
+++ b/internal/restapi/readonly_test.go
@@ -31,23 +31,25 @@ func readOnlyServer(t *testing.T) *httptest.Server {
 // (design doc 0040 §4).
 func TestReadOnlyRefusesWritesWith403(t *testing.T) {
 	srv := readOnlyServer(t)
-	for _, w := range []struct{ method, path, body string }{
-		{http.MethodPost, "/api/v1/knowledge", `{"type":"Metric","id":"m","title":"m"}`},
-		{http.MethodPut, "/api/v1/knowledge/m", `{"type":"Metric","id":"m","title":"m"}`},
-		{http.MethodDelete, "/api/v1/knowledge/m", ""},
-		{http.MethodPost, "/api/v1/verify/m", ""},
-		{http.MethodPost, "/api/v1/usage/m", `{"outcome":"worked"}`},
-		{http.MethodPost, "/api/v1/move", `{"from":"m","to":"n"}`},
-		{http.MethodPost, "/api/v1/reembed", ""},
-		{http.MethodPut, "/api/v1/attachments/m/f.txt", "x"},
-		{http.MethodDelete, "/api/v1/attachments/m/f.txt", ""},
+	const doc = "---\ntype: Metric\ntitle: m\n---\n"
+	for _, w := range []struct{ method, path, body, mediaType string }{
+		{http.MethodPut, "/api/v1/knowledge/m", doc, "text/markdown"},
+		{http.MethodDelete, "/api/v1/knowledge/m", "", ""},
+		{http.MethodPost, "/api/v1/verify/m", "", ""},
+		{http.MethodPost, "/api/v1/reject/m", `{"note":"no"}`, "application/json"},
+		{http.MethodDelete, "/api/v1/reject/m", "", ""},
+		{http.MethodPost, "/api/v1/usage/m", `{"outcome":"worked"}`, "application/json"},
+		{http.MethodPost, "/api/v1/move", `{"from":"m","to":"n"}`, "application/json"},
+		{http.MethodPost, "/api/v1/reembed", "", ""},
+		{http.MethodPut, "/api/v1/attachments/m/f.txt", "x", "application/json"},
+		{http.MethodDelete, "/api/v1/attachments/m/f.txt", "", ""},
 	} {
 		req, err := http.NewRequest(w.method, srv.URL+w.path, strings.NewReader(w.body))
 		if err != nil {
 			t.Fatal(err)
 		}
-		if w.body != "" {
-			req.Header.Set("Content-Type", "application/json")
+		if w.mediaType != "" {
+			req.Header.Set("Content-Type", w.mediaType)
 		}
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
@@ -71,14 +73,19 @@ func TestReadOnlyRefusesWritesWith403(t *testing.T) {
 // (design doc 0040 §2.3).
 func TestReadOnlyAnnouncesItselfOnEveryResponse(t *testing.T) {
 	srv := readOnlyServer(t)
-	resp, err := http.Post(srv.URL+"/api/v1/knowledge", "application/json",
-		strings.NewReader(`{"type":"Metric","id":"m","title":"m"}`))
+	req, err := http.NewRequest(http.MethodPut, srv.URL+"/api/v1/knowledge/m",
+		strings.NewReader("---\ntype: Metric\ntitle: m\n---\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "text/markdown")
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)
 	}
 	resp.Body.Close()
 	if got := resp.Header.Get("Ochakai-Read-Only"); got != "true" {
-		t.Errorf("POST /api/v1/knowledge: Ochakai-Read-Only = %q, want \"true\"", got)
+		t.Errorf("PUT /api/v1/knowledge/m: Ochakai-Read-Only = %q, want \"true\"", got)
 	}
 
 	// A route that does not exist carries it too: the header describes the

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -145,23 +145,6 @@ func Handler(svc *service.Service) http.Handler {
 		writeJSON(w, http.StatusOK, res)
 	})
 
-	mux.HandleFunc("POST /api/v1/knowledge", func(w http.ResponseWriter, r *http.Request) {
-		var k domain.Knowledge
-		if !readJSON(w, r, &k) {
-			return
-		}
-		created, err := svc.Create(r.Context(), &k, httpauth.Actor(r.Context()))
-		if err != nil {
-			writeError(w, err)
-			return
-		}
-		// The version of what was just written, like every other response
-		// that carries an entry: a client that creates and then updates
-		// conditionally should not need a GET in between.
-		w.Header().Set("ETag", etagOf(created))
-		writeJSON(w, http.StatusCreated, created)
-	})
-
 	// {id...} because the id is the entry's full bundle path (design doc
 	// 0016) — the wildcard captures every segment.
 	mux.HandleFunc("GET /api/v1/knowledge/{id...}", func(w http.ResponseWriter, r *http.Request) {
@@ -173,35 +156,72 @@ func Handler(svc *service.Service) http.Handler {
 		// The ETag is the entry's version: a client can echo it in If-Match
 		// on a later PUT to update only if nothing changed meanwhile.
 		w.Header().Set("ETag", etagOf(k))
+		if wantsDocument(r) {
+			writeDocument(w, http.StatusOK, k)
+			return
+		}
 		writeJSON(w, http.StatusOK, k)
 	})
 
+	// PUT /api/v1/knowledge/{id...} — the one way to write knowledge. The
+	// body is an OKF document, which is what an entry is (design doc 0043
+	// §3.5): the path is the address, the frontmatter and body are what it
+	// says, and there is no typed JSON write surface beside it to drift
+	// from the format.
+	//
+	// It is create-or-replace. A PUT states what the entry should say, and
+	// whether an entry already held the id is not something the writer of
+	// a document is saying anything about — so a separate POST would only
+	// make the caller answer a question it does not have to ask. The
+	// preconditions are where existence is expressed: If-None-Match "*"
+	// means "only if the id is free", If-Match a version means "only if it
+	// still says this".
 	mux.HandleFunc("PUT /api/v1/knowledge/{id...}", func(w http.ResponseWriter, r *http.Request) {
-		var k domain.Knowledge
-		if !readJSON(w, r, &k) {
+		k, ok := readDocument(w, r)
+		if !ok {
 			return
 		}
+		// The path is the address; the document carries the metadata —
+		// type included, always (no fill-in from the stored entry, design
+		// doc 0017 §4.5).
+		k.ID = r.PathValue("id")
+		actor := httpauth.Actor(r.Context())
+
 		// If-Match is an optional optimistic-concurrency precondition: its
 		// value is the ETag from a prior read. Absent means last-write-wins
-		// (design doc 0030); malformed is a client error.
+		// (design doc 0030).
 		ifMatch := parseIfMatch(r)
-		// The path is the address; the body carries the metadata — type
-		// included, always (no fill-in from the stored entry, design doc
-		// 0017 §4.5).
-		k.ID = r.PathValue("id")
-		updated, changed, err := svc.Update(r.Context(), &k, httpauth.Actor(r.Context()), ifMatch)
+		var (
+			out              *domain.Knowledge
+			created, changed bool
+			err              error
+		)
+		if onlyIfAbsent(r) {
+			out, err = svc.Create(r.Context(), k, actor)
+			created, changed = true, true
+		} else {
+			out, created, changed, err = svc.Put(r.Context(), k, actor, ifMatch)
+		}
 		if err != nil {
 			writeError(w, err)
 			return
 		}
 		// A payload identical to the stored content wrote nothing (no
-		// revision, no updated_at bump); the header lets clients report
+		// revision, no version bump); the header lets clients report
 		// "unchanged" without an extra read.
 		if !changed {
 			w.Header().Set("Ochakai-Unchanged", "true")
 		}
-		w.Header().Set("ETag", etagOf(updated))
-		writeJSON(w, http.StatusOK, updated)
+		w.Header().Set("ETag", etagOf(out))
+		status := http.StatusOK
+		if created {
+			status = http.StatusCreated
+		}
+		if wantsDocument(r) {
+			writeDocument(w, status, out)
+			return
+		}
+		writeJSON(w, status, out)
 	})
 
 	// POST /api/v1/verify/{id...} — record a verification against the
@@ -695,6 +715,82 @@ func readBody(w http.ResponseWriter, r *http.Request, limit int64, tooLarge stri
 		return nil, false
 	}
 	return data, true
+}
+
+// documentMediaType is what an OKF concept document is served and
+// accepted as. It is markdown with YAML frontmatter, which is markdown as
+// far as any consumer is concerned.
+const documentMediaType = "text/markdown; charset=utf-8"
+
+// maxDocument bounds a written document. The body limit (design doc 0001)
+// is 4 MiB and the frontmatter is small beside it, so this is the same
+// number with room for the envelope rather than a new policy.
+const maxDocument = 5 << 20
+
+// readDocument parses the request body as an OKF document. Notes — values
+// the parser accepted but read differently than written — travel back in
+// a header rather than being swallowed: a reinterpretation is never
+// silent (design doc 0036 §3.4), and there is no room for them in a
+// response whose body is the entry.
+//
+// A JSON body is refused with the reason rather than a parse error: a
+// client sending one is a client written against the typed write surface
+// that 0043 §3.5 removed, and it needs to be told that, not told its
+// document has no frontmatter.
+func readDocument(w http.ResponseWriter, r *http.Request) (*domain.Knowledge, bool) {
+	if mt := r.Header.Get("Content-Type"); strings.HasPrefix(mt, "application/json") {
+		writeJSON(w, http.StatusUnsupportedMediaType, map[string]string{
+			"error": "knowledge is written as an OKF document (Content-Type: text/markdown), " +
+				"not as JSON: the frontmatter is the metadata and the markdown is the body",
+		})
+		return nil, false
+	}
+	data, ok := readBody(w, r, maxDocument, fmt.Sprintf("document exceeds %d bytes", maxDocument))
+	if !ok {
+		return nil, false
+	}
+	d, notes, err := okf.Parse(data)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return nil, false
+	}
+	for _, n := range notes {
+		w.Header().Add("Ochakai-Note", n)
+	}
+	return &d.Knowledge, true
+}
+
+// wantsDocument reports whether the caller asked for the entry as a
+// document rather than as JSON. Only an explicit markdown Accept counts:
+// a browser sends */* and wants the JSON every existing client reads.
+func wantsDocument(r *http.Request) bool {
+	return strings.Contains(r.Header.Get("Accept"), "text/markdown")
+}
+
+// onlyIfAbsent reports an If-None-Match "*" precondition: write only if
+// the id is free. Any other value is ignored — ochakai has no use for a
+// conditional read, and a caller that means "only if absent" says "*".
+func onlyIfAbsent(r *http.Request) bool {
+	return strings.TrimSpace(r.Header.Get("If-None-Match")) == "*"
+}
+
+// writeDocument renders the entry as the document an export would write
+// — server-owned keys included, since that is what a reader of a bundle
+// sees and what `ochakai get` hands to an editor.
+//
+// A render failure after the status is out cannot be reported, so it is
+// decided first: the entry came from the store, so failing here means the
+// renderer cannot express something the store holds, which is a 500.
+func writeDocument(w http.ResponseWriter, status int, k *domain.Knowledge) {
+	doc, err := okf.Document(k)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError,
+			map[string]string{"error": "render document: " + err.Error()})
+		return
+	}
+	w.Header().Set("Content-Type", documentMediaType)
+	w.WriteHeader(status)
+	_, _ = w.Write(doc)
 }
 
 func readJSON(w http.ResponseWriter, r *http.Request, v any) bool {

--- a/internal/restapi/restapi_integration_test.go
+++ b/internal/restapi/restapi_integration_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/na0fu3y/ochakai/internal/domain"
+	"github.com/na0fu3y/ochakai/internal/okf"
 	"github.com/na0fu3y/ochakai/internal/service"
 	"github.com/na0fu3y/ochakai/internal/store"
 )
@@ -70,13 +71,10 @@ func TestRESTIntegration(t *testing.T) {
 	typ := fmt.Sprintf("restit%d", time.Now().UnixNano())
 	id := typ + "/sales/orders"
 	entry := map[string]any{"type": typ, "id": id, "title": "REST round trip"}
-	payload, _ := json.Marshal(entry)
+	payload := docFrom(t, entry)
 
 	// Create.
-	resp, err := http.Post(srv.URL+"/api/v1/knowledge", "application/json", bytes.NewReader(payload))
-	if err != nil {
-		t.Fatal(err)
-	}
+	resp := putDoc(t, srv.URL, id, payload, true)
 	if resp.StatusCode != http.StatusCreated {
 		t.Fatalf("create status = %d", resp.StatusCode)
 	}
@@ -90,12 +88,8 @@ func TestRESTIntegration(t *testing.T) {
 	}
 
 	// A content-identical PUT writes nothing and says so in the header.
-	req, _ := http.NewRequest(http.MethodPut, srv.URL+"/api/v1/knowledge/"+typ+"/sales/orders", bytes.NewReader(payload))
-	req.Header.Set("Content-Type", "application/json")
-	resp, err = http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatal(err)
-	}
+	// No If-None-Match this time: the same call replaces what it finds.
+	resp = putDoc(t, srv.URL, typ+"/sales/orders", payload, false)
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusOK || resp.Header.Get("Ochakai-Unchanged") != "true" {
 		t.Errorf("no-op PUT: status = %d, Ochakai-Unchanged = %q",
@@ -199,11 +193,8 @@ func TestRESTIntegration(t *testing.T) {
 	for i := range exportBatch + 3 {
 		id := fmt.Sprintf("%s/batch/%d", typ, i)
 		planted = append(planted, id)
-		body, _ := json.Marshal(map[string]any{"type": typ, "id": id, "title": fmt.Sprintf("batch %d", i)})
-		resp, err := http.Post(srv.URL+"/api/v1/knowledge", "application/json", bytes.NewReader(body))
-		if err != nil {
-			t.Fatal(err)
-		}
+		body := docFrom(t, map[string]any{"type": typ, "id": id, "title": fmt.Sprintf("batch %d", i)})
+		resp := putDoc(t, srv.URL, id, body, true)
 		resp.Body.Close()
 	}
 	t.Cleanup(func() {
@@ -241,7 +232,7 @@ func TestRESTIntegration(t *testing.T) {
 	}
 
 	// Delete, then the entry is gone.
-	req, _ = http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/knowledge/"+typ+"/sales/orders", nil)
+	req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/knowledge/"+typ+"/sales/orders", nil)
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -285,11 +276,8 @@ func TestRESTIntegrationAttachments(t *testing.T) {
 	defer srv.Close()
 
 	typ := fmt.Sprintf("restatt%d", time.Now().UnixNano())
-	payload, _ := json.Marshal(map[string]any{"type": typ, "id": typ + "/reading", "title": "attachment hits"})
-	resp, err := http.Post(srv.URL+"/api/v1/knowledge", "application/json", bytes.NewReader(payload))
-	if err != nil {
-		t.Fatal(err)
-	}
+	payload := docFrom(t, map[string]any{"type": typ, "id": typ + "/reading", "title": "attachment hits"})
+	resp := putDoc(t, srv.URL, typ+"/reading", payload, true)
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusCreated {
 		t.Fatalf("create status = %d", resp.StatusCode)
@@ -412,6 +400,45 @@ func (m memBlobStore) Get(_ context.Context, sum string) ([]byte, error) {
 	return data, nil
 }
 
+// docFrom renders a test's entry map as the OKF document the server takes
+// (design doc 0043 §3.5). The maps stay: they are how these tests say
+// "an entry with these fields", and only the wire format changed.
+func docFrom(t *testing.T, entry map[string]any) []byte {
+	t.Helper()
+	raw, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var k domain.Knowledge
+	if err := json.Unmarshal(raw, &k); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := okf.Canonical(&k)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return doc
+}
+
+// putDoc writes a document to id. onlyIfAbsent asks for a create, which
+// is what the tests that used to POST mean.
+func putDoc(t *testing.T, base, id string, doc []byte, onlyIfAbsent bool) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPut, base+"/api/v1/knowledge/"+id, bytes.NewReader(doc))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "text/markdown")
+	if onlyIfAbsent {
+		req.Header.Set("If-None-Match", "*")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
 func getJSON(t *testing.T, url string, v any) {
 	t.Helper()
 	resp, err := http.Get(url)
@@ -452,11 +479,8 @@ func TestRESTIntegrationVerify(t *testing.T) {
 
 	typ := fmt.Sprintf("restit%d", time.Now().UnixNano())
 	id := typ + "/verify-me"
-	payload, _ := json.Marshal(map[string]any{"type": typ, "id": id, "title": "verify round trip"})
-	resp, err := http.Post(srv.URL+"/api/v1/knowledge", "application/json", bytes.NewReader(payload))
-	if err != nil {
-		t.Fatal(err)
-	}
+	payload := docFrom(t, map[string]any{"type": typ, "id": id, "title": "verify round trip"})
+	resp := putDoc(t, srv.URL, id, payload, true)
 	if resp.StatusCode != http.StatusCreated {
 		resp.Body.Close()
 		t.Fatalf("create status = %d", resp.StatusCode)
@@ -559,14 +583,11 @@ func TestRESTContextBudgetGovernsTheResponse(t *testing.T) {
 	var ids []string
 	for i := range 4 {
 		id := fmt.Sprintf("%s/entry-%d", typ, i)
-		payload, _ := json.Marshal(map[string]any{
+		payload := docFrom(t, map[string]any{
 			"type": typ, "id": id, "title": typ + " budget",
 			"description": "an entry about " + typ, "body": body,
 		})
-		resp, err := http.Post(srv.URL+"/api/v1/knowledge", "application/json", bytes.NewReader(payload))
-		if err != nil {
-			t.Fatal(err)
-		}
+		resp := putDoc(t, srv.URL, id, payload, true)
 		resp.Body.Close()
 		if resp.StatusCode != http.StatusCreated {
 			t.Fatalf("create %s: status %d", id, resp.StatusCode)
@@ -652,13 +673,10 @@ func TestRESTIntegrationUsageBacklinksAndMove(t *testing.T) {
 	metric, insight := root+"/revenue", root+"/revenue-reading"
 	create := func(id, title, body string) {
 		t.Helper()
-		payload, _ := json.Marshal(map[string]any{
+		payload := docFrom(t, map[string]any{
 			"type": root, "id": id, "title": title, "body": body,
 		})
-		resp, err := http.Post(srv.URL+"/api/v1/knowledge", "application/json", bytes.NewReader(payload))
-		if err != nil {
-			t.Fatal(err)
-		}
+		resp := putDoc(t, srv.URL, id, payload, true)
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusCreated {
 			b, _ := io.ReadAll(resp.Body)
@@ -767,14 +785,11 @@ func TestRESTIntegrationPrefixScopesSearchNotLinks(t *testing.T) {
 	}
 	var ids []string
 	for _, e := range entries {
-		payload, _ := json.Marshal(map[string]any{
+		payload := docFrom(t, map[string]any{
 			"type": "Metric", "id": e.id, "title": "activation " + root,
 			"description": "an entry about " + root, "body": e.body,
 		})
-		resp, err := http.Post(srv.URL+"/api/v1/knowledge", "application/json", bytes.NewReader(payload))
-		if err != nil {
-			t.Fatal(err)
-		}
+		resp := putDoc(t, srv.URL, e.id, payload, true)
 		resp.Body.Close()
 		if resp.StatusCode != http.StatusCreated {
 			t.Fatalf("create %s: status %d", e.id, resp.StatusCode)
@@ -872,5 +887,108 @@ func TestRESTIntegrationPrefixScopesSearchNotLinks(t *testing.T) {
 		if h.ID == term {
 			t.Error("the out-of-scope term ranked as a hit; the scope must bound the search itself")
 		}
+	}
+}
+
+// The write path is a document, and PUT is the whole of it (design doc
+// 0043 §3.5): create-or-replace, with the preconditions carrying what
+// used to be the difference between POST and PUT.
+func TestRESTIntegrationDocumentWrites(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := store.New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	svc := &service.Service{Store: s, Log: slog.New(slog.NewTextHandler(os.Stderr, nil))}
+	srv := checkedServer(t, Handler(svc))
+	defer srv.Close()
+
+	id := fmt.Sprintf("restdoc%d/revenue", time.Now().UnixNano())
+	t.Cleanup(func() {
+		req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/knowledge/"+id+"?purge=true", nil)
+		if resp, err := http.DefaultClient.Do(req); err == nil {
+			resp.Body.Close()
+		}
+	})
+	const doc = "---\ntype: Metric\ntitle: 売上\nowner: finance\n---\n\n本文。\n"
+
+	// A create-only write on a free id is a 201.
+	resp := putDoc(t, srv.URL, id, []byte(doc), true)
+	var created domain.Knowledge
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create = %d", resp.StatusCode)
+	}
+	// The producer key rode along in the document and is kept.
+	if created.Attrs["owner"] != "finance" {
+		t.Errorf("producer key lost: %v", created.Attrs)
+	}
+
+	// The same write again is a 409: create-only means create.
+	resp = putDoc(t, srv.URL, id, []byte(doc), true)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusConflict {
+		t.Errorf("create-only over a live entry = %d, want 409", resp.StatusCode)
+	}
+
+	// Without the precondition it replaces — and an identical document
+	// writes nothing.
+	resp = putDoc(t, srv.URL, id, []byte(doc), false)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK || resp.Header.Get("Ochakai-Unchanged") != "true" {
+		t.Errorf("identical replace = %d, Ochakai-Unchanged = %q",
+			resp.StatusCode, resp.Header.Get("Ochakai-Unchanged"))
+	}
+
+	// A document ochakai wrote can be edited and sent back as it came:
+	// the keys the server owns are ignored rather than refused, which is
+	// what makes get → edit → put a loop a human can run.
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/v1/knowledge/"+id, nil)
+	req.Header.Set("Accept", "text/markdown")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	served, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if !strings.Contains(string(served), "generated:") || !strings.Contains(string(served), "created_by:") {
+		t.Fatalf("the served document carries no server-owned provenance:\n%s", served)
+	}
+	edited := strings.Replace(string(served), "title: 売上", "title: 売上(改)", 1)
+	resp = putDoc(t, srv.URL, id, []byte(edited), false)
+	var back domain.Knowledge
+	if err := json.NewDecoder(resp.Body).Decode(&back); err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK || back.Title != "売上(改)" {
+		t.Errorf("round-tripped edit = %d, title %q", resp.StatusCode, back.Title)
+	}
+	if back.CreatedBy.Name != created.CreatedBy.Name {
+		t.Errorf("a document's created_by was read back as provenance: %+v", back.CreatedBy)
+	}
+
+	// A stale version is refused and writes nothing.
+	req, _ = http.NewRequest(http.MethodPut, srv.URL+"/api/v1/knowledge/"+id, strings.NewReader(doc))
+	req.Header.Set("Content-Type", "text/markdown")
+	req.Header.Set("If-Match", `"`+created.ContentHash+`"`)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusPreconditionFailed {
+		t.Errorf("stale If-Match = %d, want 412", resp.StatusCode)
 	}
 }

--- a/internal/restapi/restapi_test.go
+++ b/internal/restapi/restapi_test.go
@@ -191,14 +191,14 @@ func TestETagRoundTrip(t *testing.T) {
 	}
 }
 
-// An oversized JSON body is a 413, matching what the attachment path
-// (readBody) already answers. Calling it "invalid JSON" sent the caller
+// An oversized document is a 413, matching what the attachment path
+// (readBody) already answers. Calling it a parse failure sent the caller
 // hunting for a syntax error in a payload that merely did not fit.
-func TestOversizedJSONBodyIsTooLarge(t *testing.T) {
+func TestOversizedDocumentIsTooLarge(t *testing.T) {
 	h := Handler(&service.Service{})
-	body := `{"type":"metrics","id":"metrics/x","body":"` + strings.Repeat("a", 5<<20) + `"}`
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/knowledge", strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
+	body := "---\ntype: Metric\n---\n\n" + strings.Repeat("a", 6<<20)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/knowledge/metrics/x", strings.NewReader(body))
+	req.Header.Set("Content-Type", "text/markdown")
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
@@ -206,6 +206,26 @@ func TestOversizedJSONBodyIsTooLarge(t *testing.T) {
 		t.Errorf("status = %d, want %d", w.Code, http.StatusRequestEntityTooLarge)
 	}
 	if got := w.Body.String(); !strings.Contains(got, "exceeds") {
+		t.Errorf("body = %s", got)
+	}
+}
+
+// A JSON body is refused with the reason rather than a parse error: the
+// caller is written against the typed write surface design doc 0043 §3.5
+// removed, and needs to be told that — not told its document has no
+// frontmatter.
+func TestJSONWriteSaysToSendADocument(t *testing.T) {
+	h := Handler(&service.Service{})
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/knowledge/metrics/x",
+		strings.NewReader(`{"type":"Metric","id":"metrics/x"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnsupportedMediaType {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnsupportedMediaType)
+	}
+	if got := w.Body.String(); !strings.Contains(got, "OKF document") {
 		t.Errorf("body = %s", got)
 	}
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -236,6 +236,44 @@ func (s *Service) Update(ctx context.Context, k *domain.Knowledge, actor domain.
 	return k, true, nil
 }
 
+// Put writes k over whatever holds its id, creating the entry when the id
+// is free: one operation, because a document PUT is a statement about
+// what the entry should say and not about whether it already existed
+// (design doc 0043 §3.5).
+//
+// ifMatch makes it conditional, which also makes it an update: a
+// precondition names a version, and a version the caller read cannot
+// belong to an entry that does not exist. A missing entry is then a 404
+// rather than a silent create.
+//
+// created reports which way it went, so a surface can answer 201 or 200;
+// changed is Update's no-op signal, always true for a create.
+func (s *Service) Put(ctx context.Context, k *domain.Knowledge, actor domain.Actor, ifMatch *string) (out *domain.Knowledge, created, changed bool, err error) {
+	updated, changed, err := s.Update(ctx, k, actor, ifMatch)
+	if err == nil {
+		return updated, false, changed, nil
+	}
+	if ifMatch != nil || !errors.Is(err, store.ErrNotFound) {
+		return nil, false, false, err
+	}
+	// The id was free at the read above. If another writer took it in the
+	// window, this is an update after all — retry once rather than
+	// handing back an ErrAlreadyExists the caller cannot act on, since
+	// what it asked for ("make the entry say this") is still achievable.
+	made, err := s.Create(ctx, k, actor)
+	if err == nil {
+		return made, true, true, nil
+	}
+	if !errors.Is(err, store.ErrAlreadyExists) {
+		return nil, false, false, err
+	}
+	updated, changed, err = s.Update(ctx, k, actor, nil)
+	if err != nil {
+		return nil, false, false, err
+	}
+	return updated, false, changed, nil
+}
+
 // RefuseIfCurated reports an error when id names an entry a human has
 // already ruled on — verified, rejected, or deprecated — for surfaces that
 // must not overwrite that ruling in place. It returns the entry's version

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -685,9 +685,15 @@ async function api(path, opts = {}) {
   const init = { method: opts.method || 'GET' };
   if (opts.raw !== undefined) {
     init.body = opts.raw; // raw bytes (attachment upload), no JSON envelope
+  } else if (opts.doc !== undefined) {
+    init.headers = { 'Content-Type': 'text/markdown' };
+    init.body = opts.doc; // an OKF document — the one way to write knowledge
   } else if (opts.body !== undefined) {
     init.headers = { 'Content-Type': 'application/json' };
     init.body = JSON.stringify(opts.body);
+  }
+  if (opts.onlyIfAbsent) {
+    init.headers = Object.assign({}, init.headers, { 'If-None-Match': '*' });
   }
   const res = await fetch(BASE + path, init);
   // A read-only deployment says so on every response (design doc 0040).
@@ -1825,24 +1831,49 @@ async function viewDetail(id) {
   });
 }
 
-// Every writable envelope field is named here, and nowhere else: a PUT is
-// a full replacement, so a field left out of a payload is a field erased.
-// The editor form builds its payload from the same list (design docs 0035
-// §4, where resource was erased by a status change, and 0035, which added
-// the OKF v0.2 families).
-const WRITABLE = ['description', 'resource', 'tags', 'sources', 'usage_window',
-  'status', 'status_note', 'stale_after',
-  'runtime', 'parameters', 'computation', 'executor', 'attester', 'attrs', 'body'];
+// The frontmatter keys a writer owns, in the spec's family order. A PUT
+// is a full replacement, so a key left out is a key erased — which is why
+// the form and the status picker both render from this one list rather
+// than each assembling their own (design doc 0035 §4, where a status
+// change erased resource because one path had forgotten it).
+//
+// links is not here: the server derives links from the body (design doc
+// 0024). Neither are the keys the server owns — generated, verified,
+// created_by, rejected_* — which it ignores on the way in.
+const WRITABLE = ['type', 'resource', 'title', 'description', 'tags',
+  'sources', 'usage_window', 'status', 'status_note', 'stale_after',
+  'runtime', 'parameters', 'computation', 'executor', 'attester'];
 
-// The writable subset of a Knowledge entry (PUT is a full replacement).
-// links is not in it — the server derives links from body (design doc
-// 0024) and ignores whatever a payload carries.
-function editablePayload(e) {
-  const p = { type: e.type, id: e.id, title: e.title };
-  for (const k of WRITABLE) {
-    if (e[k] !== undefined && e[k] !== null) p[k] = e[k];
+// Render an entry as the OKF document the server takes (design doc 0043
+// §3.5). Every value goes out as JSON, which is a subset of YAML: it
+// needs no quoting rules of its own, cannot be misread as a date or a
+// number, and survives a body full of colons and newlines. The server
+// canonicalizes what it stores, so this has to be correct, not pretty.
+//
+// Producer extension keys ride along from attrs, so editing an entry
+// through the form keeps the keys the form knows nothing about.
+function toDocument(e) {
+  const lines = [];
+  const put = (k, v) => {
+    if (v === undefined || v === null) return;
+    if (typeof v === 'string' && v === '') return;
+    if (Array.isArray(v) && v.length === 0) return;
+    lines.push(k + ': ' + JSON.stringify(v));
+  };
+  for (const k of WRITABLE) put(k, e[k]);
+  for (const [k, v] of Object.entries(e.attrs || {})) {
+    if (!WRITABLE.includes(k)) put(k, v);
   }
-  return p;
+  const body = (e.body || '').trim();
+  return '---\n' + lines.join('\n') + '\n---\n' + (body ? '\n' + body + '\n' : '');
+}
+
+// writeEntry PUTs the entry as a document. onlyIfAbsent asks for a
+// create: an occupied id is a 409 rather than a replacement.
+function writeEntry(e, onlyIfAbsent) {
+  return api('/api/v1/knowledge/' + idPath(e.id), {
+    method: 'PUT', doc: toDocument(e), onlyIfAbsent,
+  });
 }
 
 // Apply a status transition (full-replacement PUT), prompting for a
@@ -1857,10 +1888,9 @@ async function applyStatus(entry, status, askNote) {
     note = prompt(`Why ${status}? (recorded as status_note so agents stop re-proposing it)`, entry.status_note || '');
     if (note === null) return false;
   }
-  const payload = editablePayload(entry);
-  payload.status = status;
-  if (note !== undefined) payload.status_note = note;
-  await api('/api/v1/knowledge/' + idPath(entry.id), { method: 'PUT', body: payload });
+  const next = Object.assign({}, entry, { status });
+  if (note !== undefined) next.status_note = note;
+  await writeEntry(next, false);
   return true;
 }
 
@@ -2403,9 +2433,7 @@ async function viewEditor(id, prefix = '') {
     // No links in the payload: the server derives them from the body
     // (design doc 0024).
     try {
-      const saved = editing
-        ? await api('/api/v1/knowledge/' + idPath(entry.id), { method: 'PUT', body: payload })
-        : await api('/api/v1/knowledge', { method: 'POST', body: payload });
+      const saved = await writeEntry(payload, !editing);
       dirty = false;
       toast(editing ? 'Saved.' : 'Created.');
       refreshTree();


### PR DESCRIPTION
<!-- Implements design doc 0043 §§3.5, 3.11 (the write half). Fourth of the document-first implementation PRs, after #248, #249 and #251. -->

## What and why

The write path was a typed JSON mirror of the envelope, in **four** places that each had to be found and extended whenever OKF gained a key: the Go struct, the OpenAPI schema, the MCP tool input, and the web UI's payload builder. An agent that trusted the MCP enumeration could silently drop whatever the list had fallen behind on — a failure mode with no error in it.

**The body is the document now.** `PUT /api/v1/knowledge/{id}` takes `text/markdown`: the same text `ochakai get` prints and an export writes, so read → edit → write is one loop with no translation in it. The keys the server owns are *ignored rather than refused*, which is what makes that loop actually close — there's an integration test that GETs the document, edits one line, PUTs it back, and checks `created_by` was not adopted from the payload.

**POST is gone.** A PUT states what the entry should say; whether an entry already held the id is not something the writer of a document is saying anything about, so a separate create only made the caller answer a question it doesn't have. Existence moves to the preconditions, where the rest of the conditional-write vocabulary already lived: `If-None-Match: *` for "only if free" (409 otherwise), `If-Match` for "only if unchanged". 201 on create, 200 on replace.

A JSON body is a **415 naming the document form** rather than a parse error: a client sending one is written against the surface that went away, and needs to be told that, not told its document has no frontmatter.

Reinterpretations travel as `Ochakai-Note` response headers (and in the MCP result). A response whose body is the entry has no room for them, and 0036 §3.4's rule is that a reinterpretation is never silent.

Note on the web UI: it renders its form to a document by emitting every value as JSON, which is a **subset of YAML** — no quoting rules of its own, nothing misreadable as a date or number, and a body full of colons survives. Producer extension keys ride along from `attrs`, so editing through the form keeps keys the form knows nothing about.

## Checks

- [x] `scripts/check core` clean against a real PostgreSQL 16 + pgvector, so the store, service and REST integration tests **executed** — including the OpenAPI contract check, which runs every integration request and response past `api/openapi.yaml`
- [x] Behavior changes come with tests — new `TestRESTIntegrationDocumentWrites` covers create-only 201 → 409 → replace → unchanged → serve-as-markdown → edit-and-send-back → stale-412, and asserts a producer key survives the round trip; `TestJSONWriteSaysToSendADocument` pins the 415; the apiclient tests pin the wire (media type, `If-None-Match`, `If-Match` quoting, notes, `Ochakai-Unchanged`)

⚠️ `scripts/check lint` still cannot run here (pinned golangci-lint built with go1.25 vs the module's 1.26.5; fails identically on a clean `main`). `go vet` is clean. Thanks for handling the lint findings in #250 — shout if this diff trips the same rules and I'll fold the fix in.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, `internal/apiclient` in sync: `createKnowledge` removed, `updateKnowledge` → `putKnowledge` with a `text/markdown` body, `If-None-Match`, 201/409 responses, `text/markdown` on the GET, and a new `Ochakai-Note` header component
- [x] Per surface:
  - **REST** — the contract, as above
  - **CLI** — unchanged to use: `create`/`update` still read a document or JSON from `-f`/stdin, and JSON is now rendered to a document *locally*, so the server keeps one write format. `import` makes one call per entry instead of create-then-update
  - **MCP** — `create_knowledge` / `update_knowledge` take `{id, document}`; the tool schema shrinks from eighteen fields to two, and frontmatter+markdown is the shape an LLM handles best anyway
  - **Web UI** — form and status picker both write through one `writeEntry`, so a status change can no longer erase a field one path forgot (the 0035 §4 bug class)

## Design docs

- [x] Alters an accepted decision? No new doc — 0043 (#247) specifies this (§§3.5, 3.11)
- [x] Commit messages and code comments are in English

## What is left of 0043

The **read** shape (§3.5's `document` + `summary` + `observed` response, and §3.6's preservation of producer keys *inside* `sources[]` / `parameters[]`). I split it off deliberately: it changes the shape of every read — search hits, context entries, browse rows — and mixing that into this PR would have made both unreviewable. Happy to open it next.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcMFa1rh2cSHSQhEnARcov)_