### PR TITLE
Keep producer keys inside sources, parameters, executor and attester (0043 §3.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,28 @@ last entry.
 
 ## [Unreleased]
 
+### Fixed
+
+- Producer-defined keys **inside** a `sources` entry, a `parameter`, an
+  `executor` or an `attester` are kept rather than dropped (SPEC §4.1,
+  design doc [0043](docs/design/0043-document-first.md) §3.6). They ride
+  inline in a document, exactly where their writer put them, and are
+  nested under `extra` in ochakai's JSON — where nesting keeps a producer
+  key from ever colliding with one a later spec adds.
+
+  0036 §3.5 dropped them with a note, reasoning that the point of
+  promoting these families to typed fields was that four surfaces could
+  describe one shape. The premise went when the document became the
+  stored form: storage keeps whatever the writer wrote, a schema is only
+  needed by the projections that read it, and a key discarded on the way
+  in is a key no later release can recover. Nothing is reported any more,
+  because nothing is reinterpreted — a note is for a value read
+  differently than written, and a key carried through untouched is not
+  one.
+
+  A producer key is content: changing one moves the entry's version, and
+  a write that only repeats it is still a no-op.
+
 ### Changed
 
 - **BREAKING**: knowledge is written as an OKF document, and `PUT` is the

--- a/README.md
+++ b/README.md
@@ -528,10 +528,11 @@ ochakai **records** these; it never acts on them. It does not fetch a
 source's `resource`, score its credibility signals, or run an Attested
 Computation's `executor` and `attester` — weighing the signals and
 running the computation belong to whoever consumes the entry (SPEC §5.1,
-§10.5). Keys OKF does not define pass through `attrs` untouched, in
-place. Provenance itself is never read back from a bundle: it is what
-this instance observed, not what a document claims (design docs 0009,
-0035).
+§10.5). Keys OKF does not define pass through untouched and in place —
+at the top level, and inside a `sources` entry, a `parameter`, an
+`executor` or an `attester` too. Provenance itself is never read back
+from a bundle: it is what this instance observed, not what a document
+claims (design docs 0009, 0043).
 
 **Japanese knowledge bases should turn embeddings on.** PostgreSQL's
 full-text search does not tokenize Japanese, so the lexical half of search

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1983,8 +1983,8 @@ components:
         §5.1, design doc 0036). ochakai records sources: it never fetches
         resource, checks that it resolves, or turns the credibility signals
         into a score — §5.1 leaves weighing raw signals to the consumer.
-        The spec's keys are modeled exhaustively; a key OKF does not define
-        is dropped on bundle import with a note.
+        The spec's keys are modeled; anything else a producer wrote is kept
+        under extra (design doc 0043 §3.6).
       required: [resource]
       properties:
         resource:
@@ -2015,6 +2015,16 @@ components:
         usage_window:
           allOf: [{ $ref: "#/components/schemas/UsageWindow" }]
           description: Overrides the entry's usage_window for this source.
+        extra:
+          type: object
+          additionalProperties: true
+          description: >
+            The producer-defined keys of this object (SPEC §4.1), kept as
+            written. In a document they ride inline beside the keys the
+            spec defines, exactly where their writer put them; here they
+            are nested, because this JSON is ochakai's shape rather than
+            OKF's, and nesting keeps a producer key from ever colliding
+            with one a later spec adds (design doc 0043 §3.6).
     Parameter:
       type: object
       description: >
@@ -2027,6 +2037,16 @@ components:
         name: { type: string }
         type: { type: string, description: "The parameter's data type, e.g. integer or string." }
         required: { type: boolean, description: Absent and false mean the same thing. }
+        extra:
+          type: object
+          additionalProperties: true
+          description: >
+            The producer-defined keys of this object (SPEC §4.1), kept as
+            written. In a document they ride inline beside the keys the
+            spec defines, exactly where their writer put them; here they
+            are nested, because this JSON is ochakai's shape rather than
+            OKF's, and nesting keeps a producer key from ever colliding
+            with one a later spec adds (design doc 0043 §3.6).
     Executor:
       type: object
       description: >
