### PR TITLE
Say status and trust the way OKF says them (0046 §§3.9-3.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,7 +105,7 @@ last entry.
     "Document" tab.
 
 - **BREAKING**: the web UI edits documents, and the form sugar is gone
-  (design doc [0046](docs/design/0044-web-ui-edits-documents.md)). The
+  (design doc [0044](docs/design/0044-web-ui-edits-documents.md)). The
   editor is the canonical document in a textarea, checked for parse
   errors before it is sent; new entries start from a per-type template.
   The row editors for `sources` and `parameters`, and the contract
@@ -144,6 +144,26 @@ last entry.
   - The canonical rendering stays as the form ochakai writes when it
     composes a document itself, and as what a write path falls back to
     when a caller changes an entry's fields rather than its document.
+
+- **BREAKING**: status and trust are said the way OKF says them (design
+  doc [0046](docs/design/0046-bundle-address-space.md) §§3.9-3.10).
+
+  - **A document that names no status is stable**, which is SPEC §5.4's
+    default. ochakai no longer writes a `status` its writer left out —
+    a create used to land on `draft`, and an update used to keep
+    whatever was there. Both were the server authoring the writer's
+    vocabulary. An agent that means "draft" writes `status: draft`, and
+    the MCP tool descriptions say so.
+  - **`verified` as a boolean is gone.** Entries carry `trust`, SPEC
+    §5.3's tier derived from the verification ledger: `unverified`,
+    `machine-confirmed`, `human-reviewed`. It rides on every entry and
+    on every `/context` rank row beside `status`.
+  - The filter follows: `?verified=true` becomes `?trust=` (repeatable
+    and OR-ed) on REST and MCP, and `--verified true` becomes `--trust
+    human-reviewed` on the CLI. Asking for two tiers is two values
+    rather than a second kind of filter.
+  - Nothing about verifying changes: it is still a ledger append, still
+    absent from MCP, and still leaves the entry's version alone.
 
 - **BREAKING**: knowledge is written as an OKF document, and `PUT` is the
   whole write surface (design doc

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ go install github.com/na0fu3y/ochakai/cmd/ochakai@latest
 ochakai use http://localhost:8080  # Cloud Run: ochakai use https://your-service.run.app (auth = gcloud login / ADC, no tokens to configure)
 ochakai whoami                     # which server, as whom, reachable?
 ochakai context "why is revenue down?"  # the one-call read before a data question: full entries, links expanded
-ochakai search "revenue" --type Metric --verified true
+ochakai search "revenue" --type Metric --trust human-reviewed
 ochakai search --sort stale_after   # past the expiry their author declared
 ochakai search --source https://wiki.example/revenue-policy  # what derives from this
 ochakai search "revenue" --prefix queries/sales   # only what lives under one subtree

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -74,14 +74,17 @@ paths:
           in: query
           schema: { type: array, items: { $ref: "#/components/schemas/Status" } }
           explode: true
-        - name: verified
+        - name: trust
           in: query
           description: >
-            true for entries somebody has confirmed, false for ones nobody
-            has; omit to leave the question unasked. Independent of
-            status: a draft may be verified and a stable entry unverified
-            (OKF SPEC §§5.3-5.4).
-          schema: { type: boolean }
+            Filter by who confirmed the entry — OKF's own trust tiers
+            (SPEC §5.3), derived from the verification ledger. Repeatable
+            and OR-ed, so "anything somebody confirmed" is two values.
+            Omit to leave the question unasked. Independent of status: a
+            draft may be human-reviewed and a stable entry unverified
+            (SPEC §§5.3-5.4).
+          schema: { type: array, items: { $ref: "#/components/schemas/Trust" } }
+          explode: true
         - name: rejected
           in: query
           description: >
@@ -172,7 +175,7 @@ paths:
                         description: Monthly net revenue for the last 12 complete months.
                         tags: [finance]
                         status: stable
-                        verified: true
+                        trust: human-reviewed
                         verified_at: "2026-07-10T01:52:16.774301Z"
                         rejected: false
                         links:
@@ -189,7 +192,7 @@ paths:
                         tags: [finance, core]
                         status: stable
                         stale_after: "2026-12-31"
-                        verified: true
+                        trust: human-reviewed
                         verified_at: "2026-07-14T02:33:41.019778Z"
                         rejected: false
                         links:
@@ -213,7 +216,7 @@ paths:
                         tags: [finance]
                         status: draft
                         stale_after: "2027-01-31"
-                        verified: false
+                        trust: unverified
                         rejected: false
                         links:
                           - { target: metrics/revenue, text: Revenue }
@@ -236,7 +239,7 @@ paths:
                         tags: [finance]
                         status: draft
                         stale_after: "2027-01-31"
-                        verified: false
+                        trust: unverified
                         rejected: false
                         links:
                           - { target: metrics/revenue, text: Revenue }
@@ -255,7 +258,7 @@ paths:
                         title: completed-order
                         description: An order that shipped and was not refunded within the return window.
                         status: draft
-                        verified: false
+                        trust: unverified
                         rejected: false
                         content_hash: c07b4e19a35d8f206b1c94e73da508f2b6c31d9047ea825bf1c6d03b95a7e412
                         created_at: "2026-06-02T04:09:12.774903Z"
@@ -397,14 +400,15 @@ paths:
           in: query
           schema: { type: array, items: { $ref: "#/components/schemas/Status" } }
           explode: true
-        - name: verified
+        - name: trust
           in: query
           description: >
-            true for entries somebody has confirmed, false for ones nobody
-            has; omit to leave the question unasked. There is no rejected
+            Filter by OKF's trust tier (SPEC §5.3), repeatable and OR-ed;
+            omit to leave the question unasked. There is no rejected
             parameter here: a context pack never carries knowledge
             somebody turned down.
-          schema: { type: boolean }
+          schema: { type: array, items: { $ref: "#/components/schemas/Trust" } }
+          explode: true
         - name: tag
           in: query
           schema: { type: array, items: { type: string } }
@@ -502,19 +506,19 @@ paths:
                         type: Attested Computation
                         title: monthly-revenue
                         status: stable
-                        verified: true
+                        trust: human-reviewed
                         score: 1.35
                       - id: metrics/revenue
                         type: Metric
                         title: Revenue
                         status: stable
-                        verified: true
+                        trust: human-reviewed
                         score: 0.48
                       - id: insights/revenue-seasonality
                         type: Insight
                         title: Reading revenue month over month
                         status: draft
-                        verified: false
+                        trust: unverified
                         score: 0.43
                     entries:
                       - id: queries/monthly-revenue
@@ -553,7 +557,7 @@ paths:
                           description: Monthly net revenue for the last 12 complete months.
                           tags: [finance]
                           status: stable
-                          verified: true
+                          trust: human-reviewed
                           verified_at: "2026-07-10T01:52:16.774301Z"
                           rejected: false
                           links:
@@ -613,7 +617,7 @@ paths:
                           tags: [finance, core]
                           status: stable
                           stale_after: "2026-12-31"
-                          verified: true
+                          trust: human-reviewed
                           verified_at: "2026-07-14T02:33:41.019778Z"
                           rejected: false
                           links:
@@ -740,7 +744,7 @@ paths:
                       tags: [finance, core]
                       status: stable
                       stale_after: "2026-12-31"
-                      verified: true
+                      trust: human-reviewed
                       verified_at: "2026-07-14T02:33:41.019778Z"
                       rejected: false
                       links:
@@ -797,7 +801,7 @@ paths:
                       tags: [finance]
                       status: draft
                       stale_after: "2027-01-31"
-                      verified: false
+                      trust: unverified
                       rejected: false
                       links:
                         - { target: metrics/revenue, text: Revenue }
@@ -1005,7 +1009,7 @@ paths:
                       tags: [finance, core]
                       status: stable
                       stale_after: "2027-12-31"
-                      verified: true
+                      trust: human-reviewed
                       verified_at: "2026-07-14T02:33:41.019778Z"
                       rejected: false
                       links:
@@ -1181,7 +1185,7 @@ paths:
                       tags: [finance, core]
                       status: stable
                       stale_after: "2026-12-31"
-                      verified: true
+                      trust: human-reviewed
                       verified_at: "2026-07-14T02:33:41.019778Z"
                       rejected: false
                       links:
@@ -1272,7 +1276,7 @@ paths:
                       tags: [finance]
                       status: draft
                       stale_after: "2027-01-31"
-                      verified: true
+                      trust: human-reviewed
                       verified_at: "2026-07-27T00:41:12.905337Z"
                       rejected: false
                       links:
@@ -1364,7 +1368,7 @@ paths:
                       title: Gross revenue
                       description: Order totals before refunds.
                       status: draft
-                      verified: false
+                      trust: unverified
                       rejected: true
                       links:
                         - { target: tables/shop-orders, text: shop.orders }
@@ -1661,7 +1665,7 @@ paths:
                         tags: [finance]
                         status: draft
                         stale_after: "2027-01-31"
-                        verified: false
+                        trust: unverified
                         rejected: false
                         links:
                           - { target: metrics/revenue, text: Revenue }
@@ -1674,7 +1678,7 @@ paths:
                         description: Monthly net revenue for the last 12 complete months.
                         tags: [finance]
                         status: stable
-                        verified: true
+                        trust: human-reviewed
                         verified_at: "2026-07-10T01:52:16.774301Z"
                         rejected: false
                         links:
@@ -2082,7 +2086,22 @@ components:
         entry unverified (design doc 0043 §3.2). "Was never accepted" is
         likewise not a lifecycle value but a ruling, in `rejection`
         (§3.3).
+        A document that names no status is stable — SPEC §5.4's default.
+        ochakai does not write a key its writer left out, so what comes
+        back here is the value a reader reads, while the document keeps
+        its silence (design doc 0046 §3.9).
       enum: [draft, stable, deprecated]
+    Trust:
+      type: string
+      description: >
+        The tier a consumer derives from the verification ledger, in OKF's
+        own vocabulary (SPEC §5.3): unverified when nobody has confirmed
+        the entry, machine-confirmed when something other than a person
+        has, human-reviewed when a person vouched for it. Derived on read
+        and never accepted from a payload — and independent of status,
+        which says whether the entry may be consumed (design doc 0046
+        §3.10).
+      enum: [unverified, machine-confirmed, human-reviewed]
     Verification:
       type: object
       description: >
@@ -2163,7 +2182,7 @@ components:
         the entry says, and this is an index over it. A client that needs
         a key not listed here reads the document; the projection carries
         what listing surfaces sort and filter by, and stops there.
-      required: [id, type, title, status, verified, rejected, content_hash, created_at, updated_at]
+      required: [id, type, title, status, trust, rejected, content_hash, created_at, updated_at]
       properties:
         id:
           type: string
@@ -2205,14 +2224,14 @@ components:
             due for a re-check, not wrong. The one surface that reads it
             is sort=stale_after, the feed of entries whose declared date
             has passed (design doc 0037 §2.1).
-        verified:
-          type: boolean
+        trust:
+          allOf: [{ $ref: "#/components/schemas/Trust" }]
           description: >
-            Whether anybody has confirmed the entry — the verifications
-            ledger read as the boolean SPEC §5.3 derives trust from.
-            Independent of status: a draft may be verified and a stable
-            entry unverified (design doc 0043 §3.2). Who confirmed it,
-            and how often, is in observed.verified.
+            Who has confirmed the entry, in OKF's own vocabulary (SPEC
+            §5.3), derived from the verifications ledger. Independent of
+            status: a draft may be human-reviewed and a stable entry
+            unverified (design docs 0043 §3.2, 0046 §3.10). Who confirmed
+            it, and how often, is in observed.verified.
         verified_at:
           type: string
           format: date-time
@@ -2324,6 +2343,13 @@ components:
             attachment endpoints. Absent when the entry has none.
         created_at: { type: string, format: date-time, readOnly: true }
         updated_at: { type: string, format: date-time, readOnly: true }
+        trust:
+          allOf: [{ $ref: "#/components/schemas/Trust" }]
+          readOnly: true
+          description: >
+            The trust tier derived from `verifications` (SPEC §5.3),
+            carried so a caller reading a listing gets the same answer as
+            one reading the ledger.
         content_changed_at:
           type: string
           format: date-time

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -183,19 +183,6 @@ func typeList() string {
 	return strings.Join(ss, "|")
 }
 
-// triBool reads a flag that means "unasked" when empty, so a caller can
-// tell "not mentioned" from "explicitly false".
-func triBool(v, flag string) (*bool, error) {
-	if v == "" {
-		return nil, nil
-	}
-	b, err := strconv.ParseBool(v)
-	if err != nil {
-		return nil, fmt.Errorf("%s wants true or false, got %q", flag, v)
-	}
-	return &b, nil
-}
-
 // optBool turns an opt-in boolean flag into the tri-state the filters
 // take: unset stays unasked rather than becoming an explicit false.
 func optBool(v bool) *bool {
@@ -213,6 +200,11 @@ func statusList() string {
 	return strings.Join(ss, "|")
 }
 
+// trustList renders SPEC §5.3's tiers for the flag's help, from the one
+// place the vocabulary is spelled (design doc 0038 §4.4's rule, applied
+// to the second vocabulary OKF gives ochakai).
+func trustList() string { return strings.ReplaceAll(domain.TrustsHint(), ", ", "|") }
+
 // parseRef parses an entry id (an "ochakai://" prefix is tolerated).
 func parseRef(s string) (string, error) {
 	id := strings.TrimPrefix(s, "ochakai://")
@@ -226,14 +218,15 @@ func cmdSearch(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
 		"search",
 		"Usage: ochakai search [flags] [query]\n\nSearch the knowledge base; verified entries rank higher.\nOutput: score, uri, status, title — description (one hit per line).\nWith --sort verified_at the command lists by verification age instead\nof searching (oldest first, never-verified last — the\ncanary feed); output leads with verified_at. With --sort usage it lists\nby demand (most search_hits first, never-used oldest-first at the bottom\n— the draft review feed); output leads with the search_hits count.\nWith --sort failed it lists entries whose failure reports (report_outcome\nfailed) are still unanswered, worst first — the re-verification feed;\noutput leads with the failed count. `ochakai verify` takes an entry out\nof it, so a base that is kept up shows an empty feed.\nWith --sort stale_after it lists entries whose declared stale_after has\npassed, most overdue first; output leads with that date. Verifying does\nnot empty this one — the date is the writer's declaration, so clearing it\nmeans editing the entry to re-declare an expiry.\n--source and --prefix are filters, not modes: both combine with a query\nor with any --sort. --source narrows to the entries citing one resource\n(the reverse of sources[].resource); --prefix narrows to the entries\nliving under a path, which is how a team's own knowledge is told apart\nfrom the company-wide vocabulary.",
-		"  ochakai search \"gross margin\" --type Metric --type 'Glossary Term' --verified true\n  ochakai search churn --json | jq -r '.hits[] | .id'\n  ochakai search --sort verified_at --type 'Attested Computation' --verified true --limit 100\n  ochakai search --sort usage --status draft --limit 50   # review queue\n  ochakai search --sort failed --verified true              # re-verification queue\n  ochakai search --sort stale_after                         # past their declared expiry\n  ochakai search --source https://wiki.example/finance/revenue-recognition  # what cites this\n  ochakai search 活性化 --prefix teams/growth --prefix company   # our scope and the shared one\n")
+		"  ochakai search \"gross margin\" --type Metric --type 'Glossary Term' --trust human-reviewed\n  ochakai search churn --json | jq -r '.hits[] | .id'\n  ochakai search --sort verified_at --type 'Attested Computation' --trust human-reviewed --limit 100\n  ochakai search --sort usage --status draft --limit 50   # review queue\n  ochakai search --sort failed --trust human-reviewed     # re-verification queue\n  ochakai search --sort stale_after                         # past their declared expiry\n  ochakai search --source https://wiki.example/finance/revenue-recognition  # what cites this\n  ochakai search 活性化 --prefix teams/growth --prefix company   # our scope and the shared one\n")
 	var types, statuses, tags, prefixes repeated
 	fs.Var(&types, "type", "filter by type: "+typeList()+", or any custom type (repeatable)")
 	fs.Var(&statuses, "status", "filter by status: "+statusList()+" (repeatable)")
 	fs.Var(&tags, "tag", "filter by tag (repeatable)")
 	fs.Var(&prefixes, "prefix", "only entries under this `path`, e.g. teams/growth — matched on segment boundaries, so it does not reach teams/growth-archive (repeatable, OR-ed)")
 	source := fs.String("source", "", "only entries citing this `resource` (exact match against sources[].resource) — what derives from one piece of material")
-	verified := fs.String("verified", "", "`true` for entries somebody confirmed, false for ones nobody has — independent of --status, which is the lifecycle value")
+	var trust repeated
+	fs.Var(&trust, "trust", "filter by who confirmed the entry: "+trustList()+" (repeatable, OR-ed) — independent of --status, which is the lifecycle value")
 	rejected := fs.Bool("rejected", false, "only entries a human turned down — how you check whether a proposal was already rejected. Without it, rejected entries stay out of results")
 	sortBy := fs.String("sort", "", `list instead of search: "verified_at" = by verification age (oldest first), "usage" = by demand (most search_hits first), "failed" = by failed outcome reports (re-verification feed), "stale_after" = past their declared expiry, most overdue first`)
 	limit := fs.Int("limit", 0, "max results (server default 10, max 50; with --sort: 100, max 1000)")
@@ -252,14 +245,10 @@ func cmdSearch(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	verifiedFlag, err := triBool(*verified, "--verified")
-	if err != nil {
-		return err
-	}
 	hits, err := c.Search(ctx, apiclient.SearchParams{
 		Query: strings.Join(pos, " "), Types: types, Statuses: statuses, Tags: tags,
 		Source: *source, Prefixes: prefixes, Sort: *sortBy, Limit: *limit,
-		Verified: verifiedFlag, Rejected: optBool(*rejected),
+		Trust: trust, Rejected: optBool(*rejected),
 	})
 	if err != nil {
 		return err
@@ -347,13 +336,14 @@ func cmdContext(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
 		"context",
 		"Usage: ochakai context [flags] <question>\n\nGather what to read before answering a data question, in one call:\nthe full entries behind the top search hits (verified entries rank\nhigher), expanded one hop through links so the insight explaining a\nmetric travels with it. Markdown on stdout, ready for an agent's\ncontext window. No hits print nothing (exit 0).",
-		"  ochakai context \"why did revenue drop in March?\"\n  ochakai context \"monthly revenue\" --type 'Attested Computation' --verified true --json\n  ochakai context \"$PROMPT\" --budget 4000   # hooks: cap the injected bytes\n  ochakai context \"activation rate\" --prefix teams/growth --prefix company\n")
+		"  ochakai context \"why did revenue drop in March?\"\n  ochakai context \"monthly revenue\" --type 'Attested Computation' --trust human-reviewed --json\n  ochakai context \"$PROMPT\" --budget 4000   # hooks: cap the injected bytes\n  ochakai context \"activation rate\" --prefix teams/growth --prefix company\n")
 	var types, statuses, tags, prefixes repeated
 	fs.Var(&types, "type", "filter by type: "+typeList()+", or any custom type (repeatable)")
 	fs.Var(&statuses, "status", "filter by status: "+statusList()+" (repeatable)")
 	fs.Var(&tags, "tag", "filter by tag (repeatable)")
 	fs.Var(&prefixes, "prefix", "only entries under this `path`, e.g. teams/growth (repeatable, OR-ed); scopes the search, not the links it expands")
-	verified := fs.String("verified", "", "`true` for entries somebody confirmed, false for ones nobody has — independent of --status, which is the lifecycle value")
+	var trust repeated
+	fs.Var(&trust, "trust", "filter by who confirmed the entry: "+trustList()+" (repeatable, OR-ed) — independent of --status, which is the lifecycle value")
 	limit := fs.Int("limit", 0, "max full entries (server default 5, max 20)")
 	budget := fs.Int("budget", 0, "cap the response at ~this many bytes (0 = no cap); the rendered output stops printing entries, --json asks the server to cap and list what did not fit under \"outline\"")
 	minScore := fs.Float64("min-score", 0, "drop hits scoring below this; scores depend on the server's search mode (matched-fragment weight plus boosts vs RRF rank fusion), so calibrate before use (0 = off)")
@@ -378,13 +368,9 @@ func cmdContext(ctx context.Context, args []string) error {
 	if *asJSON {
 		serverBudget = *budget
 	}
-	verifiedFlag, err := triBool(*verified, "--verified")
-	if err != nil {
-		return err
-	}
 	res, err := c.Context(ctx, apiclient.ContextParams{
 		Query: strings.Join(pos, " "), Types: types, Statuses: statuses, Tags: tags,
-		Prefixes: prefixes, Verified: verifiedFlag, Limit: *limit, MinScore: *minScore, Budget: serverBudget,
+		Prefixes: prefixes, Trust: trust, Limit: *limit, MinScore: *minScore, Budget: serverBudget,
 	})
 	if err != nil {
 		return err

--- a/cmd/ochakai/client_test.go
+++ b/cmd/ochakai/client_test.go
@@ -389,7 +389,7 @@ func TestVerifyJSONPrintsTheEntry(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(domain.View{
 			ID: r.PathValue("id"),
 			Summary: domain.Summary{Type: domain.TypeComputations, ID: r.PathValue("id"),
-				Status: domain.StatusStable, Title: "Monthly revenue", Verified: true},
+				Status: domain.StatusStable, Title: "Monthly revenue", Trust: domain.TrustHuman},
 			Observed: domain.Observed{Verified: []domain.Verification{{By: human, At: verified}}},
 		})
 	})

--- a/cmd/ochakai/completion.go
+++ b/cmd/ochakai/completion.go
@@ -26,6 +26,11 @@ const typesMark = "@TYPES@"
 // no status contains a space, so one spelling serves all three shells.
 const statusesMark = "@STATUSES@"
 
+// trustsMark is the same arrangement for OKF's trust tiers (SPEC §5.3,
+// design doc 0046 §3.10): one vocabulary, spelled in domain and
+// interpolated here. No tier contains a space either.
+const trustsMark = "@TRUSTS@"
+
 var (
 	zshCompletion  = expand(zshCompletionTmpl, `"`)
 	bashCompletion = expand(bashCompletionTmpl, `'`)
@@ -38,7 +43,8 @@ func expand(tmpl, quote string) string {
 		names[i] = string(st)
 	}
 	s := strings.ReplaceAll(tmpl, typesMark, domain.TypesQuoted(quote))
-	return strings.ReplaceAll(s, statusesMark, strings.Join(names, " "))
+	s = strings.ReplaceAll(s, statusesMark, strings.Join(names, " "))
+	return strings.ReplaceAll(s, trustsMark, strings.ReplaceAll(domain.TrustsHint(), ", ", " "))
 }
 
 func cmdCompletion(_ context.Context, args []string) error {
@@ -111,7 +117,7 @@ _ochakai() {
         '*--tag[filter by tag]:tag:' \
         '*--prefix[only entries under this path]:prefix:' \
         '--source[only entries citing this resource]:source:' \
-        '--verified[true for confirmed entries, false for unconfirmed]:verified:(true false)' \
+        '*--trust[filter by who confirmed the entry (OKF SPEC §5.3)]:trust:(@TRUSTS@)' \
         '--rejected[only entries a human turned down]' \
         '--sort[list instead of searching: by verification age, demand, failed reports, or declared expiry]:sort:(verified_at usage failed stale_after)' \
         '--limit[max results]:limit:' \
@@ -124,7 +130,7 @@ _ochakai() {
         '*--status[filter by status]:status:(@STATUSES@)' \
         '*--tag[filter by tag]:tag:' \
         '*--prefix[only entries under this path]:prefix:' \
-        '--verified[true for confirmed entries, false for unconfirmed]:verified:(true false)' \
+        '*--trust[filter by who confirmed the entry (OKF SPEC §5.3)]:trust:(@TRUSTS@)' \
         '--limit[max full entries]:limit:' \
         '--budget[stop rendering after ~bytes]:budget:' \
         '--min-score[drop hits below this score]:min-score:' \
@@ -216,15 +222,15 @@ _ochakai() {
   case $prev in
     --type|-type) COMPREPLY=($(compgen -W "@TYPES@" -- "$cur")); return ;;
     --status|-status) COMPREPLY=($(compgen -W "@STATUSES@" -- "$cur")); return ;;
-    --verified|-verified) COMPREPLY=($(compgen -W "true false" -- "$cur")); return ;;
+    --trust|-trust) COMPREPLY=($(compgen -W "@TRUSTS@" -- "$cur")); return ;;
     --sort|-sort) COMPREPLY=($(compgen -W "verified_at usage failed stale_after" -- "$cur")); return ;;
     -f) compopt -o default 2>/dev/null; COMPREPLY=(); return ;;
   esac
 
   case $cmd in
-    search)        opts="--type --status --tag --prefix --source --verified --rejected --sort --limit --json --url" ;;
+    search)        opts="--type --status --tag --prefix --source --trust --rejected --sort --limit --json --url" ;;
     browse)        opts="--json --url" ;;
