### PR TITLE
Answer what a re-sync would change, not what a first import would write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,26 @@ last entry.
 
 ### Added
 
+- `ochakai import --diff` — say what a re-sync would change, per entry,
+  and write nothing. `--dry-run` answers "would import" for everything,
+  which is the whole truth on an empty knowledge base and the least
+  useful true thing the command can say on every import after the first.
+  A re-sync is where a dry run is actually needed, and that is exactly
+  where it had no answer.
+
+  Each verdict comes from the stored document compared against the exact
+  bytes the import would `PUT` — the same comparison the server makes to
+  decide a write is a no-op (design doc
+  [0043](docs/design/0043-document-first.md) §3.4), so the preview and
+  the real run cannot drift apart. Attachments ride along: the same read
+  returns their digests, so a file already stored byte for byte reads as
+  unchanged instead of as an upload.
+
+  `--dry-run` is unchanged and still reaches no server, which is what
+  makes it usable before any credentials exist. `--diff` needs to reach
+  one, and a read that fails for its own reason (auth, network) aborts
+  rather than reporting everything as new.
+
 - `ochakai verify <id>...` takes as many entries as it is given. The
   review loop this project is built on produces a *list*: a feed is
   queried, a human reads it, and what survives is confirmed. One id per

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -8,6 +8,8 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -1121,9 +1123,10 @@ func cmdExport(ctx context.Context, args []string) error {
 func cmdImport(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
 		"import",
-		"Usage: ochakai import [flags] <dir | file.tar.gz | ->\n\nImport an OKF bundle (a directory of markdown + YAML frontmatter, or\na tar.gz of one; \"-\" reads the tar.gz from stdin). The inverse of\n`ochakai export`: each path names its entry (the path minus .md is\nthe id), the frontmatter type key names the type (required — files\nwithout one are skipped and reported), reserved index.md / log.md\nfiles are skipped, keys the format does not define are kept as\nwritten, and existing entries are replaced (kept as revisions; entries identical\nto what is stored are left untouched and reported as unchanged;\nentries the server rejects as invalid — e.g. one whose type is not a\nsingle line — are skipped and reported).\nFiles referenced by an entry's body markdown links become its\nattachments, wherever they sit in the bundle (their location is\npreserved for re-export); unreferenced data files inside an entry's\ndirectory (<id>/<name>) attach to that entry. The packed shape is\nthe structure: an archive wrapped in a single directory imports\nunder that directory — the bundle keeps its own namespace. Works\nwith any OKF bundle, not just ochakai's own.\nA file that cannot be read is skipped; a value read differently than\nit was written is a note and the entry still imports. Both are\nreported and neither fails the command, because a consumer takes the\ndocument rather than rejecting it. --strict is the opposite posture,\nfor a sync nobody watches: a bundle that is not read exactly as\nwritten fails, and the counts land in the summary line either way.",
-		"  ochakai import ./knowledge\n  ochakai import ga4-bundle.tar.gz --dry-run\n  ochakai import ./knowledge --dry-run --strict   # gate a CI sync on a clean parse\n  ochakai export - | OCHAKAI_URL=https://other ochakai import -\n")
+		"Usage: ochakai import [flags] <dir | file.tar.gz | ->\n\nImport an OKF bundle (a directory of markdown + YAML frontmatter, or\na tar.gz of one; \"-\" reads the tar.gz from stdin). The inverse of\n`ochakai export`: each path names its entry (the path minus .md is\nthe id), the frontmatter type key names the type (required — files\nwithout one are skipped and reported), reserved index.md / log.md\nfiles are skipped, keys the format does not define are kept as\nwritten, and existing entries are replaced (kept as revisions; entries identical\nto what is stored are left untouched and reported as unchanged;\nentries the server rejects as invalid — e.g. one whose type is not a\nsingle line — are skipped and reported).\nFiles referenced by an entry's body markdown links become its\nattachments, wherever they sit in the bundle (their location is\npreserved for re-export); unreferenced data files inside an entry's\ndirectory (<id>/<name>) attach to that entry. The packed shape is\nthe structure: an archive wrapped in a single directory imports\nunder that directory — the bundle keeps its own namespace. Works\nwith any OKF bundle, not just ochakai's own.\nA file that cannot be read is skipped; a value read differently than\nit was written is a note and the entry still imports. Both are\nreported and neither fails the command, because a consumer takes the\ndocument rather than rejecting it. --strict is the opposite posture,\nfor a sync nobody watches: a bundle that is not read exactly as\nwritten fails, and the counts land in the summary line either way.\n--dry-run parses and lists, reaching no server and needing no\ncredentials — the answer before a bundle has ever been imported.\n--diff is the answer on every import after that: it reads the stored\nentries and says, per entry, whether the bundle would create it,\nupdate it or leave it alone. It writes nothing either, but it does\nneed to reach the server.",
+		"  ochakai import ./knowledge\n  ochakai import ga4-bundle.tar.gz --dry-run\n  ochakai import ./knowledge --diff             # what would a re-sync change?\n  ochakai import ./knowledge --dry-run --strict   # gate a CI sync on a clean parse\n  ochakai export - | OCHAKAI_URL=https://other ochakai import -\n")
 	dryRun := fs.Bool("dry-run", false, "parse and list what would be written, write nothing")