@@ -2041,6 +2061,16 @@ components:
           type: array
           items: { type: string }
           description: "The fields a run must return as evidence, e.g. [job_id, executed_sql, result]."
+        extra:
+          type: object
+          additionalProperties: true
+          description: >
+            The producer-defined keys of this object (SPEC §4.1), kept as
+            written. In a document they ride inline beside the keys the
+            spec defines, exactly where their writer put them; here they
+            are nested, because this JSON is ochakai's shape rather than
+            OKF's, and nesting keeps a producer key from ever colliding
+            with one a later spec adds (design doc 0043 §3.6).
     Attester:
       type: object
       description: >
@@ -2050,6 +2080,16 @@ components:
       required: [resource]
       properties:
         resource: { type: string, description: Path to the attester code. }
+        extra:
+          type: object
+          additionalProperties: true
+          description: >
+            The producer-defined keys of this object (SPEC §4.1), kept as
+            written. In a document they ride inline beside the keys the
+            spec defines, exactly where their writer put them; here they
+            are nested, because this JSON is ochakai's shape rather than
+            OKF's, and nesting keeps a producer key from ever colliding
+            with one a later spec adds (design doc 0043 §3.6).
     Knowledge:
       type: object
       required: [type, id]

--- a/internal/domain/knowledge.go
+++ b/internal/domain/knowledge.go
@@ -413,15 +413,42 @@ func (w *UsageWindow) sameAs(o *UsageWindow) bool {
 	return *w == *o
 }
 
+// Extra carries the producer-defined keys of a structured OKF object —
+// the ones inside a source, a parameter, an executor or an attester
+// (SPEC §4.1). They are kept, not dropped (design doc 0043 §3.6).
+//
+// 0036 §3.5 dropped them with a note, reasoning that the point of
+// promoting these families to typed fields was that four surfaces could
+// describe one shape, and an open map defeats that. The premise went
+// when the document became the stored form (0043 §3.1): storage keeps
+// whatever the writer wrote, a schema is only needed by the projections
+// that read it, and dropping a key on the way in is a loss no later
+// release can undo. A round trip that silently narrows its input is not
+// a round trip.
+//
+// In a document these ride inline, beside the keys the spec defines,
+// exactly where the producer put them. In ochakai's own JSON they are
+// nested under "extra": that JSON is ochakai's shape, not OKF's, and
+// nesting keeps a producer key from ever colliding with a key a later
+// SPEC adds.
+type Extra map[string]any
+
+func (e Extra) sameAs(o Extra) bool {
+	if len(e) == 0 && len(o) == 0 {
+		return true
+	}
+	ja, errA := json.Marshal(e)
+	jb, errB := json.Marshal(o)
+	return errA == nil && errB == nil && bytes.Equal(ja, jb)
+}
+
 // Source is one piece of external material a concept derives from (OKF
 // SPEC §5.1). ochakai records sources; it never fetches Resource, checks
 // that it resolves, or scores the credibility signals — SPEC §5.1 is
 // explicit that raw signals are for the consumer to weigh.
 //
