### PR TITLE
Keep only the link forms OKF defines (0046 §3.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,27 @@ last entry.
     composes a document itself, and as what a write path falls back to
     when a caller changes an entry's fields rather than its document.
 
+- **BREAKING**: body links keep only the two forms OKF defines (design
+  doc [0046](docs/design/0046-bundle-address-space.md) §3.6).
+  `[revenue](/metrics/revenue.md)` and `[gross](./gross.md)` are edges;
+  `ochakai://metrics/revenue` is not one any more, in a link, an
+  autolink, or bare prose.
+
+  A body travels inside the bundle, so a scheme ochakai invented meant
+  every export carried links no other consumer could resolve. Migration
+  0026 rewrites the bodies that used it — a link target becomes the
+  bundle-absolute path and keeps its anchor text, a bare or autolinked
+  URI becomes a whole markdown link named by the id, since a bare path
+  in prose is not a link and would have cost the entry an edge. The
+  ETags of rewritten entries move; `generated` does not, because
+  spelling a link the way the spec spells it is not a change to what the
+  entry says. Revision snapshots keep the spelling they were written
+  with.
+
+  The scheme stays where portability is not the question: MCP still
+  addresses an entry as `ochakai://{id}`, and `report_outcome` and the
+  CLI still tolerate the prefix on an id argument.
+
 - **BREAKING**: status and trust are said the way OKF says them (design
   doc [0046](docs/design/0046-bundle-address-space.md) §§3.9-3.10).
 

--- a/README.md
+++ b/README.md
@@ -462,8 +462,9 @@ Entries relate to each other through **the markdown links in their body**
 — there is no links field to fill in. Write `[revenue](/metrics/revenue.md)`
 in the prose and the entry links to `metrics/revenue`; the target gains a
 backlink, and `get_context` expands the edge in both directions. Relative
-paths (`./gross.md`) and canonical URIs (`ochakai://metrics/revenue`, bare
-or in a link) work too. This is OKF SPEC §5 taken at its word: a link
+paths (`./gross.md`) work too — those two are the forms SPEC §6 defines,
+and they are the only ones, so an exported bundle's links resolve for
+whoever reads it. This is OKF SPEC §5 taken at its word: a link
 asserts a relationship, and what kind of relationship it is comes from the
 surrounding prose, so ochakai stores no relationship type of its own
 (design doc 0024). Links inside fenced code blocks (``` or ~~~) and

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1108,7 +1108,7 @@ paths:
         The id is the address (design doc 0017), so a move carries
         everything keyed by it along in one transaction — revisions,
         usage, attachments, embeddings — and rewrites inbound references
-        (link targets in both bare and ochakai:// forms, and the producer
+        (link targets in both of SPEC §6's forms, and the producer
         key `model` where a document carries one)
         so nothing breaks (design doc 0021). The destination must be a
         fresh id: a live or soft-deleted entry there already owns that
@@ -2171,7 +2171,7 @@ components:
         text:
           type: string
           description: >
-            The anchor text the body used. Absent for a bare ochakai:// reference,
+            The anchor text the body used. Absent when the link carried none,
             in which case the target's last segment reads as the name.
     Summary:
       type: object
@@ -2249,10 +2249,10 @@ components:
           items: { $ref: "#/components/schemas/Link" }
           description: >
             Derived from the markdown links in the document's body,
-            recomputed on every write. Bundle-absolute
-            (/metrics/revenue.md), relative (./revenue.md), and
-            ochakai:// targets are all read; http(s) URLs and non-.md
-            files are not (the latter are attachments).
+            recomputed on every write. OKF SPEC §6's two forms are read:
+            bundle-absolute (/metrics/revenue.md) and relative
+            (./revenue.md). http(s) URLs and non-.md files are not (the
+            latter are attachments).
         content_hash:
           type: string
           description: >

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -178,8 +178,9 @@ location: `queries/sales/monthly-revenue` is one entry, and the
 directories are how you organize a knowledge base. A type is an attribute
 of an entry, not part of its address, so the layout of an exported bundle
 comes from ids alone (design doc
-[0017](design/0017-path-addressing.md)). The canonical URI is that path
-under the `ochakai://` scheme. `title` is optional — an entry without one
+[0017](design/0017-path-addressing.md)). MCP addresses an entry as a
+resource by that path under the `ochakai://` scheme — a URI for MCP's
+sake, which never travels in a bundle. `title` is optional — an entry without one
 is displayed by the last segment of its id, the way a file is named by
 its filename — and ids are NFC-normalized and searchable in their own
 right (design doc [0022](design/0022-filename-as-name.md)).
@@ -218,8 +219,8 @@ an agent can check it before re-proposing the same thing (design doc
 [0043](design/0043-document-first.md) §§3.2-3.3).
 
 **Relationships come from the prose.** There is no links field. A
-markdown link in the body — `[revenue](/metrics/revenue.md)`, a relative
-path, or an `ochakai://` URI — is the edge; the target gains a backlink,
+markdown link in the body — `[revenue](/metrics/revenue.md)` or a
+relative path, the two forms OKF SPEC §6 defines — is the edge; the target gains a backlink,
 and rename rewrites the references pointing at it. What *kind* of
 relationship it is comes from the sentence around it, so ochakai stores
 no relationship vocabulary of its own (design doc

--- a/internal/domain/links.go
+++ b/internal/domain/links.go
@@ -12,13 +12,17 @@ import (
 // says the kind of relationship is carried by the surrounding prose, not
 // by the link — so ochakai stores what the body says and nothing more.
 //
-// Five forms are recognized:
+// Two forms are recognized, and they are the two SPEC §6 defines:
 //
-//	[text](/metrics/revenue.md)     bundle-absolute, the SPEC's primary form
+//	[text](/metrics/revenue.md)     bundle-absolute, the spec's recommended form
 //	[text](./revenue.md)            relative to the entry's own directory
-//	[text](ochakai://metrics/revenue)
-//	<ochakai://metrics/revenue>     autolink, no anchor text
-//	ochakai://metrics/revenue       bare, no anchor text
+//
+// ochakai:// used to be a third, taught as first-class. It went with
+// design doc 0046 §3.6: a body travels in the bundle, and no other
+// consumer can resolve a scheme ochakai invented — an exported bundle
+// full of them is a bundle whose links only work here. (The scheme
+// survives where it is not a portability question: MCP requires a URI
+// for a resource, and that URI never leaves this server.)
 //
 // http(s) URLs are not links between entries (design doc 0024 §4), and
 // non-.md file references are attachments (design doc 0008), so both are
@@ -29,9 +33,6 @@ var (
 	// A leading "!" (image) is excluded by the caller — images are
 	// attachment references, never entry links.
 	mdLinkRe = regexp.MustCompile(`(!?)\[([^\]]*)\]\(([^)\s]+)\)`)
-	// bareURIRe matches ochakai:// references written without markdown
-	// link syntax, with or without autolink angle brackets.
-	bareURIRe = regexp.MustCompile(`<?(ochakai://[^\s<>()\[\]"']+)>?`)
 	// fenceRe matches the opening or closing line of a fenced code block.
 	fenceRe = regexp.MustCompile("^\\s{0,3}(```|~~~)")
 	// inlineCodeRe matches a backtick code span, which is stripped before
@@ -60,57 +61,14 @@ func LinksFromBody(id, body string) []Link {
 		links = append(links, l)
 	}
 	for _, line := range proseLines(body) {
-		consumed := map[string]bool{}
 		for _, m := range mdLinkRe.FindAllStringSubmatch(line, -1) {
 			if m[1] == "!" { // image: an attachment reference
 				continue
 			}
-			consumed[m[3]] = true
 			add(m[3], m[2])
-		}
-		for _, m := range bareURIRe.FindAllStringSubmatch(line, -1) {
-			uri := trimSentencePunctuation(m[1])
-			if consumed[uri] || consumed[m[1]] { // already taken as a markdown link target
-				continue
-			}
-			add(uri, "")
 		}
 	}
 	return links
-}
-
-// asciiEnders end an English sentence; cjkEnders end a Japanese one.
-// They are treated differently because English prose puts a space after
-// the stop and Japanese does not, so only the trailing run can be trimmed
-// in one and the match has to be cut at the first occurrence in the
-// other. Both apply to bare URIs alone: a markdown link's target has
-// explicit delimiters, so whatever the parentheses hold is meant.
-const (
-	asciiEnders = ".,;:!?"
-	cjkEnders   = "。、，．！？"
-)
-
-// trimSentencePunctuation ends a bare URI where the sentence around it
-// ends. "See ochakai://metrics/revenue." names metrics/revenue, not
-// "metrics/revenue." — which resolves to no entry, so the target gains no
-// backlink, a context pack never expands through it, and a move never
-// repairs it. Nothing reports the miss: a link to an id nobody wrote
-// looks exactly like a link to an entry not written yet.
-//
-// The trailing trim cannot serve Japanese, where "ochakai://tables/orders
-// を参照" has no space to stop at — so the match is also cut at the first
-// full-width stop, which no id in practice contains. Latin ids that
-// contain a dot ("ga4/events/purchase.v2") keep it: only a trailing run
-// is trimmed.
-//
-// An id may technically end in "." (only a leading dot is refused) and is
-// unreachable this way. It stays addressable in the form that says where
-// it ends: a markdown link.
-func trimSentencePunctuation(uri string) string {
-	if i := strings.IndexAny(uri, cjkEnders); i >= 0 {
-		uri = uri[:i]
-	}
-	return strings.TrimRight(uri, asciiEnders)
 }
 
 // resolveTarget turns one link target into an entry id, or "" when the
@@ -124,11 +82,9 @@ func resolveTarget(id, target string) string {
 	if target == "" {
 		return ""
 	}
-	if rest, ok := strings.CutPrefix(target, "ochakai://"); ok {
-		return strings.Trim(rest, "/")
-	}
-	// Any other scheme (http, https, mailto, gs) addresses something
-	// outside the bundle.
+	// A scheme (http, https, mailto, gs) addresses something outside the
+	// bundle — including ochakai://, which is no longer a link form a
+	// body may use (design doc 0046 §3.6).
 	if schemeRe.MatchString(target) {
 		return ""
 	}
@@ -188,9 +144,8 @@ func proseLines(body string) []string {
 // newID, and returns the body unchanged when nothing referred to oldID.
 // id is the entry whose body this is, needed to resolve relative targets.
 //
-// An ochakai:// target keeps that form; every other rewritten target
-// becomes bundle-absolute ("/newID.md"). A relative target cannot simply
-// have its id swapped — where it resolves to depends on the referring
+// A rewritten target becomes bundle-absolute ("/newID.md"). A relative
+// target cannot simply have its id swapped — where it resolves to depends on the referring
 // entry's own location, which a move may have just changed — so
 // normalizing to absolute is the one predictable outcome (design doc
 // 0024 §3.5).
@@ -199,9 +154,6 @@ func RewriteBodyLinks(id, body, oldID, newID string) string {
 		target, frag := splitFragment(target)
 		if resolveTarget(id, target) != oldID {
 			return target + frag
-		}
-		if strings.HasPrefix(target, "ochakai://") {
-			return "ochakai://" + newID + frag
 		}
 		return "/" + newID + ".md" + frag
 	})
@@ -301,35 +253,10 @@ func rewriteLine(line string, rewriteTarget func(string) string) string {
 			edits = append(edits, edit{lo, hi, t})
 		}
 	}
-	for _, m := range bareURIRe.FindAllStringSubmatchIndex(line, -1) {
-		lo, hi := m[2], m[3]
-		if inCode(m[0], m[1]) || overlapsLink(line, lo) {
-			continue
-		}
-		// The URI ends where the sentence around it does, as it does when
-		// the same line is read for links: rewriting the punctuation along
-		// with it would compare "metrics/revenue." against the moved id
-		// and leave the reference pointing at an entry that is gone.
-		hi = lo + len(trimSentencePunctuation(line[lo:hi]))
-		if t := rewriteTarget(line[lo:hi]); t != line[lo:hi] {
-			edits = append(edits, edit{lo, hi, t})
-		}
-	}
 	slices.SortFunc(edits, func(a, b edit) int { return a.lo - b.lo })
 	for i := len(edits) - 1; i >= 0; i-- {
 		e := edits[i]
 		line = line[:e.lo] + e.text + line[e.hi:]
 	}
 	return line
-}
-
-// overlapsLink reports whether offset lo sits inside a markdown link's
-// target, where the markdown pass has already handled it.
-func overlapsLink(line string, lo int) bool {
-	for _, m := range mdLinkRe.FindAllStringIndex(line, -1) {
-		if lo >= m[0] && lo < m[1] {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/domain/links_test.go
+++ b/internal/domain/links_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 )
 
-// The five forms design doc 0024 §3.3 recognizes, and the things that
-// look like links but are not: external URLs, attachments, anchors.
+// The two forms SPEC §6 defines (design docs 0024 §3.3, 0046 §3.6), and
+// the things that look like links but are not: external URLs,
+// attachments, anchors.
 func TestLinksFromBody(t *testing.T) {
 	for _, tc := range []struct {
 		name, id, body string
@@ -23,30 +24,13 @@ func TestLinksFromBody(t *testing.T) {
 			body: "Compare [gross](./gross.md) and [orders](../tables/orders.md).",
 			want: []Link{{Target: "metrics/gross", Text: "gross"}, {Target: "tables/orders", Text: "orders"}},
 		}, {
-			name: "canonical URI in a markdown link",
+			// The retired scheme is a URI like any other now: it addresses
+			// something outside the bundle, which is exactly what it did
+			// for every consumer that was not ochakai (design doc 0046
+			// §3.6). A migration rewrote the bodies that used it.
+			name: "the ochakai:// scheme is not a link between entries",
 			id:   "insights/a",
-			body: "See [revenue](ochakai://metrics/revenue).",
-			want: []Link{{Target: "metrics/revenue", Text: "revenue"}},
-		}, {
-			name: "autolink and bare URI carry no anchor text",
-			id:   "insights/a",
-			body: "Autolink <ochakai://metrics/revenue> and bare ochakai://tables/orders here.",
-			want: []Link{{Target: "metrics/revenue"}, {Target: "tables/orders"}},
-		}, {
-			// A bare URI ends where the sentence does. Left in, the
-			// trailing stop became part of the id: no backlink, no
-			// expansion through the link, and a move that never repairs
-			// it — all silent, because a link to an id nobody wrote looks
-			// the same as one to an entry not written yet.
-			name: "a bare URI ends before the sentence's punctuation",
-			id:   "insights/a",
-			body: "See ochakai://metrics/revenue. Also ochakai://tables/orders、and ochakai://terms/arr?",
-			want: []Link{{Target: "metrics/revenue"}, {Target: "tables/orders"}, {Target: "terms/arr"}},
-		}, {
-			name: "a markdown link's target keeps what the parentheses hold",
-			id:   "insights/a",
-			body: "See [revenue](ochakai://metrics/revenue.) for the definition.",
-			want: []Link{{Target: "metrics/revenue.", Text: "revenue"}},
+			body: "See [revenue](ochakai://metrics/revenue), <ochakai://metrics/revenue>, and bare ochakai://tables/orders.",
 		}, {
 			name: "external URLs are not entry links",
 			id:   "insights/a",
@@ -72,11 +56,6 @@ func TestLinksFromBody(t *testing.T) {
 				{Target: "metrics/revenue", Text: "revenue"},
 				{Target: "metrics/revenue", Text: "売上"},
 			},
-		}, {
-			name: "a link inside a markdown link is not counted twice",
-			id:   "insights/a",
-			body: "See [revenue](ochakai://metrics/revenue) only once.",
-			want: []Link{{Target: "metrics/revenue", Text: "revenue"}},
 		}, {
 			name: "a target climbing above the bundle root is not an entry",
 			id:   "a",
@@ -134,10 +113,12 @@ func TestRewriteBodyLinks(t *testing.T) {
 			body: "See [revenue](/metrics/revenue.md).",
 			want: "See [revenue](/finance/revenue.md).",
 		}, {
-			name: "canonical URI keeps its form",
+			// Not an edge any more, so a move leaves it exactly where it
+			// is — like any other URI in the prose (design doc 0046 §3.6).
+			name: "the retired scheme is left alone",
 			id:   "insights/a",
 			body: "See ochakai://metrics/revenue and <ochakai://metrics/revenue>.",
-			want: "See ochakai://finance/revenue and <ochakai://finance/revenue>.",
+			want: "See ochakai://metrics/revenue and <ochakai://metrics/revenue>.",
 		}, {
 			name: "a relative target normalizes to bundle-absolute",
 			id:   "metrics/gross",
@@ -164,11 +145,11 @@ func TestRewriteBodyLinks(t *testing.T) {
 	}
 }
 
-// Several rewrites on one line must all land, whichever pass found them.
+// Several rewrites on one line must all land.
 func TestRewriteBodyLinksMultiplePerLine(t *testing.T) {
-	body := "ochakai://metrics/revenue then [r](/metrics/revenue.md) then ochakai://metrics/revenue"
-	want := "ochakai://m/r then [r](/m/r.md) then ochakai://m/r"
-	if got := RewriteBodyLinks("insights/a", body, "metrics/revenue", "m/r"); got != want {
+	body := "[a](/metrics/revenue.md) then [r](/metrics/revenue.md) then [c](./revenue.md)"
+	want := "[a](/m/r.md) then [r](/m/r.md) then [c](/m/r.md)"
+	if got := RewriteBodyLinks("metrics/x", body, "metrics/revenue", "m/r"); got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
 }
@@ -191,10 +172,10 @@ func TestAbsolutizeBodyLinks(t *testing.T) {
 			body: "See [orders](../orders.md).",
 			want: "See [orders](/metrics/orders.md).",
 		}, {
-			name: "absolute and canonical forms are already stable",
+			name: "an absolute target is already stable",
 			id:   "metrics/revenue",
-			body: "See [g](/metrics/gross.md), ochakai://metrics/net, <ochakai://metrics/net>.",
-			want: "See [g](/metrics/gross.md), ochakai://metrics/net, <ochakai://metrics/net>.",
+			body: "See [g](/metrics/gross.md).",
+			want: "See [g](/metrics/gross.md).",
 		}, {
 			name: "non-entry targets are left alone",
 			id:   "metrics/revenue",
@@ -240,36 +221,5 @@ func TestLinkDisplayText(t *testing.T) {
 	// No anchor text: the target's last segment is the name (design doc 0022).
 	if got := (Link{Target: "metrics/revenue"}).DisplayText(); got != "revenue" {
 		t.Errorf("DisplayText = %q, want the target's last segment", got)
-	}
-}
-
-// Rewriting a body on move goes through the same reading of where a bare
-// URI ends, so a sentence-final URI has to be rewritten without eating
-// the stop -- and an id that legitimately carries a dot has to keep it.
-func TestBareURIPunctuationRoundTrip(t *testing.T) {
-	for _, tc := range []struct{ name, id, body, want string }{
-		{
-			name: "sentence-final URI keeps its full stop",
-			id:   "insights/a",
-			body: "See ochakai://metrics/revenue. Nothing else.",
-			want: "See ochakai://metrics/gross. Nothing else.",
-		}, {
-			name: "Japanese prose keeps the particle that follows",
-			id:   "insights/a",
-			body: "ochakai://metrics/revenue、を参照。",
-			want: "ochakai://metrics/gross、を参照。",
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := RewriteBodyLinks(tc.id, tc.body, "metrics/revenue", "metrics/gross"); got != tc.want {
-				t.Errorf("RewriteBodyLinks(%q) = %q, want %q", tc.body, got, tc.want)
-			}
-		})
-	}
-
-	// A dot inside a latin id is part of the id: only a trailing run goes.
-	dotted := LinksFromBody("insights/a", "See ochakai://ga4/events/purchase.v2 for the shape.")
-	if len(dotted) != 1 || dotted[0].Target != "ga4/events/purchase.v2" {
-		t.Errorf("links = %+v, want ga4/events/purchase.v2 intact", dotted)
 	}
 }

--- a/internal/restapi/restapi_integration_test.go
+++ b/internal/restapi/restapi_integration_test.go
@@ -705,7 +705,7 @@ func TestRESTIntegrationUsageBacklinksAndMove(t *testing.T) {
 		}
 	}
 	create(metric, "Revenue", "The headline number.")
-	create(insight, "Reading revenue", "Seasonality caveats for [Revenue](ochakai://"+metric+").")
+	create(insight, "Reading revenue", "Seasonality caveats for [Revenue](/"+metric+".md).")
 
 	// Backlinks: the insight links to the metric, not the other way round.
 	var backlinks struct {

--- a/internal/service/context_integration_test.go
+++ b/internal/service/context_integration_test.go
@@ -64,7 +64,7 @@ func TestContextIntegration(t *testing.T) {
 		// enforces (design doc 0036 §3.10).
 		{Type: domain.TypeComputations, ID: queryID, Title: "monthly numbers", Runtime: "bigquery"},
 		{Type: domain.TypeInsights, ID: insightID, Title: "how to read it",
-			Body: "Explains ochakai://" + metricID + "."},
+			Body: "Explains [the metric](/" + metricID + ".md)."},
 		{Type: domain.TypeInsights, ID: rejectedID, Title: "bad take",
 			Status: domain.StatusDraft,
 			Body:   "Explains [the metric](/" + metricID + ".md)."},

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -789,7 +789,7 @@ func (s *Service) Context(ctx context.Context, req ContextRequest) (*ContextResu
 	primaries := len(entries)
 	for i := range primaries {
 		for _, l := range entries[i].Links {
-			add(strings.TrimPrefix(l.Target, "ochakai://"))
+			add(l.Target)
 		}
 		linking, err := s.Store.ListLinkingTo(ctx, entries[i].ID, 2*limit)
 		if err != nil {

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"sort"
 
 	"github.com/jackc/pgx/v5"
@@ -95,6 +96,9 @@ func (s *Store) Migrate(ctx context.Context, embedDim int) error {
 	if err := s.backfillDocuments(ctx); err != nil {
 		return fmt.Errorf("backfill documents: %w", err)
 	}
+	if err := s.backfillLinkForms(ctx); err != nil {
+		return fmt.Errorf("backfill link forms: %w", err)
+	}
 
 	if embedDim > 0 {
 		if err := s.migrateEmbedding(ctx, embedDim); err != nil {
@@ -163,6 +167,95 @@ func (s *Store) backfillEntryDocuments(ctx context.Context) error {
 			return nil
 		}
 	}
+}
+
+// backfillLinkForms rewrites the ochakai:// links migration 0026 marked,
+// into the bundle-absolute form SPEC §6 defines (design doc 0046 §3.6).
+//
+// It is Go rather than SQL because three things have to move together
+// and only one of them is a column: the body inside the stored document
+// (swapped in place, so the frontmatter the writer wrote is not
+// reformatted), the links index derived from that body, and the content
+// hash over the result. A regexp_replace on the body alone would leave
+// the document contradicting its own index.
+//
+// The work list is a table, so a run that dies half-way resumes and one
+// that finishes leaves nothing to do. content_changed_at is not touched:
+// spelling a link the way the spec spells it is not a change to what the
+// entry says, any more than composing the stored document was.
+func (s *Store) backfillLinkForms(ctx context.Context) error {
+	for {
+		rows, err := s.pool.Query(ctx,
+			`SELECT `+knowledgeSelectDoc+` FROM knowledge
+			 WHERE id IN (SELECT id FROM link_form_backfill) ORDER BY id LIMIT $1`,
+			backfillBatch)
+		if err != nil {
+			if isUndefinedTable(err) {
+				return nil // migration 0026 has not run yet on this database
+			}
+			return err
+		}
+		batch, err := pgx.CollectRows(rows, scanKnowledgeDoc)
+		if err != nil {
+			return err
+		}
+		if len(batch) == 0 {
+			return nil
+		}
+		for i := range batch {
+			k := &batch[i]
+			body := rewriteOchakaiURIs(k.Body)
+			k.Doc = string(okf.ReplaceBody([]byte(k.Doc), body))
+			k.Body = body
+			k.Links = domain.LinksFromBody(k.ID, body)
+			doc, hash, err := storedDoc(k)
+			if err != nil {
+				s.log.Warn("cannot rewrite an entry's link forms", "id", k.ID, "err", err)
+				continue
+			}
+			j, err := marshalJSONFields(k)
+			if err != nil {
+				return err
+			}
+			if _, err := s.pool.Exec(ctx,
+				`UPDATE knowledge SET body=$2, links=$3, doc=$4, content_hash=$5 WHERE id=$1`,
+				k.ID, k.Body, j.links, doc, hash); err != nil {
+				return err
+			}
+		}
+		ids := make([]string, len(batch))
+		for i := range batch {
+			ids[i] = batch[i].ID
+		}
+		if _, err := s.pool.Exec(ctx, `DELETE FROM link_form_backfill WHERE id = ANY($1)`, ids); err != nil {
+			return err
+		}
+	}
+}
+
+var (
+	// ochakaiTargetRe matches the retired scheme where it was a markdown
+	// link's target; only the target is rewritten, and the anchor text
+	// the writer chose stays theirs.
+	ochakaiTargetRe = regexp.MustCompile(`\]\(ochakai://([^)\s]+)\)`)
+	// ochakaiBareRe matches what is left: an autolink, or a URI written
+	// as bare prose. The trailing sentence punctuation English and
+	// Japanese put after one is excluded, exactly as the parser excluded
+	// it while the form still existed — it was never part of the id.
+	ochakaiBareRe = regexp.MustCompile(`<?ochakai://([^\s<>()\[\]"'。、，．！？]*[^\s<>()\[\]"'。、，．！？.,;:!?])>?`)
+)
+
+// rewriteOchakaiURIs turns every ochakai://<id> in a body into the form
+// SPEC §6 recommends.
+//
+// A bare or autolinked URI becomes a whole markdown link rather than a
+// bare path: "/metrics/revenue.md" sitting in prose is a path, not a
+// link, and would leave the entry with one fewer edge than its writer
+// wrote. The anchor text is the id, which is what the bare form
+// displayed anyway.
+func rewriteOchakaiURIs(body string) string {
+	body = ochakaiTargetRe.ReplaceAllString(body, "](/$1.md)")
+	return ochakaiBareRe.ReplaceAllString(body, "[$1](/$1.md)")
 }
 
 // anyConverted reports whether any of the batch now has a document, so a

--- a/internal/store/migrate_test.go
+++ b/internal/store/migrate_test.go
@@ -1,0 +1,55 @@
+package store
+
+import "testing"
+
+// Migration 0026 rewrites the ochakai:// links out of the bodies that
+// still carry them (design doc 0046 §3.6). It has to read where a bare
+// URI ends the same way the parser read it while the form existed: the
+// stop that ends the sentence was never part of the id, in either
+// English or Japanese, and an id that legitimately carries a dot keeps
+// it.
+func TestRewriteOchakaiURIs(t *testing.T) {
+	for _, tc := range []struct{ name, body, want string }{
+		{
+			name: "a markdown link keeps its anchor text",
+			body: "See [revenue](ochakai://metrics/revenue) for the definition.",
+			want: "See [revenue](/metrics/revenue.md) for the definition.",
+		}, {
+			// A bare path in prose is not a link, so leaving one behind
+			// would cost the entry an edge its writer wrote.
+			name: "a bare URI becomes a whole link, named by its id",
+			body: "See ochakai://metrics/revenue for the definition.",
+			want: "See [metrics/revenue](/metrics/revenue.md) for the definition.",
+		}, {
+			name: "an autolink loses its brackets",
+			body: "See <ochakai://metrics/revenue>.",
+			want: "See [metrics/revenue](/metrics/revenue.md).",
+		}, {
+			name: "a sentence-final URI keeps its full stop",
+			body: "See ochakai://metrics/revenue. Nothing else.",
+			want: "See [metrics/revenue](/metrics/revenue.md). Nothing else.",
+		}, {
+			name: "Japanese prose keeps the particle that follows",
+			body: "ochakai://metrics/revenue、を参照。",
+			want: "[metrics/revenue](/metrics/revenue.md)、を参照。",
+		}, {
+			name: "a dot inside a latin id is part of the id",
+			body: "See ochakai://ga4/events/purchase.v2 for the shape.",
+			want: "See [ga4/events/purchase.v2](/ga4/events/purchase.v2.md) for the shape.",
+		}, {
+			name: "several on one line all land",
+			body: "[a](ochakai://m/r) then ochakai://m/r then <ochakai://t/o>",
+			want: "[a](/m/r.md) then [m/r](/m/r.md) then [t/o](/t/o.md)",
+		}, {
+			name: "a body with none is untouched",
+			body: "See [revenue](/metrics/revenue.md) and https://example.com/x.",
+			want: "See [revenue](/metrics/revenue.md) and https://example.com/x.",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := rewriteOchakaiURIs(tc.body); got != tc.want {
+				t.Errorf("rewriteOchakaiURIs(%q) =\n%q\nwant\n%q", tc.body, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/store/migrations/0026_spec_link_forms.sql
+++ b/internal/store/migrations/0026_spec_link_forms.sql
@@ -1,0 +1,23 @@
+-- Bodies stop carrying ochakai:// links (design doc 0046 §3.6).
+--
+-- SPEC §6 defines two link forms, bundle-absolute and relative.
+-- ochakai:// was a third, invented here and taught as first-class — and
+-- a body travels in the bundle, so every export carried links no other
+-- consumer could resolve. Retiring the form from the parser is not
+-- enough: a body that still says ochakai://metrics/revenue would simply
+-- stop having that edge.
+--
+-- The rewrite itself is Go (backfillLinkForms): it has to re-derive the
+-- links column and re-hash the document, and the document is text this
+-- migration must not reformat. All this file does is mark the entries
+-- that still need it, so the backfill has a work list it can resume.
+--
+-- Revision snapshots are left alone. They are what the entry said at the
+-- time, and what it said at the time included that spelling.
+CREATE TABLE IF NOT EXISTS link_form_backfill (
+    id text PRIMARY KEY
+);
+
+INSERT INTO link_form_backfill (id)
+SELECT id FROM knowledge WHERE body LIKE '%ochakai://%'
+ON CONFLICT (id) DO NOTHING;

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -530,14 +530,14 @@ func (s *Store) GetTombstone(ctx context.Context, id string) (*domain.Knowledge,
 // ListLinkingTo returns live entries whose links point at id, most
 // recently updated first. This is the reverse edge Context needs: the
 // insight that explains a metric links to the metric, not the other way
-// round. Both bare and ochakai:// target forms match.
+// round. A stored target is always the resolved id, whichever of SPEC
+// §6's two forms the body wrote it in.
 func (s *Store) ListLinkingTo(ctx context.Context, id string, limit int) ([]domain.Knowledge, error) {
 	return s.queryKnowledge(ctx,
 		`SELECT `+knowledgeSelect+` FROM knowledge
-		 WHERE deleted_at IS NULL AND (links @> $1 OR links @> $2)
-		 ORDER BY updated_at DESC LIMIT $3`,
+		 WHERE deleted_at IS NULL AND links @> $1
+		 ORDER BY updated_at DESC LIMIT $2`,
 		fmt.Sprintf(`[{"target": %q}]`, id),
-		fmt.Sprintf(`[{"target": %q}]`, "ochakai://"+id),
 		limit)
 }
 
@@ -920,7 +920,7 @@ func (s *Store) Purge(ctx context.Context, id string, actor domain.Actor) error 
 // 0017), so everything keyed by it follows in one transaction — the row,
 // its revisions, attachments, usage, events, and embeddings — and live
 // entries that reference the old id (link targets in both bare and
-// ochakai:// forms, and attrs.model) are rewritten so no reference
+// both of SPEC §6's forms, and attrs.model) are rewritten so no reference
 // breaks. Attachment bytes never move: blobs are content-addressed
 // (design doc 0011). The destination must be a fresh id — a row there,
 // even soft-deleted, already owns that address and its revision history.
@@ -1039,10 +1039,9 @@ func (s *Store) rewriteReferences(ctx context.Context, tx pgx.Tx, oldID string, 
 	// queue instead of deadlocking.
 	rows, err := tx.Query(ctx,
 		`SELECT `+knowledgeSelectDoc+` FROM knowledge
-		 WHERE deleted_at IS NULL AND (links @> $1 OR links @> $2 OR attrs->>'model' = $3 OR id = $4)
+		 WHERE deleted_at IS NULL AND (links @> $1 OR attrs->>'model' = $2 OR id = $3)
 		 ORDER BY id FOR UPDATE`,
 		fmt.Sprintf(`[{"target": %q}]`, oldID),
-		fmt.Sprintf(`[{"target": %q}]`, "ochakai://"+oldID),
 		oldID, newID)
 	if err != nil {
 		return err

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -425,8 +425,9 @@ func TestIntegrationToleratesMissingEmbeddingTable(t *testing.T) {
 }
 
 // ListLinkingTo powers get_context's reverse-link expansion: entries
-// whose links point at the target must surface — in both the bare and
-// the ochakai:// target forms — and soft-deleted entries must not.
+// whose links point at the target must surface — a stored target is
+// always the resolved id, whichever of SPEC §6's forms the body wrote —
+// and soft-deleted entries must not.
 func TestIntegrationListLinkingTo(t *testing.T) {
 	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
 	if dbURL == "" {
@@ -452,8 +453,8 @@ func TestIntegrationListLinkingTo(t *testing.T) {
 		{Type: domain.TypeMetrics, ID: "it-link-metric", Title: "target", Status: domain.StatusDraft, CreatedBy: actor},
 		{Type: domain.TypeInsights, ID: "it-link-bare", Title: "bare link", Status: domain.StatusDraft, CreatedBy: actor,
 			Links: []domain.Link{{Target: "it-link-metric", Text: "explains"}}},
-		{Type: domain.TypeInsights, ID: "it-link-uri", Title: "uri link", Status: domain.StatusDraft, CreatedBy: actor,
-			Links: []domain.Link{{Target: "ochakai://it-link-metric", Text: "explains"}}},
+		{Type: domain.TypeInsights, ID: "it-link-rel", Title: "relative link", Status: domain.StatusDraft, CreatedBy: actor,
+			Links: []domain.Link{{Target: "it-link-metric", Text: "explains"}}},
 		{Type: domain.TypeInsights, ID: "it-link-gone", Title: "deleted link", Status: domain.StatusDraft, CreatedBy: actor,
 			Links: []domain.Link{{Target: "it-link-metric", Text: "explains"}}},
 	}
@@ -474,8 +475,8 @@ func TestIntegrationListLinkingTo(t *testing.T) {
 	for _, k := range got {
 		ids[k.ID] = true
 	}
-	if len(got) != 2 || !ids["it-link-bare"] || !ids["it-link-uri"] {
-		t.Errorf("ListLinkingTo = %v, want it-link-bare and it-link-uri", ids)
+	if len(got) != 2 || !ids["it-link-bare"] || !ids["it-link-rel"] {
+		t.Errorf("ListLinkingTo = %v, want it-link-bare and it-link-rel", ids)
 	}
 }
 
@@ -727,9 +728,9 @@ func TestIntegrationMove(t *testing.T) {
 		{Type: domain.TypeInsights, ID: "it-move-bare", Title: "bare link", Status: domain.StatusDraft, CreatedBy: actor,
 			Body:  "Explains [the metric](/it-move-src/metric.md).",
 			Links: []domain.Link{{Target: "it-move-src/metric", Text: "the metric"}}},
-		{Type: domain.TypeInsights, ID: "it-move-uri", Title: "uri link", Status: domain.StatusDraft, CreatedBy: actor,
-			Body:  "Explains ochakai://it-move-src/metric further.",
-			Links: []domain.Link{{Target: "it-move-src/metric", Text: ""}}},
+		{Type: domain.TypeInsights, ID: "it-move-src/sibling", Title: "relative link", Status: domain.StatusDraft, CreatedBy: actor,
+			Body:  "Explains [the metric](./metric.md) further.",
+			Links: []domain.Link{{Target: "it-move-src/metric", Text: "the metric"}}},
 		{Type: domain.TypeMetrics, ID: "it-move-attrs", Title: "attrs.model ref", Status: domain.StatusDraft, CreatedBy: actor,
 			Attrs: map[string]any{"model": "it-move-src/metric"}},
 		{Type: domain.TypeInsights, ID: "it-move-taken", Title: "occupies destination", Status: domain.StatusDraft, CreatedBy: actor},
@@ -821,11 +822,12 @@ func TestIntegrationMove(t *testing.T) {
 
 	// Inbound references rewritten in the body — the links column follows
 	// because it is derived from it (design doc 0024) — each as a
-	// revision. Targets are stored bare; the body keeps the notation its
-	// author used.
+	// revision. Targets are stored as ids; a rewritten link comes out
+	// bundle-absolute whichever form it went in as, since that is the one
+	// form a later move cannot reinterpret (0024 §3.5).
 	for id, wantBody := range map[string]string{
-		"it-move-bare": "Explains [the metric](/it-move-dst/metric.md).",
-		"it-move-uri":  "Explains ochakai://it-move-dst/metric further.",
+		"it-move-bare":        "Explains [the metric](/it-move-dst/metric.md).",
+		"it-move-src/sibling": "Explains [the metric](/it-move-dst/metric.md) further.",
 	} {
 		k, err := s.Get(ctx, id)
 		if err != nil {

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -631,12 +631,7 @@ function md(src, resolveFile, resolveEntry) {
     .replace(/(^|\W)\*([^*\n]+)\*(?=\W|$)/g, '$1<em>$2</em>')
     .replace(/!\[([^\]]*)\]\(([^)\s]+)\)/g, img)
     .replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, link)
-    // Bare and autolinked ochakai:// references, which carry no anchor
-    // text and read as the target's last segment.
-    .replace(/(?:&lt;)?(ochakai:\/\/[^\s&<>()[\]"']+)(?:&gt;)?/g, (m, uri) => {
-      const route = resolveEntry && resolveEntry(uri);
-      return route ? `<a href="${route}">${uri.split('/').pop()}</a>` : m;
-    }));
+    );
   const flushPara = () => { if (para.length) { out += '<p>' + inline(para.join(' ')) + '</p>'; para = []; } };
   const flushList = () => { if (inList) { out += `</${inList}>`; inList = null; } };
   for (const line of lines) {
@@ -1558,16 +1553,15 @@ async function viewDetail(id) {
     return hit ? attURL(hit.name) : null;
   };
   // Links to other entries, resolved the way the server derives them from
-  // this same body (design doc 0024): bundle-absolute "/x/y.md", relative
-  // "./y.md" against the document's directory, or the canonical URI. A
+  // this same body (design doc 0024): SPEC §6's two forms, bundle-absolute
+  // "/x/y.md" and relative "./y.md" against the document's directory. A
   // reference to anything else — an attachment, an external URL, an
-  // anchor — is not an entry link and stays literal text.
+  // anchor, a URI scheme — is not an entry link and stays literal text.
   const resolveEntry = ref => {
     const target = String(ref).split(/[#?]/)[0];
     if (!target) return null;
     let id;
-    if (target.startsWith('ochakai://')) id = normalize(target.slice('ochakai://'.length));
-    else if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(target)) return null; // some other scheme
+    if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(target)) return null; // a scheme: outside the bundle
     else if (!target.endsWith('.md')) return null; // an attachment, not an entry
     else {
       const rel = target.slice(0, -'.md'.length);


### PR DESCRIPTION
Fourth in the 0044 stack. **Base is #262** → #258 → #257.

## Why

`ochakai://metrics/revenue` was a link form ochakai invented, taught as first-class in three spellings (link target, autolink, bare prose). Bodies travel **inside the bundle**, so every export carried links no other consumer can resolve — the one place the format was ochakai's rather than OKF's, in the artifact whose entire purpose is to be readable elsewhere.

SPEC §6 defines two forms. Those are now the two that make an edge:

```markdown
[revenue](/metrics/revenue.md)   bundle-absolute
[gross](./gross.md)              relative to the entry's directory
```

## The migration matters more than the parser change

Retiring the form from the parser alone would silently drop edges that bodies already have — a link to an id nobody wrote looks exactly like a link to an entry not written yet, which is the failure mode 0024 warned about.

So migration 0026 marks the entries whose body still contains the scheme, and a Go backfill rewrites them. Go rather than SQL because three things move together and only one is a column: the body **inside the stored document** (swapped in place via `ReplaceBody`, so the frontmatter stays byte-for-byte the writer's), the `links` index derived from that body, and the content hash over the result. A `regexp_replace` on the body alone would leave the document contradicting its own index.

- A link target becomes the bundle-absolute path and **keeps its anchor text**.
- A bare or autolinked URI becomes a **whole markdown link**, named by the id — a bare `/metrics/revenue.md` in prose is a path, not a link, and leaving one would cost the entry the edge its writer wrote.
- ETags of rewritten entries move; `generated` does not (spelling a link the spec's way is not a change to what the entry says).
- Revision snapshots are left alone: they are what the entry said at the time, and what it said included that spelling.

The work list is a table, so a half-finished run resumes and a finished one leaves nothing to do.

## Where the reading of a bare URI went

The extractor's careful handling of where a bare URI ends — the full stop in English, the particle in Japanese, the dot inside `ga4/events/purchase.v2` — is gone from `domain/links.go` along with `bareURIRe`, `trimSentencePunctuation` and `overlapsLink`, and reappears in the migration, which is now the only thing that needs it. Its test moved with it.

## The scheme survives where portability is not the question

MCP requires a URI to address a resource; `ochakai://{+id}` stays, and never leaves the server. `report_outcome` and the CLI still tolerate the prefix on an id argument.

## Checks

`scripts/check --db` passes. Store, REST and service integration tests updated to SPEC forms; web UI renderer, `openapi.yaml`, README and `docs/architecture.md` follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)