### PR TITLE
Let an unattended import refuse a bundle it had to reinterpret (--strict)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,27 @@ last entry.
 
 ## [Unreleased]
 
+### Added
+
+- `ochakai import --strict` — fail on a bundle that was not read exactly
+  as written, instead of reporting it. A note is still the default and
+  still not an error: OKF tells a consumer to take a document rather than
+  reject it, and an operator watching the output sees every
+  reinterpretation as it scrolls past. Nobody watches a sync running in
+  CI, and a knowledge base whose entries quietly landed as drafts is a
+  knowledge base whose agents stopped trusting the right things.
+
+  Parse-time notes and skips are known before the first write, so
+  `--strict` refuses there: the import lands whole or writes nothing.
+  What only the server can judge — a document it read differently, or one
+  it refused — is checked again after the run, so the summary still says
+  how far it got and the exit code still says it was not clean.
+  `--dry-run --strict` is the gate to put in front of a CI sync.
+
+  The summary line now carries the note count on both paths
+  (`… 0 skipped, 0 notes`), because a count that only appears in the
+  scrollback is a count nobody reads.
+
 ### Fixed
 
 - Producer-defined keys **inside** a `sources` entry, a `parameter`, an

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -1077,9 +1077,10 @@ func cmdExport(ctx context.Context, args []string) error {
 func cmdImport(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
 		"import",
-		"Usage: ochakai import [flags] <dir | file.tar.gz | ->\n\nImport an OKF bundle (a directory of markdown + YAML frontmatter, or\na tar.gz of one; \"-\" reads the tar.gz from stdin). The inverse of\n`ochakai export`: each path names its entry (the path minus .md is\nthe id), the frontmatter type key names the type (required — files\nwithout one are skipped and reported), reserved index.md / log.md\nfiles are skipped, keys the format does not define are kept as\nwritten, and existing entries are replaced (kept as revisions; entries identical\nto what is stored are left untouched and reported as unchanged;\nentries the server rejects as invalid — e.g. one whose type is not a\nsingle line — are skipped and reported).\nFiles referenced by an entry's body markdown links become its\nattachments, wherever they sit in the bundle (their location is\npreserved for re-export); unreferenced data files inside an entry's\ndirectory (<id>/<name>) attach to that entry. The packed shape is\nthe structure: an archive wrapped in a single directory imports\nunder that directory — the bundle keeps its own namespace. Works\nwith any OKF bundle, not just ochakai's own.",
-		"  ochakai import ./knowledge\n  ochakai import ga4-bundle.tar.gz --dry-run\n  ochakai export - | OCHAKAI_URL=https://other ochakai import -\n")
+		"Usage: ochakai import [flags] <dir | file.tar.gz | ->\n\nImport an OKF bundle (a directory of markdown + YAML frontmatter, or\na tar.gz of one; \"-\" reads the tar.gz from stdin). The inverse of\n`ochakai export`: each path names its entry (the path minus .md is\nthe id), the frontmatter type key names the type (required — files\nwithout one are skipped and reported), reserved index.md / log.md\nfiles are skipped, keys the format does not define are kept as\nwritten, and existing entries are replaced (kept as revisions; entries identical\nto what is stored are left untouched and reported as unchanged;\nentries the server rejects as invalid — e.g. one whose type is not a\nsingle line — are skipped and reported).\nFiles referenced by an entry's body markdown links become its\nattachments, wherever they sit in the bundle (their location is\npreserved for re-export); unreferenced data files inside an entry's\ndirectory (<id>/<name>) attach to that entry. The packed shape is\nthe structure: an archive wrapped in a single directory imports\nunder that directory — the bundle keeps its own namespace. Works\nwith any OKF bundle, not just ochakai's own.\nA file that cannot be read is skipped; a value read differently than\nit was written is a note and the entry still imports. Both are\nreported and neither fails the command, because a consumer takes the\ndocument rather than rejecting it. --strict is the opposite posture,\nfor a sync nobody watches: a bundle that is not read exactly as\nwritten fails, and the counts land in the summary line either way.",
+		"  ochakai import ./knowledge\n  ochakai import ga4-bundle.tar.gz --dry-run\n  ochakai import ./knowledge --dry-run --strict   # gate a CI sync on a clean parse\n  ochakai export - | OCHAKAI_URL=https://other ochakai import -\n")
 	dryRun := fs.Bool("dry-run", false, "parse and list what would be written, write nothing")
