### PR TITLE
Index the frontmatter, and filter on any key (0046 §3.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,30 @@ last entry.
 
 ### Added
 
+- **Any frontmatter key is a filter**: `?fm.owner=finance` on REST,
+  `fm: {owner: finance}` on MCP, `--fm owner=finance` on the CLI (design
+  doc [0046](docs/design/0046-bundle-address-space.md) §3.11). It matches
+  a scalar exactly or a member of a list, and repeating it with different
+  keys ANDs them.
+
+  The whole frontmatter is now indexed as `jsonb`, so a key OKF adds in a
+  later version — or one a producer invented — is askable the day
+  somebody writes it, with no column, no migration and no release.
+  Storage became additive when the document became the stored form;
+  querying did not follow until now.
+
+  Exact match and list membership are the only two comparisons. Ranges,
+  negation and boolean expressions are the doorway to a query language,
+  and what ochakai returns is knowledge rather than rows.
+
+  The typed columns stay where they are — they are the same values with
+  better indexes (trigram over the text, a date for `stale_after`, an
+  array for tags) — so `type`, `status`, `tag`, `source` and
+  `stale_after` keep answering from them. Migration 0027 adds the column
+  and a GIN index and backfills from each stored document; no timestamp
+  moves and no hash changes, since indexing what an entry already said is
+  not a change to what it says.
+
 - `ochakai import --strict` — fail on a bundle that was not read exactly
   as written, instead of reporting it. A note is still the default and
   still not an error: OKF tells a consumer to take a document rather than

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -85,6 +85,23 @@ paths:
             (SPEC §§5.3-5.4).
           schema: { type: array, items: { $ref: "#/components/schemas/Trust" } }
           explode: true
+        - name: fm.{key}
+          in: query
+          description: >
+            Filter by any frontmatter key, exactly: `fm.owner=finance`
+            finds the entries whose frontmatter says owner is finance,
+            matching a scalar or a member of a list. Repeat with
+            different keys to AND them.
+
+            This is the filter that does not need a release. A key OKF
+            adds in a later version, or one a producer invented, is
+            askable the day somebody writes it — the whole frontmatter is
+            indexed, not the subset ochakai happens to name (design doc
+            0046 §3.11). Exact match and list membership are the only two
+            comparisons: ranges and boolean expressions are the doorway
+            to a query language, and what ochakai returns is knowledge
+            rather than rows.
+          schema: { type: string }
         - name: rejected
           in: query
           description: >
@@ -409,6 +426,23 @@ paths:
             somebody turned down.
           schema: { type: array, items: { $ref: "#/components/schemas/Trust" } }
           explode: true
+        - name: fm.{key}
+          in: query
+          description: >
+            Filter by any frontmatter key, exactly: `fm.owner=finance`
+            finds the entries whose frontmatter says owner is finance,
+            matching a scalar or a member of a list. Repeat with
+            different keys to AND them.
+
+            This is the filter that does not need a release. A key OKF
+            adds in a later version, or one a producer invented, is
+            askable the day somebody writes it — the whole frontmatter is
+            indexed, not the subset ochakai happens to name (design doc
+            0046 §3.11). Exact match and list membership are the only two
+            comparisons: ranges and boolean expressions are the doorway
+            to a query language, and what ochakai returns is knowledge
+            rather than rows.
+          schema: { type: string }
         - name: tag
           in: query
           schema: { type: array, items: { type: string } }

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -205,6 +205,25 @@ func statusList() string {
 // to the second vocabulary OKF gives ochakai).
 func trustList() string { return strings.ReplaceAll(domain.TrustsHint(), ", ", "|") }
 
+// fmPairs turns repeated --fm key=value flags into the map the API takes.
+// A flag with no "=" is a mistake worth naming: silently ignoring it
+// would answer a narrower question than the caller asked, without saying
+// so.
+func fmPairs(vals []string) (map[string]string, error) {
+	if len(vals) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]string, len(vals))
+	for _, v := range vals {
+		key, value, ok := strings.Cut(v, "=")
+		if !ok || key == "" {
+			return nil, fmt.Errorf("--fm wants key=value, got %q", v)
+		}
+		out[key] = value
+	}
+	return out, nil
+}
+
 // parseRef parses an entry id (an "ochakai://" prefix is tolerated).
 func parseRef(s string) (string, error) {
 	id := strings.TrimPrefix(s, "ochakai://")
@@ -227,6 +246,8 @@ func cmdSearch(ctx context.Context, args []string) error {
 	source := fs.String("source", "", "only entries citing this `resource` (exact match against sources[].resource) — what derives from one piece of material")
 	var trust repeated
 	fs.Var(&trust, "trust", "filter by who confirmed the entry: "+trustList()+" (repeatable, OR-ed) — independent of --status, which is the lifecycle value")
+	var fm repeated
+	fs.Var(&fm, "fm", "filter by a frontmatter `key=value`, exactly (repeatable, AND-ed) — for keys with no flag of their own, a producer's or a later OKF version's")
 	rejected := fs.Bool("rejected", false, "only entries a human turned down — how you check whether a proposal was already rejected. Without it, rejected entries stay out of results")
 	sortBy := fs.String("sort", "", `list instead of search: "verified_at" = by verification age (oldest first), "usage" = by demand (most search_hits first), "failed" = by failed outcome reports (re-verification feed), "stale_after" = past their declared expiry, most overdue first`)
 	limit := fs.Int("limit", 0, "max results (server default 10, max 50; with --sort: 100, max 1000)")
@@ -245,10 +266,14 @@ func cmdSearch(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
+	pairs, err := fmPairs(fm)
+	if err != nil {
+		return err
+	}
 	hits, err := c.Search(ctx, apiclient.SearchParams{
 		Query: strings.Join(pos, " "), Types: types, Statuses: statuses, Tags: tags,
 		Source: *source, Prefixes: prefixes, Sort: *sortBy, Limit: *limit,
-		Trust: trust, Rejected: optBool(*rejected),
+		Trust: trust, Rejected: optBool(*rejected), FM: pairs,
 	})
 	if err != nil {
 		return err
@@ -344,6 +369,8 @@ func cmdContext(ctx context.Context, args []string) error {
 	fs.Var(&prefixes, "prefix", "only entries under this `path`, e.g. teams/growth (repeatable, OR-ed); scopes the search, not the links it expands")
 	var trust repeated
 	fs.Var(&trust, "trust", "filter by who confirmed the entry: "+trustList()+" (repeatable, OR-ed) — independent of --status, which is the lifecycle value")
+	var fm repeated
+	fs.Var(&fm, "fm", "filter by a frontmatter `key=value`, exactly (repeatable, AND-ed) — for keys with no flag of their own, a producer's or a later OKF version's")
 	limit := fs.Int("limit", 0, "max full entries (server default 5, max 20)")
 	budget := fs.Int("budget", 0, "cap the response at ~this many bytes (0 = no cap); the rendered output stops printing entries, --json asks the server to cap and list what did not fit under \"outline\"")
 	minScore := fs.Float64("min-score", 0, "drop hits scoring below this; scores depend on the server's search mode (matched-fragment weight plus boosts vs RRF rank fusion), so calibrate before use (0 = off)")
@@ -368,9 +395,13 @@ func cmdContext(ctx context.Context, args []string) error {
 	if *asJSON {
 		serverBudget = *budget
 	}
+	pairs, err := fmPairs(fm)
+	if err != nil {
+		return err
+	}
 	res, err := c.Context(ctx, apiclient.ContextParams{
 		Query: strings.Join(pos, " "), Types: types, Statuses: statuses, Tags: tags,
-		Prefixes: prefixes, Trust: trust, Limit: *limit, MinScore: *minScore, Budget: serverBudget,
+		Prefixes: prefixes, Trust: trust, FM: pairs, Limit: *limit, MinScore: *minScore, Budget: serverBudget,
 	})
 	if err != nil {
 		return err

--- a/cmd/ochakai/completion.go
+++ b/cmd/ochakai/completion.go
@@ -118,6 +118,7 @@ _ochakai() {
         '*--prefix[only entries under this path]:prefix:' \
         '--source[only entries citing this resource]:source:' \
         '*--trust[filter by who confirmed the entry (OKF SPEC §5.3)]:trust:(@TRUSTS@)' \
+        '*--fm[filter by a frontmatter key=value]:fm:' \
         '--rejected[only entries a human turned down]' \
         '--sort[list instead of searching: by verification age, demand, failed reports, or declared expiry]:sort:(verified_at usage failed stale_after)' \
         '--limit[max results]:limit:' \
@@ -131,6 +132,7 @@ _ochakai() {
         '*--tag[filter by tag]:tag:' \
         '*--prefix[only entries under this path]:prefix:' \
         '*--trust[filter by who confirmed the entry (OKF SPEC §5.3)]:trust:(@TRUSTS@)' \
+        '*--fm[filter by a frontmatter key=value]:fm:' \
         '--limit[max full entries]:limit:' \
         '--budget[stop rendering after ~bytes]:budget:' \
         '--min-score[drop hits below this score]:min-score:' \
@@ -228,9 +230,9 @@ _ochakai() {
   esac
 
   case $cmd in
-    search)        opts="--type --status --tag --prefix --source --trust --rejected --sort --limit --json --url" ;;
+    search)        opts="--type --status --tag --prefix --source --trust --fm --rejected --sort --limit --json --url" ;;
     browse)        opts="--json --url" ;;
-    context)       opts="--type --status --tag --prefix --trust --limit --budget --min-score --json --url" ;;
+    context)       opts="--type --status --tag --prefix --trust --fm --limit --budget --min-score --json --url" ;;
     get)           opts="--json --download --url" ;;
     usage)         opts="--json --url" ;;
     revisions|backlinks) opts="--limit --json --url" ;;
@@ -322,6 +324,7 @@ complete -c ochakai -n '__fish_seen_subcommand_from search context' -l tag -x -d
 complete -c ochakai -n '__fish_seen_subcommand_from search context' -l prefix -x -d 'only entries under this path'
 complete -c ochakai -n '__fish_seen_subcommand_from search' -l source -x -d 'only entries citing this resource'
 complete -c ochakai -n '__fish_seen_subcommand_from search context' -l trust -x -a '@TRUSTS@' -d 'filter by who confirmed the entry (OKF SPEC §5.3)'
+complete -c ochakai -n '__fish_seen_subcommand_from search context' -l fm -x -d 'filter by a frontmatter key=value'
 complete -c ochakai -n '__fish_seen_subcommand_from search' -l rejected -d 'only entries a human turned down'
 complete -c ochakai -n '__fish_seen_subcommand_from reject' -l note -x -d 'why it was not accepted'
 complete -c ochakai -n '__fish_seen_subcommand_from reject' -l lift -d 'withdraw the rejection'

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -165,6 +165,8 @@ context window. No hits print nothing (exit 0).
 Flags:
   -budget int
     	cap the response at ~this many bytes (0 = no cap); the rendered output stops printing entries, --json asks the server to cap and list what did not fit under "outline"
+  -fm key=value
+    	filter by a frontmatter key=value, exactly (repeatable, AND-ed) — for keys with no flag of their own, a producer's or a later OKF version's
   -json
     	print the raw JSON response
   -limit int
@@ -536,6 +538,8 @@ living under a path, which is how a team's own knowledge is told apart
 from the company-wide vocabulary.
 
 Flags:
+  -fm key=value
+    	filter by a frontmatter key=value, exactly (repeatable, AND-ed) — for keys with no flag of their own, a producer's or a later OKF version's
   -json
     	print the raw JSON response
   -limit int

--- a/internal/apiclient/apiclient.go
+++ b/internal/apiclient/apiclient.go
@@ -141,7 +141,9 @@ type SearchParams struct {
 	// Both are tri-state: nil leaves the question unasked. Nil Rejected
 	// still hides rejected entries — asking for them is opt-in, which is
 	// how an agent checks whether a proposal was already turned down.
-	Trust    []string
+	Trust []string
+	// FM narrows by frontmatter key, sent as fm.<key>=<value>.
+	FM       map[string]string
 	Rejected *bool
 	Limit    int
 }
@@ -171,6 +173,9 @@ func (c *Client) Search(ctx context.Context, p SearchParams) ([]domain.SearchHit
 	}
 	for _, t := range p.Trust {
 		q.Add("trust", t)
+	}
+	for k, v := range p.FM {
+		q.Set("fm."+k, v)
 	}
 	if p.Rejected != nil {
 		q.Set("rejected", strconv.FormatBool(*p.Rejected))
@@ -211,7 +216,9 @@ type ContextParams struct {
 	// Trust narrows by who confirmed the entry, as on
 	// SearchParams. Rejected has no counterpart here: a context pack never
 	// carries knowledge somebody turned down.
-	Trust    []string
+	Trust []string
+	// FM narrows by frontmatter key, sent as fm.<key>=<value>.
+	FM       map[string]string
 	Limit    int
 	MinScore float64
 	// Budget, when positive, caps the response bytes server-side: entries
@@ -242,6 +249,9 @@ func (c *Client) Context(ctx context.Context, p ContextParams) (*ContextResult, 
 	}
 	for _, t := range p.Trust {
 		q.Add("trust", t)
+	}
+	for k, v := range p.FM {
+		q.Set("fm."+k, v)
 	}
 	if p.Limit > 0 {
 		q.Set("limit", strconv.Itoa(p.Limit))

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -200,7 +200,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 		f := store.Filter{
 			Types: domain.ToTypes(in.Types), Statuses: domain.ToStatuses(in.Statuses),
 			Tags: in.Tags, Source: in.Source, Prefixes: in.Prefixes,
-			Trust: domain.ToTrusts(in.Trust), Rejected: in.Rejected,
+			Trust: domain.ToTrusts(in.Trust), Rejected: in.Rejected, Frontmatter: in.FM,
 		}
 		hits, err := svc.SearchOrList(ctx, in.Query, in.Sort, f, in.Limit)
 		if err != nil {
@@ -228,7 +228,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			Query: in.Query,
 			Filter: store.Filter{
 				Types: domain.ToTypes(in.Types), Statuses: domain.ToStatuses(in.Statuses), Tags: in.Tags,
-				Prefixes: in.Prefixes, Trust: domain.ToTrusts(in.Trust),
+				Prefixes: in.Prefixes, Trust: domain.ToTrusts(in.Trust), Frontmatter: in.FM,
 			},
 			Limit: in.Limit, Budget: budget,
 		})
@@ -488,16 +488,17 @@ type searchIn struct {
 	// Query drives the search. Optional in the schema because sort mode
 	// rejects it — exactly one of query / sort must be set (the service
 	// rejects an empty search, the handler rejects the combination).
-	Query    string   `json:"query,omitempty" jsonschema:"search text; required unless sort is set (omit it then)"`
-	Types    []string `json:"types,omitempty" jsonschema:"filter by type (Metric, Attested Computation, Skill, Playbook, Insight, Policy, Glossary Term, BigQuery Dataset, BigQuery Table, API Endpoint, Reference, or any custom type); matched case-insensitively"`
-	Statuses []string `json:"statuses,omitempty" jsonschema:"filter by lifecycle status: draft, stable, deprecated. Whether anyone confirmed an entry is a separate question — use verified"`
-	Trust    []string `json:"trust,omitempty" jsonschema:"filter by who confirmed the entry: unverified, machine-confirmed, human-reviewed (OKF SPEC §5.3); repeat to OR them, omit to not ask. Independent of status: a draft can be human-reviewed and a stable entry unverified"`
-	Rejected *bool    `json:"rejected,omitempty" jsonschema:"true to list only entries a human turned down — how you check whether a proposal was already rejected before making it again. Omit and rejected entries stay out of results"`
-	Tags     []string `json:"tags,omitempty" jsonschema:"filter by tag"`
-	Source   string   `json:"source,omitempty" jsonschema:"only entries citing this resource, matched exactly against sources[].resource — the reverse lookup for \"this material changed, what derives from it?\"; a filter, so it combines with query or sort"`
-	Prefixes []string `json:"prefixes,omitempty" jsonschema:"only entries addressed under these paths, e.g. [\"teams/growth\", \"company\"] — an id is a path, so this scopes the search to a subtree (\"metrics\" covers metrics and everything under metrics/, but not metrics-legacy/); listing several ORs them, which is how you ask your own scope and the shared one in one call; a filter, so it combines with query or sort"`
-	Sort     string   `json:"sort,omitempty" jsonschema:"omit to search; \"verified_at\" lists by verification age, \"usage\" lists by demand (draft review feed), \"failed\" lists entries reported wrong (re-verification feed), \"stale_after\" lists entries past their declared expiry (most overdue first) — all mutually exclusive with query"`
-	Limit    int      `json:"limit,omitempty" jsonschema:"max results: searching default 10, max 50; with sort default 100, max 1000 (out-of-range falls back to the default)"`
+	Query    string            `json:"query,omitempty" jsonschema:"search text; required unless sort is set (omit it then)"`
+	Types    []string          `json:"types,omitempty" jsonschema:"filter by type (Metric, Attested Computation, Skill, Playbook, Insight, Policy, Glossary Term, BigQuery Dataset, BigQuery Table, API Endpoint, Reference, or any custom type); matched case-insensitively"`
+	Statuses []string          `json:"statuses,omitempty" jsonschema:"filter by lifecycle status: draft, stable, deprecated. Whether anyone confirmed an entry is a separate question — use verified"`
+	Trust    []string          `json:"trust,omitempty" jsonschema:"filter by who confirmed the entry: unverified, machine-confirmed, human-reviewed (OKF SPEC §5.3); repeat to OR them, omit to not ask. Independent of status: a draft can be human-reviewed and a stable entry unverified"`
+	FM       map[string]string `json:"fm,omitempty" jsonschema:"filter by any frontmatter key, exactly: {\"owner\": \"finance\"} finds entries whose frontmatter says owner is finance, matching a scalar or a member of a list. Every pair must match. Use it for keys this tool does not name — a producer's own, or one a later OKF version added"`
+	Rejected *bool             `json:"rejected,omitempty" jsonschema:"true to list only entries a human turned down — how you check whether a proposal was already rejected before making it again. Omit and rejected entries stay out of results"`
+	Tags     []string          `json:"tags,omitempty" jsonschema:"filter by tag"`
+	Source   string            `json:"source,omitempty" jsonschema:"only entries citing this resource, matched exactly against sources[].resource — the reverse lookup for \"this material changed, what derives from it?\"; a filter, so it combines with query or sort"`
+	Prefixes []string          `json:"prefixes,omitempty" jsonschema:"only entries addressed under these paths, e.g. [\"teams/growth\", \"company\"] — an id is a path, so this scopes the search to a subtree (\"metrics\" covers metrics and everything under metrics/, but not metrics-legacy/); listing several ORs them, which is how you ask your own scope and the shared one in one call; a filter, so it combines with query or sort"`
+	Sort     string            `json:"sort,omitempty" jsonschema:"omit to search; \"verified_at\" lists by verification age, \"usage\" lists by demand (draft review feed), \"failed\" lists entries reported wrong (re-verification feed), \"stale_after\" lists entries past their declared expiry (most overdue first) — all mutually exclusive with query"`
+	Limit    int               `json:"limit,omitempty" jsonschema:"max results: searching default 10, max 50; with sort default 100, max 1000 (out-of-range falls back to the default)"`
 }
 
 type searchOut struct {
@@ -511,14 +512,15 @@ type searchOut struct {
 // parameter whose own documentation says to leave it alone. What an agent
 // actually needs to bound a response is budget.
 type contextIn struct {
-	Query    string   `json:"query" jsonschema:"the data question to gather context for"`
-	Types    []string `json:"types,omitempty" jsonschema:"filter by type (Metric, Attested Computation, Skill, Playbook, Insight, Policy, Glossary Term, BigQuery Dataset, BigQuery Table, API Endpoint, Reference, or any custom type); matched case-insensitively"`
-	Statuses []string `json:"statuses,omitempty" jsonschema:"filter by lifecycle status: draft, stable, deprecated. Whether anyone confirmed an entry is a separate question — use verified"`
-	Trust    []string `json:"trust,omitempty" jsonschema:"filter by who confirmed the entry: unverified, machine-confirmed, human-reviewed (OKF SPEC §5.3); repeat to OR them, omit to not ask. Independent of status: a draft can be human-reviewed and a stable entry unverified"`
-	Tags     []string `json:"tags,omitempty" jsonschema:"filter by tag"`
-	Prefixes []string `json:"prefixes,omitempty" jsonschema:"only entries addressed under these paths, e.g. [\"teams/growth\", \"company\"] — an id is a path, so this scopes the search to a subtree; listing several ORs them, which is how you ask your own scope and the shared one in one call. It scopes the search, not the link expansion: an entry in scope that cites a term outside it still arrives with that term"`
-	Limit    int      `json:"limit,omitempty" jsonschema:"max primary entries: default 5, max 20 (out-of-range falls back to the default); linked companions share a 2x limit total cap"`
-	Budget   int      `json:"budget,omitempty" jsonschema:"max bytes of the knowledge in the response — the entries plus the outline rows naming the rest (default 12000); nothing else carries a body, since \"hits\" is the ranking only. Entries past it are listed under \"outline\" with their size, fetchable by id with get_knowledge, and those rows count against the same budget. Raise it when you need whole entries, lower it when context is tight"`
+	Query    string            `json:"query" jsonschema:"the data question to gather context for"`
+	Types    []string          `json:"types,omitempty" jsonschema:"filter by type (Metric, Attested Computation, Skill, Playbook, Insight, Policy, Glossary Term, BigQuery Dataset, BigQuery Table, API Endpoint, Reference, or any custom type); matched case-insensitively"`
+	Statuses []string          `json:"statuses,omitempty" jsonschema:"filter by lifecycle status: draft, stable, deprecated. Whether anyone confirmed an entry is a separate question — use verified"`
+	Trust    []string          `json:"trust,omitempty" jsonschema:"filter by who confirmed the entry: unverified, machine-confirmed, human-reviewed (OKF SPEC §5.3); repeat to OR them, omit to not ask. Independent of status: a draft can be human-reviewed and a stable entry unverified"`
+	FM       map[string]string `json:"fm,omitempty" jsonschema:"filter by any frontmatter key, exactly: {\"owner\": \"finance\"} finds entries whose frontmatter says owner is finance, matching a scalar or a member of a list. Every pair must match. Use it for keys this tool does not name — a producer's own, or one a later OKF version added"`
+	Tags     []string          `json:"tags,omitempty" jsonschema:"filter by tag"`
+	Prefixes []string          `json:"prefixes,omitempty" jsonschema:"only entries addressed under these paths, e.g. [\"teams/growth\", \"company\"] — an id is a path, so this scopes the search to a subtree; listing several ORs them, which is how you ask your own scope and the shared one in one call. It scopes the search, not the link expansion: an entry in scope that cites a term outside it still arrives with that term"`
+	Limit    int               `json:"limit,omitempty" jsonschema:"max primary entries: default 5, max 20 (out-of-range falls back to the default); linked companions share a 2x limit total cap"`
+	Budget   int               `json:"budget,omitempty" jsonschema:"max bytes of the knowledge in the response — the entries plus the outline rows naming the rest (default 12000); nothing else carries a body, since \"hits\" is the ranking only. Entries past it are listed under \"outline\" with their size, fetchable by id with get_knowledge, and those rows count against the same budget. Raise it when you need whole entries, lower it when context is tight"`
 }
 
 type contextOut struct {

--- a/internal/okf/parse.go
+++ b/internal/okf/parse.go
@@ -78,6 +78,39 @@ func yamlScalar(v any) any {
 	return v
 }
 
+// Frontmatter returns a document's frontmatter as a plain map, which is
+// what the store indexes (design doc 0046 §3.11). Values come back the
+// way the rest of this package reads them — a date with no clock stays a
+// date rather than becoming an instant (yamlScalar) — so the index says
+// what the document says.
+//
+// Server-owned keys are dropped: they are not in a stored document
+// (design doc 0043 §2.2), and a filter that could match on one would be
+// asking the index about provenance, which is the ledgers' answer.
+//
+// A document whose frontmatter will not parse yields an empty map rather
+// than an error. Storing an entry never depends on being able to index
+// it: the document is the truth, and an index that cannot be built from
+// it is a gap in querying, not a reason to refuse a write.
+func Frontmatter(doc []byte) map[string]any {
+	fm, _, ok := splitFrontmatter(string(NormalizeText(doc)))
+	if !ok || fm == "" {
+		return map[string]any{}
+	}
+	var raw map[string]any
+	if err := yaml.Unmarshal([]byte(fm), &raw); err != nil {
+		return map[string]any{}
+	}
+	out := make(map[string]any, len(raw))
+	for k, v := range raw {
+		if serverOwnedKeys[k] {
+			continue
+		}
+		out[k] = yamlScalar(v)
+	}
+	return out
+}
+
 // parseDoc parses one OKF document, also returning the frontmatter type
 // verbatim so the caller can report an unusable one. k.Type is "" when the
 // frontmatter carries no type a knowledge entry can hold.

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -58,13 +58,14 @@ func Handler(svc *service.Service) http.Handler {
 			return
 		}
 		f := store.Filter{
-			Types:    domain.ToTypes(q["type"]),
-			Statuses: domain.ToStatuses(q["status"]),
-			Tags:     q["tag"],
-			Source:   q.Get("source"),
-			Prefixes: q["prefix"],
-			Trust:    domain.ToTrusts(q["trust"]),
-			Rejected: rejected,
+			Types:       domain.ToTypes(q["type"]),
+			Statuses:    domain.ToStatuses(q["status"]),
+			Tags:        q["tag"],
+			Source:      q.Get("source"),
+			Prefixes:    q["prefix"],
+			Trust:       domain.ToTrusts(q["trust"]),
+			Rejected:    rejected,
+			Frontmatter: frontmatterFilter(q),
 		}
 		hits, err := svc.SearchOrList(r.Context(), q.Get("q"), q.Get("sort"), f, limit)
 		if err != nil {
@@ -120,11 +121,12 @@ func Handler(svc *service.Service) http.Handler {
 		res, err := svc.Context(r.Context(), service.ContextRequest{
 			Query: q.Get("q"),
 			Filter: store.Filter{
-				Types:    domain.ToTypes(q["type"]),
-				Statuses: domain.ToStatuses(q["status"]),
-				Tags:     q["tag"],
-				Prefixes: q["prefix"],
-				Trust:    domain.ToTrusts(q["trust"]),
+				Types:       domain.ToTypes(q["type"]),
+				Statuses:    domain.ToStatuses(q["status"]),
+				Tags:        q["tag"],
+				Prefixes:    q["prefix"],
+				Trust:       domain.ToTrusts(q["trust"]),
+				Frontmatter: frontmatterFilter(q),
 			},
 			Limit: limit, MinScore: minScore, Budget: budget,
 		})
@@ -753,6 +755,30 @@ func readDocument(w http.ResponseWriter, r *http.Request) (*domain.Knowledge, bo
 		w.Header().Add("Ochakai-Note", n)
 	}
 	return &d.Knowledge, true
+}
+
+// frontmatterFilter reads the "fm." query parameters — `?fm.question=…`,
+// `?fm.owner=finance` — into the filter that asks the frontmatter index
+// (design doc 0046 §3.11). The prefix is what keeps the surface
+// additive: a key the spec adds later needs no parameter of its own, and
+// none of the ones ochakai already names can be shadowed by one.
+//
+// A repeated parameter keeps its last value. The pairs are AND-ed, and
+// "the same key twice" is a contradiction rather than a question, so
+// there is nothing sensible to OR.
+func frontmatterFilter(q url.Values) map[string]string {
+	var out map[string]string
+	for key, vals := range q {
+		name, ok := strings.CutPrefix(key, "fm.")
+		if !ok || name == "" || len(vals) == 0 {
+			continue
+		}
+		if out == nil {
+			out = map[string]string{}
+		}
+		out[name] = vals[len(vals)-1]
+	}
+	return out
 }
 
 // wantsDocument reports whether the caller asked for the entry as a

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -99,6 +99,9 @@ func (s *Store) Migrate(ctx context.Context, embedDim int) error {
 	if err := s.backfillLinkForms(ctx); err != nil {
 		return fmt.Errorf("backfill link forms: %w", err)
 	}
+	if err := s.backfillFrontmatter(ctx); err != nil {
+		return fmt.Errorf("backfill frontmatter: %w", err)
+	}
 
 	if embedDim > 0 {
 		if err := s.migrateEmbedding(ctx, embedDim); err != nil {
@@ -228,6 +231,63 @@ func (s *Store) backfillLinkForms(ctx context.Context) error {
 			ids[i] = batch[i].ID
 		}
 		if _, err := s.pool.Exec(ctx, `DELETE FROM link_form_backfill WHERE id = ANY($1)`, ids); err != nil {
+			return err
+		}
+	}
+}
+
+// backfillFrontmatter fills the queryable index over each stored
+// document (design doc 0046 §3.11), for the entries migration 0027
+// listed.
+//
+// Go rather than SQL for the reason the link-form backfill is: reading a
+// key out of a document means parsing YAML the way the parser parses it,
+// dates included, and a second reading written in SQL would be a second
+// definition of what the document says.
+//
+// No timestamp moves and no hash changes. Building an index over what an
+// entry already said is not a change to what it says.
+func (s *Store) backfillFrontmatter(ctx context.Context) error {
+	for {
+		rows, err := s.pool.Query(ctx,
+			`SELECT id, doc FROM knowledge
+			 WHERE id IN (SELECT id FROM frontmatter_backfill) ORDER BY id LIMIT $1`,
+			backfillBatch)
+		if err != nil {
+			if isUndefinedTable(err) {
+				return nil // migration 0027 has not run yet on this database
+			}
+			return err
+		}
+		type row struct{ id, doc string }
+		batch, err := pgx.CollectRows(rows, func(r pgx.CollectableRow) (row, error) {
+			var out row
+			err := r.Scan(&out.id, &out.doc)
+			return out, err
+		})
+		if err != nil {
+			return err
+		}
+		if len(batch) == 0 {
+			return nil
+		}
+		ids := make([]string, len(batch))
+		for i, b := range batch {
+			ids[i] = b.id
+			fm, err := storedFrontmatter(b.doc)
+			if err != nil {
+				// An index that cannot be built is a gap in querying, not
+				// a reason to hold up a start: the document still answers
+				// everything the index would have.
+				s.log.Warn("cannot index an entry's frontmatter", "id", b.id, "err", err)
+				continue
+			}
+			if _, err := s.pool.Exec(ctx,
+				`UPDATE knowledge SET frontmatter = $2 WHERE id = $1`, b.id, fm); err != nil {
+				return err
+			}
+		}
+		if _, err := s.pool.Exec(ctx, `DELETE FROM frontmatter_backfill WHERE id = ANY($1)`, ids); err != nil {
 			return err
 		}
 	}

--- a/internal/store/migrations/0027_frontmatter_index.sql
+++ b/internal/store/migrations/0027_frontmatter_index.sql
@@ -1,0 +1,35 @@
+-- The frontmatter becomes the index (design doc 0046 §3.11).
+--
+-- Storage became additive when the document became the stored form: a key
+-- OKF adds in a later version is kept, round-tripped and served without
+-- ochakai knowing anything about it. Querying did not follow. Every key a
+-- filter can name is a typed column, so "can I ask for this?" still has a
+-- release-shaped answer — which is the same coupling design doc 0043 set
+-- out to remove, surviving in the one place it did not look.
+--
+-- So the whole frontmatter is indexed as jsonb, with a containment index
+-- over it. A key the spec adds is queryable the day a writer writes it,
+-- with no column, no migration and no release.
+--
+-- The typed columns stay. They are the same values with better indexes —
+-- trigram over the text, a date column for stale_after, an array for
+-- tags — and this is an index beside them, not a replacement for them.
+ALTER TABLE knowledge ADD COLUMN IF NOT EXISTS frontmatter jsonb NOT NULL DEFAULT '{}';
+
+-- jsonb_path_ops: this index answers containment and nothing else, which
+-- is exactly what the fm filter asks, and it is the smaller of the two
+-- jsonb operator classes.
+CREATE INDEX IF NOT EXISTS knowledge_frontmatter_gin
+    ON knowledge USING gin (frontmatter jsonb_path_ops);
+
+-- The work list for the backfill, which is Go: reading the frontmatter
+-- out of a stored document means parsing YAML, and the parser that
+-- decides what a key means has to be the one that already does
+-- (internal/okf), not a second reading of the same text written in SQL.
+CREATE TABLE IF NOT EXISTS frontmatter_backfill (
+    id text PRIMARY KEY
+);
+
+INSERT INTO frontmatter_backfill (id)
+SELECT id FROM knowledge WHERE doc <> '' AND frontmatter = '{}'
+ON CONFLICT (id) DO NOTHING;

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log/slog"
 	"path"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -175,13 +176,25 @@ type Filter struct {
 	// default is not "no constraint" but "not the ones we said no to".
 	Trust    []domain.Trust
 	Rejected *bool
+
+	// Frontmatter narrows by any frontmatter key, which is what makes the
+	// query surface additive: a key OKF adds in a later version — or one
+	// a producer invented — is askable the day somebody writes it, with
+	// no column and no release (design doc 0046 §3.11). Every pair must
+	// match (AND), matching a scalar exactly or a list by membership.
+	//
+	// Exact and membership are the only two, deliberately: ranges,
+	// negation and boolean expressions are the doorway to a query
+	// language, and ochakai is a knowledge store whose answers are
+	// entries rather than a database whose answers are rows (0046 §5).
+	Frontmatter map[string]string
 }
 
 const knowledgeCols = `type, id, title, description, resource, tags, status, status_note, stale_after,
 	sources, usage_window, runtime, parameters, computation, executor, attester,
 	created_by_kind, created_by_name, created_by_via,
 	updated_by_kind, updated_by_name, updated_by_via,
-	links, attrs, body, created_at, updated_at, content_changed_at, doc, content_hash`
+	links, attrs, body, created_at, updated_at, content_changed_at, doc, frontmatter, content_hash`
 
 // ledgerCols is the two instance ledgers — verifications and the
 // rejection — read as JSON beside the entry's own columns (design doc
@@ -217,12 +230,33 @@ func lastVerifiedAt(alias string) string {
 // (design doc 0043 §3.1), and carrying the whole document beside the
 // body it contains would double every search result for nothing. Writes
 // keep it — they are what the index is derived from.
+// withoutFrontmatter drops only the index column, for the reads that do
+// want the document itself.
+func withoutFrontmatter(cols string) string {
+	var kept []string
+	for _, c := range strings.Split(cols, ",") {
+		if t := strings.TrimSpace(c); !strings.HasSuffix(t, "frontmatter") {
+			kept = append(kept, t)
+		}
+	}
+	return strings.Join(kept, ", ")
+}
+
 func withoutDoc(cols string) string {
 	var kept []string
 	for _, c := range strings.Split(cols, ",") {
-		if t := strings.TrimSpace(c); t != "doc" && t != "k.doc" && t != "knowledge.doc" {
-			kept = append(kept, t)
+		t := strings.TrimSpace(c)
+		if t == "doc" || t == "k.doc" || t == "knowledge.doc" {
+			continue
 		}
+		// The frontmatter index is never read back either: it is a
+		// question-answering copy of what the document already carries
+		// (design doc 0046 §3.11), so every read leaves it in the
+		// database where the filters use it.
+		if t == "frontmatter" || t == "k.frontmatter" || t == "knowledge.frontmatter" {
+			continue
+		}
+		kept = append(kept, t)
 	}
 	return strings.Join(kept, ", ")
 }
@@ -235,8 +269,21 @@ var (
 	// knowledgeSelectDoc is the same read with the stored document, for
 	// the paths that hand one out (design doc 0046 §2.2): a single get,
 	// an export, and the move that rewrites a body in place.
-	knowledgeSelectDoc = knowledgeCols + ", " + ledgerCols("knowledge")
+	knowledgeSelectDoc = withoutFrontmatter(knowledgeCols) + ", " + ledgerCols("knowledge")
 )
+
+// sortedKeys orders a filter's frontmatter keys so a query's arguments —
+// and therefore its prepared-statement text — are the same on every call
+// with the same filter. Map iteration order would otherwise make the
+// plan cache miss for no reason.
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
 
 // notCurated is Knowledge.Curated() as a SQL predicate, for the guards
 // that must agree with it inside a transaction. alias names the knowledge
@@ -369,6 +416,13 @@ func knowledgeDestFor(k *domain.Knowledge, withDoc bool) (dests []any, finish fu
 // the only document it has. Either way the hash covers what is stored, so
 // the version means "these bytes", and neither a ruling nor a
 // verification, which write no bytes here, can move it.
+// storedFrontmatter is the queryable index over the document a write
+// stores (design doc 0046 §3.11) — derived from the same bytes, in the
+// same call, so the two cannot drift.
+func storedFrontmatter(doc string) ([]byte, error) {
+	return json.Marshal(okf.Frontmatter([]byte(doc)))
+}
+
 func storedDoc(k *domain.Knowledge) (doc, hash string, err error) {
 	b := []byte(k.Doc)
 	if len(b) > 0 && !documentSays(b, k) {
@@ -572,13 +626,17 @@ func (s *Store) Create(ctx context.Context, k *domain.Knowledge, keepCuratedTomb
 		if err != nil {
 			return err
 		}
+		fm, err := storedFrontmatter(doc)
+		if err != nil {
+			return err
+		}
 		k.ContentHash = hash
 		args := []any{
 			k.Type, k.ID, k.Title, k.Description, k.Resource, k.Tags, k.Status, k.StatusNote, staleAfter,
 			j.sources, j.usageWindow, k.Runtime, j.parameters, k.Computation, j.executor, j.attester,
 			k.CreatedBy.Kind, k.CreatedBy.Name, k.CreatedBy.Via,
 			k.UpdatedBy.Kind, k.UpdatedBy.Name, k.UpdatedBy.Via,
-			j.links, j.attrs, k.Body, k.CreatedAt, k.UpdatedAt, k.ContentChangedAt, doc, hash,
+			j.links, j.attrs, k.Body, k.CreatedAt, k.UpdatedAt, k.ContentChangedAt, doc, fm, hash,
 		}
 		tag, err := tx.Exec(ctx, `INSERT INTO knowledge (`+knowledgeCols+`)
 			VALUES (`+knowledgeParams+`)
@@ -641,12 +699,16 @@ func (s *Store) Update(ctx context.Context, k *domain.Knowledge, actor domain.Ac
 		if err != nil {
 			return err
 		}
+		fm, err := storedFrontmatter(doc)
+		if err != nil {
+			return err
+		}
 		k.ContentHash = hash
 		cond := ""
 		args := []any{k.ID, k.Type, k.Title, k.Description, k.Resource, k.Tags, k.Status, k.StatusNote, staleAfter,
 			j.sources, j.usageWindow, k.Runtime, j.parameters, k.Computation, j.executor, j.attester,
 			k.UpdatedBy.Kind, k.UpdatedBy.Name, k.UpdatedBy.Via,
-			j.links, j.attrs, k.Body, k.UpdatedAt, k.ContentChangedAt, doc, hash}
+			j.links, j.attrs, k.Body, k.UpdatedAt, k.ContentChangedAt, doc, fm, hash}
 		if ifMatch != nil {
 			args = append(args, *ifMatch)
 			cond = fmt.Sprintf(" AND content_hash=$%d", len(args))
@@ -656,7 +718,7 @@ func (s *Store) Update(ctx context.Context, k *domain.Knowledge, actor domain.Ac
 			sources=$10, usage_window=$11, runtime=$12, parameters=$13, computation=$14, executor=$15, attester=$16,
 			updated_by_kind=$17, updated_by_name=$18, updated_by_via=$19,
 			links=$20, attrs=$21, body=$22, updated_at=$23, content_changed_at=$24,
-			doc=$25, content_hash=$26
+			doc=$25, frontmatter=$26, content_hash=$27
 			WHERE id=$1 AND deleted_at IS NULL`+cond, args...)
 		if err != nil {
 			return err
@@ -1121,14 +1183,18 @@ func (s *Store) rewriteReferences(ctx context.Context, tx pgx.Tx, oldID string, 
 		if err != nil {
 			return err
 		}
+		fm, err := storedFrontmatter(doc)
+		if err != nil {
+			return err
+		}
 		r.ContentHash = hash
 		tag, err := tx.Exec(ctx,
 			`UPDATE knowledge SET links=$2, attrs=$3, body=$4, updated_at=$5,
 			 updated_by_kind=$6, updated_by_name=$7, updated_by_via=$8,
-			 doc=$9, content_hash=$10, content_changed_at=$11
+			 doc=$9, content_hash=$10, content_changed_at=$11, frontmatter=$12
 			 WHERE id=$1 AND deleted_at IS NULL`,
 			r.ID, j.links, j.attrs, r.Body, r.UpdatedAt, actor.Kind, actor.Name, actor.Via, doc, hash,
-			r.ContentChangedAt)
+			r.ContentChangedAt, fm)
 		if err != nil {
 			return err
 		}
@@ -1607,6 +1673,24 @@ func (f Filter) buildWhere(prefix string) (string, []any) {
 	if len(f.Tags) > 0 {
 		args = append(args, f.Tags)
 		conds = append(conds, fmt.Sprintf("%stags && $%d", prefix, len(args)))
+	}
+	// Containment against the frontmatter index, twice per key: a value
+	// the document wrote as a scalar and one it wrote inside a list are
+	// both "the entry says k is v", and a caller asking `fm.tags=finance`
+	// should not have to know which shape the writer chose. Both forms
+	// are answered by the same GIN index.
+	for _, key := range sortedKeys(f.Frontmatter) {
+		scalar, err := json.Marshal(map[string]any{key: f.Frontmatter[key]})
+		if err != nil {
+			continue
+		}
+		list, err := json.Marshal(map[string]any{key: []string{f.Frontmatter[key]}})
+		if err != nil {
+			continue
+		}
+		args = append(args, string(scalar), string(list))
+		conds = append(conds, fmt.Sprintf("(%[1]sfrontmatter @> $%[2]d OR %[1]sfrontmatter @> $%[3]d)",
+			prefix, len(args)-1, len(args)))
 	}
 	if f.Source != "" {
 		// Containment, so the GIN index on sources answers it directly.

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"slices"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -14,6 +15,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/na0fu3y/ochakai/internal/domain"
+	"github.com/na0fu3y/ochakai/internal/okf"
 )
 
 // hitScore returns the score of id among hits, or -1 when it is absent.
@@ -2722,5 +2724,87 @@ func TestIntegrationProducerKeysInsideObjectsSurviveStorage(t *testing.T) {
 	}
 	if got.ContentHash == before {
 		t.Error("changing a producer key left the version where it was; it is content")
+	}
+}
+
+// The frontmatter index is what makes the query surface additive: a key
+// no release of ochakai has ever heard of is askable the day a writer
+// writes it (design doc 0046 §3.11). The test therefore asks for one
+// deliberately outside every vocabulary the program knows.
+func TestIntegrationFrontmatterFilter(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	prefix := fmt.Sprintf("it-fm-%d", time.Now().UnixNano())
+	actor := domain.Actor{Kind: domain.ActorHuman, Name: "test"}
+
+	// Written as documents, because the index is derived from the
+	// document and not from the fields beside it.
+	docs := map[string]string{
+		"owned":  "---\ntype: Metric\nowner: finance\nsystems:\n  - dbt\n  - looker\n---\n\n本文。\n",
+		"other":  "---\ntype: Metric\nowner: growth\n---\n\n本文。\n",
+		"silent": "---\ntype: Metric\n---\n\n本文。\n",
+	}
+	for name, text := range docs {
+		d, _, err := okf.Parse([]byte(text))
+		if err != nil {
+			t.Fatal(err)
+		}
+		d.ID = prefix + "/" + name
+		d.CreatedBy, d.UpdatedBy = actor, actor
+		// What the service does for a document that names no status: the
+		// index column holds what a reader reads (design doc 0046 §3.9).
+		d.Status = d.Lifecycle()
+		if err := s.Create(ctx, &d.Knowledge, false); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _, _ = s.pool.Exec(ctx, `DELETE FROM knowledge WHERE id = $1`, d.ID) })
+	}
+
+	find := func(fm map[string]string) []string {
+		t.Helper()
+		// Any listing takes the same filter; the verification-age feed is
+		// the one that needs no query and no other precondition.
+		hits, err := s.ListByVerifiedAt(ctx, Filter{Prefixes: []string{prefix}, Frontmatter: fm}, 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ids := make([]string, len(hits))
+		for i := range hits {
+			ids[i] = strings.TrimPrefix(hits[i].ID, prefix+"/")
+		}
+		sort.Strings(ids)
+		return ids
+	}
+
+	for _, tc := range []struct {
+		name string
+		fm   map[string]string
+		want []string
+	}{
+		{"a scalar key ochakai does not know", map[string]string{"owner": "finance"}, []string{"owned"}},
+		{"a member of a list", map[string]string{"systems": "dbt"}, []string{"owned"}},
+		{"a value nobody wrote", map[string]string{"owner": "nobody"}, nil},
+		{"a key nobody wrote", map[string]string{"unheard-of": "x"}, nil},
+		{"two keys are AND-ed", map[string]string{"owner": "finance", "systems": "looker"}, []string{"owned"}},
+		{"one of them missing excludes the entry", map[string]string{"owner": "finance", "systems": "airflow"}, nil},
+		{"a key the spec does define, indexed like any other", map[string]string{"type": "Metric"},
+			[]string{"other", "owned", "silent"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := find(tc.fm); !slices.Equal(got, tc.want) {
+				t.Errorf("fm=%v matched %v, want %v", tc.fm, got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fifth in the 0046 series, and the first that is not about how a document is stored but about what you can ask of it.

## Why

0043 made **storage** additive: a key OKF adds in a later version is kept, round-tripped and served without ochakai knowing anything about it. **Querying never followed.** Every key a filter can name is a typed column, so "can I ask for this?" still has a release-shaped answer — the same coupling 0043 set out to remove, surviving in the one place it did not look.

## What lands

The whole frontmatter is indexed as `jsonb` with a `jsonb_path_ops` GIN index, and one filter asks it:

```bash
ochakai search --fm owner=finance --fm systems=dbt
```
```
GET /api/v1/knowledge?fm.owner=finance          # REST, and /context
{"fm": {"owner": "finance"}}                     # MCP
```

- **Exact for a scalar, membership for a list.** `fm.systems=dbt` matches `systems: [dbt, looker]` and `systems: dbt` alike — a caller should not have to know which shape the writer chose. Both forms are answered by the same index.
- **Keys AND.** Repeating one key is a contradiction rather than a question, so nothing ORs.
- **Nothing else.** Ranges, negation and boolean expressions are the doorway to a query language, and what ochakai returns is knowledge rather than rows (0046 §5).

The integration test asks for a key deliberately outside every vocabulary the program knows, because that is the whole point.

## A place where I think the record is wrong

§3.11 also says the **named** filters become sugar for expressions over the same jsonb. I did not implement that, and I do not think it should be.

`type`, `status`, `tag`, `source` and `stale_after` have indexes suited to them — trigram over the text, a `text[]` for tags, a date column for `stale_after`, a GIN over `sources` from 0037. Restating them as containment would trade working indexes for **no observable difference**. So the jsonb is an index *beside* the typed columns rather than a replacement for them.

If that is the wrong call it is the record that needs revising, and §3.11 is the place — I would rather flag it than quietly implement half a sentence.

## Migration 0027

Adds the column and the index, then a Go backfill fills it from each stored document. Go rather than SQL for the same reason the link-form backfill is: reading a key means parsing YAML the way the parser parses it, dates included, and a second reading written in SQL would be a second definition of what the document says. Resumable via a work-list table. **No timestamp moves and no hash changes** — indexing what an entry already said is not a change to what it says. A document whose frontmatter will not parse is logged and left unindexed rather than holding up a start: the document still answers everything the index would have.

## Checks

`scripts/check --db` passes.

## Still to come

The one address space (§§3.1-3.3, 3.5) and the derived `index.md` / `log.md` (§§3.7-3.8). Notes toward the first, already settled while scoping it: files stop being refused by media type and are served safely instead (`Content-Disposition: attachment` + `nosniff` for anything not png/jpeg/webp/pdf/text); attribution is derived body-links-first then the `<id>/` namespace; the attachment→object migration resolves a path collision in favour of `okf_path`, moving the loser to the canonical layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)