### PR TITLE
Build the linter with the Go version go.mod targets

### DIFF
--- a/scripts/check
+++ b/scripts/check
@@ -84,6 +84,17 @@ linter_version() {
 	     f && $1 == "version:" {print $2; exit}' .github/workflows/ci.yaml
 }
 
+# The toolchain to build the tools below with: the version go.mod
+# targets, or newer if a tool asks for it. `go run tool@version` picks
+# its toolchain from that tool's own go.mod, so on a machine whose Go is
+# older than ours golangci-lint gets built with the Go 1.25 it asks for
+# — and then refuses to run, because a linter cannot check a module that
+# targets a Go newer than the one that built it. CI installs a released
+# binary, which is built with a current Go, and never sees this.
+tool_toolchain() {
+	awk '$1 == "go" {print "go" $2 "+auto"; exit}' go.mod
+}
+
 run_core() {
 	step "gofmt"
 	test -z "$(gofmt -l .)" || {
@@ -113,14 +124,16 @@ run_lint() {
 		;;
 	esac
 	step "golangci-lint $v"
-	go run "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$v" run ./...
+	GOTOOLCHAIN=$(tool_toolchain) \
+		go run "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$v" run ./...
 }
 
 run_vuln() {
 	step "govulncheck"
 	# Unpinned, like CI: a new govulncheck release failing means a new
 	# vulnerability, not a new check.
-	go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+	GOTOOLCHAIN=$(tool_toolchain) \
+		go run golang.org/x/vuln/cmd/govulncheck@latest ./...
 }
 
 if [ "$want_db" = yes ]; then start_db; fi


### PR DESCRIPTION
## What and why

`scripts/check lint` fails outright on a machine whose Go is older than the
version `go.mod` targets:

```
go: github.com/golangci/golangci-lint/v2@v2.12.2 requires go >= 1.25.0; switching to go1.25.12
Error: can't load config: the Go language version (go1.25) used to build golangci-lint is lower than the targeted Go version (1.26.5)
```

`go run tool@version` picks its toolchain from *that tool's* `go.mod`, not from
ours. golangci-lint v2.12.2 asks for Go 1.25, so the linter gets built with Go
1.25 and then refuses to check a module targeting Go 1.26.5.

This PR pins the toolchain those `go run` invocations build under to the version
`go.mod` targets — read out of `go.mod`, the same way the linter version is read
out of `ci.yaml`, so there is still only one place each is written. The `+auto`
suffix leaves the upgrade path intact: a tool that needs something newer still
gets it.

govulncheck is invoked the same way and gets the same treatment.

Reviewer notes:

- CI is unaffected and never saw this. The lint job installs a **released**
  golangci-lint binary via the action, which is built with a current Go; the
  test and govulncheck jobs run under `setup-go` with `go-version-file: go.mod`.
- No upgrade is available: v2.12.2 is the latest golangci-lint release.
- Verified by reproducing the reported failure and the fix in the same
  environment, forcing the older toolchain:
  - `GOTOOLCHAIN=go1.25.12 go run …/golangci-lint@v2.12.2 run ./...` → reproduces
    the error above
  - `GOTOOLCHAIN=go1.25.12 scripts/check lint` → `0 issues.`
  - `GOTOOLCHAIN=go1.25.12 scripts/check vuln` → clean

## Checks

- [x] `scripts/check` is clean — add `--db` when the change touches the store
- [x] Behavior changes come with tests — n/a: this is the check script itself;
      verified by running it under a forced older toolchain, as above

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — n/a, no wire surface changes
- [x] The change lands on every surface it belongs on — n/a, tooling only

## Design docs

- [x] Not applicable: no accepted decision changes. `docs/design/0035` says the
      checks must run clean on a contributor's machine; this makes that true
      again without altering what is checked.
- [x] Commit messages and code comments are in English