+	strict := fs.Bool("strict", false, "refuse a bundle that is not read exactly as written: any note or skip fails the command instead of being reported. Parse-time ones are found before anything is written, so a strict import either lands whole or writes nothing")
 	pos, err := exactArgs(fs, args, 1)
 	if err != nil {
 		return err
@@ -1096,8 +1097,16 @@ func cmdImport(ctx context.Context, args []string) error {
 	// differently than it was written. Reporting them keeps a foreign
 	// bundle's reinterpreted status or dropped stale_after visible without
 	// pretending the document was rejected (OKF SPEC §11).
+	noted := len(notes)
 	for _, n := range notes {
 		fmt.Fprintln(os.Stderr, "note:", n)
+	}
+	// Everything the parser reinterpreted is known before the first write,
+	// so --strict refuses here and the knowledge base is left untouched.
+	// The alternative — writing 65 entries and failing on the 66th — is
+	// the half-applied sync this flag exists to prevent.
+	if *strict && (noted > 0 || len(skipped) > 0) {
+		return strictErr(noted, len(skipped), "nothing was written")
 	}
 	if *dryRun {
 		for i := range entries {
@@ -1106,7 +1115,8 @@ func cmdImport(ctx context.Context, args []string) error {
 		for _, a := range atts {
 			fmt.Printf("would attach %s/%s (from %s)\n", a.ID, a.Name, a.Path)
 		}
-		fmt.Printf("dry run: %d entries, %d attachments, %d skipped\n", len(entries), len(atts), len(skipped))
+		fmt.Printf("dry run: %d entries, %d attachments, %d skipped, %d notes\n",
+			len(entries), len(atts), len(skipped), noted)
 		return nil
 	}
 	c, err := newClient(ctx, *url)
@@ -1134,6 +1144,7 @@ func cmdImport(ctx context.Context, args []string) error {
 			return
 		}
 		if _, err := c.Verify(ctx, d.ID); err != nil {
+			noted++
 			fmt.Fprintf(os.Stderr, "note: %s imported, but recording its verification failed: %v\n", d.ID, err)
 		}
 	}
@@ -1157,6 +1168,7 @@ func cmdImport(ctx context.Context, args []string) error {
 			}
 			return fmt.Errorf("%s: %w", k.URI(), err)
 		}
+		noted += len(notes)
 		reportNotes(notes)
 		if wasCreated {
 			created++
@@ -1192,9 +1204,32 @@ func cmdImport(ctx context.Context, args []string) error {
 		attached++
 		fmt.Printf("attached %s/%s\n", a.ID, a.Name)
 	}
-	fmt.Printf("imported %d entries (%d created, %d updated, %d unchanged, %d attachments, %d skipped)\n",
-		created+updated+unchanged, created, updated, unchanged, attached, len(skipped))
+	fmt.Printf("imported %d entries (%d created, %d updated, %d unchanged, %d attachments, %d skipped, %d notes)\n",
+		created+updated+unchanged, created, updated, unchanged, attached, len(skipped), noted)
+	// The parse-time gate above cannot see what the server read differently
+	// or refused, so --strict asks again with the writes already done. The
+	// summary is printed first: the exit code says the sync is not clean,
+	// and the line above it says how far it got.
+	if *strict && (noted > 0 || len(skipped) > 0) {
+		return strictErr(noted, len(skipped), "the entries above are already written")
+	}
 	return nil
+}
+
+// strictErr is what --strict fails with. It counts rather than repeats:
+// every note and skip has already been printed to stderr as it happened,
+// and the error's job is to name the exit code's reason and say what the
+// knowledge base looks like now.
+func strictErr(notes, skipped int, state string) error {
+	return fmt.Errorf("--strict: the bundle was not read exactly as written (%d %s, %d %s); %s",
+		notes, plural(notes, "note"), skipped, plural(skipped, "skipped file"), state)
+}
+
+func plural(n int, word string) string {
+	if n == 1 {
+		return word
+	}
+	return word + "s"
 }
 
 // isInvalid reports a 400: the server understood the request and judged

--- a/cmd/ochakai/client_test.go
+++ b/cmd/ochakai/client_test.go
@@ -273,11 +273,73 @@ func TestImportReportsUnchanged(t *testing.T) {
 	for _, want := range []string{
 		"unchanged ochakai://metrics/same\n",
 		"updated ochakai://metrics/diff\n",
-		"imported 2 entries (0 created, 1 updated, 1 unchanged, 0 attachments, 0 skipped)\n",
+		"imported 2 entries (0 created, 1 updated, 1 unchanged, 0 attachments, 0 skipped, 0 notes)\n",
 	} {
 		if !strings.Contains(string(out), want) {
 			t.Errorf("output misses %q:\n%s", want, out)
 		}
+	}
+}
+
+// TestImportStrictRefusesBeforeWriting pins the whole point of --strict:
+// a note is a report by default and an entry carrying one still imports,
+// but under --strict the same bundle fails — and fails before the first
+// PUT, so a sync that would drift lands nothing at all. Without the flag
+// the identical bundle is written, which is what makes this a posture and
+// not a parser change.
+func TestImportStrictRefusesBeforeWriting(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "metrics"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// "verified" was never an OKF lifecycle value, so the parser reads it
+	// as a draft and says so. That reinterpretation is exactly the one an
+	// unattended import must not absorb quietly.
+	doc := "---\ntype: Metric\ntitle: Revenue\nstatus: verified\n---\n\nbody\n"
+	if err := os.WriteFile(filepath.Join(dir, "metrics", "revenue.md"), []byte(doc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	puts := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("PUT /api/v1/knowledge/{id...}", func(w http.ResponseWriter, r *http.Request) {
+		puts++
+		body, _ := io.ReadAll(r.Body)
+		d, _, err := okf.Parse(body)
+		if err != nil {
+			t.Errorf("bad PUT payload: %v\n%s", err, body)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		k := d.Knowledge
+		k.ID = r.PathValue("id")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(k)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	err := cmdImport(context.Background(), []string{dir, "--strict", "--url", srv.URL})
+	if err == nil {
+		t.Fatal("--strict imported a bundle with a note, want an error")
+	}
+	if !strings.Contains(err.Error(), "nothing was written") {
+		t.Errorf("--strict error = %v, want it to say nothing was written", err)
+	}
+	if puts != 0 {
+		t.Errorf("--strict wrote %d entries before failing, want 0", puts)
+	}
+
+	// --dry-run --strict is the CI gate: same verdict, still no writes.
+	if err := cmdImport(context.Background(), []string{dir, "--dry-run", "--strict", "--url", srv.URL}); err == nil {
+		t.Error("--dry-run --strict accepted a bundle with a note, want an error")
+	}
+
+	if err := cmdImport(context.Background(), []string{dir, "--url", srv.URL}); err != nil {
+		t.Fatalf("without --strict the same bundle must import: %v", err)
+	}
+	if puts != 1 {
+		t.Errorf("import without --strict wrote %d entries, want 1", puts)
 	}
 }
 

--- a/cmd/ochakai/completion.go
+++ b/cmd/ochakai/completion.go
@@ -171,7 +171,7 @@ _ochakai() {
       _arguments '--no-attachments[export the markdown only]' '--url[server URL]:url:' '1:directory:_files -/'
       ;;
     import)
-      _arguments '--dry-run[parse and list, write nothing]' '--url[server URL]:url:' '1:bundle:_files'
+      _arguments '--dry-run[parse and list, write nothing]' '--strict[fail on any note or skip]' '--url[server URL]:url:' '1:bundle:_files'
       ;;
     use)
       local -a servers
@@ -242,7 +242,7 @@ _ochakai() {
     attach)        opts="--name --json --url" ;;
     reembed)       opts="--limit --once --json --url" ;;
     export)        opts="--url --no-attachments" ;;
-    import)        opts="--dry-run --url" ;;
+    import)        opts="--dry-run --strict --url" ;;
     whoami)        opts="--json --url" ;;
     ui)            opts="--port --url" ;;
     mcp-stdio)     opts="--url" ;;