+	diff := fs.Bool("diff", false, "say what would change — created, updated or unchanged, per entry — by reading the stored entries and comparing. Implies --dry-run and writes nothing, but unlike it needs to reach the server")
 	strict := fs.Bool("strict", false, "refuse a bundle that is not read exactly as written: any note or skip fails the command instead of being reported. Parse-time ones are found before anything is written, so a strict import either lands whole or writes nothing")
 	pos, err := exactArgs(fs, args, 1)
 	if err != nil {
@@ -1152,7 +1155,7 @@ func cmdImport(ctx context.Context, args []string) error {
 	if *strict && (noted > 0 || len(skipped) > 0) {
 		return strictErr(noted, len(skipped), "nothing was written")
 	}
-	if *dryRun {
+	if *dryRun && !*diff {
 		for i := range entries {
 			fmt.Printf("would import %s\n", entries[i].URI())
 		}
@@ -1166,6 +1169,9 @@ func cmdImport(ctx context.Context, args []string) error {
 	c, err := newClient(ctx, *url)
 	if err != nil {
 		return err
+	}
+	if *diff {
+		return importDiff(ctx, c, entries, atts, skipped, noted)
 	}
 	// A 400 is the server's judgment on one document (e.g. a models entry
 	// whose spec fails write-time validation) — skip and report it like a
@@ -1260,6 +1266,88 @@ func cmdImport(ctx context.Context, args []string) error {
 	return nil
 }
 
+// importDiff answers the question a re-sync actually asks — what would
+// change — and writes nothing. A plain --dry-run cannot: it needs no
+// credentials, which is worth keeping for the first import of a bundle,
+// but on the second one "would import" for every entry is the least
+// useful true thing the command could say.
+//
+// Every verdict comes from the stored document itself, compared against
+// the exact bytes the import would PUT. That is the same comparison the
+// server makes to decide whether a write is a no-op (design doc 0043
+// §3.4 — the version is the hash of the canonical document), so the
+// answer here and the answer the real run gives cannot drift apart.
+// Attachments ride along: one read returns their metadata, and a file
+// whose bytes already hash the same is not going to be re-uploaded.
+//
+// A read that fails for its own reason (auth, network) aborts, as it
+// does on the write path — a diff that silently reports "would create"
+// because it could not read is worse than no diff.
+func importDiff(ctx context.Context, c *apiclient.Client, entries []okf.Doc,
+	atts []okf.BundleAttachment, skipped []string, noted int,
+) error {
+	var create, update, same int
+	stored := map[string]*domain.View{}
+	for i := range entries {
+		k := &entries[i].Knowledge
+		doc, err := documentOf(k)
+		if err != nil {
+			skipped = append(skipped, k.ID+".md: "+err.Error())
+			fmt.Fprintln(os.Stderr, "skip:", skipped[len(skipped)-1])
+			continue
+		}
+		v, err := c.Get(ctx, k.ID)
+		switch {
+		case isNotFound(err):
+			create++
+			fmt.Printf("would create %s\n", k.URI())
+		case err != nil:
+			return fmt.Errorf("%s: %w", k.URI(), err)
+		case v.Document == string(doc):
+			same++
+			stored[k.ID] = v
+			fmt.Printf("unchanged %s\n", k.URI())
+		default:
+			update++
+			stored[k.ID] = v
+			fmt.Printf("would update %s\n", k.URI())
+		}
+	}
+	var attach, sameAtt int
+	for _, a := range atts {
+		if held(stored[a.ID], a) {
+			sameAtt++
+			fmt.Printf("unchanged %s/%s (from %s)\n", a.ID, a.Name, a.Path)
+			continue
+		}
+		attach++
+		fmt.Printf("would attach %s/%s (from %s)\n", a.ID, a.Name, a.Path)
+	}
+	fmt.Printf("diff: %d entries (%d would create, %d would update, %d unchanged), "+
+		"%d attachments (%d would attach, %d unchanged), %d skipped, %d notes\n",
+		create+update+same, create, update, same,
+		attach+sameAtt, attach, sameAtt, len(skipped), noted)
+	return nil
+}
+
+// held reports whether the stored entry already carries this bundle file
+// byte for byte. The name is the identity within an entry and the digest
+// is the content, so both have to agree; an entry that is not stored at
+// all (v == nil) holds nothing.
+func held(v *domain.View, a okf.BundleAttachment) bool {
+	if v == nil {
+		return false
+	}
+	sum := sha256.Sum256(a.Data)
+	digest := hex.EncodeToString(sum[:])
+	for i := range v.Attachments {
+		if v.Attachments[i].Name == a.Name && v.Attachments[i].SHA256 == digest {
+			return true
+		}
+	}
+	return false
+}
+
 // strictErr is what --strict fails with. It counts rather than repeats:
 // every note and skip has already been printed to stderr as it happened,
 // and the error's job is to name the exit code's reason and say what the
@@ -1281,6 +1369,12 @@ func plural(n int, word string) string {
 func isInvalid(err error) bool {
 	var apiErr *apiclient.APIError
 	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusBadRequest
+}
+
+// isNotFound reports a 404: the id is free, so an import would create it.
+func isNotFound(err error) bool {
+	var apiErr *apiclient.APIError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound
 }
 
 func isConflict(err error) bool {

--- a/cmd/ochakai/client_test.go
+++ b/cmd/ochakai/client_test.go
@@ -343,6 +343,96 @@ func TestImportStrictRefusesBeforeWriting(t *testing.T) {
 	}
 }
 
+// TestImportDiffTellsCreatedFromUpdated pins what a re-sync asks for: a
+// bundle re-run against a base that already holds part of it must say
+// which entries would change, and must still write nothing. The stored
+// document is compared against the exact bytes the import would PUT, so
+// an entry the server would treat as a no-op reads as unchanged here.
+func TestImportDiffTellsCreatedFromUpdated(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "metrics"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	docs := map[string]string{
+		"same":  "---\ntype: Metric\ntitle: Same\n---\n\nbody\n",
+		"drift": "---\ntype: Metric\ntitle: Drift\n---\n\nnew body\n",
+		"new":   "---\ntype: Metric\ntitle: New\n---\n\nbody\n",
+	}
+	for name, doc := range docs {
+		if err := os.WriteFile(filepath.Join(dir, "metrics", name+".md"), []byte(doc), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// What the server holds: metrics/same byte-identical to what the
+	// bundle renders, metrics/drift something else, metrics/new absent.
+	canonical := func(src string) string {
+		d, _, err := okf.Parse([]byte(src))
+		if err != nil {
+			t.Fatal(err)
+		}
+		b, err := okf.Canonical(&d.Knowledge)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(b)
+	}
+	held := map[string]string{
+		"metrics/same":  canonical(docs["same"]),
+		"metrics/drift": canonical("---\ntype: Metric\ntitle: Drift\n---\n\nold body\n"),
+	}
+
+	writes := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("PUT /api/v1/knowledge/{id...}", func(http.ResponseWriter, *http.Request) { writes++ })
+	mux.HandleFunc("POST /api/v1/knowledge", func(http.ResponseWriter, *http.Request) { writes++ })
+	mux.HandleFunc("GET /api/v1/knowledge/{id...}", func(w http.ResponseWriter, r *http.Request) {
+		id := r.PathValue("id")
+		doc, ok := held[id]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "knowledge not found"})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(domain.View{
+			ID: id, Document: doc,
+			Summary: domain.Summary{ID: id, Type: domain.TypeMetrics},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	orig := os.Stdout
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = pw
+	diffErr := cmdImport(context.Background(), []string{dir, "--diff", "--url", srv.URL})
+	pw.Close()
+	os.Stdout = orig
+	out, err := io.ReadAll(pr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diffErr != nil {
+		t.Fatalf("cmdImport --diff: %v\noutput:\n%s", diffErr, out)
+	}
+	for _, want := range []string{
+		"unchanged ochakai://metrics/same\n",
+		"would update ochakai://metrics/drift\n",
+		"would create ochakai://metrics/new\n",
+		"diff: 3 entries (1 would create, 1 would update, 1 unchanged), " +
+			"0 attachments (0 would attach, 0 unchanged), 0 skipped, 0 notes\n",
+	} {
+		if !strings.Contains(string(out), want) {
+			t.Errorf("--diff output misses %q:\n%s", want, out)
+		}
+	}
+	if writes != 0 {
+		t.Errorf("--diff made %d writes, want 0", writes)
+	}
+}
+
 // `ochakai update --if-match` sends the version as the If-Match header,
 // and a 412 comes back as an actionable conflict message (re-read, redo,
 // retry) rather than the raw server error.

--- a/cmd/ochakai/completion.go
+++ b/cmd/ochakai/completion.go
@@ -171,7 +171,7 @@ _ochakai() {
       _arguments '--no-attachments[export the markdown only]' '--url[server URL]:url:' '1:directory:_files -/'
       ;;
     import)
-      _arguments '--dry-run[parse and list, write nothing]' '--strict[fail on any note or skip]' '--url[server URL]:url:' '1:bundle:_files'
+      _arguments '--dry-run[parse and list, write nothing]' '--diff[say what would change, write nothing]' '--strict[fail on any note or skip]' '--url[server URL]:url:' '1:bundle:_files'
       ;;
     use)
       local -a servers
@@ -242,7 +242,7 @@ _ochakai() {
     attach)        opts="--name --json --url" ;;
     reembed)       opts="--limit --once --json --url" ;;
     export)        opts="--url --no-attachments" ;;
-    import)        opts="--dry-run --strict --url" ;;
+    import)        opts="--dry-run --diff --strict --url" ;;
     whoami)        opts="--json --url" ;;
     ui)            opts="--port --url" ;;
     mcp-stdio)     opts="--url" ;;
@@ -301,6 +301,7 @@ complete -c ochakai -n __fish_use_subcommand -a version -d 'print the version'
 complete -c ochakai -n '__fish_seen_subcommand_from search browse context get create update verify reject delete purge reembed move attach detach usage report revisions backlinks export import whoami ui mcp-stdio' -l url -x -d 'server URL'
 complete -c ochakai -n '__fish_seen_subcommand_from ui' -l port -x -d 'port on 127.0.0.1'
 complete -c ochakai -n '__fish_seen_subcommand_from import' -l dry-run -d 'parse and list, write nothing'
+complete -c ochakai -n '__fish_seen_subcommand_from import' -l diff -d 'say what would change, write nothing'
 complete -c ochakai -n '__fish_seen_subcommand_from import' -l strict -d 'fail on any note or skip'
 complete -c ochakai -n '__fish_seen_subcommand_from import' -F
 complete -c ochakai -n '__fish_seen_subcommand_from search browse context get create update verify reject reembed attach usage report revisions backlinks whoami' -l json -d 'print raw JSON'

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -325,8 +325,16 @@ reported and neither fails the command, because a consumer takes the
 document rather than rejecting it. --strict is the opposite posture,
 for a sync nobody watches: a bundle that is not read exactly as
 written fails, and the counts land in the summary line either way.
+--dry-run parses and lists, reaching no server and needing no
+credentials — the answer before a bundle has ever been imported.
+--diff is the answer on every import after that: it reads the stored
+entries and says, per entry, whether the bundle would create it,
+update it or leave it alone. It writes nothing either, but it does
+need to reach the server.
 
 Flags:
+  -diff
+    	say what would change — created, updated or unchanged, per entry — by reading the stored entries and comparing. Implies --dry-run and writes nothing, but unlike it needs to reach the server
   -dry-run
     	parse and list what would be written, write nothing
   -strict
@@ -337,6 +345,7 @@ Flags:
 Examples:
   ochakai import ./knowledge
   ochakai import ga4-bundle.tar.gz --dry-run
+  ochakai import ./knowledge --diff             # what would a re-sync change?
   ochakai import ./knowledge --dry-run --strict   # gate a CI sync on a clean parse
   ochakai export - | OCHAKAI_URL=https://other ochakai import -
 ```


### PR DESCRIPTION
> ⚠️ Stacked on #260, which is stacked on #259. Base is `claude/ochakai-feedback-review-v3tu18-verify-many`; review the top commit only. Retarget to `main` once the two below merge.

## What and why

From user feedback: *"全件 "would import"。空の KB では十分でしたが、dry-run が本当に欲しいのは再同期のときで、そこで「何が変わるか」を答えられない。本番 import は created/updated/unchanged を出し分けているので情報自体はあるはずです。"*

Correct, and the diagnosis of *why* is the interesting part. `--dry-run` deliberately reaches no server — `examples/bigquery-catalog` documents that it needs no credentials, which is what makes it usable before a deployment exists. That property is worth keeping, and it is also exactly why it cannot answer the re-sync question: the answer lives on the server.

So this is a second mode rather than a change to the first.

`ochakai import ./knowledge --diff`:

```
unchanged ochakai://metrics/same
would update ochakai://metrics/drift
would create ochakai://metrics/new
diff: 3 entries (1 would create, 1 would update, 1 unchanged), 0 attachments (0 would attach, 0 unchanged), 0 skipped, 0 notes
```

- Every verdict comes from the **stored document** compared against the **exact bytes the import would `PUT`**. That is the same comparison the server makes to decide a write is a no-op (0043 §3.4: the version is the SHA-256 of the canonical document), so the preview and the real run cannot drift apart — they are asking the same question of the same bytes.
- Attachments ride along for free: the entry read already returns their digests, so a file stored byte for byte reads as `unchanged` rather than as a pending upload. A 66-entry bundle with data files re-syncs to a mostly-empty diff, which is the point.
- A read that fails for its own reason (auth, network, 5xx) **aborts**. A diff that quietly reports "would create" because it could not read is worse than no diff at all.
- `--diff` implies `--dry-run`: it writes nothing. `--dry-run` alone is unchanged, still credential-free, still the right answer before a bundle has ever been imported.

Cost is honest and stated in the help: one `GET` per entry, so a diff costs about what the import costs in round trips and writes nothing.

## Checks

- [x] `scripts/check` is clean — `scripts/check core` passes; no store change, so `--db` adds nothing here
- [x] Behavior changes come with tests — `TestImportDiffTellsCreatedFromUpdated` builds a fake server holding one entry byte-identical to what the bundle renders, one that differs, and none for the third; it pins all three verdicts, the summary line, and that **zero** writes are made

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, `internal/apiclient` say the same thing — none of them changed. `--diff` is composed entirely from `GET /api/v1/knowledge/{id}`, which already returns the canonical document and the attachment digests.
- [x] The change lands on every surface it belongs on — **CLI only.** Import is CLI-only by design (0015 §3.2), and a diff is a property of an import; there is no import on REST, MCP or the Web UI for it to attach to.

Regenerated `docs/cli.md` and updated all three completion scripts by hand, as `TestCompletionScriptsStayInSync` requires.

## Design docs

- [x] Not applicable — no accepted decision is altered. 0005 gave import a dry run; this adds a mode to it and leaves the parse-only one exactly as specified, including the credential-free property `examples/bigquery-catalog` relies on.
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ar2c4cFZcnnxYbhjuKSbCv)_