### PR TITLE
Verify as many entries as the review queue hands over

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,27 @@ last entry.
 
 ## [Unreleased]
 
+### Added
+
+- `ochakai import --strict` — fail on a bundle that was not read exactly
+  as written, instead of reporting it. A note is still the default and
+  still not an error: OKF tells a consumer to take a document rather than
+  reject it, and an operator watching the output sees every
+  reinterpretation as it scrolls past. Nobody watches a sync running in
+  CI, and a knowledge base whose entries quietly landed as drafts is a
+  knowledge base whose agents stopped trusting the right things.
+
+  Parse-time notes and skips are known before the first write, so
+  `--strict` refuses there: the import lands whole or writes nothing.
+  What only the server can judge — a document it read differently, or one
+  it refused — is checked again after the run, so the summary still says
+  how far it got and the exit code still says it was not clean.
+  `--dry-run --strict` is the gate to put in front of a CI sync.
+
+  The summary line now carries the note count on both paths
+  (`… 0 skipped, 0 notes`), because a count that only appears in the
+  scrollback is a count nobody reads.
+
 ### Fixed
 
 - Producer-defined keys **inside** a `sources` entry, a `parameter`, an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,28 @@ last entry.
 
 ### Added
 
+- `ochakai verify <id>...` takes as many entries as it is given. The
+  review loop this project is built on produces a *list*: a feed is
+  queried, a human reads it, and what survives is confirmed. One id per
+  invocation left `xargs -n1` as the only way to close that loop, which
+  quietly made "import everything as verified" the cheaper path —
+  pressure in exactly the wrong direction, since the whole point of the
+  draft tier is that somebody chose to leave it.
+
+  Ids are parsed before the first request, so a typo in the tenth fails
+  the command instead of being found after nine writes. One that the
+  server refuses is reported and the rest still run, and the command
+  exits non-zero: a half-reviewed queue should not read as a clean one.
+  A lone id keeps its bare error, unchanged. With `--json` each entry
+  prints as its own object, so a single id reads exactly as it did
+  before and a list is a stream `jq` already consumes.
+
+  The quick start now shows the loop it describes:
+  `ochakai search --sort usage --status draft --json | jq -r '.hits[].id' | xargs ochakai verify`.
+  Its `verify` line also said the command "promotes a draft", which
+  stopped being true when verification became a ledger that does not
+  touch the document.
+
 - `ochakai import --strict` — fail on a bundle that was not read exactly
   as written, instead of reporting it. A note is still the default and
   still not an error: OKF tells a consumer to take a document rather than

--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ ochakai search --sort stale_after   # past the expiry their author declared
 ochakai search --source https://wiki.example/revenue-policy  # what derives from this
 ochakai search "revenue" --prefix queries/sales   # only what lives under one subtree
 ochakai get queries/sales/monthly-revenue
-ochakai verify metrics/revenue      # promotes a draft — and re-affirms a verified entry, clearing the review feeds
+ochakai verify metrics/revenue      # append a confirmation — the first and the tenth are the same command, and both clear the review feeds
+ochakai search --sort usage --status draft --json | jq -r '.hits[].id' | xargs ochakai verify   # work a review queue in one pass
 ochakai attach insights/reading-revenue weekly.png   # files travel with the entry
 ochakai export ./knowledge   # or: ochakai export - > okf.tar.gz
 ochakai import ./knowledge   # the inverse; works with any OKF bundle (a client-side loop — see below)

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -154,6 +154,27 @@ func idArgs(fs *flag.FlagSet, args []string, n int) (id string, rest []string, e
 	return id, pos[1:], nil
 }
 