@@ -301,6 +301,7 @@ complete -c ochakai -n __fish_use_subcommand -a version -d 'print the version'
 complete -c ochakai -n '__fish_seen_subcommand_from search browse context get create update verify reject delete purge reembed move attach detach usage report revisions backlinks export import whoami ui mcp-stdio' -l url -x -d 'server URL'
 complete -c ochakai -n '__fish_seen_subcommand_from ui' -l port -x -d 'port on 127.0.0.1'
 complete -c ochakai -n '__fish_seen_subcommand_from import' -l dry-run -d 'parse and list, write nothing'
+complete -c ochakai -n '__fish_seen_subcommand_from import' -l strict -d 'fail on any note or skip'
 complete -c ochakai -n '__fish_seen_subcommand_from import' -F
 complete -c ochakai -n '__fish_seen_subcommand_from search browse context get create update verify reject reembed attach usage report revisions backlinks whoami' -l json -d 'print raw JSON'
 complete -c ochakai -n '__fish_seen_subcommand_from report' -l note -x -d 'context recorded with the report'

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -319,16 +319,25 @@ directory (<id>/<name>) attach to that entry. The packed shape is
 the structure: an archive wrapped in a single directory imports
 under that directory — the bundle keeps its own namespace. Works
 with any OKF bundle, not just ochakai's own.
