### PR TITLE
Store a document as it was written (0044 §§2.2, 3.4, 3.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,9 +52,12 @@ last entry.
   sent straight back.
 
   - The **ETag is the hash of those bytes**, so reformatting an entry
-    moves its version. `generated.at` does not: whether the content
-    changed is still decided by comparing what the document says, not
-    how it is laid out.
+    moves its version: the file did change. What the entry *says* did
+    not, so `generated` stays with whoever the content already stood by
+    — which needs a column of its own, `content_changed_at`, since
+    `updated_at` had been standing in for it. It rides on the wire
+    beside `updated_at`. Sending byte-identical bytes is still nothing
+    happening: no row written, no revision, `Ochakai-Unchanged: true`.
   - A **recommended type keeps the writer's casing**. `type: metric` is
     stored as written rather than corrected to `Metric`; filters still
     match case-insensitively. The type is the writer's vocabulary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,29 @@ last entry.
 
 ### Changed
 
+- **BREAKING**: a document is stored as it was written (design doc
+  [0044](docs/design/0044-bundle-address-space.md) §§2.2, 3.4, 3.9). The
+  bytes a writer sends are the bytes the entry holds: frontmatter
+  comments, key order and quoting style survive a round trip, because
+  nothing re-serializes them. Only the line endings are normalized, and
+  the keys this instance owns are taken out line-wise on the way in and
+  appended on the way out — so a document served by `ochakai get` can be
+  sent straight back.
+
+  - The **ETag is the hash of those bytes**, so reformatting an entry
+    moves its version. `generated.at` does not: whether the content
+    changed is still decided by comparing what the document says, not
+    how it is laid out.
+  - A **recommended type keeps the writer's casing**. `type: metric` is
+    stored as written rather than corrected to `Metric`; filters still
+    match case-insensitively. The type is the writer's vocabulary
+    (design doc [0038](docs/design/0038-type-vocabulary-realignment.md)),
+    and rewriting it would also leave the index disagreeing with the
+    document it is derived from.
+  - The canonical rendering stays as the form ochakai writes when it
+    composes a document itself, and as what a write path falls back to
+    when a caller changes an entry's fields rather than its document.
+
 - **BREAKING**: knowledge is written as an OKF document, and `PUT` is the
   whole write surface (design doc
   [0043](docs/design/0043-document-first.md) §§3.5, 3.11).

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2241,6 +2241,17 @@ components:
             attachment endpoints, never through create/update payloads.
         created_at: { type: string, format: date-time, readOnly: true }
         updated_at: { type: string, format: date-time, readOnly: true }
+        content_changed_at:
+          type: string
+          format: date-time
+          readOnly: true
+          description: >
+            When what the entry says last changed — OKF's generated.at
+            (SPEC §5.2). Distinct from updated_at, which is when the row
+            was last written: reformatting a document (reordering its
+            frontmatter, adding a comment) changes the file and moves the
+            ETag, while what the entry says stays put (design doc 0044
+            §3.4).
     Attachment:
       type: object
       description: >

--- a/internal/domain/knowledge.go
+++ b/internal/domain/knowledge.go
@@ -564,6 +564,12 @@ type Knowledge struct {
 	Attachments []Attachment `json:"attachments,omitempty"`
 	CreatedAt   time.Time    `json:"created_at"`
 	UpdatedAt   time.Time    `json:"updated_at"`
+	// ContentChangedAt is when what the entry says last changed, which is
+	// what OKF's generated.at means (SPEC §5.2). It parted ways with
+	// UpdatedAt when the document became the writer's own bytes:
+	// reformatting an entry writes the row and moves its version without
+	// changing a word of what it says (design doc 0044 §3.4).
+	ContentChangedAt time.Time `json:"content_changed_at"`
 	// Doc is the document as it was received: the writer's own bytes,
 	// normalized for line endings and stripped of the keys this instance
 	// owns, and nothing else (design doc 0044 §2.2). It is what the store

--- a/internal/domain/knowledge.go
+++ b/internal/domain/knowledge.go
@@ -102,19 +102,6 @@ func BuiltinType(t Type) bool {
 	return false
 }
 
-// CanonicalType returns the built-in spelling of t when t names one
-// (however it was cased), else t unchanged. Write paths use it so the
-// recommended types have one spelling in storage while callers may write
-// them in any case.
-func CanonicalType(t Type) Type {
-	for _, v := range Types {
-		if EqualType(t, v) {
-			return v
-		}
-	}
-	return t
-}
-
 // ValidType reports whether t can be a knowledge type: one non-empty line,
 // no "/" so a type never reads as an address, within 128 bytes. Types are
 // the OKF vocabulary verbatim (design doc 0023) — "BigQuery Table", not a
@@ -577,11 +564,22 @@ type Knowledge struct {
 	Attachments []Attachment `json:"attachments,omitempty"`
 	CreatedAt   time.Time    `json:"created_at"`
 	UpdatedAt   time.Time    `json:"updated_at"`
-	// ContentHash is the entry's version: the SHA-256 of its canonical
-	// document (design doc 0043 §3.4), which is what the ETag carries and
-	// what If-Match is checked against. It is a hash of the content
-	// alone, so a verification, a rejection or an attachment leaves it
-	// where it was — only an edit moves it.
+	// Doc is the document as it was received: the writer's own bytes,
+	// normalized for line endings and stripped of the keys this instance
+	// owns, and nothing else (design doc 0044 §2.2). It is what the store
+	// holds and what ContentHash covers.
+	//
+	// Empty in two cases, both of which fall back to the canonical
+	// rendering: a row read for a listing, which does not select the
+	// column because the index columns beside it already answer the
+	// query, and an entry composed in memory rather than parsed from a
+	// document.
+	Doc string `json:"-"`
+	// ContentHash is the entry's version: the SHA-256 of the document as
+	// stored (design docs 0043 §3.4, 0044 §3.4), which is what the ETag
+	// carries and what If-Match is checked against. It covers the
+	// content alone, so a verification, a rejection or a file beside the
+	// entry leaves it where it was — only an edit moves it.
 	ContentHash string `json:"content_hash,omitempty"`
 }
 

--- a/internal/domain/knowledge_test.go
+++ b/internal/domain/knowledge_test.go
@@ -260,12 +260,6 @@ func TestTypeMatchingIsCaseInsensitive(t *testing.T) {
 	if !BuiltinType("attested computation") {
 		t.Error(`BuiltinType("attested computation") = false, want true`)
 	}
-	if got := CanonicalType("bigquery dataset"); got != TypeDatasets {
-		t.Errorf("CanonicalType = %q, want %q", got, TypeDatasets)
-	}
-	if got := CanonicalType("Data Contract"); got != Type("Data Contract") {
-		t.Errorf("CanonicalType must leave a free type alone, got %q", got)
-	}
 }
 
 // FoldType is the same rule in the form the store needs: one comparison

--- a/internal/okf/fuzz_test.go
+++ b/internal/okf/fuzz_test.go
@@ -101,13 +101,15 @@ func FuzzDocumentRoundTrip(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, typ, title, desc, tags, status, staleAfter, body string) {
 		k := &domain.Knowledge{
-			// Types are canonicalized on every write path (service's
+			// Every write path trims and NFC-normalizes the type (service's
 			// normalizeKeys), so this is the only form that can reach
 			// storage — and therefore the only one an export can contain.
 			// Without it the property is about entries that cannot exist:
 			// "Metric " is a valid type by ValidType, but Parse trims it
 			// and no write would have stored the trailing space either.
-			Type:  domain.CanonicalType(domain.Type(strings.TrimSpace(domain.Normalize(typ)))),
+			// The casing is *not* normalized (design doc 0044 §3.9), so
+			// whatever the fuzzer produces has to survive as written.
+			Type:  domain.Type(strings.TrimSpace(domain.Normalize(typ))),
 			Title: title, Description: desc,
 			Status: domain.Status(status), StaleAfter: staleAfter, Body: body,
 		}

--- a/internal/okf/okf.go
+++ b/internal/okf/okf.go
@@ -429,7 +429,7 @@ func render(k *domain.Knowledge, serverKeys bool) ([]byte, error) {
 		Computation: text(k.Computation),
 	}
 	if serverKeys {
-		g := actorEvent(&k.UpdatedBy, &k.UpdatedAt)
+		g := actorEvent(&k.UpdatedBy, &k.ContentChangedAt)
 		fm.Generated = &g
 		fm.CreatedBy = text(k.CreatedBy.String())
 	}

--- a/internal/okf/okf.go
+++ b/internal/okf/okf.go
@@ -377,29 +377,40 @@ func sourcesOut(in []domain.Source) []source {
 	return out
 }
 
-// Document renders one knowledge entry as an OKF concept document: the
-// canonical text the entry is stored as, plus the keys this instance
-// owns and only ever writes — generated and verified (SPEC §5.2), and
-// ochakai's created_by / rejected_* extensions. This is what an export
-// and a read hand out.
+// Document is the export form of one entry: the document as stored, plus
+// the keys this instance owns and only ever writes — generated and
+// verified (SPEC §5.2), and ochakai's created_by / rejected_* extensions.
+// This is what an export writes, what a read with Accept: text/markdown
+// returns, and what `ochakai get` hands to an editor.
+//
+// The stored document is the writer's own bytes (design doc 0044 §2.2),
+// so the keys are appended to its frontmatter rather than merged into a
+// re-serialization of it. An entry that was composed in memory instead of
+// parsed from a document has no such bytes; its canonical form is its
+// document, which is also what the fallback below writes for a row read
+// without the doc column.
 //
 // The trust family follows SPEC §5.2: generated is who the content
 // stands by and when it last changed, verified is every confirmation the
 // instance recorded. status carries OKF's three-value lifecycle and
 // nothing else — whether anyone confirmed the entry is the verified
 // key's business (§5.3, design doc 0043 §3.2).
-func Document(k *domain.Knowledge) ([]byte, error) { return render(k, true) }
+func Document(k *domain.Knowledge) ([]byte, error) {
+	if k.Doc != "" {
+		return WithServerKeys([]byte(k.Doc), k)
+	}
+	return render(k, true)
+}
 
-// Canonical renders the document without the server-owned keys: exactly
-// the text a writer authored, in one normal form. It is what the store
-// keeps and what the content hash is taken over (design doc 0043 §§3.4,
-// 3.7), and it is a pure function of the fields SameContent compares —
-// so two entries hash alike if and only if they say the same thing.
+// Canonical renders an entry in one normal form, with no server-owned key
+// in it. It is no longer the stored shape (design doc 0044 §2.2 stores
+// the bytes as received); it is the derived value the store compares to
+// decide whether a write changed what the entry says, and the form
+// ochakai writes when it composes a document itself rather than being
+// handed one.
 //
-// Excluding the server-owned keys is what makes the hash a content hash
-// rather than a row hash: verifying an entry must not change its
-// version, or every confirmation would invalidate an editor's held
-// precondition.
+// It is a pure function of the fields SameContent compares, so two
+// entries render alike if and only if they say the same thing.
 func Canonical(k *domain.Knowledge) ([]byte, error) { return render(k, false) }
 
 func render(k *domain.Knowledge, serverKeys bool) ([]byte, error) {

--- a/internal/okf/okf_test.go
+++ b/internal/okf/okf_test.go
@@ -21,22 +21,24 @@ func sample() []domain.Knowledge {
 			Type: domain.TypeInsights, ID: "insights/revenue-seasonality",
 			Title: "売上の季節性", Description: "12月は繁忙期",
 			Tags: []string{"sales"}, Status: domain.StatusStable,
-			StaleAfter:    "2026-12-31",
-			CreatedBy:     domain.Actor{Kind: "process", Name: "claude-code"},
-			UpdatedBy:     domain.Actor{Kind: "process", Name: "claude-code"},
-			Verifications: []domain.Verification{{By: domain.Actor{Kind: "human", Name: "na0"}, At: verifiedAt}},
-			Attrs:         map[string]any{"kind": "seasonality"},
-			Body:          "12月は+40%が通常。[売上](/metrics/revenue.md) の話である。",
-			UpdatedAt:     verifiedAt,
+			StaleAfter:       "2026-12-31",
+			CreatedBy:        domain.Actor{Kind: "process", Name: "claude-code"},
+			UpdatedBy:        domain.Actor{Kind: "process", Name: "claude-code"},
+			Verifications:    []domain.Verification{{By: domain.Actor{Kind: "human", Name: "na0"}, At: verifiedAt}},
+			Attrs:            map[string]any{"kind": "seasonality"},
+			Body:             "12月は+40%が通常。[売上](/metrics/revenue.md) の話である。",
+			UpdatedAt:        verifiedAt,
+			ContentChangedAt: verifiedAt,
 		},
 		{
 			Type: domain.TypeTables, ID: "tables/orders",
 			Title: "orders", Status: domain.StatusDraft,
-			CreatedBy: domain.Actor{Kind: "human", Name: "na0"},
-			UpdatedBy: domain.Actor{Kind: "human", Name: "na0", Via: "process:insightflow"},
-			Resource:  "myproject.shop.orders",
-			Attrs:     map[string]any{"model": "sales_analytics"},
-			UpdatedAt: verifiedAt,
+			CreatedBy:        domain.Actor{Kind: "human", Name: "na0"},
+			UpdatedBy:        domain.Actor{Kind: "human", Name: "na0", Via: "process:insightflow"},
+			Resource:         "myproject.shop.orders",
+			Attrs:            map[string]any{"model": "sales_analytics"},
+			UpdatedAt:        verifiedAt,
+			ContentChangedAt: verifiedAt,
 		},
 	}
 }
@@ -131,7 +133,8 @@ func TestDocumentRejectedProvenance(t *testing.T) {
 		Rejection: &domain.Rejection{
 			By: domain.Actor{Kind: "human", Name: "na0"}, At: rejectedAt, Note: "重複",
 		},
-		UpdatedAt: rejectedAt,
+		UpdatedAt:        rejectedAt,
+		ContentChangedAt: rejectedAt,
 	}
 	doc, err := Document(&k)
 	if err != nil {
@@ -173,7 +176,8 @@ func TestDocumentWritesEveryVerification(t *testing.T) {
 			{By: domain.Actor{Kind: "human", Name: "na0"}, At: first},
 			{By: domain.Actor{Kind: "human", Name: "tanaka"}, At: second},
 		},
-		UpdatedAt: second,
+		UpdatedAt:        second,
+		ContentChangedAt: second,
 	}
 	doc, err := Document(&k)
 	if err != nil {
@@ -429,8 +433,9 @@ func TestCanonicalOmitsServerOwnedKeys(t *testing.T) {
 		Verifications: []domain.Verification{
 			{By: domain.Actor{Kind: "human", Name: "na0"}, At: at},
 		},
-		Rejection: &domain.Rejection{By: domain.Actor{Kind: "human", Name: "na0"}, At: at},
-		UpdatedAt: at,
+		Rejection:        &domain.Rejection{By: domain.Actor{Kind: "human", Name: "na0"}, At: at},
+		UpdatedAt:        at,
+		ContentChangedAt: at,
 	}
 	canon, err := Canonical(&k)
 	if err != nil {

--- a/internal/okf/parse.go
+++ b/internal/okf/parse.go
@@ -268,6 +268,10 @@ func parseDoc(doc []byte) (*Doc, string, []string, error) {
 		Attester:    att,
 		Attrs:       attrs,
 		Body:        strings.TrimSpace(body),
+		// What was received, minus the keys this instance owns: the
+		// document is stored as its writer wrote it (design doc 0044
+		// §2.2), and the fields above are the index derived from it.
+		Doc: string(StripServerKeys(NormalizeText([]byte(s)))),
 	}}, fm.typ, notes, nil
 }
 

--- a/internal/okf/parse_test.go
+++ b/internal/okf/parse_test.go
@@ -342,12 +342,24 @@ func TestParseStaleAfter(t *testing.T) {
 	if _, ok := k.Attrs["stale_after"]; ok {
 		t.Errorf("stale_after is an envelope key, not an attr: %v", k.Attrs)
 	}
+	// The export is the document as written, so the writer's own bare
+	// date comes back (design doc 0044 §2.2) — while the canonical
+	// rendering, which composes a date rather than passing one through,
+	// quotes it so YAML does not type it as a timestamp on the way back
+	// in (design doc 0036 §3.7).
 	doc, err := Document(&k.Knowledge)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(doc), "stale_after: \"2026-12-31\"") {
+	if !strings.Contains(string(doc), "stale_after: 2026-12-31\n") {
 		t.Errorf("stale_after lost on export:\n%s", doc)
+	}
+	canon, err := Canonical(&k.Knowledge)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(canon), "stale_after: \"2026-12-31\"") {
+		t.Errorf("stale_after lost in the canonical form:\n%s", canon)
 	}
 
 	// A malformed date is dropped with a note — the document still imports
@@ -443,7 +455,12 @@ dialect: standard-sql
 		t.Errorf("attrs = %v, want only the producer extension key", k.Attrs)
 	}
 
-	out, err := Document(&k.Knowledge)
+	// The canonical form is what ochakai writes when it composes a
+	// document itself; it is also what the index has to be able to
+	// reproduce, so the spellings and the key order are asserted on it
+	// rather than on the export, which now hands back the writer's bytes
+	// (design doc 0044 §2.2).
+	out, err := Canonical(&k.Knowledge)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -458,7 +475,7 @@ dialect: standard-sql
 	// The frontmatter follows the spec's own family order (design doc
 	// 0036 §3.6), so a document reads the way SPEC introduces it.
 	var last int
-	for _, key := range []string{"\ntype:", "\ntags:", "\nsources:", "\nusage_window:", "\ngenerated:", "\nstatus:", "\nruntime:", "\nparameters:", "\nexecutor:", "\nattester:", "\ncreated_by:"} {
+	for _, key := range []string{"\ntype:", "\ntags:", "\nsources:", "\nusage_window:", "\nstatus:", "\nruntime:", "\nparameters:", "\nexecutor:", "\nattester:"} {
 		at := strings.Index("\n"+string(out), key)
 		if at < 0 {
 			t.Fatalf("key %q missing from the export:\n%s", key, out)

--- a/internal/okf/raw.go
+++ b/internal/okf/raw.go
@@ -1,0 +1,226 @@
+package okf
+
+import (
+	"strings"
+	"time"
+
+	"go.yaml.in/yaml/v3"
+
+	"github.com/na0fu3y/ochakai/internal/domain"
+)
+
+// This file holds the operations ochakai performs on a document *as
+// text*, rather than by parsing it into a struct and rendering it back.
+//
+// The distinction is the whole of design doc 0044 §2.2: what is stored is
+// the document as it was handed over. Re-serializing loses frontmatter
+// comments and key order, and OKF asks for neither — what SPEC §4.1 asks
+// is that unknown keys be preserved and round-tripped, which a byte-for-
+// byte store satisfies by construction. The canonical form (Canonical)
+// stays, as a derived value: it is what SameContent compares and what a
+// document ochakai composed itself is written in.
+//
+// So the only edits made to a received document are the ones that have a
+// reason: newlines are normalized, the keys this instance owns are taken
+// out on the way in and put back on the way out, and a move rewrites the
+// body. Each is line- or block-wise, and leaves every byte it is not
+// about exactly where it was.
+
+// serverOwnedKeys are the top-level frontmatter keys ochakai writes and
+// never reads back: the v0.2 trust family (SPEC §5.2), ochakai's own
+// created_by / rejected_* extensions, and the v0.1 spellings (SPEC
+// §13.1). Provenance is what this instance observed, never a document's
+// claim (design doc 0009), so they are stripped from what a writer sends
+// and injected into what a reader gets.
+var serverOwnedKeys = map[string]bool{
+	"generated": true, "verified": true, "created_by": true,
+	"rejected_by": true, "rejected_at": true,
+	"timestamp": true, "verified_by": true, "verified_at": true,
+}
+
+// NormalizeText is every change made to a received document's bytes
+// before they are stored: the BOM is dropped, CRLF becomes LF (OKF
+// specifies UTF-8 markdown but not line endings), and the text ends in
+// exactly one newline. Nothing else — no NFC normalization of the
+// content, which design doc 0022 applies to keys (ids, filenames, link
+// targets, queries) and deliberately not to what a writer wrote.
+func NormalizeText(raw []byte) []byte {
+	s := strings.TrimPrefix(string(raw), "\ufeff")
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.TrimRight(s, "\n")
+	if s == "" {
+		return nil
+	}
+	return []byte(s + "\n")
+}
+
+// splitFrontmatter cuts a normalized document into the text inside its
+// frontmatter delimiters and everything after them. ok is false when the
+// text is not an OKF document, in which case the caller leaves it alone —
+// nothing here is worth failing a write over, since a document that does
+// not parse never reaches these functions.
+func splitFrontmatter(s string) (fm, rest string, ok bool) {
+	if !strings.HasPrefix(s, "---\n") {
+		return "", s, false
+	}
+	body := s[len("---\n"):]
+	if strings.HasPrefix(body, "---\n") { // empty frontmatter
+		return "", body[len("---\n"):], true
+	}
+	end := strings.Index(body, "\n---\n")
+	if end < 0 {
+		if strings.HasSuffix(body, "\n---") {
+			return body[:end+1], "", true
+		}
+		return "", s, false
+	}
+	return body[:end+1], body[end+len("\n---\n"):], true
+}
+
+// StripServerKeys removes the server-owned keys from a document's
+// frontmatter, leaving every other byte — key order, quoting, comments,
+// blank lines — where it was. This is what a write path does with a
+// document that carries them: `ochakai get` hands out the export form, so
+// a writer must be able to send back what it received, and the values are
+// still not read (design doc 0043 §3.5).
+//
+// Which lines to remove is decided from the parsed frontmatter, not from
+// a scan for "key:" at the start of a line. YAML has more than one way to
+// write the same key — "generated :", quoted, or with the block indented
+// under it — and a spelling the scan missed would survive the strip and
+// then collide with the key WithServerKeys appends, turning the export
+// form into a document that no longer parses. That is the failure the
+// round-trip fuzz property found, and reading the key positions out of
+// the parse is what makes it unreachable: what the parser calls a key is
+// exactly what is taken out.
+func StripServerKeys(raw []byte) []byte {
+	s := string(raw)
+	fm, rest, ok := splitFrontmatter(s)
+	if !ok || fm == "" {
+		return raw
+	}
+	lines := strings.Split(strings.TrimSuffix(fm, "\n"), "\n")
+	drop := make([]bool, len(lines)+1) // 1-based, as YAML counts
+	for _, r := range ownedKeyRanges(fm, len(lines)) {
+		for i := r.from; i <= r.to; i++ {
+			drop[i] = true
+		}
+	}
+	var kept []string
+	for i, line := range lines {
+		if !drop[i+1] {
+			kept = append(kept, line)
+		}
+	}
+	if len(kept) == 0 {
+		return []byte("---\n---\n" + rest)
+	}
+	return []byte("---\n" + strings.Join(kept, "\n") + "\n---\n" + rest)
+}
+
+type lineRange struct{ from, to int }
+
+// ownedKeyRanges returns the 1-based line ranges the server-owned keys
+// occupy in a frontmatter block. A key's block runs from its own line to
+// the line before the next key's, minus any trailing blank or comment
+// lines — those introduce the key that follows, and belong to it. Unless
+// that key is going away too, in which case the blank line between them
+// separates nothing and goes with them.
+//
+// Frontmatter that does not parse as a mapping yields nothing: a document
+// that cannot be read is one no write path stores, and guessing at its
+// shape here could only damage it.
+func ownedKeyRanges(fm string, lines int) []lineRange {
+	var root yaml.Node
+	if err := yaml.Unmarshal([]byte(fm), &root); err != nil ||
+		len(root.Content) == 0 || root.Content[0].Kind != yaml.MappingNode {
+		return nil
+	}
+	pairs := root.Content[0].Content
+	all := strings.Split(fm, "\n")
+	var out []lineRange
+	for i := 0; i+1 < len(pairs); i += 2 {
+		if !serverOwnedKeys[pairs[i].Value] {
+			continue
+		}
+		r := lineRange{from: pairs[i].Line, to: lines}
+		nextOwned := false
+		if i+2 < len(pairs) {
+			r.to = pairs[i+2].Line - 1
+			nextOwned = serverOwnedKeys[pairs[i+2].Value]
+		}
+		for !nextOwned && r.to > r.from {
+			line := strings.TrimSpace(all[r.to-1])
+			if line != "" && !strings.HasPrefix(line, "#") {
+				break
+			}
+			r.to--
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+// WithServerKeys is the inverse: it appends this instance's observations
+// to a stored document's frontmatter, producing the export form — what a
+// bundle reader sees, what `ochakai get` hands to an editor, and what a
+// GET with Accept: text/markdown returns.
+//
+// They are appended rather than merged into SPEC's key families because
+// merging means re-serializing, and the point of storing the bytes is
+// that nobody re-serializes them. SPEC constrains neither key order nor
+// position (§4.1), and a reader that cares reads keys, not offsets.
+func WithServerKeys(raw []byte, k *domain.Knowledge) ([]byte, error) {
+	g := actorEvent(&k.UpdatedBy, &k.UpdatedAt)
+	own := serverKeysOnly{Generated: &g, CreatedBy: text(k.CreatedBy.String())}
+	for i := range k.Verifications {
+		v := &k.Verifications[i]
+		own.Verified = append(own.Verified, actorEvent(&v.By, &v.At))
+	}
+	if k.Rejection != nil {
+		own.RejectedBy = text(k.Rejection.By.String())
+		own.RejectedAt = text(k.Rejection.At.UTC().Format(time.RFC3339))
+	}
+	owned, err := yaml.Marshal(&own)
+	if err != nil {
+		return nil, err
+	}
+	s := string(raw)
+	fmText, rest, ok := splitFrontmatter(s)
+	if !ok {
+		// Not a document with frontmatter — nothing this instance owns
+		// has a place to go, and inventing one would corrupt the file.
+		return raw, nil
+	}
+	return []byte("---\n" + fmText + string(owned) + "---\n" + rest), nil
+}
+
+// serverKeysOnly is the frontmatter subset WithServerKeys emits. It
+// repeats the field types rather than reusing frontmatter so that adding
+// a writer-owned key to the renderer cannot silently start appending it
+// to every stored document.
+type serverKeysOnly struct {
+	Generated  *event  `yaml:"generated,omitempty"`
+	Verified   []event `yaml:"verified,omitempty"`
+	CreatedBy  text    `yaml:"created_by,omitempty"`
+	RejectedBy text    `yaml:"rejected_by,omitempty"`
+	RejectedAt text    `yaml:"rejected_at,omitempty"`
+}
+
+// ReplaceBody swaps a stored document's body, leaving its frontmatter
+// byte for byte. A move rewrites the links in a referring entry's body
+// (design doc 0021); that is a change to the body and to nothing else, so
+// it must not reformat the frontmatter of every entry that happened to
+// cite the moved one.
+func ReplaceBody(raw []byte, body string) []byte {
+	s := string(raw)
+	fm, _, ok := splitFrontmatter(s)
+	if !ok {
+		return NormalizeText([]byte(body))
+	}
+	head := "---\n" + fm + "---\n"
+	if body = strings.TrimSpace(body); body == "" {
+		return []byte(head)
+	}
+	return []byte(head + "\n" + body + "\n")
+}

--- a/internal/okf/raw.go
+++ b/internal/okf/raw.go
@@ -171,7 +171,10 @@ func ownedKeyRanges(fm string, lines int) []lineRange {
 // that nobody re-serializes them. SPEC constrains neither key order nor
 // position (§4.1), and a reader that cares reads keys, not offsets.
 func WithServerKeys(raw []byte, k *domain.Knowledge) ([]byte, error) {
-	g := actorEvent(&k.UpdatedBy, &k.UpdatedAt)
+	// generated is SPEC §5.2's "who the content stands by, and when it
+	// last meaningfully changed" — so the timestamp is the content's, not
+	// the row's (design doc 0044 §3.4).
+	g := actorEvent(&k.UpdatedBy, &k.ContentChangedAt)
 	own := serverKeysOnly{Generated: &g, CreatedBy: text(k.CreatedBy.String())}
 	for i := range k.Verifications {
 		v := &k.Verifications[i]

--- a/internal/okf/raw_test.go
+++ b/internal/okf/raw_test.go
@@ -1,0 +1,170 @@
+package okf
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/na0fu3y/ochakai/internal/domain"
+)
+
+func testEntry() *domain.Knowledge {
+	at := time.Date(2026, 7, 28, 4, 12, 0, 0, time.UTC)
+	return &domain.Knowledge{
+		CreatedBy: domain.Actor{Kind: domain.ActorHuman, Name: "tanaka@example.co.jp"},
+		UpdatedBy: domain.Actor{Kind: domain.ActorProcess, Name: "analyst@example.iam.gserviceaccount.com"},
+		UpdatedAt: at,
+		Verifications: []domain.Verification{
+			{By: domain.Actor{Kind: domain.ActorHuman, Name: "tanaka@example.co.jp"}, At: at},
+		},
+	}
+}
+
+// The document a writer sends is the document that is stored: comments,
+// key order and quoting style are the writer's, and OKF asks nothing of
+// any of them (design doc 0044 §2.2). This is the property the whole
+// change exists for, so it is asserted on a document that would look
+// nothing like the canonical rendering.
+func TestParseKeepsTheDocumentAsWritten(t *testing.T) {
+	in := "---\n" +
+		"# what this entry is for\n" +
+		"title: 'Revenue'   # single quotes, and a trailing comment\n" +
+		"type: Metric\n" + // type after title: not the canonical order
+		"tags:\n- finance\n- 売上\n" + // sequence at the parent's indentation
+		"stale_after: 2026-12-31\n" +
+		"question: どうやって売上を数えるか\n" +
+		"---\n\n本文。\n"
+	d, _, err := Parse([]byte(in))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Doc != in {
+		t.Errorf("the stored document is not what was written:\n--- want ---\n%s\n--- got ---\n%s", in, d.Doc)
+	}
+	// The index derived from it still reads every key.
+	if d.Title != "Revenue" || d.Type != domain.TypeMetrics || d.StaleAfter != "2026-12-31" ||
+		len(d.Tags) != 2 || d.Attrs["question"] != "どうやって売上を数えるか" {
+		t.Errorf("the index does not reproduce the document: %+v", d.Knowledge)
+	}
+}
+
+// Only the line endings and the trailing newline are touched.
+func TestNormalizeText(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"---\r\ntype: Metric\r\n---\r\n", "---\ntype: Metric\n---\n"},
+		{"a", "a\n"},
+		{"a\n\n\n", "a\n"},
+		{"\ufeff---\n", "---\n"},
+		{"", ""},
+	} {
+		if got := string(NormalizeText([]byte(tc.in))); got != tc.want {
+			t.Errorf("NormalizeText(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// Stripping takes out the keys this instance owns — in every block shape
+// YAML allows for them — and nothing else. A producer key whose name
+// merely starts like an owned one stays: the match is on the key, not on
+// a prefix.
+func TestStripServerKeysRemovesOnlyTheInstanceKeys(t *testing.T) {
+	in := "---\n" +
+		"type: Metric\n" +
+		"generated:\n    by: process:x\n    at: 2026-07-28T04:12:00Z\n" +
+		"verified:\n- by: human:tanaka\n  at: 2026-07-27T00:00:00Z\n" +
+		"\n" +
+		"created_by: human:tanaka\n" +
+		"generated_at_source: yes\n" +
+		"title: Revenue\n" +
+		"---\n\n本文。\n"
+	want := "---\ntype: Metric\ngenerated_at_source: yes\ntitle: Revenue\n---\n\n本文。\n"
+	if got := string(StripServerKeys([]byte(in))); got != want {
+		t.Errorf("StripServerKeys:\n--- want ---\n%s\n--- got ---\n%s", want, got)
+	}
+	// The v0.1 spellings are owned too (SPEC §13.1).
+	old := "---\ntype: Metric\ntimestamp: 2026-01-01T00:00:00Z\nverified_by: human:x\nverified_at: 2026-01-02T00:00:00Z\n---\n"
+	if got := string(StripServerKeys([]byte(old))); got != "---\ntype: Metric\n---\n" {
+		t.Errorf("v0.1 spellings survived stripping: %q", got)
+	}
+}
+
+// The export form is the stored document plus this instance's keys, and
+// taking them off again gets the stored document back — which is what
+// makes get → edit → put a round trip that changes only what the editor
+// changed.
+func TestServerKeysRoundTrip(t *testing.T) {
+	stored := "---\n# a comment\ntitle: 'Revenue'\ntype: Metric\n---\n\n本文。\n"
+	out, err := WithServerKeys([]byte(stored), testEntry())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"generated:", "verified:", "created_by: human:tanaka@example.co.jp"} {
+		if !strings.Contains(string(out), want) {
+			t.Errorf("the export form is missing %q:\n%s", want, out)
+		}
+	}
+	if got := string(StripServerKeys(out)); got != stored {
+		t.Errorf("round trip:\n--- want ---\n%s\n--- got ---\n%s", stored, got)
+	}
+	// And what comes back parses as the same entry it went in as.
+	d, _, err := Parse(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Doc != stored {
+		t.Errorf("re-parsing the export form stored %q, want %q", d.Doc, stored)
+	}
+}
+
+// A move rewrites a referring entry's body. Its frontmatter is not what
+// changed, and must come out byte for byte (design doc 0044 §2.2).
+func TestReplaceBodyLeavesFrontmatterAlone(t *testing.T) {
+	in := "---\n# a comment\ntitle: 'Revenue'\ntype: Metric\n---\n\nold body\n"
+	got := string(ReplaceBody([]byte(in), "new [body](/metrics/net.md)"))
+	want := "---\n# a comment\ntitle: 'Revenue'\ntype: Metric\n---\n\nnew [body](/metrics/net.md)\n"
+	if got != want {
+		t.Errorf("ReplaceBody:\n--- want ---\n%s\n--- got ---\n%s", want, got)
+	}
+	if got := string(ReplaceBody([]byte(in), "")); got != "---\n# a comment\ntitle: 'Revenue'\ntype: Metric\n---\n" {
+		t.Errorf("an emptied body left something behind: %q", got)
+	}
+}
+
+// The property the two operations owe each other, over whatever the
+// fuzzer can produce: appending this instance's keys and taking them off
+// again is the identity on any document ochakai stores (design doc 0035 —
+// invariants the type system cannot carry are checked from outside).
+func FuzzServerKeyRoundTrip(f *testing.F) {
+	f.Add("---\ntype: Metric\n---\n")
+	f.Add("---\ntype: Metric\ntags:\n- a\n---\n\nbody\n")
+	f.Add("---\n# comment\ntype: Metric\n\ntitle: x\n---\n")
+	f.Add("---\ntype: Metric\ngenerated: {by: x}\n---\n")
+	f.Add("---\n---\nbody only\n")
+	f.Add("not a document at all\n")
+
+	f.Fuzz(func(t *testing.T, raw string) {
+		// Only documents ochakai would have stored: the write path parses
+		// before it stores, so a text Parse refuses is not one this
+		// property is about.
+		d, _, err := Parse(NormalizeText([]byte(raw)))
+		if err != nil {
+			t.Skip()
+		}
+		stored := d.Doc
+		out, err := WithServerKeys([]byte(stored), testEntry())
+		if err != nil {
+			t.Fatalf("WithServerKeys(%q): %v", stored, err)
+		}
+		if got := string(StripServerKeys(out)); got != stored {
+			t.Errorf("round trip lost bytes:\n--- stored ---\n%q\n--- back ---\n%q", stored, got)
+		}
+		// And the export form is still a document that reads the same.
+		back, _, err := Parse(out)
+		if err != nil {
+			t.Fatalf("the export form no longer parses: %v\n%s", err, out)
+		}
+		if back.Doc != stored {
+			t.Errorf("re-parsing the export form stored %q, want %q", back.Doc, stored)
+		}
+	})
+}

--- a/internal/okf/testdata/fuzz/FuzzServerKeyRoundTrip/a243a37c4fb23162
+++ b/internal/okf/testdata/fuzz/FuzzServerKeyRoundTrip/a243a37c4fb23162
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("---\ntype: A\ngenerated :\n---")

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -497,16 +497,22 @@ func (s *Service) Move(ctx context.Context, id, newID string, actor domain.Actor
 // written. The type joined them in 0023: it is free text now, so a
 // foreign bundle can carry a non-ASCII type, and search filters compare
 // against it. Filters fold case themselves (domain.FoldType), but not
-// width or accent composition — so the type is stored NFC and trimmed,
-// leaving lower() enough to fold the column. A recommended type also
-// settles on its canonical spelling, so storage holds one casing.
+// width or accent composition — so the type is indexed NFC and trimmed,
+// leaving lower() enough to fold the column.
+//
+// The casing is not touched. A recommended type used to settle on its
+// canonical spelling here, which meant the stored entry no longer said
+// what its writer wrote — and once the document is what is stored
+// (design doc 0044 §2.2), it would also mean the index disagreeing with
+// the document it is derived from. The type is the writer's vocabulary
+// (design doc 0038); matching folds case, storage keeps it.
 //
 // Links are not normalized here because they are not read from the
 // payload at all — deriveLinks recomputes them from the body, normalizing
 // each target on the way (design doc 0024).
 func normalizeKeys(k *domain.Knowledge) {
 	k.ID = domain.Normalize(k.ID)
-	k.Type = domain.CanonicalType(domain.Type(strings.TrimSpace(domain.Normalize(string(k.Type)))))
+	k.Type = domain.Type(strings.TrimSpace(domain.Normalize(string(k.Type))))
 }
 
 // deriveLinks replaces whatever links the payload carried with the ones

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -220,13 +220,29 @@ func (s *Service) Update(ctx context.Context, k *domain.Knowledge, actor domain.
 	// replaces the document and rules on nothing (design doc 0043
 	// §§3.2-3.3). Carrying them over keeps the returned entry honest.
 	k.Verifications, k.Rejection = old.Verifications, old.Rejection
-	if k.SameContent(old) {
+	// Three outcomes, because the document being the writer's own bytes
+	// (design doc 0044 §2.2) separates two questions that used to be one.
+	//
+	// The same bytes: nothing happened. No row written, no revision, and
+	// the surface says so.
+	doc, _, err := store.StoredDocument(k)
+	if err != nil {
+		return nil, false, err
+	}
+	if doc == old.Doc {
 		return old, false, nil
 	}
-	// Past this point the content really changes, so the caller is who the
-	// entry now stands by — OKF's generated.by (design doc 0036 §3.3).
-	// Unchanged writes return above and leave the old one in place.
-	k.UpdatedBy = actor
+	// Different bytes saying the same thing — a reformat, a comment, a
+	// reordered frontmatter. The file changed, so it is written and its
+	// version moves; what the entry says did not, so generated stays with
+	// whoever the content already stood by (design doc 0044 §3.4).
+	if k.SameContent(old) {
+		k.UpdatedBy, k.ContentChangedAt = old.UpdatedBy, old.ContentChangedAt
+	} else {
+		// Past this point the content really changes, so the caller is who
+		// the entry now stands by — OKF's generated (design doc 0036 §3.3).
+		k.UpdatedBy, k.ContentChangedAt = actor, store.NowStored()
+	}
 	// Pass the precondition through so the write is also guarded against a
 	// concurrent update landing between the Get above and the write.
 	if err := s.Store.Update(ctx, k, actor, ifMatch); err != nil {

--- a/internal/service/service_integration_test.go
+++ b/internal/service/service_integration_test.go
@@ -14,8 +14,104 @@ import (
 
 	"github.com/na0fu3y/ochakai/internal/domain"
 	"github.com/na0fu3y/ochakai/internal/embed"
+	"github.com/na0fu3y/ochakai/internal/okf"
 	"github.com/na0fu3y/ochakai/internal/store"
 )
+
+// A document that is reformatted but says the same thing is a change to
+// the file and not to the entry, and design doc 0044 §3.4 splits the two:
+// the bytes are stored and the version moves, while generated — the actor
+// and the timestamp — stays with whoever the content already stood by.
+// Byte-identical bytes are still nothing happening at all.
+func TestReformattingIsAChangeToTheFileOnlyIntegration(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := store.New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	svc := &Service{Store: s, Log: slog.New(slog.DiscardHandler)}
+	author := domain.Actor{Kind: domain.ActorHuman, Name: "author"}
+	editor := domain.Actor{Kind: domain.ActorHuman, Name: "editor"}
+	id := fmt.Sprintf("svcit-reformat-%d", time.Now().UnixNano())
+
+	put := func(doc string, actor domain.Actor) (*domain.Knowledge, bool) {
+		t.Helper()
+		d, _, err := okf.Parse([]byte(doc))
+		if err != nil {
+			t.Fatal(err)
+		}
+		d.ID = id
+		out, _, changed, err := svc.Put(ctx, &d.Knowledge, actor, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return out, changed
+	}
+
+	const written = "---\ntype: Metric\ntitle: 売上\nstatus: draft\n---\n\n受注合計。\n"
+	// The same entry, laid out differently: a comment, and the title after
+	// the status. Nothing it says has changed.
+	const reformatted = "---\ntype: Metric\n# 定義は財務の合意による\nstatus: draft\ntitle: 売上\n---\n\n受注合計。\n"
+
+	put(written, author)
+	created, err := svc.Get(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, changed := put(reformatted, editor)
+	if !changed {
+		t.Error("a reformatted document reported changed=false; the file did change")
+	}
+	if got.ContentHash == created.ContentHash {
+		t.Error("a reformatted document left the version where it was")
+	}
+	if got.Doc != reformatted {
+		t.Errorf("the reformatted bytes were not what got stored:\n%q", got.Doc)
+	}
+	if !got.ContentChangedAt.Equal(created.ContentChangedAt) {
+		t.Errorf("reformatting moved generated.at: %v -> %v", created.ContentChangedAt, got.ContentChangedAt)
+	}
+	if got.UpdatedBy != created.UpdatedBy {
+		t.Errorf("reformatting reassigned generated.by: %v -> %v", created.UpdatedBy, got.UpdatedBy)
+	}
+
+	// The same bytes again: nothing happened.
+	before, err := svc.Revisions(ctx, id, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, changed := put(reformatted, editor); changed {
+		t.Error("an identical document reported changed=true")
+	}
+	after, err := svc.Revisions(ctx, id, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after) != len(before) {
+		t.Errorf("an identical document wrote a revision: %d -> %d", len(before), len(after))
+	}
+
+	// And a real edit moves both.
+	edited, changed := put("---\ntype: Metric\ntitle: 売上\nstatus: draft\n---\n\n受注合計。返品は含まない。\n", editor)
+	if !changed {
+		t.Fatal("an edit reported changed=false")
+	}
+	if edited.ContentChangedAt.Equal(created.ContentChangedAt) {
+		t.Error("an edit left generated.at where it was")
+	}
+	if edited.UpdatedBy != editor {
+		t.Errorf("generated.by = %v, want the editor", edited.UpdatedBy)
+	}
+}
 
 // TestUpdateNoOpIntegration exercises the no-op update path against a real
 // PostgreSQL: a content-identical update must write nothing — no revision,

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -81,12 +81,16 @@ func (e *ExportSnapshot) IndexRows(ctx context.Context) ([]domain.Knowledge, err
 // memory at once.
 func (e *ExportSnapshot) ListByIDs(ctx context.Context, ids []string) ([]domain.Knowledge, error) {
 	rows, err := e.tx.Query(ctx,
-		`SELECT `+knowledgeSelect+` FROM knowledge
+		`SELECT `+knowledgeSelectDoc+` FROM knowledge
 		 WHERE deleted_at IS NULL AND id = ANY($1) ORDER BY id`, ids)
 	if err != nil {
 		return nil, err
 	}
-	return pgx.CollectRows(rows, scanKnowledge)
+	// With the document: an export writes what the entry is stored as,
+	// plus this instance's own keys (design doc 0044 §2.2). Composing it
+	// from the index columns instead would hand back a reformatted copy
+	// of what the writer wrote.
+	return pgx.CollectRows(rows, scanKnowledgeDoc)
 }
 
 // AttachmentMeta returns every live entry's attachment metadata, ordered

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -140,7 +140,10 @@ func (s *Store) backfillEntryDocuments(ctx context.Context) error {
 			return nil
 		}
 		for i := range batch {
-			doc, hash, err := canonicalDoc(&batch[i])
+			// The row has no received bytes — it predates the document
+			// being what is stored — so storedDoc composes the canonical
+			// form, which is the document this entry has.
+			doc, hash, err := storedDoc(&batch[i])
 			if err != nil {
 				// A row the renderer cannot read is left with an empty
 				// doc rather than a wrong one, and named so somebody can

--- a/internal/store/migrations/0025_content_changed_at.sql
+++ b/internal/store/migrations/0025_content_changed_at.sql
@@ -1,0 +1,23 @@
+-- generated.at gets a column of its own (design doc 0044 §3.4).
+--
+-- updated_at has been standing in for it. That worked while the stored
+-- document was the canonical rendering: a write that changed no content
+-- rendered the same bytes, so it was refused as a no-op and updated_at
+-- could not move without the content moving with it.
+--
+-- Storing the document as received (0044 §2.2) breaks that coincidence.
+-- Reformatting an entry — reordering its frontmatter, adding a comment —
+-- changes the file and therefore its version, while what the entry says
+-- is exactly what it said before. SPEC §5.2 defines generated.at as the
+-- last meaningful change, so the two need separate columns: updated_at
+-- is when the row was last written, content_changed_at is when what it
+-- says last changed.
+--
+-- The backfill is updated_at, which is what the column meant until now.
+ALTER TABLE knowledge ADD COLUMN IF NOT EXISTS content_changed_at timestamptz;
+
+UPDATE knowledge SET content_changed_at = updated_at WHERE content_changed_at IS NULL;
+
+ALTER TABLE knowledge
+    ALTER COLUMN content_changed_at SET DEFAULT now(),
+    ALTER COLUMN content_changed_at SET NOT NULL;

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -180,7 +180,7 @@ const knowledgeCols = `type, id, title, description, resource, tags, status, sta
 	sources, usage_window, runtime, parameters, computation, executor, attester,
 	created_by_kind, created_by_name, created_by_via,
 	updated_by_kind, updated_by_name, updated_by_via,
-	links, attrs, body, created_at, updated_at, doc, content_hash`
+	links, attrs, body, created_at, updated_at, content_changed_at, doc, content_hash`
 
 // ledgerCols is the two instance ledgers — verifications and the
 // rejection — read as JSON beside the entry's own columns (design doc
@@ -325,7 +325,7 @@ func knowledgeDestFor(k *domain.Knowledge, withDoc bool) (dests []any, finish fu
 		&sources, &usageWindow, &k.Runtime, &parameters, &k.Computation, &executor, &attester,
 		&k.CreatedBy.Kind, &k.CreatedBy.Name, &k.CreatedBy.Via,
 		&k.UpdatedBy.Kind, &k.UpdatedBy.Name, &k.UpdatedBy.Via,
-		&links, &attrs, &k.Body, &k.CreatedAt, &k.UpdatedAt}
+		&links, &attrs, &k.Body, &k.CreatedAt, &k.UpdatedAt, &k.ContentChangedAt}
 	if withDoc {
 		dests = append(dests, &k.Doc)
 	}
@@ -380,6 +380,13 @@ func storedDoc(k *domain.Knowledge) (doc, hash string, err error) {
 	sum := sha256.Sum256(b)
 	return string(b), hex.EncodeToString(sum[:]), nil
 }
+
+// StoredDocument is what a write of k would put in the row: the document
+// as received when it still says what k says, and the canonical
+// rendering otherwise (storedDoc). The service compares it with the
+// stored one to tell a write that changes nothing at all from a write
+// that changes only the layout (design doc 0044 §3.4).
+func StoredDocument(k *domain.Knowledge) (doc, hash string, err error) { return storedDoc(k) }
 
 // documentSays reports whether doc still says what k says. A caller that
 // edited the entry's fields without editing the document it came from is
@@ -543,7 +550,7 @@ func (s *Store) ListLinkingTo(ctx context.Context, id string, limit int) ([]doma
 // either way.
 func (s *Store) Create(ctx context.Context, k *domain.Knowledge, keepCuratedTombstones bool) error {
 	now := NowStored()
-	k.CreatedAt, k.UpdatedAt = now, now
+	k.CreatedAt, k.UpdatedAt, k.ContentChangedAt = now, now, now
 	// Reviving a tombstone overwrites its status in place. When the caller
 	// must not replace a human ruling (design doc 0015 §3.1), the revival
 	// carries the same restriction as the UPDATE itself, so a curation
@@ -572,7 +579,7 @@ func (s *Store) Create(ctx context.Context, k *domain.Knowledge, keepCuratedTomb
 			j.sources, j.usageWindow, k.Runtime, j.parameters, k.Computation, j.executor, j.attester,
 			k.CreatedBy.Kind, k.CreatedBy.Name, k.CreatedBy.Via,
 			k.UpdatedBy.Kind, k.UpdatedBy.Name, k.UpdatedBy.Via,
-			j.links, j.attrs, k.Body, k.CreatedAt, k.UpdatedAt, doc, hash,
+			j.links, j.attrs, k.Body, k.CreatedAt, k.UpdatedAt, k.ContentChangedAt, doc, hash,
 		}
 		tag, err := tx.Exec(ctx, `INSERT INTO knowledge (`+knowledgeCols+`)
 			VALUES (`+knowledgeParams+`)
@@ -616,6 +623,12 @@ func (s *Store) Create(ctx context.Context, k *domain.Knowledge, keepCuratedTomb
 // the prior last-write-wins behavior for callers that do not opt in.
 func (s *Store) Update(ctx context.Context, k *domain.Knowledge, actor domain.Actor, ifMatch *string) error {
 	k.UpdatedAt = NowStored()
+	// The caller decides whether this write changed what the entry says;
+	// only then does generated.at move (design doc 0044 §3.4). A write
+	// that reformats the document leaves it where it was.
+	if k.ContentChangedAt.IsZero() {
+		k.ContentChangedAt = k.UpdatedAt
+	}
 	return s.withTx(ctx, func(tx pgx.Tx) error {
 		j, err := marshalJSONFields(k)
 		if err != nil {
@@ -634,7 +647,7 @@ func (s *Store) Update(ctx context.Context, k *domain.Knowledge, actor domain.Ac
 		args := []any{k.ID, k.Type, k.Title, k.Description, k.Resource, k.Tags, k.Status, k.StatusNote, staleAfter,
 			j.sources, j.usageWindow, k.Runtime, j.parameters, k.Computation, j.executor, j.attester,
 			k.UpdatedBy.Kind, k.UpdatedBy.Name, k.UpdatedBy.Via,
-			j.links, j.attrs, k.Body, k.UpdatedAt, doc, hash}
+			j.links, j.attrs, k.Body, k.UpdatedAt, k.ContentChangedAt, doc, hash}
 		if ifMatch != nil {
 			args = append(args, *ifMatch)
 			cond = fmt.Sprintf(" AND content_hash=$%d", len(args))
@@ -643,7 +656,8 @@ func (s *Store) Update(ctx context.Context, k *domain.Knowledge, actor domain.Ac
 			type=$2, title=$3, description=$4, resource=$5, tags=$6, status=$7, status_note=$8, stale_after=$9,
 			sources=$10, usage_window=$11, runtime=$12, parameters=$13, computation=$14, executor=$15, attester=$16,
 			updated_by_kind=$17, updated_by_name=$18, updated_by_via=$19,
-			links=$20, attrs=$21, body=$22, updated_at=$23, doc=$24, content_hash=$25
+			links=$20, attrs=$21, body=$22, updated_at=$23, content_changed_at=$24,
+			doc=$25, content_hash=$26
 			WHERE id=$1 AND deleted_at IS NULL`+cond, args...)
 		if err != nil {
 			return err
@@ -917,6 +931,7 @@ func (s *Store) Move(ctx context.Context, oldID, newID string, actor domain.Acto
 		return nil, err
 	}
 	k.UpdatedAt = NowStored()
+	k.ContentChangedAt = k.UpdatedAt
 	// A move rewrites the entry's own relative links and every referrer's
 	// body, so the mover is who the content now stands by: generated.by
 	// in an export (design doc 0036 §3.3).
@@ -945,7 +960,7 @@ func (s *Store) Move(ctx context.Context, oldID, newID string, actor domain.Acto
 		// exactly as in SoftDelete: the Get above ran outside this
 		// transaction.
 		tag, err := tx.Exec(ctx,
-			`UPDATE knowledge SET id=$2, updated_at=$3,
+			`UPDATE knowledge SET id=$2, updated_at=$3, content_changed_at=$3,
 			 updated_by_kind=$4, updated_by_name=$5, updated_by_via=$6
 			 WHERE id=$1 AND deleted_at IS NULL`,
 			oldID, newID, k.UpdatedAt, actor.Kind, actor.Name, actor.Via)
@@ -1091,6 +1106,10 @@ func (s *Store) rewriteReferences(ctx context.Context, tx pgx.Tx, oldID string, 
 		} else {
 			r.UpdatedAt = now
 		}
+		// A repaired link is a change to what the entry says, so
+		// generated moves with it — both halves of it, the actor above
+		// and the timestamp here (design doc 0044 §3.4).
+		r.ContentChangedAt = r.UpdatedAt
 		// deleted_at IS NULL restates what the locked read already
 		// established, so the statement does not depend on the reader
 		// having filtered: rewriting a tombstone would plant a repaired
@@ -1108,9 +1127,10 @@ func (s *Store) rewriteReferences(ctx context.Context, tx pgx.Tx, oldID string, 
 		tag, err := tx.Exec(ctx,
 			`UPDATE knowledge SET links=$2, attrs=$3, body=$4, updated_at=$5,
 			 updated_by_kind=$6, updated_by_name=$7, updated_by_via=$8,
-			 doc=$9, content_hash=$10
+			 doc=$9, content_hash=$10, content_changed_at=$11
 			 WHERE id=$1 AND deleted_at IS NULL`,
-			r.ID, j.links, j.attrs, r.Body, r.UpdatedAt, actor.Kind, actor.Name, actor.Via, doc, hash)
+			r.ID, j.links, j.attrs, r.Body, r.UpdatedAt, actor.Kind, actor.Name, actor.Via, doc, hash,
+			r.ContentChangedAt)
 		if err != nil {
 			return err
 		}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -231,6 +231,10 @@ var (
 	// entry's columns (minus the stored document) plus its ledgers.
 	knowledgeSelect  = withoutDoc(knowledgeCols) + ", " + ledgerCols("knowledge")
 	knowledgeSelectK = withoutDoc(knowledgeColsK) + ", " + ledgerCols("k")
+	// knowledgeSelectDoc is the same read with the stored document, for
+	// the paths that hand one out (design doc 0044 §2.2): a single get,
+	// an export, and the move that rewrites a body in place.
+	knowledgeSelectDoc = knowledgeCols + ", " + ledgerCols("knowledge")
 )
 
 // notCurated is Knowledge.Curated() as a SQL predicate, for the guards
@@ -298,7 +302,21 @@ var (
 // k, plus a finish func that decodes the JSON columns and nullable actors
 // after the scan. Row shapes with trailing columns (score, usage totals)
 // append their own destinations — the column list lives here once.
+//
+// doc is included only for withDoc: a listing does not select the stored
+// document (withoutDoc), because the index columns beside it already
+// answer the query and carrying the document per row would double every
+// result for nothing. The reads that hand out a document — one entry, an
+// export, a move about to rewrite a body — do.
 func knowledgeDest(k *domain.Knowledge) (dests []any, finish func() error) {
+	return knowledgeDestFor(k, false)
+}
+
+func knowledgeDestWithDoc(k *domain.Knowledge) (dests []any, finish func() error) {
+	return knowledgeDestFor(k, true)
+}
+
+func knowledgeDestFor(k *domain.Knowledge, withDoc bool) (dests []any, finish func() error) {
 	var staleAfter *time.Time
 	var links, attrs []byte
 	var sources, usageWindow, parameters, executor, attester []byte
@@ -307,8 +325,11 @@ func knowledgeDest(k *domain.Knowledge) (dests []any, finish func() error) {
 		&sources, &usageWindow, &k.Runtime, &parameters, &k.Computation, &executor, &attester,
 		&k.CreatedBy.Kind, &k.CreatedBy.Name, &k.CreatedBy.Via,
 		&k.UpdatedBy.Kind, &k.UpdatedBy.Name, &k.UpdatedBy.Via,
-		&links, &attrs, &k.Body, &k.CreatedAt, &k.UpdatedAt, &k.ContentHash,
-		&verifications, &rejection}
+		&links, &attrs, &k.Body, &k.CreatedAt, &k.UpdatedAt}
+	if withDoc {
+		dests = append(dests, &k.Doc)
+	}
+	dests = append(dests, &k.ContentHash, &verifications, &rejection)
 	finish = func() error {
 		if staleAfter != nil {
 			k.StaleAfter = staleAfter.UTC().Format(domain.StaleAfterLayout)
@@ -337,21 +358,55 @@ func knowledgeDest(k *domain.Knowledge) (dests []any, finish func() error) {
 	return dests, finish
 }
 
-// canonicalDoc renders the entry's stored form and its version: the
-// canonical OKF document with no server-owned key in it, and the SHA-256
-// of exactly those bytes (design doc 0043 §§3.4, 3.7).
+// storedDoc returns what the row holds as the entry's document, and the
+// entry's version: the document as received, and the SHA-256 of exactly
+// those bytes (design doc 0044 §§2.2, 3.4).
 //
-// The hash is taken over the canonical text rather than over the struct
-// so that the version means "what this entry says", not "how this
-// release happened to serialize it" — and so that a ruling, which writes
-// no key into the canonical form, cannot move it.
-func canonicalDoc(k *domain.Knowledge) (doc, hash string, err error) {
-	b, err := okf.Canonical(k)
-	if err != nil {
-		return "", "", err
+// A write that came from a document carries it. One that did not — an
+// entry composed in memory — is written in the canonical form, which is
+// the only document it has. Either way the hash covers what is stored, so
+// the version means "these bytes", and neither a ruling nor a
+// verification, which write no bytes here, can move it.
+func storedDoc(k *domain.Knowledge) (doc, hash string, err error) {
+	b := []byte(k.Doc)
+	if len(b) > 0 && !documentSays(b, k) {
+		b = nil
+	}
+	if len(b) == 0 {
+		if b, err = okf.Canonical(k); err != nil {
+			return "", "", err
+		}
 	}
 	sum := sha256.Sum256(b)
 	return string(b), hex.EncodeToString(sum[:]), nil
+}
+
+// documentSays reports whether doc still says what k says. A caller that
+// edited the entry's fields without editing the document it came from is
+// not asking for those bytes to be stored — storing them anyway would
+// leave the row's document contradicting the index derived from it, and
+// the document is what wins that argument (design doc 0043 §3.1). So the
+// document is dropped and the canonical form composed instead.
+//
+// This is the guard that lets every write path share one rule: hand over
+// a document and it is stored verbatim; change fields and what is stored
+// is what the fields say.
+func documentSays(doc []byte, k *domain.Knowledge) bool {
+	d, _, err := okf.Parse(doc)
+	if err != nil {
+		return false
+	}
+	// A document carries neither the entry's address — the path is
+	// (design doc 0017) — nor its links, which are derived from the body
+	// it does carry (design doc 0024).
+	d.ID, d.Links = k.ID, k.Links
+	// Nor is a document that names no status disagreeing about one: it is
+	// saying nothing, and the write path still fills a default in until
+	// the read projection applies OKF's (design doc 0044 §3.9).
+	if d.Status == "" {
+		d.Status = k.Status
+	}
+	return d.SameContent(k)
 }
 
 // staleAfterArg turns the entry's stale_after into a date argument: NULL
@@ -372,6 +427,17 @@ func staleAfterArg(s string) (*time.Time, error) {
 func scanKnowledge(row pgx.CollectableRow) (domain.Knowledge, error) {
 	var k domain.Knowledge
 	dests, finish := knowledgeDest(&k)
+	if err := row.Scan(dests...); err != nil {
+		return k, err
+	}
+	return k, finish()
+}
+
+// scanKnowledgeDoc scans a row selected with knowledgeSelectDoc: the same
+// entry, with the document it is stored as.
+func scanKnowledgeDoc(row pgx.CollectableRow) (domain.Knowledge, error) {
+	var k domain.Knowledge
+	dests, finish := knowledgeDestWithDoc(&k)
 	if err := row.Scan(dests...); err != nil {
 		return k, err
 	}
@@ -428,11 +494,11 @@ func (s *Store) getOneFrom(ctx context.Context, q querier, id string, deleted bo
 		cond = "deleted_at IS NOT NULL"
 	}
 	rows, err := q.Query(ctx,
-		`SELECT `+knowledgeSelect+` FROM knowledge WHERE id = $1 AND `+cond, id)
+		`SELECT `+knowledgeSelectDoc+` FROM knowledge WHERE id = $1 AND `+cond, id)
 	if err != nil {
 		return nil, err
 	}
-	k, err := pgx.CollectExactlyOneRow(rows, scanKnowledge)
+	k, err := pgx.CollectExactlyOneRow(rows, scanKnowledgeDoc)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, ErrNotFound
 	}
@@ -496,7 +562,7 @@ func (s *Store) Create(ctx context.Context, k *domain.Knowledge, keepCuratedTomb
 		if err != nil {
 			return err
 		}
-		doc, hash, err := canonicalDoc(k)
+		doc, hash, err := storedDoc(k)
 		if err != nil {
 			return err
 		}
@@ -559,7 +625,7 @@ func (s *Store) Update(ctx context.Context, k *domain.Knowledge, actor domain.Ac
 		if err != nil {
 			return err
 		}
-		doc, hash, err := canonicalDoc(k)
+		doc, hash, err := storedDoc(k)
 		if err != nil {
 			return err
 		}
@@ -958,7 +1024,7 @@ func (s *Store) rewriteReferences(ctx context.Context, tx pgx.Tx, oldID string, 
 	// was lost. ORDER BY id gives concurrent moves one lock order, so they
 	// queue instead of deadlocking.
 	rows, err := tx.Query(ctx,
-		`SELECT `+knowledgeSelect+` FROM knowledge
+		`SELECT `+knowledgeSelectDoc+` FROM knowledge
 		 WHERE deleted_at IS NULL AND (links @> $1 OR links @> $2 OR attrs->>'model' = $3 OR id = $4)
 		 ORDER BY id FOR UPDATE`,
 		fmt.Sprintf(`[{"target": %q}]`, oldID),
@@ -967,7 +1033,10 @@ func (s *Store) rewriteReferences(ctx context.Context, tx pgx.Tx, oldID string, 
 	if err != nil {
 		return err
 	}
-	referrers, err := pgx.CollectRows(rows, scanKnowledge)
+	// With the document: the rewrite below replaces the body inside the
+	// stored bytes, leaving the frontmatter of every entry that merely
+	// cited the moved one exactly as its writer left it.
+	referrers, err := pgx.CollectRows(rows, scanKnowledgeDoc)
 	if err != nil {
 		return err
 	}
@@ -1001,6 +1070,7 @@ func (s *Store) rewriteReferences(ctx context.Context, tx pgx.Tx, oldID string, 
 			continue // matched the links index but nothing to repair
 		}
 		r.Body = body
+		r.Doc = string(okf.ReplaceBody([]byte(r.Doc), body))
 		r.Links = domain.LinksFromBody(r.ID, r.Body)
 		// The rewrite is a content change by the mover, and it is recorded
 		// as one ("update" revision below), so the entry's generated.by
@@ -1026,10 +1096,11 @@ func (s *Store) rewriteReferences(ctx context.Context, tx pgx.Tx, oldID string, 
 		// having filtered: rewriting a tombstone would plant a repaired
 		// body and a revision on an entry nobody can see, to resurface
 		// whenever someone revives it.
-		// The stored document and its hash are recomposed with the body:
-		// they are what the entry says, and the index columns beside them
-		// are derived from the same value (design doc 0043 §3.1).
-		doc, hash, err := canonicalDoc(r)
+		// The stored document and its hash move with the body: the body
+		// is swapped inside the bytes the entry is stored as, and the
+		// index columns beside them are derived from the same value
+		// (design docs 0043 §3.1, 0044 §2.2).
+		doc, hash, err := storedDoc(r)
 		if err != nil {
 			return err
 		}
@@ -1052,6 +1123,11 @@ func (s *Store) rewriteReferences(ctx context.Context, tx pgx.Tx, oldID string, 
 			moved.Body = r.Body
 			moved.Links = r.Links
 			moved.Attrs = r.Attrs
+			// And the document the body was rewritten inside, with the
+			// version that goes with it: the "move" revision the caller
+			// records is written from this entry (design doc 0044 §2.2).
+			moved.Doc = r.Doc
+			moved.ContentHash = r.ContentHash
 			continue
 		}
 		if err := s.addRevision(ctx, tx, r, "update", actor); err != nil {

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -2637,7 +2637,13 @@ func TestIntegrationStoredDocumentMatchesTheIndex(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rendered, hash, err := canonicalDoc(read)
+	// From the index columns alone: the entry was written as a struct, so
+	// what is stored is the canonical rendering, and dropping the doc the
+	// read carried is what keeps this a check on the index rather than a
+	// comparison of the column with itself.
+	fromIndex := *read
+	fromIndex.Doc = ""
+	rendered, hash, err := storedDoc(&fromIndex)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Second in the 0044 stack. **Base is #257** (the design doc), so review that first; this PR's diff is the code alone.

## What changes

0043 stored the *canonical rendering* of what a writer sent — parse, then re-serialize. That costs the frontmatter's comments and its key order, and OKF asks for neither: SPEC §4.1 asks that unknown keys be **preserved and round-tripped**, which storing the bytes satisfies by construction.

So the received bytes become what is stored. The only edits made to a document are the ones with a reason:

- **newlines** — CRLF → LF, one trailing newline (OKF fixes UTF-8 markdown, not line endings);
- **the keys this instance owns** — `generated`, `verified`, `created_by`, `rejected_*` and the v0.1 spellings are stripped on the way in and appended on the way out, so a document `ochakai get` served can be sent straight back (design doc 0043 §3.5's rule, now a text operation rather than a re-render).

`Canonical` stays, as a **derived** value: it is what `SameContent` compares and the form ochakai writes when it composes a document itself.

## The two things worth reviewing closely

**1. The strip reads key positions out of the parse, not out of a line scan.** The first version scanned for `key:` at column 0. The round-trip fuzz property found `generated :` within seconds — a spelling YAML accepts, a scan misses, and which then *collides* with the key `WithServerKeys` appends, producing an export that no longer parses. Key positions now come from `yaml.Node`, so what the parser calls a key is exactly what is removed. That input is a permanent seed (`testdata/fuzz/FuzzServerKeyRoundTrip`), per CONTRIBUTING.

**2. `storedDoc` drops a document that no longer says what the entry says.** A caller that edits fields rather than the document — a move rewriting a link inside a body, an entry composed in memory, a test — would otherwise store bytes contradicting the index derived from them. One rule covers every write path: hand over a document and it is stored verbatim; change fields and what is stored is what the fields say. The move path does neither and instead swaps the body *inside* the stored bytes (`ReplaceBody`), so an entry that merely cited the moved one keeps its own frontmatter byte for byte.

## Behavior

- **ETag is the hash of the stored bytes**, so reformatting moves the version. `generated.at` does not — whether the content changed is still `SameContent`.
- **A recommended type keeps the writer's casing** (§3.9): `type: metric` stays `metric`. Filters still fold case. Rewriting it would leave the index disagreeing with the document, which is the same defect as re-serializing.
- Reads that hand out a document (one entry, an export, a move about to rewrite a body) now select the `doc` column; listings still do not.

## Not in this PR

The rest of §3.9 — not inventing a `status` the writer omitted — needs the read projection to apply OKF's default, and lands with the trust tier (§3.10) next in the stack. Until then the write path still fills one in, and `documentSays` treats a document that is silent on status as not disagreeing about it.

## Checks

`scripts/check --db` passes (core, lint, vuln, and the store integration tests against a throwaway PostgreSQL). `FuzzServerKeyRoundTrip` ran 3.6M executions clean after the fix.

Unrelated note for the maintainer: a `ochakai-test-pg` container left running from an earlier session had a half-migrated schema, which made every store integration test fail at `0022_actor_process.sql`. Resetting the schema fixed it — nothing on main is broken, but it is a confusing failure to hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)