-    context)       opts="--type --status --tag --prefix --verified --limit --budget --min-score --json --url" ;;
+    context)       opts="--type --status --tag --prefix --trust --limit --budget --min-score --json --url" ;;
     get)           opts="--json --download --url" ;;
     usage)         opts="--json --url" ;;
     revisions|backlinks) opts="--limit --json --url" ;;
@@ -315,7 +321,7 @@ complete -c ochakai -n '__fish_seen_subcommand_from search' -l sort -x -a 'verif
 complete -c ochakai -n '__fish_seen_subcommand_from search context' -l tag -x -d 'filter by tag'
 complete -c ochakai -n '__fish_seen_subcommand_from search context' -l prefix -x -d 'only entries under this path'
 complete -c ochakai -n '__fish_seen_subcommand_from search' -l source -x -d 'only entries citing this resource'
-complete -c ochakai -n '__fish_seen_subcommand_from search context' -l verified -x -a 'true false' -d 'true for confirmed entries, false for unconfirmed'
+complete -c ochakai -n '__fish_seen_subcommand_from search context' -l trust -x -a '@TRUSTS@' -d 'filter by who confirmed the entry (OKF SPEC §5.3)'
 complete -c ochakai -n '__fish_seen_subcommand_from search' -l rejected -d 'only entries a human turned down'
 complete -c ochakai -n '__fish_seen_subcommand_from reject' -l note -x -d 'why it was not accepted'
 complete -c ochakai -n '__fish_seen_subcommand_from reject' -l lift -d 'withdraw the rejection'

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -177,16 +177,16 @@ Flags:
     	filter by status: draft|stable|deprecated (repeatable)
   -tag value
     	filter by tag (repeatable)