+A file that cannot be read is skipped; a value read differently than
+it was written is a note and the entry still imports. Both are
+reported and neither fails the command, because a consumer takes the
+document rather than rejecting it. --strict is the opposite posture,
+for a sync nobody watches: a bundle that is not read exactly as
+written fails, and the counts land in the summary line either way.
 
 Flags:
   -dry-run
     	parse and list what would be written, write nothing
+  -strict
+    	refuse a bundle that is not read exactly as written: any note or skip fails the command instead of being reported. Parse-time ones are found before anything is written, so a strict import either lands whole or writes nothing
   -url ochakai use
     	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
 
 Examples:
   ochakai import ./knowledge
   ochakai import ga4-bundle.tar.gz --dry-run
+  ochakai import ./knowledge --dry-run --strict   # gate a CI sync on a clean parse
   ochakai export - | OCHAKAI_URL=https://other ochakai import -
 ```
 


### PR DESCRIPTION
## What and why

From user feedback on a 66-entry bundle import: *"問題は変更そのものより、これがエラーではなく note + 格下げであることです。(…) exit code を変えるか `--strict` が欲しい。CI で import を回している人は、ある日から全部 draft になっても気づけません。"*

The report was accurate about the consequence even where it was wrong about the cause. `import --dry-run` is entirely client-side and deterministic, so the behaviour did not change under them mid-session — but the rule that produced the surprise (in 0.15.0 the trust tier came from the presence of the `verified` key, not from `status`) is written down nowhere a user meets it, and the reinterpretation it triggers is reported at a volume nobody has to act on.

0043 already fixed half of this: `status` is the lifecycle value alone, a foreign `stable` survives the trip, and verification is a ledger. What it did not change is that **a note leaves the exit code at 0**. An import running in CI can turn 66 entries into drafts and report success. draft-vs-verified is the axis the whole product is built on; losing it quietly is the worst available failure mode.

This adds the opposite posture as an opt-in:

- `--strict` fails on any note or skip. Parse-time ones are known before the first write, so it refuses **there** — the import lands whole or writes nothing, rather than writing 65 entries and failing on the 66th.
- What only the server can judge (a document it read differently, or refused) is checked again after the run. The summary prints first, so the output still says how far it got and the exit code still says it was not clean.
- `ochakai import ./kb --dry-run --strict` is the gate to put in front of a CI sync — it needs no credentials, as `--dry-run` already did.
- Both summary lines gained the note count (`… 0 skipped, 0 notes`). A count that only exists in the scrollback is a count nobody reads.

The default is unchanged, deliberately. OKF's conformance rule tells a consumer to take the document rather than reject it, and an operator watching a one-off import genuinely does read the notes as they scroll past.

## Checks

- [x] `scripts/check` is clean — `scripts/check core` passes; no store change, so `--db` adds nothing here
- [x] Behavior changes come with tests — `TestImportStrictRefusesBeforeWriting` pins that `--strict` fails, that it makes **zero** PUTs, that `--dry-run --strict` gives the same verdict, and that the identical bundle still imports without the flag

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, `internal/apiclient` say the same thing — none of them changed; this is a client-side posture over calls that already exist
- [x] The change lands on every surface it belongs on — **CLI only.** Import is deliberately CLI-only (design doc 0015 §3.2: the bundle parse, attachment attribution and skip report live in the client precisely so no server-side bulk endpoint becomes a second path to the same artifact). There is nothing for REST, MCP or the Web UI to carry.

Regenerated `docs/cli.md` from the command's own help and updated all three completion scripts by hand, as `TestCompletionScriptsStayInSync` requires.

## Design docs

- [x] Not applicable — no accepted decision is altered. Notes stay notes and the parser is untouched; `--strict` is an opt-in the caller asks for, which is the same shape 0019's per-file skip report already has.
- [x] Commit messages and code comments are in English

---

Part of a set of four from the same feedback. Follow-ups stack on this branch because they touch the same `cmdImport` block:

1. **this PR** — `import --strict`
2. `ochakai verify <id>...` and the review loop in the help
3. `import --diff` — dry-run that says created / updated / unchanged
4. import-adopted verifications: made explicit and marked in the ledger (needs a design doc)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ar2c4cFZcnnxYbhjuKSbCv)_