-// The spec's six keys are modeled exhaustively, so a producer key inside a
-// source mapping is dropped on import with a note rather than kept
-// (design doc 0036 §3.5): the whole point of the promotion is that four
-// surfaces can describe one shape.
+// The spec's six keys are modeled; anything else a producer wrote is
+// kept in Extra (SPEC §4.1, design doc 0043 §3.6).
 type Source struct {
 	Resource string `json:"resource"` // REQUIRED within an entry: the artifact this came from
 	ID       string `json:"id,omitempty"`
@@ -432,6 +459,7 @@ type Source struct {
 	UsageCount   *int         `json:"usage_count,omitempty"`
 	LastModified string       `json:"last_modified,omitempty"` // YYYY-MM-DD
 	UsageWindow  *UsageWindow `json:"usage_window,omitempty"`  // overrides the entry's window for this source
+	Extra        Extra        `json:"extra,omitempty"`
 }
 
 // Valid reports whether s is a usable source. A source that names no
@@ -447,7 +475,7 @@ func (s Source) sameAs(o Source) bool {
 		s.Author != o.Author || s.LastModified != o.LastModified {
 		return false
 	}
-	if !s.UsageWindow.sameAs(o.UsageWindow) {
+	if !s.UsageWindow.sameAs(o.UsageWindow) || !s.Extra.sameAs(o.Extra) {
 		return false
 	}
 	if s.UsageCount == nil || o.UsageCount == nil {
@@ -467,9 +495,15 @@ type Parameter struct {
 	Name     string `json:"name"` // REQUIRED within an entry
 	Type     string `json:"type"` // REQUIRED within an entry
 	Required bool   `json:"required,omitempty"`
+	Extra    Extra  `json:"extra,omitempty"`
 }
 
 func (p Parameter) Valid() bool { return p.Name != "" && p.Type != "" }
+
+func (p Parameter) sameAs(o Parameter) bool {
+	return p.Name == o.Name && p.Type == o.Type && p.Required == o.Required &&
+		p.Extra.sameAs(o.Extra)
+}
 
 // Executor says how an Attested Computation is run and what a run must
 // hand back as evidence (OKF SPEC §10.2). ochakai stores it and never
@@ -478,6 +512,7 @@ func (p Parameter) Valid() bool { return p.Name != "" && p.Type != "" }
 type Executor struct {
 	Resource string   `json:"resource"` // REQUIRED within executor: run instructions or code
 	Receipt  []string `json:"receipt"`  // REQUIRED within executor: the fields a run must return
+	Extra    Extra    `json:"extra,omitempty"`
 }
 
 func (e *Executor) Valid() bool {
@@ -489,6 +524,7 @@ func (e *Executor) Valid() bool {
 // Executor, ochakai records the path and never executes it.
 type Attester struct {
 	Resource string `json:"resource"` // REQUIRED within attester
+	Extra    Extra  `json:"extra,omitempty"`
 }
 
 func (a *Attester) Valid() bool { return a == nil || a.Resource != "" }
@@ -665,7 +701,7 @@ func (k *Knowledge) SameContent(o *Knowledge) bool {
 		slices.Equal(k.Tags, o.Tags) &&
 		slices.EqualFunc(k.Sources, o.Sources, Source.sameAs) &&
 		k.UsageWindow.sameAs(o.UsageWindow) &&
-		slices.Equal(k.Parameters, o.Parameters) &&
+		slices.EqualFunc(k.Parameters, o.Parameters, Parameter.sameAs) &&
 		executorsEqual(k.Executor, o.Executor) &&
 		attestersEqual(k.Attester, o.Attester) &&
 		slices.Equal(k.Links, o.Links) &&
@@ -676,14 +712,15 @@ func executorsEqual(a, b *Executor) bool {
 	if a == nil || b == nil {
 		return a == b
 	}
-	return a.Resource == b.Resource && slices.Equal(a.Receipt, b.Receipt)
+	return a.Resource == b.Resource && slices.Equal(a.Receipt, b.Receipt) &&
+		a.Extra.sameAs(b.Extra)
 }
 
 func attestersEqual(a, b *Attester) bool {
 	if a == nil || b == nil {
 		return a == b
 	}
-	return *a == *b
+	return a.Resource == b.Resource && a.Extra.sameAs(b.Extra)
 }
 
 func attrsEqual(a, b map[string]any) bool {

--- a/internal/okf/okf.go
+++ b/internal/okf/okf.go
@@ -77,14 +77,20 @@ type frontmatter struct {
 // otherwise resolve to a timestamp, so last_modified goes out as
 // "2026-05-30" and comes back the plain day the producer wrote — the same
 // treatment stale_after gets (design doc 0036 §3.7).
+// The Extra fields below are yaml ",inline": a producer key comes back
+// out beside the keys the spec defines, exactly where its writer put it
+// (SPEC §4.1, design doc 0043 §3.6). yaml.v3 sorts an inlined map's
+// keys, so the rendering stays deterministic — which the content hash
+// depends on.
 type source struct {
-	Resource     text         `yaml:"resource"`
-	ID           text         `yaml:"id,omitempty"`
-	Title        text         `yaml:"title,omitempty"`
-	Author       text         `yaml:"author,omitempty"`
-	UsageCount   *int         `yaml:"usage_count,omitempty"` // a pointer: zero uses and no count at all are different claims
-	LastModified text         `yaml:"last_modified,omitempty"`
-	UsageWindow  *usageWindow `yaml:"usage_window,omitempty"`
+	Resource     text           `yaml:"resource"`
+	ID           text           `yaml:"id,omitempty"`
+	Title        text           `yaml:"title,omitempty"`
+	Author       text           `yaml:"author,omitempty"`
+	UsageCount   *int           `yaml:"usage_count,omitempty"` // a pointer: zero uses and no count at all are different claims
+	LastModified text           `yaml:"last_modified,omitempty"`
+	UsageWindow  *usageWindow   `yaml:"usage_window,omitempty"`
+	Extra        map[string]any `yaml:",inline"`
 }
 
 type usageWindow struct {
@@ -93,18 +99,21 @@ type usageWindow struct {
 }
 
 type parameter struct {
-	Name     text `yaml:"name"`
-	Type     text `yaml:"type"`
-	Required bool `yaml:"required,omitempty"` // absent and false mean the same thing (SPEC §10.2)
+	Name     text           `yaml:"name"`
+	Type     text           `yaml:"type"`
+	Required bool           `yaml:"required,omitempty"` // absent and false mean the same thing (SPEC §10.2)
+	Extra    map[string]any `yaml:",inline"`
 }
 
 type executor struct {
-	Resource text   `yaml:"resource"`
-	Receipt  []text `yaml:"receipt"`
+	Resource text           `yaml:"resource"`
+	Receipt  []text         `yaml:"receipt"`
+	Extra    map[string]any `yaml:",inline"`
 }
 
 type attester struct {
-	Resource text `yaml:"resource"`
+	Resource text           `yaml:"resource"`
+	Extra    map[string]any `yaml:",inline"`
 }
 
 // event is one entry of the trust family: who, when, and — as a producer
@@ -188,6 +197,19 @@ func texts(in []string) []text {
 // producer extension keys are emitted under the same rule as the envelope
 // (see text). Attrs arrive from JSON or YAML, so these are the only kinds
 // that can hold one.
+// textifyMap is textify over a producer's extension keys, returning nil
+// for an empty map so an inlined field adds nothing to the rendering.
+func textifyMap(m domain.Extra) map[string]any {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = textify(v)
+	}
+	return out
+}
+
 func textify(v any) any {
 	switch v := v.(type) {
 	case string:
@@ -349,6 +371,7 @@ func sourcesOut(in []domain.Source) []source {
 			Resource: text(s.Resource), ID: text(s.ID), Title: text(s.Title), Author: text(s.Author),
 			UsageCount: s.UsageCount, LastModified: text(s.LastModified),
 			UsageWindow: windowOut(s.UsageWindow),
+			Extra:       textifyMap(s.Extra),
 		})
 	}
 	return out
@@ -400,13 +423,15 @@ func render(k *domain.Knowledge, serverKeys bool) ([]byte, error) {
 		fm.CreatedBy = text(k.CreatedBy.String())
 	}
 	for _, p := range k.Parameters {
-		fm.Parameters = append(fm.Parameters, parameter{Name: text(p.Name), Type: text(p.Type), Required: p.Required})
+		fm.Parameters = append(fm.Parameters, parameter{
+			Name: text(p.Name), Type: text(p.Type), Required: p.Required, Extra: textifyMap(p.Extra)})
 	}
 	if k.Executor != nil {
-		fm.Executor = &executor{Resource: text(k.Executor.Resource), Receipt: texts(k.Executor.Receipt)}
+		fm.Executor = &executor{Resource: text(k.Executor.Resource), Receipt: texts(k.Executor.Receipt),
+			Extra: textifyMap(k.Executor.Extra)}
 	}
 	if k.Attester != nil {
-		fm.Attester = &attester{Resource: text(k.Attester.Resource)}
+		fm.Attester = &attester{Resource: text(k.Attester.Resource), Extra: textifyMap(k.Attester.Extra)}
 	}
 	// The whole verification ledger, oldest first — SPEC §5.2's list, with
 	// as many entries as the instance recorded. The key's presence is what

--- a/internal/okf/okf_test.go
+++ b/internal/okf/okf_test.go
@@ -472,3 +472,82 @@ func TestCanonicalOmitsServerOwnedKeys(t *testing.T) {
 		t.Errorf("rulings changed the canonical form:\n%s\nvs\n%s", canon, bareCanon)
 	}
 }
+
+// A producer key inside a structured object survives the round trip, in
+// place (SPEC §4.1, design doc 0043 §3.6). It was dropped with a note
+// until 0.16, on the reasoning that four surfaces should be able to
+// describe one shape — a premise that went when the document became the
+// stored form, since a key discarded on the way in is a key no later
+// release can recover.
+func TestProducerKeysInsideStructuredObjectsRoundTrip(t *testing.T) {
+	const in = `---
+type: Attested Computation
+title: 月次売上
+runtime: bigquery
+sources:
+  - resource: policies/revenue.md
+    id: rev
+    license: CC-BY
+    reviewed_by: finance
+parameters:
+  - name: year
+    type: integer
+    ui_hint: dropdown
+executor:
+  resource: run.md
+  receipt: [job_id]
+  timeout_s: 300
+attester:
+  resource: check.py
+  language: python
+---
+
+本文。
+`
+	d, notes, err := Parse([]byte(in))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(notes) != 0 {
+		t.Errorf("keeping a key is not a reinterpretation, so nothing should be reported: %v", notes)
+	}
+	if got := d.Sources[0].Extra; got["license"] != "CC-BY" || got["reviewed_by"] != "finance" {
+		t.Errorf("source producer keys = %v", got)
+	}
+	if got := d.Parameters[0].Extra; got["ui_hint"] != "dropdown" {
+		t.Errorf("parameter producer keys = %v", got)
+	}
+	if got := d.Executor.Extra; got["timeout_s"] != 300 {
+		t.Errorf("executor producer keys = %v", got)
+	}
+	if got := d.Attester.Extra; got["language"] != "python" {
+		t.Errorf("attester producer keys = %v", got)
+	}
+
+	// They come back out beside the keys the spec defines, not nested
+	// under one of ochakai's own.
+	out, err := Canonical(&d.Knowledge)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"license: CC-BY", "reviewed_by: finance",
+		"ui_hint: dropdown", "timeout_s: 300", "language: python"} {
+		if !strings.Contains(string(out), want) {
+			t.Errorf("re-export lost %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(string(out), "extra:") {
+		t.Errorf("producer keys must ride inline, not under an ochakai key:\n%s", out)
+	}
+
+	// And the entry is unchanged by the trip, so a re-import writes
+	// nothing — the property the whole round trip is stated in.
+	back, _, err := Parse(out)
+	if err != nil {
+		t.Fatalf("our own output does not parse: %v\n%s", err, out)
+	}
+	back.ID = d.ID
+	if !back.SameContent(&d.Knowledge) {
+		t.Errorf("round trip changed the entry:\n got %+v\nwant %+v", back.Knowledge, d.Knowledge)
+	}
+}

--- a/internal/okf/parse.go
+++ b/internal/okf/parse.go
@@ -2,7 +2,6 @@ package okf
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -377,15 +376,17 @@ func sourcesFrom(v any) ([]domain.Source, []string) {
 		}
 		w, wn := windowFrom(m["usage_window"], fmt.Sprintf("sources[%d].usage_window", i))
 		s.UsageWindow, notes = w, append(notes, wn...)
-		if extra := unknownKeys(m, sourceKeys); len(extra) > 0 {
-			notes = append(notes, fmt.Sprintf("sources[%d]: dropped keys OKF does not define: %s", i, strings.Join(extra, ", ")))
-		}
+		s.Extra = extraKeys(m, sourceKeys)
 		out = append(out, s)
 	}
 	return out, notes
 }
 
-var parameterKeys = map[string]bool{"name": true, "type": true, "required": true}
+var (
+	parameterKeys = map[string]bool{"name": true, "type": true, "required": true}
+	executorKeys  = map[string]bool{"resource": true, "receipt": true}
+	attesterKeys  = map[string]bool{"resource": true}
+)
 
 func parametersFrom(v any) ([]domain.Parameter, []string) {
 	if v == nil {
@@ -409,9 +410,7 @@ func parametersFrom(v any) ([]domain.Parameter, []string) {
 			continue
 		}
 		p.Required, _ = m["required"].(bool)
-		if extra := unknownKeys(m, parameterKeys); len(extra) > 0 {
-			notes = append(notes, fmt.Sprintf("parameters[%d]: dropped keys OKF does not define: %s", i, strings.Join(extra, ", ")))
-		}
+		p.Extra = extraKeys(m, parameterKeys)
 		out = append(out, p)
 	}
 	return out, notes
@@ -425,7 +424,7 @@ func executorFrom(v any) (*domain.Executor, []string) {
 	if !ok {
 		return nil, []string{"executor is not a mapping; dropped"}
 	}
-	e := &domain.Executor{Resource: strOf(m, "resource")}
+	e := &domain.Executor{Resource: strOf(m, "resource"), Extra: extraKeys(m, executorKeys)}
 	switch r := m["receipt"].(type) {
 	case []any:
 		for _, f := range r {
@@ -454,7 +453,7 @@ func attesterFrom(v any) (*domain.Attester, []string) {
 	if !ok {
 		return nil, []string{"attester is not a mapping; dropped"}
 	}
-	a := &domain.Attester{Resource: strOf(m, "resource")}
+	a := &domain.Attester{Resource: strOf(m, "resource"), Extra: extraKeys(m, attesterKeys)}
 	if !a.Valid() {
 		return nil, []string{"attester needs a resource (SPEC §10.2); dropped"}
 	}
@@ -479,13 +478,24 @@ func intFrom(v any) (int, bool) {
 	return 0, false
 }
 
-func unknownKeys(m map[string]any, known map[string]bool) []string {
-	var extra []string
-	for k := range m {
-		if !known[k] {
-			extra = append(extra, k)
+// extraKeys collects the producer-defined keys of a structured object —
+// everything the spec does not name (SPEC §4.1). They are kept rather
+// than dropped: the document is the stored form, so a key discarded here
+// is a key no later release can recover (design doc 0043 §3.6).
+//
+// Nothing is reported, because nothing was reinterpreted. A note is for a
+// value read differently than written (design doc 0036 §3.4), and a key
+// carried through untouched is not one.
+func extraKeys(m map[string]any, known map[string]bool) domain.Extra {
+	var extra domain.Extra
+	for k, v := range m {
+		if known[k] {
+			continue
 		}
+		if extra == nil {
+			extra = domain.Extra{}
+		}
+		extra[k] = yamlScalar(v)
 	}
-	sort.Strings(extra) // map iteration order must not reach a user-visible note
 	return extra
 }

--- a/internal/okf/parse_test.go
+++ b/internal/okf/parse_test.go
@@ -508,11 +508,22 @@ attester: {}
 			k.UsageWindow, k.Executor, k.Attester, k.Parameters)
 	}
 	for _, want := range []string{
-		"last_modified", "names no resource", "dropped keys OKF does not define: license",
+		"last_modified", "names no resource",
 		"usage_count", "usage_window", "parameters[0]", "executor", "attester",
 	} {
 		if !slices.ContainsFunc(notes, func(n string) bool { return strings.Contains(n, want) }) {
 			t.Errorf("no note mentions %q: %v", want, notes)
+		}
+	}
+	// The producer key is kept, and reported by nothing: a note is for a
+	// value read differently than written (design doc 0036 §3.4), and a
+	// key carried through untouched is not one (design doc 0043 §3.6).
+	if len(k.Sources) > 0 && k.Sources[0].Extra["license"] != "CC-BY" {
+		t.Errorf("sources[0] lost its producer key: %+v", k.Sources[0].Extra)
+	}
+	for _, n := range notes {
+		if strings.Contains(n, "license") {
+			t.Errorf("a kept key was reported as dropped: %q", n)
 		}
 	}
 }

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -2648,3 +2648,71 @@ func TestIntegrationStoredDocumentMatchesTheIndex(t *testing.T) {
 		t.Errorf("stored hash %q does not match the document's %q", read.ContentHash, hash)
 	}
 }
+
+// A producer key inside a source or a parameter survives storage, which
+// is the point of keeping it (design doc 0043 §3.6): the document is the
+// stored form, so a key dropped on the way in is a key no later release
+// can recover. It has to round-trip through the jsonb index columns as
+// well as through the document.
+func TestIntegrationProducerKeysInsideObjectsSurviveStorage(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	actor := domain.Actor{Kind: domain.ActorHuman, Name: "test"}
+	id := fmt.Sprintf("it-extra-%d", time.Now().UnixNano())
+	k := &domain.Knowledge{
+		Type: domain.TypeComputations, ID: id, Title: "extras", Runtime: "bigquery",
+		Status: domain.StatusDraft, CreatedBy: actor,
+		Sources: []domain.Source{{Resource: "policies/revenue.md",
+			Extra: domain.Extra{"license": "CC-BY"}}},
+		Parameters: []domain.Parameter{{Name: "year", Type: "integer",
+			Extra: domain.Extra{"ui_hint": "dropdown"}}},
+		Executor: &domain.Executor{Resource: "run.md", Receipt: []string{"job_id"},
+			Extra: domain.Extra{"timeout_s": float64(300)}},
+		Attester: &domain.Attester{Resource: "check.py",
+			Extra: domain.Extra{"language": "python"}},
+	}
+	if err := s.Create(ctx, k, false); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _, _ = s.pool.Exec(ctx, `DELETE FROM knowledge WHERE id = $1`, id) })
+
+	got, err := s.Get(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Sources[0].Extra["license"] != "CC-BY" || got.Parameters[0].Extra["ui_hint"] != "dropdown" {
+		t.Errorf("producer keys lost: %+v %+v", got.Sources[0].Extra, got.Parameters[0].Extra)
+	}
+	if got.Executor.Extra["timeout_s"] != float64(300) || got.Attester.Extra["language"] != "python" {
+		t.Errorf("contract producer keys lost: %+v %+v", got.Executor.Extra, got.Attester.Extra)
+	}
+	// The stored document carries them too, inline — and a write that
+	// changes nothing else is still a no-op, so they are part of the
+	// content the hash is over.
+	var doc string
+	if err := s.pool.QueryRow(ctx, `SELECT doc FROM knowledge WHERE id = $1`, id).Scan(&doc); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(doc, "license: CC-BY") {
+		t.Errorf("the stored document dropped a producer key:\n%s", doc)
+	}
+	before := got.ContentHash
+	got.Sources[0].Extra["license"] = "MIT"
+	if err := s.Update(ctx, got, actor, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got.ContentHash == before {
+		t.Error("changing a producer key left the version where it was; it is content")
+	}
+}


### PR DESCRIPTION
<!-- Implements design doc 0043 §3.6. Fifth of the document-first implementation PRs, after #248, #249, #251 and #252. -->

## What and why

A key OKF does not define, written *inside* one of the structured objects the spec does define, was dropped on import with a note. [0036](docs/design/0036-okf-schema-first.md) §3.5 chose that deliberately: the point of promoting these families to typed fields was that four surfaces could describe one shape, and an open map defeats it.

That premise went when the document became the stored form (#251). Storage keeps whatever the writer wrote; a schema is only needed by the *projections* that read it. And a key discarded on the way in is a key no later release can recover — a round trip that silently narrows its input is not a round trip, which matters rather more now that the stored bytes are the thing an export hands out.

I did this before the read reshape on purpose: it decides whether document-first storage is actually **lossless**, and every day it is not is data a deployment cannot get back.

**Where the keys live.** Inline in a document, beside the spec's keys and exactly where their writer put them (`yaml:",inline"`, which yaml.v3 renders with sorted keys, so the content hash stays deterministic). Nested under `extra` in ochakai's own JSON — that JSON is ochakai's shape rather than OKF's, and a nested map cannot collide with a key a later spec adds at the same level.

**Nothing is reported any more.** A note is for a value read differently than it was written (0036 §3.4); a key carried through untouched is not one. The test that asserted the note now asserts the key survives *and* that nothing mentions it.

**A producer key is content**: it renders into the canonical document, so changing one moves the entry's version and a write that only repeats it is still a no-op. Both asserted.

## Checks

- [x] `scripts/check core` clean against a real PostgreSQL 16 + pgvector, so the store and REST integration tests **executed**
- [x] Behavior changes come with tests — a new okf test round-trips producer keys through all four objects and checks they come back *inline* rather than under an ochakai key, and that re-parsing gives `SameContent`; a new store test checks they survive the jsonb index columns and the stored document, and that editing one moves the content hash

⚠️ `scripts/check lint` still cannot run here (pinned golangci-lint built with go1.25 vs the module's 1.26.5; identical on a clean `main`). `go vet` is clean.

## Surfaces and contract

- [x] `api/openapi.yaml` gains `extra` on `Source`, `Parameter`, `Executor` and `Attester`; `internal/restapi`, `internal/mcpserver` and `internal/apiclient` carry it through `domain.Knowledge` with no per-surface code — which is the payoff of the write surface already being a document (#252)
- [x] Per surface: no new capability, so nothing lands or is omitted anywhere — this is a fidelity fix that reaches every surface through the shared model. README's "keys OKF does not define pass through untouched" now says *where*

**Not breaking for writers**; it is additive for readers (`extra` appears where keys used to vanish). A bundle that lost keys to an earlier import does not get them back — that is the loss this stops.

## Design docs

- [x] Alters an accepted decision? It reverses 0036 §3.5, which [0043](docs/design/0043-document-first.md) §3.6 already records and justifies (0036 is `Superseded by 0043`). No new doc
- [x] Commit messages and code comments are in English

## What is left of 0043

Only **§3.5's read shape** — `{id, document, summary, observed}` in place of the flat `Knowledge` JSON, and the listing rows becoming that summary projection. It is the largest single reshape left (it changes search hits, context entries, browse rows, and every client that reads them), which is why it is on its own. Happy to open it next.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcMFa1rh2cSHSQhEnARcov)_