+  -trust value
+    	filter by who confirmed the entry: unverified|machine-confirmed|human-reviewed (repeatable, OR-ed) — independent of --status, which is the lifecycle value
   -type value
     	filter by type: Metric|Attested Computation|Skill|Playbook|Insight|Policy|Glossary Term|BigQuery Dataset|BigQuery Table|API Endpoint|Reference, or any custom type (repeatable)
   -url ochakai use
     	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
-  -verified true
-    	true for entries somebody confirmed, false for ones nobody has — independent of --status, which is the lifecycle value
 
 Examples:
   ochakai context "why did revenue drop in March?"
-  ochakai context "monthly revenue" --type 'Attested Computation' --verified true --json
+  ochakai context "monthly revenue" --type 'Attested Computation' --trust human-reviewed --json
   ochakai context "$PROMPT" --budget 4000   # hooks: cap the injected bytes
   ochakai context "activation rate" --prefix teams/growth --prefix company
 ```
@@ -552,19 +552,19 @@ Flags:
     	filter by status: draft|stable|deprecated (repeatable)
   -tag value
     	filter by tag (repeatable)
+  -trust value
+    	filter by who confirmed the entry: unverified|machine-confirmed|human-reviewed (repeatable, OR-ed) — independent of --status, which is the lifecycle value
   -type value
     	filter by type: Metric|Attested Computation|Skill|Playbook|Insight|Policy|Glossary Term|BigQuery Dataset|BigQuery Table|API Endpoint|Reference, or any custom type (repeatable)
   -url ochakai use
     	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
-  -verified true
-    	true for entries somebody confirmed, false for ones nobody has — independent of --status, which is the lifecycle value
 
 Examples:
-  ochakai search "gross margin" --type Metric --type 'Glossary Term' --verified true
+  ochakai search "gross margin" --type Metric --type 'Glossary Term' --trust human-reviewed
   ochakai search churn --json | jq -r '.hits[] | .id'
-  ochakai search --sort verified_at --type 'Attested Computation' --verified true --limit 100
+  ochakai search --sort verified_at --type 'Attested Computation' --trust human-reviewed --limit 100
   ochakai search --sort usage --status draft --limit 50   # review queue
-  ochakai search --sort failed --verified true              # re-verification queue
+  ochakai search --sort failed --trust human-reviewed     # re-verification queue
   ochakai search --sort stale_after                         # past their declared expiry
   ochakai search --source https://wiki.example/finance/revenue-recognition  # what cites this
   ochakai search 活性化 --prefix teams/growth --prefix company   # our scope and the shared one

--- a/docs/guides/golden-query-canary.md
+++ b/docs/guides/golden-query-canary.md
@@ -27,7 +27,7 @@ supplies the material and records what you found.
 ### 1. List — least recently verified first
 
 ```sh