+// idsArgs is idArgs for a command that takes a list of entry ids: one or
+// more, all parsed before the first request goes out. A typo in the tenth
+// id fails the command rather than being discovered after nine writes.
+func idsArgs(fs *flag.FlagSet, args []string) ([]string, error) {
+	pos, err := parseArgs(fs, args)
+	if err != nil {
+		return nil, err
+	}
+	if len(pos) == 0 {
+		fs.Usage()
+		return nil, errReported
+	}
+	ids := make([]string, len(pos))
+	for i, p := range pos {
+		if ids[i], err = parseRef(p); err != nil {
+			return nil, err
+		}
+	}
+	return ids, nil
+}
+
 func newClient(ctx context.Context, url string) (*apiclient.Client, error) {
 	if url == "" {
 		return nil, errors.New("server URL required: run `ochakai use <url>`, set OCHAKAI_URL, or pass --url")
@@ -837,13 +858,19 @@ func cmdUpdate(ctx context.Context, args []string) error {
 // verified is the point as much as promoting a draft: it is how a review
 // feed empties (design doc 0025 §6), and `update` cannot express it —
 // an unchanged payload writes nothing and verified_at is carried over.
+//
+// It takes as many ids as it is given, because the review loop the README
+// is built on produces a list: a feed is queried, a human reads it, and
+// what survives is confirmed. One id per invocation left `xargs -n1` as
+// the only way to close that loop, which made "import everything as
+// verified" the cheaper path — pressure in exactly the wrong direction.
 func cmdVerify(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
 		"verify",
-		"Usage: ochakai verify [flags] <id>\n\nAppend a verification against the entry as it stands: you and the time\nare added to its ledger. The first confirmation and the tenth re-check\nare the same command, and re-checking is what takes an entry out of\nboth review feeds (--sort verified_at, --sort failed).\nIt does not edit the entry: the lifecycle status and the ETag stay put,\nbecause confirming knowledge and publishing it are different acts. Use\n`update` to move a draft to stable.\nVerifying a rejected entry lifts the rejection.",
-		"  ochakai verify metrics/revenue\n  ochakai verify metrics/revenue --json | jq -r '.observed.verified[-1].at'\n")
-	asJSON := fs.Bool("json", false, "print the verified entry as JSON")
-	id, _, err := idArgs(fs, args, 1)
+		"Usage: ochakai verify [flags] <id>...\n\nAppend a verification against each entry as it stands: you and the time\nare added to its ledger. The first confirmation and the tenth re-check\nare the same command, and re-checking is what takes an entry out of\nboth review feeds (--sort verified_at, --sort failed).\nIt does not edit the entry: the lifecycle status and the ETag stay put,\nbecause confirming knowledge and publishing it are different acts. Use\n`update` to move a draft to stable.\nVerifying a rejected entry lifts the rejection.\nSeveral ids are confirmed one call at a time, in the order given. One\nthat fails is reported and the rest still run, and the command exits\nnon-zero — a half-reviewed queue should not look like a clean one.\nWith --json each entry prints as its own JSON object, so a single id\nreads exactly as it did before and a list is a stream jq consumes.",
+		"  ochakai verify metrics/revenue\n  ochakai verify metrics/revenue --json | jq -r '.observed.verified[-1].at'\n  ochakai search --sort usage --status draft --limit 50 --json | jq -r '.hits[].id' | xargs ochakai verify\n")
+	asJSON := fs.Bool("json", false, "print each verified entry as JSON")
+	ids, err := idsArgs(fs, args)
 	if err != nil {
 		return err
 	}
@@ -851,18 +878,35 @@ func cmdVerify(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	k, err := c.Verify(ctx, id)
-	if err != nil {
-		return err
+	var failed []string
+	for _, id := range ids {
+		k, err := c.Verify(ctx, id)
+		if err != nil {
+			// A lone id keeps the bare error: the caller named one entry,
+			// so the failure is the whole answer and needs no tally.
+			if len(ids) == 1 {
+				return err
+			}
+			failed = append(failed, id)
+			fmt.Fprintf(os.Stderr, "skip: %s: %v\n", id, err)
+			continue
+		}
+		if *asJSON {
+			if err := printJSON(k); err != nil {
+				return err
+			}
+			continue
+		}
+		by := "?"
+		if v := k.Observed.LastVerified(); v != nil {
+			by = v.By.String()
+		}
+		fmt.Printf("verified ochakai://%s by %s\n", k.ID, by)
 	}
-	if *asJSON {
-		return printJSON(k)
+	if len(failed) > 0 {
+		return fmt.Errorf("%d of %d entries were not verified: %s",
+			len(failed), len(ids), strings.Join(failed, " "))
 	}
-	by := "?"
-	if v := k.Observed.LastVerified(); v != nil {
-		by = v.By.String()
-	}
-	fmt.Printf("verified ochakai://%s by %s\n", k.ID, by)
 	return nil
 }
 

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -1077,9 +1077,10 @@ func cmdExport(ctx context.Context, args []string) error {
 func cmdImport(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
 		"import",
-		"Usage: ochakai import [flags] <dir | file.tar.gz | ->\n\nImport an OKF bundle (a directory of markdown + YAML frontmatter, or\na tar.gz of one; \"-\" reads the tar.gz from stdin). The inverse of\n`ochakai export`: each path names its entry (the path minus .md is\nthe id), the frontmatter type key names the type (required — files\nwithout one are skipped and reported), reserved index.md / log.md\nfiles are skipped, keys the format does not define are kept as\nwritten, and existing entries are replaced (kept as revisions; entries identical\nto what is stored are left untouched and reported as unchanged;\nentries the server rejects as invalid — e.g. one whose type is not a\nsingle line — are skipped and reported).\nFiles referenced by an entry's body markdown links become its\nattachments, wherever they sit in the bundle (their location is\npreserved for re-export); unreferenced data files inside an entry's\ndirectory (<id>/<name>) attach to that entry. The packed shape is\nthe structure: an archive wrapped in a single directory imports\nunder that directory — the bundle keeps its own namespace. Works\nwith any OKF bundle, not just ochakai's own.",
-		"  ochakai import ./knowledge\n  ochakai import ga4-bundle.tar.gz --dry-run\n  ochakai export - | OCHAKAI_URL=https://other ochakai import -\n")
+		"Usage: ochakai import [flags] <dir | file.tar.gz | ->\n\nImport an OKF bundle (a directory of markdown + YAML frontmatter, or\na tar.gz of one; \"-\" reads the tar.gz from stdin). The inverse of\n`ochakai export`: each path names its entry (the path minus .md is\nthe id), the frontmatter type key names the type (required — files\nwithout one are skipped and reported), reserved index.md / log.md\nfiles are skipped, keys the format does not define are kept as\nwritten, and existing entries are replaced (kept as revisions; entries identical\nto what is stored are left untouched and reported as unchanged;\nentries the server rejects as invalid — e.g. one whose type is not a\nsingle line — are skipped and reported).\nFiles referenced by an entry's body markdown links become its\nattachments, wherever they sit in the bundle (their location is\npreserved for re-export); unreferenced data files inside an entry's\ndirectory (<id>/<name>) attach to that entry. The packed shape is\nthe structure: an archive wrapped in a single directory imports\nunder that directory — the bundle keeps its own namespace. Works\nwith any OKF bundle, not just ochakai's own.\nA file that cannot be read is skipped; a value read differently than\nit was written is a note and the entry still imports. Both are\nreported and neither fails the command, because a consumer takes the\ndocument rather than rejecting it. --strict is the opposite posture,\nfor a sync nobody watches: a bundle that is not read exactly as\nwritten fails, and the counts land in the summary line either way.",
+		"  ochakai import ./knowledge\n  ochakai import ga4-bundle.tar.gz --dry-run\n  ochakai import ./knowledge --dry-run --strict   # gate a CI sync on a clean parse\n  ochakai export - | OCHAKAI_URL=https://other ochakai import -\n")
 	dryRun := fs.Bool("dry-run", false, "parse and list what would be written, write nothing")
+	strict := fs.Bool("strict", false, "refuse a bundle that is not read exactly as written: any note or skip fails the command instead of being reported. Parse-time ones are found before anything is written, so a strict import either lands whole or writes nothing")
 	pos, err := exactArgs(fs, args, 1)
 	if err != nil {
 		return err
@@ -1096,8 +1097,16 @@ func cmdImport(ctx context.Context, args []string) error {
 	// differently than it was written. Reporting them keeps a foreign
 	// bundle's reinterpreted status or dropped stale_after visible without
 	// pretending the document was rejected (OKF SPEC §11).
+	noted := len(notes)
 	for _, n := range notes {
 		fmt.Fprintln(os.Stderr, "note:", n)
+	}
+	// Everything the parser reinterpreted is known before the first write,
+	// so --strict refuses here and the knowledge base is left untouched.
+	// The alternative — writing 65 entries and failing on the 66th — is
+	// the half-applied sync this flag exists to prevent.
+	if *strict && (noted > 0 || len(skipped) > 0) {
+		return strictErr(noted, len(skipped), "nothing was written")
 	}
 	if *dryRun {
 		for i := range entries {
@@ -1106,7 +1115,8 @@ func cmdImport(ctx context.Context, args []string) error {
 		for _, a := range atts {
 			fmt.Printf("would attach %s/%s (from %s)\n", a.ID, a.Name, a.Path)
 		}
-		fmt.Printf("dry run: %d entries, %d attachments, %d skipped\n", len(entries), len(atts), len(skipped))
+		fmt.Printf("dry run: %d entries, %d attachments, %d skipped, %d notes\n",
+			len(entries), len(atts), len(skipped), noted)
 		return nil
 	}
 	c, err := newClient(ctx, *url)
@@ -1134,6 +1144,7 @@ func cmdImport(ctx context.Context, args []string) error {
 			return
 		}
 		if _, err := c.Verify(ctx, d.ID); err != nil {
+			noted++
 			fmt.Fprintf(os.Stderr, "note: %s imported, but recording its verification failed: %v\n", d.ID, err)
 		}
 	}
@@ -1157,6 +1168,7 @@ func cmdImport(ctx context.Context, args []string) error {
 			}
 			return fmt.Errorf("%s: %w", k.URI(), err)
 		}
+		noted += len(notes)
 		reportNotes(notes)
 		if wasCreated {
 			created++
@@ -1192,9 +1204,32 @@ func cmdImport(ctx context.Context, args []string) error {
 		attached++
 		fmt.Printf("attached %s/%s\n", a.ID, a.Name)
 	}
-	fmt.Printf("imported %d entries (%d created, %d updated, %d unchanged, %d attachments, %d skipped)\n",
-		created+updated+unchanged, created, updated, unchanged, attached, len(skipped))
+	fmt.Printf("imported %d entries (%d created, %d updated, %d unchanged, %d attachments, %d skipped, %d notes)\n",
+		created+updated+unchanged, created, updated, unchanged, attached, len(skipped), noted)
+	// The parse-time gate above cannot see what the server read differently
+	// or refused, so --strict asks again with the writes already done. The
+	// summary is printed first: the exit code says the sync is not clean,
+	// and the line above it says how far it got.
+	if *strict && (noted > 0 || len(skipped) > 0) {
+		return strictErr(noted, len(skipped), "the entries above are already written")
+	}
 	return nil
+}
+
+// strictErr is what --strict fails with. It counts rather than repeats:
+// every note and skip has already been printed to stderr as it happened,
+// and the error's job is to name the exit code's reason and say what the
+// knowledge base looks like now.
+func strictErr(notes, skipped int, state string) error {
+	return fmt.Errorf("--strict: the bundle was not read exactly as written (%d %s, %d %s); %s",
+		notes, plural(notes, "note"), skipped, plural(skipped, "skipped file"), state)
+}
+
+func plural(n int, word string) string {
+	if n == 1 {
+		return word
+	}
+	return word + "s"
 }
 
 // isInvalid reports a 400: the server understood the request and judged

--- a/cmd/ochakai/client_test.go
+++ b/cmd/ochakai/client_test.go
@@ -421,3 +421,51 @@ func TestVerifyJSONPrintsTheEntry(t *testing.T) {
 		t.Errorf("verified entry = %+v, want the server's response with its verification", got)
 	}
 }
+
+// TestVerifyTakesManyIDs pins the review loop the README describes: a
+// feed hands over a list of ids and one command confirms them, in order,
+// one call each. A failure partway does not swallow the rest and does not
+// leave a zero exit code — a half-reviewed queue must not read as clean.
+func TestVerifyTakesManyIDs(t *testing.T) {
+	var got []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v1/verify/{id...}", func(w http.ResponseWriter, r *http.Request) {
+		id := r.PathValue("id")
+		got = append(got, id)
+		if id == "metrics/gone" {
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "knowledge not found"})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(domain.View{
+			ID:       id,
+			Summary:  domain.Summary{ID: id, Type: domain.TypeMetrics, Verified: true},
+			Observed: domain.Observed{Verified: []domain.Verification{{By: domain.Actor{Kind: domain.ActorHuman, Name: "na0"}}}},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	err := cmdVerify(context.Background(), []string{
+		"metrics/a", "ochakai://metrics/gone", "metrics/b", "--url", srv.URL})
+	if err == nil {
+		t.Fatal("one id failed but the command succeeded, want a non-zero exit")
+	}
+	if !strings.Contains(err.Error(), "1 of 3") || !strings.Contains(err.Error(), "metrics/gone") {
+		t.Errorf("error = %v, want it to count the failures and name them", err)
+	}
+	want := []string{"metrics/a", "metrics/gone", "metrics/b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("verified %v, want %v — every id is attempted, in order", got, want)
+	}
+
+	// A bad id is caught before any request: nine writes followed by a
+	// typo is not a state worth reaching.
+	got = nil
+	if err := cmdVerify(context.Background(), []string{"metrics/a", "ochakai://", "--url", srv.URL}); err == nil {
+		t.Error("an unparseable id succeeded, want an error")
+	}
+	if len(got) != 0 {
+		t.Errorf("an unparseable id let %v through, want nothing sent", got)
+	}
+}

--- a/cmd/ochakai/client_test.go
+++ b/cmd/ochakai/client_test.go
@@ -273,11 +273,73 @@ func TestImportReportsUnchanged(t *testing.T) {
 	for _, want := range []string{
 		"unchanged ochakai://metrics/same\n",
 		"updated ochakai://metrics/diff\n",
-		"imported 2 entries (0 created, 1 updated, 1 unchanged, 0 attachments, 0 skipped)\n",
+		"imported 2 entries (0 created, 1 updated, 1 unchanged, 0 attachments, 0 skipped, 0 notes)\n",
 	} {
 		if !strings.Contains(string(out), want) {
 			t.Errorf("output misses %q:\n%s", want, out)
 		}
+	}
+}
+
+// TestImportStrictRefusesBeforeWriting pins the whole point of --strict:
+// a note is a report by default and an entry carrying one still imports,
+// but under --strict the same bundle fails — and fails before the first
+// PUT, so a sync that would drift lands nothing at all. Without the flag
+// the identical bundle is written, which is what makes this a posture and
+// not a parser change.
+func TestImportStrictRefusesBeforeWriting(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "metrics"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// "verified" was never an OKF lifecycle value, so the parser reads it
+	// as a draft and says so. That reinterpretation is exactly the one an
+	// unattended import must not absorb quietly.
+	doc := "---\ntype: Metric\ntitle: Revenue\nstatus: verified\n---\n\nbody\n"
+	if err := os.WriteFile(filepath.Join(dir, "metrics", "revenue.md"), []byte(doc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	puts := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("PUT /api/v1/knowledge/{id...}", func(w http.ResponseWriter, r *http.Request) {
+		puts++
+		body, _ := io.ReadAll(r.Body)
+		d, _, err := okf.Parse(body)
+		if err != nil {
+			t.Errorf("bad PUT payload: %v\n%s", err, body)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		k := d.Knowledge
+		k.ID = r.PathValue("id")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(k)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	err := cmdImport(context.Background(), []string{dir, "--strict", "--url", srv.URL})
+	if err == nil {
+		t.Fatal("--strict imported a bundle with a note, want an error")
+	}
+	if !strings.Contains(err.Error(), "nothing was written") {
+		t.Errorf("--strict error = %v, want it to say nothing was written", err)
+	}
+	if puts != 0 {
+		t.Errorf("--strict wrote %d entries before failing, want 0", puts)
+	}
+
+	// --dry-run --strict is the CI gate: same verdict, still no writes.
+	if err := cmdImport(context.Background(), []string{dir, "--dry-run", "--strict", "--url", srv.URL}); err == nil {
+		t.Error("--dry-run --strict accepted a bundle with a note, want an error")
+	}
+
+	if err := cmdImport(context.Background(), []string{dir, "--url", srv.URL}); err != nil {
+		t.Fatalf("without --strict the same bundle must import: %v", err)
+	}
+	if puts != 1 {
+		t.Errorf("import without --strict wrote %d entries, want 1", puts)
 	}
 }
 

--- a/cmd/ochakai/completion.go
+++ b/cmd/ochakai/completion.go
@@ -153,7 +153,7 @@ _ochakai() {
       _arguments '-f[input file]:file:_files' '--if-match[update only if the entry still has this version (updated_at)]:version:' '--json[print the entry as JSON]' '--url[server URL]:url:'
       ;;
     verify)
-      _arguments '--json[print the entry as JSON]' '--url[server URL]:url:'
+      _arguments '--json[print each entry as JSON]' '--url[server URL]:url:' '*:id:'
       ;;
     reject)
       _arguments '--note[why it was not accepted]:note:' '--lift[withdraw the rejection]' '--json[print the entry as JSON]' '--url[server URL]:url:'

--- a/cmd/ochakai/completion.go
+++ b/cmd/ochakai/completion.go
@@ -171,7 +171,7 @@ _ochakai() {
       _arguments '--no-attachments[export the markdown only]' '--url[server URL]:url:' '1:directory:_files -/'
       ;;
     import)
-      _arguments '--dry-run[parse and list, write nothing]' '--url[server URL]:url:' '1:bundle:_files'
+      _arguments '--dry-run[parse and list, write nothing]' '--strict[fail on any note or skip]' '--url[server URL]:url:' '1:bundle:_files'
       ;;
     use)
       local -a servers
@@ -242,7 +242,7 @@ _ochakai() {
     attach)        opts="--name --json --url" ;;
     reembed)       opts="--limit --once --json --url" ;;
     export)        opts="--url --no-attachments" ;;
-    import)        opts="--dry-run --url" ;;
+    import)        opts="--dry-run --strict --url" ;;
     whoami)        opts="--json --url" ;;
     ui)            opts="--port --url" ;;
     mcp-stdio)     opts="--url" ;;
@@ -301,6 +301,7 @@ complete -c ochakai -n __fish_use_subcommand -a version -d 'print the version'
 complete -c ochakai -n '__fish_seen_subcommand_from search browse context get create update verify reject delete purge reembed move attach detach usage report revisions backlinks export import whoami ui mcp-stdio' -l url -x -d 'server URL'
 complete -c ochakai -n '__fish_seen_subcommand_from ui' -l port -x -d 'port on 127.0.0.1'
 complete -c ochakai -n '__fish_seen_subcommand_from import' -l dry-run -d 'parse and list, write nothing'
+complete -c ochakai -n '__fish_seen_subcommand_from import' -l strict -d 'fail on any note or skip'
 complete -c ochakai -n '__fish_seen_subcommand_from import' -F
 complete -c ochakai -n '__fish_seen_subcommand_from search browse context get create update verify reject reembed attach usage report revisions backlinks whoami' -l json -d 'print raw JSON'
 complete -c ochakai -n '__fish_seen_subcommand_from report' -l note -x -d 'context recorded with the report'

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -319,16 +319,25 @@ directory (<id>/<name>) attach to that entry. The packed shape is
 the structure: an archive wrapped in a single directory imports
 under that directory — the bundle keeps its own namespace. Works
 with any OKF bundle, not just ochakai's own.
+A file that cannot be read is skipped; a value read differently than
+it was written is a note and the entry still imports. Both are
+reported and neither fails the command, because a consumer takes the
+document rather than rejecting it. --strict is the opposite posture,
+for a sync nobody watches: a bundle that is not read exactly as
+written fails, and the counts land in the summary line either way.
 
 Flags:
   -dry-run
     	parse and list what would be written, write nothing
+  -strict
+    	refuse a bundle that is not read exactly as written: any note or skip fails the command instead of being reported. Parse-time ones are found before anything is written, so a strict import either lands whole or writes nothing
   -url ochakai use
     	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
 
 Examples:
   ochakai import ./knowledge
   ochakai import ga4-bundle.tar.gz --dry-run
+  ochakai import ./knowledge --dry-run --strict   # gate a CI sync on a clean parse
   ochakai export - | OCHAKAI_URL=https://other ochakai import -
 ```
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -667,9 +667,9 @@ Examples:
 ## ochakai verify
 
 ```
-Usage: ochakai verify [flags] <id>
+Usage: ochakai verify [flags] <id>...
 
-Append a verification against the entry as it stands: you and the time
+Append a verification against each entry as it stands: you and the time
 are added to its ledger. The first confirmation and the tenth re-check
 are the same command, and re-checking is what takes an entry out of
 both review feeds (--sort verified_at, --sort failed).
@@ -677,16 +677,22 @@ It does not edit the entry: the lifecycle status and the ETag stay put,
 because confirming knowledge and publishing it are different acts. Use
 `update` to move a draft to stable.
 Verifying a rejected entry lifts the rejection.
+Several ids are confirmed one call at a time, in the order given. One
+that fails is reported and the rest still run, and the command exits
+non-zero — a half-reviewed queue should not look like a clean one.
+With --json each entry prints as its own JSON object, so a single id
+reads exactly as it did before and a list is a stream jq consumes.
 
 Flags:
   -json
-    	print the verified entry as JSON
+    	print each verified entry as JSON
   -url ochakai use
     	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
 
 Examples:
   ochakai verify metrics/revenue
   ochakai verify metrics/revenue --json | jq -r '.observed.verified[-1].at'
+  ochakai search --sort usage --status draft --limit 50 --json | jq -r '.hits[].id' | xargs ochakai verify
 ```
 
 ## ochakai whoami


### PR DESCRIPTION
> ⚠️ Stacked on #259. Base is `claude/ochakai-feedback-review-v3tu18-strict-import`; review the top commit only. Retarget to `main` once #259 merges.

## What and why

From user feedback: *"README はレビュー昇格ループを中心に据えているのに、昇格コマンドがありません。(…) `ochakai verify <id>...` があれば、私は迷わず draft 投入を選んでいました。今の構成だと「一括投入するなら verified で入れるしかない」という、設計思想と逆向きの圧力がかかります。"*

The premise was half wrong and the conclusion was right. `ochakai verify` has existed since well before 0.15.0 — it is in `docs/cli.md` and in the quick start. But it takes exactly one id, and a reviewer who has just read a 66-entry feed has a *list*. `xargs -n1 ochakai verify` is 66 round trips typed by someone who had to work out that it was the answer, and a user who does not find it concludes there is no promotion path at all. That conclusion is what makes "import the bundle as verified" the cheaper path — pressure in exactly the wrong direction, since the whole value of the draft tier is that somebody chose to leave it there.

So: `ochakai verify <id>...`.

- Ids are parsed before the first request. A typo in the tenth fails the command rather than being discovered after nine writes.
- One the server refuses is reported (`skip: <id>: …`) and the rest still run, and the command exits non-zero. A half-reviewed queue must not read as a clean one.
- A lone id keeps its bare error, unchanged — the caller named one entry, so the failure is the whole answer and needs no tally.
- `--json` prints one object per entry. With a single id the output is byte-identical to before; with a list it is a JSON stream, which is what `jq` already consumes. The documented `ochakai verify x --json | jq -r '.observed.verified[-1].at'` keeps working.

The quick start now shows the loop the README spends a section describing:

```sh
ochakai search --sort usage --status draft --json | jq -r '.hits[].id' | xargs ochakai verify
```

While there: that same README line said `verify` "promotes a draft". That stopped being true in 0043, where verification became a ledger append that does not touch the document — the lifecycle status and the ETag stay put, and moving a draft to stable is an edit. Corrected rather than left to teach the old model.

`reject` stays single-id on purpose: a rejection carries a reason, and one reason shared across a batch is not the reason for any of them.

## Checks

- [x] `scripts/check` is clean — `scripts/check core` passes; no store change, so `--db` adds nothing here
- [x] Behavior changes come with tests — `TestVerifyTakesManyIDs` pins that every id is attempted in order, that a mid-list failure neither swallows the rest nor leaves a zero exit, and that an unparseable id sends nothing at all. `TestVerifyJSONPrintsTheEntry` still pins the single-id `--json` shape.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, `internal/apiclient` say the same thing — none of them changed. The wire call is unchanged; this is a loop in the client over `POST /api/v1/verify/{id}`, which stays one entry per call.
- [x] The change lands on every surface it belongs on — **CLI only**, deliberately:
  - **REST**: nothing to add. A batch endpoint would be a second path to the same artifact for no capability gain (0015 §3.2's reasoning about bulk import applies verbatim), and partial failure is already expressible as N responses.
  - **MCP**: verify is not an MCP tool and this does not make it one — it is the human's side of the loop (`service.Verify`'s own comment, design doc 0025).
  - **Web UI**: verifies the entry on screen. There is no list in hand there, so there is nothing to take.

Regenerated `docs/cli.md` from the command's own help and updated the zsh completion (verify now takes repeated id arguments), as `TestCompletionScriptsStayInSync` requires.

## Design docs

- [x] Not applicable — no accepted decision is altered. 0025 §6 and 0043 §3.2 define what a verification *is*; this changes only how many the CLI can ask for in one invocation.
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ar2c4cFZcnnxYbhjuKSbCv)_