-ochakai search --sort verified_at --type 'Attested Computation' --verified true --limit 100 --json \
+ochakai search --sort verified_at --type 'Attested Computation' --trust human-reviewed --limit 100 --json \
   | jq -r '.hits[] | [.id, .verified_at, .title] | @tsv'
 ```
 
@@ -38,7 +38,7 @@ Fetch the ones you are about to run with `ochakai get <id>`, which prints
 the document — question, `runtime` and `# Computation` fence included.
 
 Straight REST is
-`GET /api/v1/knowledge?type=Attested%20Computation&verified=true&sort=verified_at&limit=100`;
+`GET /api/v1/knowledge?type=Attested%20Computation&trust=human-reviewed&sort=verified_at&limit=100`;
 over MCP, `search_knowledge` with `sort: "verified_at"` returns the same
 feed. `sort=verified_at` orders by verification time, oldest first, with
 unverified entries last. "Verified queries not re-checked in 90 days" is
@@ -88,7 +88,7 @@ canonicalize a run against. ochakai takes no part in this step.
   and failed totals show up under `/usage`, so verified entries that have
   accumulated failures can be picked up for re-verification first. **The
   `sort=failed` re-verification feed** (`ochakai search --sort failed
-  --verified true`, REST: `GET /api/v1/knowledge?sort=failed`, MCP:
+  --trust human-reviewed`, REST: `GET /api/v1/knowledge?sort=failed`, MCP:
   `search_knowledge` with `sort: "failed"`) lists them in order of how
   often they were reported wrong. It is the evidence-based entrance,
   complementing the time-based `sort=verified_at` (design doc 0025).
@@ -114,7 +114,7 @@ jobs:
         run: |
           TOKEN=$(gcloud auth print-identity-token --audiences="$OCHAKAI_URL")
           curl -s -H "Authorization: Bearer $TOKEN" \
-            "$OCHAKAI_URL/api/v1/knowledge?type=Attested%20Computation&verified=true&sort=verified_at&limit=50" \
+            "$OCHAKAI_URL/api/v1/knowledge?type=Attested%20Computation&trust=human-reviewed&sort=verified_at&limit=50" \
           | jq -r '.hits[].id' | while read -r id; do
               doc=$(curl -s -H "Authorization: Bearer $TOKEN" \
                 -H 'Accept: text/markdown' "$OCHAKAI_URL/api/v1/knowledge/$id")

--- a/internal/apiclient/apiclient.go
+++ b/internal/apiclient/apiclient.go
@@ -136,12 +136,12 @@ type SearchParams struct {
 	// (design doc 0041). Repeatable and OR-ed, matched on segment
 	// boundaries. Composes with Query and with any Sort.
 	Prefixes []string
-	// Verified and Rejected ask about the instance ledgers rather than the
+	// Trust and Rejected ask about the instance ledgers rather than the
 	// document (design doc 0043 §§3.2-3.3), independently of Statuses.
 	// Both are tri-state: nil leaves the question unasked. Nil Rejected
 	// still hides rejected entries — asking for them is opt-in, which is
 	// how an agent checks whether a proposal was already turned down.
-	Verified *bool
+	Trust    []string
 	Rejected *bool
 	Limit    int
 }
@@ -169,8 +169,8 @@ func (c *Client) Search(ctx context.Context, p SearchParams) ([]domain.SearchHit
 	for _, pre := range p.Prefixes {
 		q.Add("prefix", pre)
 	}
-	if p.Verified != nil {
-		q.Set("verified", strconv.FormatBool(*p.Verified))
+	for _, t := range p.Trust {
+		q.Add("trust", t)
 	}
 	if p.Rejected != nil {
 		q.Set("rejected", strconv.FormatBool(*p.Rejected))
@@ -208,10 +208,10 @@ type ContextParams struct {
 	Statuses []string
 	Tags     []string
 	Prefixes []string
-	// Verified narrows to confirmed (or unconfirmed) entries, as on
+	// Trust narrows by who confirmed the entry, as on
 	// SearchParams. Rejected has no counterpart here: a context pack never
 	// carries knowledge somebody turned down.
-	Verified *bool
+	Trust    []string
 	Limit    int
 	MinScore float64
 	// Budget, when positive, caps the response bytes server-side: entries
@@ -240,8 +240,8 @@ func (c *Client) Context(ctx context.Context, p ContextParams) (*ContextResult, 
 	for _, pre := range p.Prefixes {
 		q.Add("prefix", pre)
 	}
-	if p.Verified != nil {
-		q.Set("verified", strconv.FormatBool(*p.Verified))
+	for _, t := range p.Trust {
+		q.Add("trust", t)
 	}
 	if p.Limit > 0 {
 		q.Set("limit", strconv.Itoa(p.Limit))

--- a/internal/domain/knowledge.go
+++ b/internal/domain/knowledge.go
@@ -170,6 +170,62 @@ func ValidStatus(s Status) bool {
 	return slices.Contains(Statuses, s)
 }
 
+// Trust is the tier a consumer derives from an entry's verification
+// ledger, in OKF's own vocabulary (SPEC §5.3). It is not a lifecycle
+// value and not a field a writer can set: status says whether the entry
+// may be consumed, trust says who has confirmed it, and the two are
+// independent — a draft can be human-reviewed and a stable entry
+// unverified (design docs 0043 §3.2, 0046 §3.10).
+type Trust string
+
+const (
+	TrustUnverified = Trust("unverified")        // nobody has confirmed it
+	TrustMachine    = Trust("machine-confirmed") // confirmed, but by no person
+	TrustHuman      = Trust("human-reviewed")    // a person vouched for it
+)
+
+// Trusts lists the tiers lowest to highest, which is the order SPEC §5.3
+// introduces them in and the order a filter's help text reads best in.
+var Trusts = []Trust{TrustUnverified, TrustMachine, TrustHuman}
+
+// ValidTrust reports whether t names a tier.
+func ValidTrust(t Trust) bool { return slices.Contains(Trusts, t) }
+
+// TrustsHint renders the vocabulary for help and error text, so no
+// surface keeps a copy of the list to fall behind.
+func TrustsHint() string {
+	names := make([]string, len(Trusts))
+	for i, t := range Trusts {
+		names[i] = string(t)
+	}
+	return strings.Join(names, ", ")
+}
+
+// TrustOf derives the tier from a verification ledger. SPEC §5.3 reads it
+// from the human: prefix alone: any person makes it human-reviewed, any
+// other confirmation machine-confirmed, none unverified.
+func TrustOf(vs []Verification) Trust {
+	tier := TrustUnverified
+	for i := range vs {
+		if vs[i].By.Kind == ActorHuman {
+			return TrustHuman
+		}
+		tier = TrustMachine
+	}
+	return tier
+}
+
+// Lifecycle is the entry's status as a reader sees it: what it says, or
+// OKF's default when it says nothing (SPEC §5.4). ochakai does not write
+// a status its writer left out (design doc 0046 §3.9) — absence is what
+// the document says, and applying the default is the projection's job.
+func (k *Knowledge) Lifecycle() Status {
+	if k.Status == "" {
+		return StatusStable
+	}
+	return k.Status
+}
+
 // StatusFromOKF maps a frontmatter status onto ochakai's vocabulary,
 // which since design doc 0043 §3.2 is OKF's vocabulary — so the mapping
 // is the identity on every value the spec defines, and the whole of what
@@ -581,6 +637,11 @@ type Knowledge struct {
 	// query, and an entry composed in memory rather than parsed from a
 	// document.
 	Doc string `json:"-"`
+	// Trust is the tier SPEC §5.3 derives from Verifications, carried on
+	// the wire so a caller that only reads a listing gets the same answer
+	// as one that reads the ledger (design doc 0046 §3.10). Derived on
+	// read; never accepted from a payload.
+	Trust Trust `json:"trust,omitempty"`
 	// ContentHash is the entry's version: the SHA-256 of the document as
 	// stored (design docs 0043 §3.4, 0046 §3.4), which is what the ETag
 	// carries and what If-Match is checked against. It covers the
@@ -690,6 +751,11 @@ func Normalize(s string) string { return norm.NFC.String(s) }
 // JSON, so the same value decoded from YAML (int) and from JSONB (float64)
 // compares equal; values JSON cannot encode compare as different.
 //
+// Status is compared as a reader reads it, so a document that names
+// stable and one that names nothing are the same claim (SPEC §5.4) —
+// which is what lets a silent document round-trip without the index
+// column it derives disagreeing with it.
+//
 // The list comparisons are order-sensitive on purpose: reordering an
 // entry's citations or an Attested Computation's parameters is a change to
 // what it says, and a write that reorders them must not be swallowed as a
@@ -698,7 +764,7 @@ func (k *Knowledge) SameContent(o *Knowledge) bool {
 	return k.Type == o.Type && k.ID == o.ID &&
 		k.Title == o.Title && k.Description == o.Description &&
 		k.Resource == o.Resource &&
-		k.Status == o.Status && k.StatusNote == o.StatusNote &&
+		k.Lifecycle() == o.Lifecycle() && k.StatusNote == o.StatusNote &&
 		k.StaleAfter == o.StaleAfter &&
 		k.Runtime == o.Runtime && k.Computation == o.Computation &&
 		k.Body == o.Body &&
@@ -820,6 +886,15 @@ func ToTypes(ss []string) []Type {
 }
 
 // ToStatuses is ToTypes for status filters.
+func ToTrusts(ts []string) []Trust {
+	out := make([]Trust, 0, len(ts))
+	for _, t := range ts {
+		out = append(out, Trust(t))
+	}
+	return out
+}
+
+// ToStatuses converts wire strings to statuses.
 func ToStatuses(ss []string) []Status {
 	out := make([]Status, 0, len(ss))
 	for _, s := range ss {
@@ -851,7 +926,10 @@ type Summary struct {
 	Tags        []string `json:"tags,omitempty"`
 	Status      Status   `json:"status"`
 	StaleAfter  string   `json:"stale_after,omitempty"`
-	Verified    bool     `json:"verified"`
+	// Trust is OKF's tier (SPEC §5.3), derived from the verification
+	// ledger; a boolean is not a distinction the spec draws (design doc
+	// 0046 §3.10).
+	Trust Trust `json:"trust"`
 	// VerifiedAt is the newest verification's time, absent when there is
 	// none. A row carries it because it is what the verification-age feed
 	// ranks by — a reviewer reading that feed is reading these times.
@@ -868,8 +946,8 @@ type Summary struct {
 func SummaryOf(k *Knowledge) Summary {
 	s := Summary{
 		ID: k.ID, Type: k.Type, Title: k.DisplayTitle(), Description: k.Description,
-		Resource: k.Resource, Tags: k.Tags, Status: k.Status, StaleAfter: k.StaleAfter,
-		Verified: k.Verified(), Rejected: k.Rejection != nil, Links: k.Links,
+		Resource: k.Resource, Tags: k.Tags, Status: k.Lifecycle(), StaleAfter: k.StaleAfter,
+		Trust: TrustOf(k.Verifications), Rejected: k.Rejection != nil, Links: k.Links,
 		ContentHash: k.ContentHash, CreatedAt: k.CreatedAt, UpdatedAt: k.UpdatedAt,
 	}
 	if v := k.LastVerified(); v != nil {
@@ -971,11 +1049,12 @@ type ContextRank struct {
 	Type   Type   `json:"type"`
 	Title  string `json:"title"`
 	Status Status `json:"status"`
-	// Verified is the ledger's answer, which the lifecycle status no
-	// longer carries (design doc 0043 §3.2): a caller deciding whether to
-	// spend a round trip wants to know whether anyone confirmed the entry.
-	Verified bool    `json:"verified"`
-	Score    float64 `json:"score"`
+	// Trust is the ledger's answer in OKF's vocabulary (SPEC §5.3), which
+	// the lifecycle status does not carry (design docs 0043 §3.2, 0046
+	// §3.10): a caller deciding whether to spend a round trip wants to
+	// know who confirmed the entry, not merely whether somebody did.
+	Trust Trust   `json:"trust"`
+	Score float64 `json:"score"`
 }
 
 // URI is the entry's canonical address, as on Knowledge: a rank is a
@@ -988,7 +1067,7 @@ func ContextRanks(hits []SearchHit) []ContextRank {
 	for i := range hits {
 		out[i] = ContextRank{
 			ID: hits[i].ID, Type: hits[i].Type, Title: hits[i].Title,
-			Status: hits[i].Status, Verified: hits[i].Verified, Score: hits[i].Score,
+			Status: hits[i].Status, Trust: hits[i].Trust, Score: hits[i].Score,
 		}
 	}
 	return out

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -200,7 +200,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 		f := store.Filter{
 			Types: domain.ToTypes(in.Types), Statuses: domain.ToStatuses(in.Statuses),
 			Tags: in.Tags, Source: in.Source, Prefixes: in.Prefixes,
-			Verified: in.Verified, Rejected: in.Rejected,
+			Trust: domain.ToTrusts(in.Trust), Rejected: in.Rejected,
 		}
 		hits, err := svc.SearchOrList(ctx, in.Query, in.Sort, f, in.Limit)
 		if err != nil {
@@ -228,7 +228,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			Query: in.Query,
 			Filter: store.Filter{
 				Types: domain.ToTypes(in.Types), Statuses: domain.ToStatuses(in.Statuses), Tags: in.Tags,
-				Prefixes: in.Prefixes, Verified: in.Verified,
+				Prefixes: in.Prefixes, Trust: domain.ToTrusts(in.Trust),
 			},
 			Limit: in.Limit, Budget: budget,
 		})
@@ -262,8 +262,10 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "create_knowledge",
 		Annotations: nonDestructive,
-		Description: "Create a knowledge entry. Write back what you learned: metric caveats, verified answers, " +
-			"glossary terms. Entries default to draft; your identity is recorded as created_by. " +
+		Description: "Create a knowledge entry. Write back what you learned: metric caveats, confirmed answers, " +
+			"glossary terms. Write status: draft unless you are recording something already agreed — a " +
+			"document that names no status reads as stable (OKF SPEC §5.4). Your identity is recorded as " +
+			"created_by, and the entry stays unverified until a person confirms it. " +
 			"Before creating, search with rejected=true to avoid " +
 			"re-proposing knowledge that was already rejected (the ruling records why). " +
 			"For BigQuery Table/BigQuery Dataset/Reference entries, set resource to the asset's canonical URI and favor " +
@@ -271,7 +273,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"An \"Attested Computation\" entry records a sanctioned computation others must run instead of " +
 			"improvising: put the computation in a # Computation fence in body and the contract in the " +
 			"runtime, parameters, executor and attester fields. ochakai stores it and never runs it. " +
-			"A verified question-and-SQL pair is one of these: runtime says where the SQL runs, and " +
+			"A confirmed question-and-SQL pair is one of these: runtime says where the SQL runs, and " +
 			"attrs.question carries the natural-language question it answers. " +
 			"Cite the material an entry derives from in sources — each needs a resource, and an id lets " +
 			"markdown footnotes in body attribute single claims to it. " +
@@ -311,9 +313,10 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"Entries a human has ruled on — verified, rejected, or deprecated — cannot be updated from " +
 			"this surface: if a verified entry is wrong, report_outcome failed; otherwise create_knowledge " +
 			"a better draft and let a human promote it. " +
-			"Setting status=verified records you as verified_by — " +
-			"do it only for knowledge you have actually validated. Setting status=rejected records you " +
-			"as rejected_by; put the reason in status_note (also useful when deprecating).",
+			"status is the lifecycle only — draft, stable, deprecated (OKF SPEC §5.4); a document that " +
+			"names none reads as stable, so write status: draft for a draft. Whether anyone has confirmed " +
+			"the entry is not yours to set: it comes from the verification ledger, and this surface does " +
+			"not verify or reject. Put the reason for deprecating in status_note.",
 	}, tool(svc, func(ctx context.Context, actor domain.Actor, in writeIn) (*mcp.CallToolResult, knowledgeOut, error) {
 		// MCP has no conditional-update channel, so it cannot opt into the
 		// If-Match precondition (nil) and writes are last-write-wins. That
@@ -488,7 +491,7 @@ type searchIn struct {
 	Query    string   `json:"query,omitempty" jsonschema:"search text; required unless sort is set (omit it then)"`
 	Types    []string `json:"types,omitempty" jsonschema:"filter by type (Metric, Attested Computation, Skill, Playbook, Insight, Policy, Glossary Term, BigQuery Dataset, BigQuery Table, API Endpoint, Reference, or any custom type); matched case-insensitively"`
 	Statuses []string `json:"statuses,omitempty" jsonschema:"filter by lifecycle status: draft, stable, deprecated. Whether anyone confirmed an entry is a separate question — use verified"`
-	Verified *bool    `json:"verified,omitempty" jsonschema:"true for entries somebody has confirmed, false for ones nobody has; omit to not ask. Independent of status: a draft can be verified and a stable entry unverified"`
+	Trust    []string `json:"trust,omitempty" jsonschema:"filter by who confirmed the entry: unverified, machine-confirmed, human-reviewed (OKF SPEC §5.3); repeat to OR them, omit to not ask. Independent of status: a draft can be human-reviewed and a stable entry unverified"`
 	Rejected *bool    `json:"rejected,omitempty" jsonschema:"true to list only entries a human turned down — how you check whether a proposal was already rejected before making it again. Omit and rejected entries stay out of results"`
 	Tags     []string `json:"tags,omitempty" jsonschema:"filter by tag"`
 	Source   string   `json:"source,omitempty" jsonschema:"only entries citing this resource, matched exactly against sources[].resource — the reverse lookup for \"this material changed, what derives from it?\"; a filter, so it combines with query or sort"`
@@ -511,7 +514,7 @@ type contextIn struct {
 	Query    string   `json:"query" jsonschema:"the data question to gather context for"`
 	Types    []string `json:"types,omitempty" jsonschema:"filter by type (Metric, Attested Computation, Skill, Playbook, Insight, Policy, Glossary Term, BigQuery Dataset, BigQuery Table, API Endpoint, Reference, or any custom type); matched case-insensitively"`
 	Statuses []string `json:"statuses,omitempty" jsonschema:"filter by lifecycle status: draft, stable, deprecated. Whether anyone confirmed an entry is a separate question — use verified"`
-	Verified *bool    `json:"verified,omitempty" jsonschema:"true for entries somebody has confirmed, false for ones nobody has; omit to not ask. Independent of status: a draft can be verified and a stable entry unverified"`
+	Trust    []string `json:"trust,omitempty" jsonschema:"filter by who confirmed the entry: unverified, machine-confirmed, human-reviewed (OKF SPEC §5.3); repeat to OR them, omit to not ask. Independent of status: a draft can be human-reviewed and a stable entry unverified"`
 	Tags     []string `json:"tags,omitempty" jsonschema:"filter by tag"`
 	Prefixes []string `json:"prefixes,omitempty" jsonschema:"only entries addressed under these paths, e.g. [\"teams/growth\", \"company\"] — an id is a path, so this scopes the search to a subtree; listing several ORs them, which is how you ask your own scope and the shared one in one call. It scopes the search, not the link expansion: an entry in scope that cites a term outside it still arrives with that term"`
 	Limit    int      `json:"limit,omitempty" jsonschema:"max primary entries: default 5, max 20 (out-of-range falls back to the default); linked companions share a 2x limit total cap"`

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -52,11 +52,6 @@ func Handler(svc *service.Service) http.Handler {
 			writeError(w, err)
 			return
 		}
-		verified, err := queryTriBool(q, "verified")
-		if err != nil {
-			writeError(w, err)
-			return
-		}
 		rejected, err := queryTriBool(q, "rejected")
 		if err != nil {
 			writeError(w, err)
@@ -68,7 +63,7 @@ func Handler(svc *service.Service) http.Handler {
 			Tags:     q["tag"],
 			Source:   q.Get("source"),
 			Prefixes: q["prefix"],
-			Verified: verified,
+			Trust:    domain.ToTrusts(q["trust"]),
 			Rejected: rejected,
 		}
 		hits, err := svc.SearchOrList(r.Context(), q.Get("q"), q.Get("sort"), f, limit)
@@ -122,11 +117,6 @@ func Handler(svc *service.Service) http.Handler {
 			writeError(w, err)
 			return
 		}
-		verified, err := queryTriBool(q, "verified")
-		if err != nil {
-			writeError(w, err)
-			return
-		}
 		res, err := svc.Context(r.Context(), service.ContextRequest{
 			Query: q.Get("q"),
 			Filter: store.Filter{
@@ -134,7 +124,7 @@ func Handler(svc *service.Service) http.Handler {
 				Statuses: domain.ToStatuses(q["status"]),
 				Tags:     q["tag"],
 				Prefixes: q["prefix"],
-				Verified: verified,
+				Trust:    domain.ToTrusts(q["trust"]),
 			},
 			Limit: limit, MinScore: minScore, Budget: budget,
 		})

--- a/internal/restapi/restapi_integration_test.go
+++ b/internal/restapi/restapi_integration_test.go
@@ -85,7 +85,11 @@ func TestRESTIntegration(t *testing.T) {
 	// §3.5).
 	var got domain.View
 	getJSON(t, srv.URL+"/api/v1/knowledge/"+typ+"/sales/orders", &got)
-	if got.Summary.Title != "REST round trip" || got.Summary.Status != domain.StatusDraft {
+	// The document named no status, so it reads as OKF's default rather
+	// than as a draft — and nobody has confirmed it, which is what the
+	// trust tier says (design doc 0046 §§3.9-3.10).
+	if got.Summary.Title != "REST round trip" || got.Summary.Status != domain.StatusStable ||
+		got.Summary.Trust != domain.TrustUnverified {
 		t.Errorf("summary = %+v", got.Summary)
 	}
 	if !strings.Contains(got.Document, "title: REST round trip") {
@@ -525,7 +529,9 @@ func TestRESTIntegrationVerify(t *testing.T) {
 	}
 
 	first := verify()
-	if len(first.Observed.Verified) != 1 || !first.Summary.Verified {
+	// The test server reads no identity, so the confirmation is a
+	// process's: machine-confirmed, not human-reviewed (SPEC §5.3).
+	if len(first.Observed.Verified) != 1 || first.Summary.Trust != domain.TrustMachine {
 		t.Fatalf("verify appended nothing: %+v", first.Observed.Verified)
 	}
 	// The ledger is an observation, so it travels beside the document

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -171,9 +171,13 @@ func (s *Service) create(ctx context.Context, k *domain.Knowledge, actor domain.
 		return nil, err
 	}
 	deriveLinks(k)
-	if k.Status == "" {
-		k.Status = domain.StatusDraft
-	}
+	// A document that names no status is not a draft — it is silent, and
+	// OKF says a silent document is stable (SPEC §5.4). The index column
+	// holds what a reader would read, and the document keeps its silence:
+	// ochakai does not write a key its writer left out (design doc 0046
+	// §3.9). Whether anybody has confirmed the entry is a separate
+	// question, which the trust tier answers (§3.10).
+	k.Status = k.Lifecycle()
 	k.CreatedBy, k.UpdatedBy = actor, actor
 	if err := s.Store.Create(ctx, k, keepCuratedTombstones); err != nil {
 		return nil, err
@@ -212,9 +216,10 @@ func (s *Service) Update(ctx context.Context, k *domain.Knowledge, actor domain.
 	if ifMatch != nil && old.ContentHash != *ifMatch {
 		return nil, false, store.ErrConflict
 	}
-	if k.Status == "" {
-		k.Status = old.Status
-	}
+	// A PUT is a full replacement, so an omitted status is not "keep the
+	// one you had": it is the document saying nothing, which reads as
+	// OKF's default (design doc 0046 §3.9).
+	k.Status = k.Lifecycle()
 	k.CreatedBy = old.CreatedBy
 	k.CreatedAt = old.CreatedAt
 	// The ledgers belong to the instance, not to the payload: an update
@@ -1164,7 +1169,11 @@ func rrfFuse(limit int, lists ...[]domain.SearchHit) []domain.SearchHit {
 	}
 	out := make([]domain.SearchHit, 0, len(byKey))
 	for _, e := range byKey {
-		if e.hit.Verified {
+		// Any confirmation earns the nudge, whichever tier it is: the
+		// boost is about "somebody checked this", and weighting the tiers
+		// against each other would be a ranking decision no record makes
+		// (design docs 0033, 0046 §3.10).
+		if e.hit.Trust == domain.TrustHuman || e.hit.Trust == domain.TrustMachine {
 			e.score += 0.002
 		}
 		e.hit.Score = e.score

--- a/internal/service/service_integration_test.go
+++ b/internal/service/service_integration_test.go
@@ -144,9 +144,12 @@ func TestUpdateNoOpIntegration(t *testing.T) {
 		return &domain.Knowledge{
 			Type: domain.TypeMetrics, ID: id, Title: "売上",
 			Description: "統合テスト用", Tags: []string{"sales"},
-			Status: domain.StatusDraft,
-			Attrs:  map[string]any{"threshold": 5},
-			Body:   "受注合計。[sales モデル](/model/sales.md) で定義。",
+			// No status: the entry reads as OKF's default, which is what
+			// makes the status-omitting payload below content-identical
+			// rather than a claim about a different lifecycle value
+			// (design doc 0046 §3.9).
+			Attrs: map[string]any{"threshold": 5},
+			Body:  "受注合計。[sales モデル](/model/sales.md) で定義。",
 		}
 	}
 	if _, err := svc.Create(ctx, entry(), actor); err != nil {

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -23,10 +23,11 @@ func hit(id string, status domain.Status) domain.SearchHit {
 }
 
 // verifiedHit is hit plus a confirmation. The rank boost keys off the
-// ledger rather than the status now (design doc 0043 §3.2).
+// trust tier the ledger yields rather than the status (design docs 0043
+// §3.2, 0046 §3.10).
 func verifiedHit(id string) domain.SearchHit {
 	h := hit(id, domain.StatusStable)
-	h.Verified = true
+	h.Trust = domain.TrustHuman
 	return h
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -168,11 +168,12 @@ type Filter struct {
 	// Values arrive normalized by the service — NFC, no trailing slash.
 	Prefixes []string
 
-	// Verified and Rejected ask about the instance ledgers rather than the
-	// document (design doc 0043 §§3.2-3.3). Both are tri-state: nil leaves
-	// the question unasked. Nil Rejected still hides rejected entries —
-	// the default is not "no constraint" but "not the ones we said no to".
-	Verified *bool
+	// Trust and Rejected ask about the instance ledgers rather than the
+	// document (design docs 0043 §§3.2-3.3, 0046 §3.10). Trust is empty
+	// when the question is not asked, and OR-ed like Statuses when it is;
+	// Rejected is tri-state, and nil still hides rejected entries — the
+	// default is not "no constraint" but "not the ones we said no to".
+	Trust    []domain.Trust
 	Rejected *bool
 }
 
@@ -331,6 +332,7 @@ func knowledgeDestFor(k *domain.Knowledge, withDoc bool) (dests []any, finish fu
 	}
 	dests = append(dests, &k.ContentHash, &verifications, &rejection)
 	finish = func() error {
+		defer func() { k.Trust = domain.TrustOf(k.Verifications) }()
 		if staleAfter != nil {
 			k.StaleAfter = staleAfter.UTC().Format(domain.StaleAfterLayout)
 		}
@@ -407,12 +409,9 @@ func documentSays(doc []byte, k *domain.Knowledge) bool {
 	// (design doc 0017) — nor its links, which are derived from the body
 	// it does carry (design doc 0024).
 	d.ID, d.Links = k.ID, k.Links
-	// Nor is a document that names no status disagreeing about one: it is
-	// saying nothing, and the write path still fills a default in until
-	// the read projection applies OKF's (design doc 0046 §3.9).
-	if d.Status == "" {
-		d.Status = k.Status
-	}
+	// A document that names no status still agrees with the index column
+	// derived from it: SameContent compares what a reader reads, and a
+	// silent document reads as OKF's default (design doc 0046 §3.9).
 	return d.SameContent(k)
 }
 
@@ -1576,13 +1575,34 @@ func (f Filter) buildWhere(prefix string) (string, []any) {
 	} else {
 		conds = append(conds, "NOT "+rejectedExists)
 	}
-	if f.Verified != nil {
-		verifiedExists := fmt.Sprintf(
+	if len(f.Trust) > 0 {
+		// SPEC §5.3's tiers as predicates over the ledger: a person makes
+		// an entry human-reviewed, any other confirmation
+		// machine-confirmed, none unverified. Asking for several ORs them,
+		// so "anything somebody confirmed" is two values rather than a
+		// second kind of filter.
+		anyVerification := fmt.Sprintf(
 			"EXISTS (SELECT 1 FROM knowledge_verification v WHERE v.id = %sid)", outer)
-		if *f.Verified {
-			conds = append(conds, verifiedExists)
-		} else {
-			conds = append(conds, "NOT "+verifiedExists)
+		byHuman := fmt.Sprintf(
+			"EXISTS (SELECT 1 FROM knowledge_verification v WHERE v.id = %sid AND v.by_kind = 'human')", outer)
+		var tiers []string
+		for _, t := range f.Trust {
+			switch t {
+			case domain.TrustUnverified:
+				tiers = append(tiers, "NOT "+anyVerification)
+			case domain.TrustMachine:
+				tiers = append(tiers, anyVerification+" AND NOT "+byHuman)
+			case domain.TrustHuman:
+				tiers = append(tiers, byHuman)
+			default:
+				// A tier nobody defines matches nothing. Dropping it
+				// instead would answer a question the caller did not ask
+				// — and answer it with everything.
+				tiers = append(tiers, "false")
+			}
+		}
+		if len(tiers) > 0 {
+			conds = append(conds, "("+strings.Join(tiers, ") OR (")+")")
 		}
 	}
 	if len(f.Tags) > 0 {

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -540,9 +540,11 @@ function lastVerification(observed) {
   const vs = (observed || {}).verified || [];
   return vs.length ? vs[vs.length - 1] : null;
 }
-// A summary answers "has anyone confirmed this" as a bool; the ledger
-// itself travels in observed (design doc 0043 §3.5).
-function isVerified(e) { return !!e.verified; }
+// A summary answers "who confirmed this" with OKF's tier (SPEC §5.3);
+// the ledger itself travels in observed (design docs 0043 §3.5, 0046
+// §3.10).
+function trustOf(e) { return e.trust || 'unverified'; }
+function isVerified(e) { return trustOf(e) !== 'unverified'; }
 
 // Whole days since an ISO timestamp (null for unparseable input).
 function daysSince(s) {
@@ -838,8 +840,8 @@ function viewExplore() {
     // point — and being able to read them is how somebody checks what was
     // already declined.
     + `
-    <label class="chip" title="Only entries somebody has confirmed"><input type="checkbox" id="f-verified"
-      aria-label="verified only" ${explore.verified ? 'checked' : ''}>✓ verified</label>
+    <label class="chip" title="Only entries somebody has confirmed — machine-confirmed or human-reviewed (OKF SPEC §5.3)"><input type="checkbox" id="f-verified"
+      aria-label="confirmed only" ${explore.verified ? 'checked' : ''}>✓ confirmed</label>
     <label class="chip" title="Only entries a human reviewed and turned down — hidden everywhere else"><input type="checkbox" id="f-rejected"
       aria-label="rejected only" ${explore.rejected ? 'checked' : ''}>rejected</label>`;
   // Filters collapse into a disclosure on narrow screens; keep it open on
@@ -961,7 +963,9 @@ async function runSearch() {
   else if (!explore.source) p.set('sort', 'usage');
   for (const t of explore.types) p.append('type', t);
   for (const s of explore.statuses) p.append('status', s);
-  if (explore.verified) p.set('verified', 'true');
+  // The filter asks SPEC §5.3's question — who confirmed this — rather
+  // than a boolean the spec has no word for (design doc 0046 §3.10).
+  if (explore.verified) { p.append('trust', 'human-reviewed'); p.append('trust', 'machine-confirmed'); }
   if (explore.rejected) p.set('rejected', 'true');
   if (explore.tag) p.append('tag', explore.tag);
   // A path scope is a filter like tag, so it rides along with whatever
@@ -1481,7 +1485,7 @@ async function viewDetail(id) {
           ${STATUSES.map(s => `<option value="${s}" ${s === entry.status ? 'selected' : ''}>${s}</option>`).join('')}
         </select>
       </span>
-      ${isVerified(entry) ? '<span class="badge verified-mark" title="Somebody confirmed this entry">✓ verified</span>' : ''}
+      ${isVerified(entry) ? `<span class="badge verified-mark" title="The trust tier OKF derives from the verification ledger (SPEC §5.3)">✓ ${trustOf(entry)}</span>` : ''}
       ${entry.rejected ? '<span class="badge rejected-mark" title="Reviewed and not accepted">rejected</span>' : ''}
       ${tags}
       <span class="actions write-only">


### PR DESCRIPTION
Third in the 0044 stack. **Base is #258**, which is based on #257 (the design doc). This PR's diff is the two vocabularies.

## Status: absence is absence

A document that named no status was read as a **draft** on create, and as *whatever was already there* on update. Both are the server writing a key its writer left out.

SPEC §5.4 says a silent document is `stable`. So the write path stops inventing a value and the **projection applies the default**: the index column holds what a reader would read, the document keeps its silence, and `SameContent` compares the same way — which is what lets a silent document round-trip without the column derived from it disagreeing with it. (That also lets `documentSays` in #258 drop the tolerance it was carrying.)

**The consequence is deliberate**: an agent that means "draft" now writes `status: draft`, and the MCP tool descriptions say so in as many words. Nothing is lost by it — whether anybody has confirmed an entry was never the lifecycle's business, which is the other half of this PR.

An update also stops inheriting the stored status: a PUT is a full replacement, and an omitted key is the document saying nothing, not the document declining to comment.

## Trust: SPEC §5.3's three tiers, not a boolean

`verified: true/false` is not a distinction OKF draws. §5.3 derives three tiers from the verification ledger, read off the `human:` prefix alone:

`unverified` → `machine-confirmed` → `human-reviewed`

They ride on every entry and every `/context` rank row beside `status`, derived on read and never accepted from a payload. The filter follows on all four surfaces:

| | before | after |
|---|---|---|
| REST | `?verified=true` | `?trust=human-reviewed` (repeatable, OR-ed) |
| MCP | `verified: bool` | `trust: []string` |
| CLI | `--verified true` | `--trust human-reviewed` |
| Web UI | "✓ verified" chip | "✓ confirmed" chip → two tiers; the badge shows the tier |

Asking for two tiers is two values rather than a second kind of filter. An unrecognized tier matches nothing rather than being dropped — dropping it would answer a question the caller did not ask, and answer it with everything.

Verifying itself is untouched: a ledger append, absent from MCP, and it still leaves the entry's version where it was.

## Also in here

- The `update_knowledge` and `create_knowledge` descriptions lost prose that predated 0043 — they still told agents to set `status=verified` and promised it would record them as `verified_by`, neither of which has existed since the ledgers landed.
- `Trust` is in `openapi.yaml` as a schema, on the entry, and on both filters; `Status`'s description now states the default.
- `TrustsHint()` is the single home of the vocabulary, interpolated into the three completion scripts the same way the types and statuses already are (0038 §4.4), so `--trust <Tab>` cannot fall behind.

## Checks

`scripts/check --db` passes. `docs/cli.md` regenerated; the guides and README examples updated.

Note: the store integration tests leave their entries live, so a long-lived test database eventually accumulates enough same-titled rows to crowd a search assertion out of its limit. Resetting the schema fixes it; it is not caused by this change, but it is a sharp edge worth knowing about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)