### PR TITLE
Serve index.md and log.md, at the paths OKF reserves (0046 §§3.7-3.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ last entry.
 
 ### Added
 
+- **`ochakai log [path]`** prints the update history as OKF's `log.md`
+  (SPEC §9): date-grouped, newest first, for a path or the whole bundle
+  (design doc [0046](docs/design/0046-bundle-address-space.md) §3.8).
+  It says what `ochakai revisions` says, in the format a bundle carries
+  — which is what makes a history portable.
+
 - **Any frontmatter key is a filter**: `?fm.owner=finance` on REST,
   `fm: {owner: finance}` on MCP, `--fm owner=finance` on the CLI (design
   doc [0046](docs/design/0046-bundle-address-space.md) §3.11). It matches
@@ -86,6 +92,33 @@ last entry.
   a write that only repeats it is still a no-op.
 
 ### Changed
+
+- **BREAKING**: the two files OKF reserves are served at the paths OKF
+  reserves them at (design doc
+  [0046](docs/design/0046-bundle-address-space.md) §§3.7-3.8).
+  `GET /api/v1/bundle/{path}` answers `index.md` (SPEC §8's directory
+  listing) and `log.md` (SPEC §9's update history); both are generated
+  from the bundle, so `PUT` and `DELETE` are `405`.
+
+  - **`GET /api/v1/browse` is gone.** A directory listing is what
+    `index.md` is, and ochakai was serving it at an address of its own
+    invention. `GET /api/v1/bundle/metrics/index.md` is the same
+    listing: with `Accept: application/json` it is the same JSON the
+    browse endpoint returned, and without it, it is the file. The
+    `prefix` parameter went with it — the directory is the path now.
+  - **`GET /api/v1/revisions/{id}` is gone**, for the same reason.
+    `GET /api/v1/bundle/{id}/log.md` returns the history, as JSON when
+    asked for it and as the file otherwise, and a *directory's* log.md
+    covers everything under it — which the revisions endpoint could not
+    answer at all.
+  - The history is published, never read back: an import skips both
+    files, the same way it skips `generated` and `verified` (design doc
+    0009). What happened in one instance is that instance's
+    observation.
+  - **CLI**: `ochakai browse` and `ochakai revisions` print what they
+    always did, and read the new paths. `ochakai log` is new.
+  - **Web UI**: unchanged on screen — the tree and the history tab read
+    the JSON representation of the same two files.
 
 - **BREAKING**: a read of one entry is a *view* — `{id, document,
   summary, observed}` — and a listing row is the `summary` alone (design

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -307,30 +307,61 @@ paths:
                   value:
                     error: search needs a query; use sort=verified_at|usage|failed|stale_after to list entries without one, or source=URI to list what cites a resource
         "403": { $ref: "#/components/responses/Forbidden" }
-  /api/v1/browse:
+  /api/v1/bundle/{path}:
     get:
-      operationId: browseKnowledge
-      summary: Browse one level of the ID hierarchy
+      operationId: getBundleFile
+      summary: Read one of the files OKF reserves
       description: >
-        An entry's id is its bundle path; this returns one level of that
-        tree (design docs 0014, 0016): the subdirectories directly under
-        prefix ("" or omitted is the root — the top-level segments),
-        each with the count of entries beneath, plus the entries at that
-        level as a light projection (no body). Rejected and deleted
-        entries are excluded, as in search. Entries at one level cap at
-        1000 with truncated=true. Browsing records no usage.
+        The two filenames SPEC §3.1 reserves, generated from the bundle
+        rather than stored in it (design doc 0046 §§3.7-3.8).
+
+        `index.md` is one level of the tree — the subdirectories directly
+        under the path, each with the count of entries beneath, plus the
+        entries at that level (design docs 0014, 0016). Rejected and
+        deleted entries are excluded, as in search; a level caps at 1000
+        with truncated=true; listing records no usage.
+
+        `log.md` is the update history under the path, newest first and
+        grouped by date, as SPEC §9 writes one. It publishes an instance
+        ledger: an import never reads it back, the same way it never
+        reads back `generated` (design doc 0009). `limit` bounds it
+        (default and maximum 1000).
+
+        The representation follows Accept. `application/json` returns the
+        listing or the revisions; anything else returns the file the path
+        names. Two representations of one thing, at one address — the
+        JSON is what a web UI's tree needs, not a second surface.
+
+        PUT and DELETE are 405: a generated file is not one anybody
+        writes. Paths other than the two reserved names are 404 for now —
+        the rest of the bundle joins this address in a later change
+        (0046 §3.5).
       parameters:
-        - name: prefix
-          in: query
-          description: ID prefix ("a/b" or "a/b/"); omit for the root.
+        - name: path
+          in: path
+          required: true
+          description: >
+            The reserved file's bundle path — "index.md" or "log.md" at
+            the root, "metrics/index.md" below it. Slashes are real path
+            separators.
           schema: { type: string }
-          allowReserved: true
+        - name: limit
+          in: query
+          description: log.md only — maximum entries (default and max 1000).
+          schema: { type: integer }
       responses:
         "200":
-          description: One level of the tree.
+          description: The generated file, or its structured form.
           headers:
             Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
           content:
+            text/markdown:
+              schema: { type: string }
+              example: |
+                # metrics
+
+                * [Revenue](revenue.md) - Net revenue from completed orders.
+                * [Churn](churn.md) - Monthly logo churn.
             application/json:
               schema:
                 type: object
@@ -358,7 +389,7 @@ paths:
                     description: The entry list hit the 1000-per-level cap.
               examples:
                 root:
-                  summary: GET /api/v1/browse
+                  summary: "GET /api/v1/bundle/index.md (Accept: application/json)"
                   description: The top-level segments of the ID hierarchy, with the entry count beneath each.
                   value:
                     dirs:
@@ -368,7 +399,7 @@ paths:
                       - { name: queries, count: 57 }
                       - { name: tables, count: 96 }
                 level:
-                  summary: GET /api/v1/browse?prefix=metrics
+                  summary: "GET /api/v1/bundle/metrics/index.md (Accept: application/json)"
                   description: >
                     One level down. The projection carries no body — a
                     directory listing renders from the description.
@@ -387,6 +418,34 @@ paths:
                         updated_at: "2026-07-14T02:33:41.019778Z"
         "400": { $ref: "#/components/responses/Error" }
         "403": { $ref: "#/components/responses/Forbidden" }
+    put:
+      operationId: putBundleFile
+      summary: Refused — the reserved files are generated
+      description: >
+        index.md and log.md are derived from the bundle (design doc 0046
+        §§3.7-3.8), so neither is written. The same goes for DELETE.
+      responses:
+        "405":
+          description: A generated file is not one anybody writes.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error: { type: string }
+    delete:
+      operationId: deleteBundleFile
+      summary: Refused — the reserved files are generated
+      description: See PUT.
+      responses:
+        "405":
+          description: A generated file is not one anybody writes.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error: { type: string }
   /api/v1/context:
     get:
       operationId: getContext
@@ -869,7 +928,7 @@ paths:
                   summary: No live entry at that id
                   description: >
                     A soft-deleted entry reads as missing here; its history is
-                    still at /api/v1/revisions/{id}.
+                    still in the log.md of the directory it was in.
                   value:
                     error: knowledge not found
     put:
@@ -1545,102 +1604,6 @@ paths:
                     worked: 23
                     failed: 3
                     last_used_at: "2026-07-27T02:07:44.291508Z"
-        "400": { $ref: "#/components/responses/Error" }
-        "403": { $ref: "#/components/responses/Forbidden" }
-        "404": { $ref: "#/components/responses/Error" }
-  /api/v1/revisions/{id}:
-    parameters:
-      - name: id
-        in: path
-        required: true
-        description: The entry's id; slashes are real path separators.
-        schema: { type: string }
-    get:
-      operationId: listKnowledgeRevisions
-      summary: Change history for one knowledge entry
-      description: >
-        Every change — create, update, verify, delete, move, attach,
-        detach — newest first, each with
-        who made it, when, and the whole entry as it stood, as an OKF
-        document — the
-        read surface behind "every change kept as a revision". Works for
-        soft-deleted entries too: the audit trail is most interesting
-        exactly when the entry is gone.
-      parameters:
-        - name: limit
-          in: query
-          description: >
-            Default 50, max 200. Out-of-range values fall back to the
-            default; non-integer values are a 400.
-          schema: { type: integer }
-      responses:
-        "200":
-          description: Revisions, newest first (never empty — create writes rev 1).
-          headers:
-            Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  revisions:
-                    type: array
-                    items: { $ref: "#/components/schemas/Revision" }
-              examples:
-                history:
-                  summary: GET /api/v1/revisions/insights/revenue-seasonality
-                  description: >
-                    Newest first, and never empty — the create is rev 1. Each
-                    revision carries the whole entry as it stood after that
-                    change, as an OKF document, so a diff between two
-                    revisions is a text diff rather than a replay.
-                  value:
-                    revisions:
-                      - rev: 2
-                        change: verify
-                        changed_by: { kind: human, name: tanaka@example.co.jp }
-                        changed_at: "2026-07-27T00:41:12.905337Z"
-                        document: |
-                          ---
-                          type: Insight
-                          title: Reading revenue month over month
-                          description: Why a December spike and a January drop are normal.
-                          tags:
-                              - finance
-                          generated:
-                              by: process:analyst@example.iam.gserviceaccount.com
-                              at: "2026-07-27T00:41:12Z"
-                          verified:
-                              - by: human:tanaka@example.co.jp
-                                at: "2026-07-27T00:41:12Z"
-                          status: stable
-                          stale_after: "2027-01-31"
-                          created_by: process:analyst@example.iam.gserviceaccount.com
-                          ---
-
-                          [Revenue](/metrics/revenue.md) is seasonal: December
-                          runs well above the trailing median and January falls
-                          back below it.
-                      - rev: 1
-                        change: create
-                        changed_by: { kind: process, name: analyst@example.iam.gserviceaccount.com }
-                        changed_at: "2026-07-21T06:14:55.402881Z"
-                        document: |
-                          ---
-                          type: Insight
-                          title: Reading revenue month over month
-                          description: Why a December spike and a January drop are normal.
-                          tags:
-                              - finance
-                          generated:
-                              by: process:analyst@example.iam.gserviceaccount.com
-                              at: "2026-07-21T06:14:55Z"
-                          status: draft
-                          stale_after: "2027-01-31"
-                          created_by: process:analyst@example.iam.gserviceaccount.com
-                          ---
-
-                          [Revenue](/metrics/revenue.md) is seasonal.
         "400": { $ref: "#/components/responses/Error" }
         "403": { $ref: "#/components/responses/Forbidden" }
         "404": { $ref: "#/components/responses/Error" }

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -43,6 +43,7 @@ var clientCommands = map[string]func(context.Context, []string) error{
 	"usage":     cmdUsage,
 	"report":    cmdReport,
 	"revisions": cmdRevisions,
+	"log":       cmdLog,
 	"backlinks": cmdBacklinks,
 	"export":    cmdExport,
 	"import":    cmdImport,
@@ -565,6 +566,39 @@ func cmdRevisions(ctx context.Context, args []string) error {
 			r.ChangedBy, r.ChangedAt.Format(time.RFC3339))
 	}
 	return nil
+}
+
+// cmdLog prints the generated log.md for a path: the update history in
+// the shape OKF SPEC §9 defines, which is a file somebody else can read
+// rather than a listing only ochakai knows how to print (design doc
+// 0046 §3.8).
+func cmdLog(ctx context.Context, args []string) error {
+	fs, url := newFlagSet(
+		"log",
+		"Usage: ochakai log [flags] [path]\n\nPrint the update history under a path as OKF's log.md (SPEC §9):\ndate-grouped, newest first. With no path, the whole bundle.\n\nIt is generated from the revision ledger, so it says the same thing\n`ochakai revisions` does — in the format a bundle carries, which is\nwhat makes the history portable.",
+		"  ochakai log\n  ochakai log metrics\n  ochakai log metrics/revenue --limit 20\n")
+	limit := fs.Int("limit", 0, "max entries (default 1000)")
+	pos, err := parseArgs(fs, args)
+	if err != nil {
+		return err
+	}
+	if len(pos) > 1 {
+		return fmt.Errorf("log takes one path at most")
+	}
+	var prefix string
+	if len(pos) == 1 {
+		prefix = pos[0]
+	}
+	c, err := newClient(ctx, *url)
+	if err != nil {
+		return err
+	}
+	doc, err := c.Log(ctx, prefix, *limit)
+	if err != nil {
+		return err
+	}
+	_, err = os.Stdout.Write(doc)
+	return err
 }
 
 func cmdBacklinks(ctx context.Context, args []string) error {

--- a/cmd/ochakai/client_test.go
+++ b/cmd/ochakai/client_test.go
@@ -127,12 +127,12 @@ func TestExtractTarGzRefusesEscapes(t *testing.T) {
 // Guard: the client dispatch table and domain types stay in sync with the
 // commands documented in usage().
 func TestClientCommandsCoverDesignDoc(t *testing.T) {
-	for _, name := range []string{"search", "browse", "context", "get", "create", "update", "verify", "reject", "delete", "purge", "reembed", "move", "attach", "detach", "usage", "report", "revisions", "backlinks", "export", "import", "use", "whoami", "ui", "mcp-stdio", "completion"} {
+	for _, name := range []string{"search", "browse", "context", "get", "create", "update", "verify", "reject", "delete", "purge", "reembed", "move", "attach", "detach", "usage", "report", "revisions", "log", "backlinks", "export", "import", "use", "whoami", "ui", "mcp-stdio", "completion"} {
 		if _, ok := clientCommands[name]; !ok {
 			t.Errorf("missing client command %q", name)
 		}
 	}
-	if len(clientCommands) != 25 {
+	if len(clientCommands) != 26 {
 		t.Errorf("unexpected extra client commands: %d", len(clientCommands))
 	}
 	_ = domain.Types // keep the import honest

--- a/cmd/ochakai/completion.go
+++ b/cmd/ochakai/completion.go
@@ -92,6 +92,7 @@ _ochakai() {
     'usage:show usage totals for an entry'
     'report:report an outcome (worked/failed) for an entry'
     'revisions:list the change history of an entry (newest first)'
+    'log:print the history under a path as OKF log.md'
     'backlinks:list entries whose links point at this one'
     'export:download the knowledge base as an OKF bundle'
     'import:upload an OKF bundle'
@@ -150,6 +151,9 @@ _ochakai() {
       ;;
     revisions|backlinks)
       _arguments '--limit[max results]:limit:' '--json[print the raw JSON response]' '--url[server URL]:url:'
+      ;;
+    log)
+      _arguments '--limit[max entries]:limit:' '--url[server URL]:url:'
       ;;
     report)
       _arguments '--note[context recorded with the report]:note:' '--json[print JSON]' '--url[server URL]:url:' '2:outcome:(worked failed)'
@@ -236,6 +240,7 @@ _ochakai() {
     get)           opts="--json --download --url" ;;
     usage)         opts="--json --url" ;;
     revisions|backlinks) opts="--limit --json --url" ;;
+    log)           opts="--limit --url" ;;
     report)
       if [[ $prev != -* && $COMP_CWORD -eq 3 && $cur != -* ]]; then
         COMPREPLY=($(compgen -W "worked failed" -- "$cur"))
@@ -294,6 +299,7 @@ complete -c ochakai -n __fish_use_subcommand -a detach -d 'remove an attachment'
 complete -c ochakai -n __fish_use_subcommand -a usage -d 'show usage totals for an entry'
 complete -c ochakai -n __fish_use_subcommand -a report -d 'report an outcome (worked/failed) for an entry'
 complete -c ochakai -n __fish_use_subcommand -a revisions -d 'list the change history of an entry (newest first)'
+complete -c ochakai -n __fish_use_subcommand -a log -d 'print the history under a path as OKF log.md'
 complete -c ochakai -n __fish_use_subcommand -a backlinks -d 'list entries whose links point at this one'
 complete -c ochakai -n __fish_use_subcommand -a export -d 'download the knowledge base as an OKF bundle'
 complete -c ochakai -n __fish_use_subcommand -a import -d 'upload an OKF bundle'
@@ -306,7 +312,7 @@ complete -c ochakai -n __fish_use_subcommand -a serve -d 'start the MCP + REST s
 complete -c ochakai -n __fish_use_subcommand -a serve-ui -d 'serve the team web UI as a deployed service'
 complete -c ochakai -n __fish_use_subcommand -a version -d 'print the version'
 
-complete -c ochakai -n '__fish_seen_subcommand_from search browse context get create update verify reject delete purge reembed move attach detach usage report revisions backlinks export import whoami ui mcp-stdio' -l url -x -d 'server URL'
+complete -c ochakai -n '__fish_seen_subcommand_from search browse context get create update verify reject delete purge reembed move attach detach usage report revisions log backlinks export import whoami ui mcp-stdio' -l url -x -d 'server URL'
 complete -c ochakai -n '__fish_seen_subcommand_from ui' -l port -x -d 'port on 127.0.0.1'
 complete -c ochakai -n '__fish_seen_subcommand_from import' -l dry-run -d 'parse and list, write nothing'
 complete -c ochakai -n '__fish_seen_subcommand_from import' -l strict -d 'fail on any note or skip'
@@ -328,7 +334,7 @@ complete -c ochakai -n '__fish_seen_subcommand_from search context' -l fm -x -d 
 complete -c ochakai -n '__fish_seen_subcommand_from search' -l rejected -d 'only entries a human turned down'
 complete -c ochakai -n '__fish_seen_subcommand_from reject' -l note -x -d 'why it was not accepted'
 complete -c ochakai -n '__fish_seen_subcommand_from reject' -l lift -d 'withdraw the rejection'
-complete -c ochakai -n '__fish_seen_subcommand_from search context revisions backlinks' -l limit -x -d 'max results'
+complete -c ochakai -n '__fish_seen_subcommand_from search context revisions log backlinks' -l limit -x -d 'max results'
 complete -c ochakai -n '__fish_seen_subcommand_from reembed' -l limit -x -d 'max entries per pass'
 complete -c ochakai -n '__fish_seen_subcommand_from reembed' -l once -d 'a single pass'
 complete -c ochakai -n '__fish_seen_subcommand_from context' -l budget -x -d 'stop rendering after ~bytes'

--- a/cmd/ochakai/main.go
+++ b/cmd/ochakai/main.go
@@ -103,6 +103,7 @@ Client commands (talk to a server; --url > $OCHAKAI_URL > "use" selection):
   usage <id>              show usage totals (search hits, fetches, outcomes)
   report <id> <outcome>   report an outcome: worked | failed (--note for why)
   revisions <id>          list an entry's change history (newest first)
+  log [path]              print the history under a path as OKF's log.md
   backlinks <id>          list entries whose links point at this one
   export <dir | ->        download the knowledge base as an OKF bundle
   import <dir | tgz | ->  upload an OKF bundle (any producer's, not just ours)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -38,6 +38,7 @@ Client commands (talk to a server; --url > $OCHAKAI_URL > "use" selection):
   usage <id>              show usage totals (search hits, fetches, outcomes)
   report <id> <outcome>   report an outcome: worked | failed (--note for why)
   revisions <id>          list an entry's change history (newest first)
+  log [path]              print the history under a path as OKF's log.md
   backlinks <id>          list entries whose links point at this one
   export <dir | ->        download the knowledge base as an OKF bundle
   import <dir | tgz | ->  upload an OKF bundle (any producer's, not just ours)
@@ -341,6 +342,30 @@ Examples:
   ochakai import ga4-bundle.tar.gz --dry-run
   ochakai import ./knowledge --dry-run --strict   # gate a CI sync on a clean parse
   ochakai export - | OCHAKAI_URL=https://other ochakai import -
+```
+
+## ochakai log
+
+```
+Usage: ochakai log [flags] [path]
+
+Print the update history under a path as OKF's log.md (SPEC §9):
+date-grouped, newest first. With no path, the whole bundle.
+
+It is generated from the revision ledger, so it says the same thing
+`ochakai revisions` does — in the format a bundle carries, which is
+what makes the history portable.
+
+Flags:
+  -limit int
+    	max entries (default 1000)
+  -url ochakai use
+    	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
+
+Examples:
+  ochakai log
+  ochakai log metrics
+  ochakai log metrics/revenue --limit 20
 ```
 
 ## ochakai mcp-stdio

--- a/internal/apiclient/apiclient.go
+++ b/internal/apiclient/apiclient.go
@@ -77,7 +77,7 @@ func (c *Client) Identity() (actor, auth string, err error) {
 // proves the URL resolves, the server answers, and — behind Cloud Run —
 // IAM accepts the caller.
 func (c *Client) Health(ctx context.Context) error {
-	resp, err := c.do(ctx, http.MethodGet, "/health", nil, nil)
+	resp, err := c.get(ctx, "/health", nil)
 	if err != nil {
 		return err
 	}
@@ -90,7 +90,7 @@ func (c *Client) Health(ctx context.Context) error {
 // outside that surface, so this is its own request. Servers predating
 // the header omit it and are reported writable, which is what they were.
 func (c *Client) ReadOnly(ctx context.Context) (bool, error) {
-	resp, err := c.do(ctx, http.MethodGet, "/api/v1/browse", nil, nil)
+	resp, err := c.get(ctx, "/api/v1/bundle/index.md", nil)
 	if err != nil {
 		return false, err
 	}
@@ -266,30 +266,48 @@ func (c *Client) Context(ctx context.Context, p ContextParams) (*ContextResult, 
 	return &out, nil
 }
 
-// Browse lists one level of the ID hierarchy (GET /api/v1/browse,
-// design docs 0014, 0016): the subdirectories and entries directly
-// under prefix ("" is the root — the top-level segments).
+// Browse lists one level of the ID hierarchy: the JSON representation of
+// that directory's index.md (design docs 0014, 0016, and 0046 §3.7 for
+// where it now lives). The subdirectories and entries directly under
+// prefix — "" is the root, the top-level segments.
 func (c *Client) Browse(ctx context.Context, prefix string) (*BrowseResult, error) {
-	q := url.Values{}
-	if prefix != "" {
-		q.Set("prefix", prefix)
-	}
 	var out BrowseResult
-	if err := c.doJSON(ctx, http.MethodGet, "/api/v1/browse", q, nil, &out); err != nil {
+	if err := c.doJSON(ctx, http.MethodGet, reservedPath(prefix, "index.md"), nil, nil, &out); err != nil {
 		return nil, err
 	}
 	return &out, nil
 }
 
-// Revisions fetches an entry's change history, newest first, with full
-// snapshots (GET /api/v1/revisions/{id}). Works for soft-deleted
-// entries too. limit 0 uses the server default.
+// Log fetches the generated log.md for a path: the changes under it,
+// newest first, as OKF SPEC §9 writes them (design doc 0046 §3.8).
+func (c *Client) Log(ctx context.Context, prefix string, limit int) ([]byte, error) {
+	resp, err := c.get(ctx, reservedPath(prefix, "log.md"), limitQuery(limit))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	return io.ReadAll(resp.Body)
+}
+
+// Revisions fetches an entry's change history, newest first — the JSON
+// representation of its directory's log.md, narrowed to the entry
+// (design doc 0046 §3.8). Works for soft-deleted entries too; limit 0
+// uses the server default.
 func (c *Client) Revisions(ctx context.Context, id string, limit int) ([]domain.Revision, error) {
 	var out struct {
 		Revisions []domain.Revision `json:"revisions"`
 	}
-	err := c.doJSON(ctx, http.MethodGet, escapedPath("/api/v1/revisions/", id), limitQuery(limit), nil, &out)
+	err := c.doJSON(ctx, http.MethodGet, reservedPath(id, "log.md"), limitQuery(limit), nil, &out)
 	return out.Revisions, err
+}
+
+// reservedPath addresses one of the two generated files under a bundle
+// path. The root's are at /api/v1/bundle/index.md and .../log.md.
+func reservedPath(prefix, name string) string {
+	if prefix == "" {
+		return "/api/v1/bundle/" + name
+	}
+	return escapedPath("/api/v1/bundle/", strings.TrimSuffix(prefix, "/")+"/"+name)
 }
 
 // Backlinks fetches live entries whose links point at the given entry,
@@ -460,7 +478,7 @@ func (c *Client) Attach(ctx context.Context, id, name, okfPath string, data []by
 // /api/v1/attachments/{id}/{name}). Full metadata travels with
 // the entry (Get → Knowledge.Attachments).
 func (c *Client) Attachment(ctx context.Context, id, name string) (data []byte, mediaType string, err error) {
-	resp, err := c.do(ctx, http.MethodGet, attachmentPath(id, name), nil, nil)
+	resp, err := c.get(ctx, attachmentPath(id, name), nil)
 	if err != nil {
 		return nil, "", err
 	}
@@ -512,7 +530,7 @@ func (c *Client) Export(ctx context.Context, attachments bool) (io.ReadCloser, e
 	if !attachments {
 		q = url.Values{"attachments": {"false"}}
 	}
-	resp, err := c.do(ctx, http.MethodGet, "/api/v1/export", q, nil)
+	resp, err := c.get(ctx, "/api/v1/export", q)
 	if err != nil {
 		return nil, err
 	}
@@ -566,7 +584,16 @@ func escapedPath(base, id string) string {
 	return b.String()
 }
 
-func (c *Client) do(ctx context.Context, method, path string, query url.Values, body any) (*http.Response, error) {
+// get is a body-less read that takes whatever representation the path
+// serves by default. The reads that want JSON specifically go through
+// doJSON, which asks for it (design doc 0046 §§3.7-3.8).
+func (c *Client) get(ctx context.Context, path string, query url.Values) (*http.Response, error) {
+	return c.doRaw(ctx, http.MethodGet, path, query, "", nil, nil)
+}
+
+// doAccept is do with an Accept header, for the paths whose default
+// representation is a file rather than JSON (design doc 0046 §§3.7-3.8).
+func (c *Client) doAccept(ctx context.Context, method, path string, query url.Values, body any, accept string) (*http.Response, error) {
 	var rd io.Reader
 	contentType := ""
 	if body != nil {
@@ -577,7 +604,7 @@ func (c *Client) do(ctx context.Context, method, path string, query url.Values, 
 		rd = bytes.NewReader(buf)
 		contentType = "application/json"
 	}
-	return c.doRaw(ctx, method, path, query, contentType, nil, rd)
+	return c.doRaw(ctx, method, path, query, contentType, http.Header{"Accept": []string{accept}}, rd)
 }
 
 // doRaw is do without the JSON encoding: the body is sent verbatim
@@ -625,7 +652,10 @@ func (c *Client) doRaw(ctx context.Context, method, path string, query url.Value
 }
 
 func (c *Client) doJSON(ctx context.Context, method, path string, query url.Values, body, out any) error {
-	resp, err := c.do(ctx, method, path, query, body)
+	// Asked for as JSON, not merely decoded as JSON: the reserved paths
+	// serve a file unless a caller says otherwise (design doc 0046
+	// §§3.7-3.8), and every other endpoint ignores the header.
+	resp, err := c.doAccept(ctx, method, path, query, body, "application/json")
 	if err != nil {
 		return err
 	}

--- a/internal/apiclient/apiclient_test.go
+++ b/internal/apiclient/apiclient_test.go
@@ -100,13 +100,19 @@ func TestSearchUsageSortDecodesUsage(t *testing.T) {
 	}
 }
 
-func TestBrowseBuildsQueryAndDecodesLevels(t *testing.T) {
-	var got url.Values
+// Browsing reads the JSON representation of a directory's index.md
+// (design doc 0046 §3.7), so the path carries the directory rather than
+// a query parameter.
+func TestBrowseReadsTheDirectorysIndex(t *testing.T) {
+	var path string
 	c := newTestPair(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/browse" {
+		if r.Method != http.MethodGet {
 			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
-		got = r.URL.Query()
+		if a := r.Header.Get("Accept"); a != "application/json" {
+			t.Errorf("Accept = %q, want the structured representation", a)
+		}
+		path = r.URL.Path
 		_ = json.NewEncoder(w).Encode(BrowseResult{
 			Dirs:    []BrowseDir{{Name: "sales", Count: 4}},
 			Entries: []BrowseEntry{{Type: "queries", ID: "monthly-revenue", Title: "月次売上", Status: domain.StatusStable}},
@@ -116,27 +122,27 @@ func TestBrowseBuildsQueryAndDecodesLevels(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Get("prefix") != "queries/" {
-		t.Errorf("query = %v", got)
+	if path != "/api/v1/bundle/queries/index.md" {
+		t.Errorf("path = %s", path)
 	}
 	if len(res.Dirs) != 1 || res.Dirs[0].Name != "sales" ||
 		len(res.Entries) != 1 || res.Entries[0].ID != "monthly-revenue" {
 		t.Errorf("res = %+v", res)
 	}
 
-	// Root level: no parameters at all.
+	// The root's own index.
 	if _, err := c.Browse(context.Background(), ""); err != nil {
 		t.Fatal(err)
 	}
-	if len(got) != 0 {
-		t.Errorf("root query = %v, want empty", got)
+	if path != "/api/v1/bundle/index.md" {
+		t.Errorf("root path = %s", path)
 	}
 }
 
 func TestRevisionsHitsCanonicalPathAndSendsLimit(t *testing.T) {
 	var got url.Values
 	c := newTestPair(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v1/revisions/queries/sales/monthly-revenue" {
+		if r.URL.Path != "/api/v1/bundle/queries/sales/monthly-revenue/log.md" {
 			t.Errorf("path = %s", r.URL.Path)
 		}
 		got = r.URL.Query()

--- a/internal/okf/okf.go
+++ b/internal/okf/okf.go
@@ -311,31 +311,28 @@ func (d *dir) subdirNames() []string {
 // where an okf_version declaration is the one permitted block (§11) — and
 // list their entries with relative links, as in the spec's examples.
 func (d *dir) writeIndexes(files map[string][]byte, prefix string) {
-	var b strings.Builder
-	if prefix == "" {
-		fmt.Fprintf(&b, "---\nokf_version: %q\n---\n\n# ochakai knowledge bundle\n\n", Version)
-	} else {
-		fmt.Fprintf(&b, "# %s\n\n", strings.TrimSuffix(prefix, "/"))
-	}
+	var dirs, concepts []IndexLine
 	for _, name := range d.subdirNames() {
 		noun := "concepts"
 		if d.subdirs[name].count == 1 {
 			noun = "concept"
 		}
-		fmt.Fprintf(&b, "* [%s/](%s/index.md) - %d %s\n", name, name, d.subdirs[name].count, noun)
+		dirs = append(dirs, IndexLine{Text: name + "/", Target: name + "/index.md",
+			Description: fmt.Sprintf("%d %s", d.subdirs[name].count, noun)})
 	}
 	for _, e := range d.entries {
 		title := e.k.Title
 		if title == "" {
 			title = e.name
 		}
-		desc := e.k.Description
-		if desc != "" {
-			desc = " - " + desc
-		}
-		fmt.Fprintf(&b, "* [%s](%s.md)%s\n", title, e.name, desc)
+		concepts = append(concepts, IndexLine{Text: title, Target: e.name + ".md", Description: e.k.Description})
 	}
-	files[prefix+"index.md"] = []byte(b.String())
+	// One renderer for both callers: an export writes the whole tree,
+	// a read generates one directory, and a bundle whose index.md
+	// changed shape depending on which asked would be two formats
+	// (design doc 0046 §3.7).
+	files[prefix+"index.md"] = IndexDocument(strings.TrimSuffix(prefix, "/"),
+		[]IndexSection{{Lines: dirs}, {Lines: concepts}})
 	for name, sub := range d.subdirs {
 		sub.writeIndexes(files, prefix+name+"/")
 	}

--- a/internal/okf/reserved.go
+++ b/internal/okf/reserved.go
@@ -1,0 +1,129 @@
+package okf
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/na0fu3y/ochakai/internal/domain"
+)
+
+// The two filenames OKF reserves, and what ochakai puts in them.
+//
+// SPEC §3.1 names index.md (a directory listing, §8) and log.md (an
+// update history, §9). ochakai has held both of these all along — the
+// tree a browse walks, and the revision ledger — and served them at
+// addresses it invented, in shapes it invented: /api/v1/browse and
+// /api/v1/revisions/{id}. Design doc 0046 §§3.7-3.8 stops inventing.
+// They are derived surfaces now, generated on demand at the paths the
+// spec already names.
+//
+// Both are export-only in the sense that matters: an import skips them
+// (they are derived, so there is nothing to read back), and the history
+// in log.md is this instance's observation, published the way generated
+// and verified are and never read back as a claim (design doc 0009).
+
+// IndexLine is one row of a §8 listing: a link, and the description the
+// spec says an entry SHOULD carry.
+type IndexLine struct {
+	Text        string
+	Target      string
+	Description string
+}
+
+// IndexDocument renders one directory's index.md (SPEC §8). dir is the
+// bundle-relative directory, "" for the root — the one index that may
+// carry frontmatter, and then only okf_version (SPEC §12).
+//
+// notes are rendered as a trailing line rather than dropped: a listing
+// cut off at a limit that says nothing is a listing that lies about what
+// the directory holds (design doc 0014's cut-off, kept and made visible).
+func IndexDocument(dir string, sections []IndexSection, notes ...string) []byte {
+	var b strings.Builder
+	if dir == "" {
+		fmt.Fprintf(&b, "---\nokf_version: %q\n---\n\n# ochakai knowledge bundle\n\n", Version)
+	} else {
+		fmt.Fprintf(&b, "# %s\n\n", dir)
+	}
+	for _, s := range sections {
+		if len(s.Lines) == 0 {
+			continue
+		}
+		if s.Heading != "" {
+			fmt.Fprintf(&b, "## %s\n\n", s.Heading)
+		}
+		for _, l := range s.Lines {
+			desc := ""
+			if l.Description != "" {
+				desc = " - " + l.Description
+			}
+			fmt.Fprintf(&b, "* [%s](%s)%s\n", l.Text, l.Target, desc)
+		}
+		b.WriteString("\n")
+	}
+	for _, n := range notes {
+		fmt.Fprintf(&b, "%s\n", n)
+	}
+	return []byte(strings.TrimRight(b.String(), "\n") + "\n")
+}
+
+// IndexSection is a group of lines under an optional heading. SPEC §8
+// describes grouped sections; a directory with only concepts in it reads
+// better without a heading, so an empty one prints none.
+type IndexSection struct {
+	Heading string
+	Lines   []IndexLine
+}
+
+// LogLine is one recorded change, as log.md lists it.
+type LogLine struct {
+	At     time.Time
+	Change string // create | update | move | delete, the revision vocabulary
+	Path   string // the concept's bundle path
+	Title  string
+	By     domain.Actor
+}
+
+// LogDocument renders a log.md (SPEC §9): date-grouped, newest first,
+// ISO 8601 date headings, one line per change.
+//
+// The leading bold word is what §9 calls a convention, and the change
+// vocabulary fills it — the same words the revision ledger uses, so the
+// published history and the stored one say the same thing. The actor
+// rides at the end because an update history whose entries do not say
+// who is a history nobody can act on, and because the spec leaves the
+// prose to the producer.
+func LogDocument(title string, lines []LogLine) []byte {
+	sort.SliceStable(lines, func(i, j int) bool { return lines[i].At.After(lines[j].At) })
+	var b strings.Builder
+	if title == "" {
+		title = "Update Log"
+	}
+	fmt.Fprintf(&b, "# %s\n", title)
+	day := ""
+	for _, l := range lines {
+		if d := l.At.UTC().Format(domain.DateLayout); d != day {
+			day = d
+			fmt.Fprintf(&b, "\n## %s\n\n", d)
+		}
+		text := l.Title
+		if text == "" {
+			text = l.Path
+		}
+		fmt.Fprintf(&b, "* **%s**: [%s](/%s) — %s\n",
+			strings.ToUpper(l.Change[:1])+l.Change[1:], text, l.Path, l.By.String())
+	}
+	return []byte(b.String())
+}
+
+// ReservedName reports whether a bundle path's last segment is one of the
+// two names SPEC §3.1 reserves. Both are derived here, so a write to one
+// is refused and a read of one is generated.
+func ReservedName(path string) bool {
+	base := path
+	if i := strings.LastIndex(path, "/"); i >= 0 {
+		base = path[i+1:]
+	}
+	return base == "index.md" || base == "log.md"
+}

--- a/internal/restapi/openapi_test.go
+++ b/internal/restapi/openapi_test.go
@@ -79,7 +79,7 @@ var idAddressed = []string{
 	"/api/v1/knowledge/",
 	"/api/v1/verify/",
 	"/api/v1/usage/",
-	"/api/v1/revisions/",
+	"/api/v1/bundle/",
 	"/api/v1/backlinks/",
 	"/api/v1/attachments/",
 }

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -75,18 +75,84 @@ func Handler(svc *service.Service) http.Handler {
 		writeHits(w, r, svc, hits)
 	})
 
-	// GET /api/v1/browse?prefix=... — one level of the ID hierarchy
-	// (design docs 0014, 0017): the subdirectories and entries directly
-	// under prefix ("" is the root, i.e. the top-level segments). The
-	// tree view behind the web UI's Browse tab.
-	mux.HandleFunc("GET /api/v1/browse", func(w http.ResponseWriter, r *http.Request) {
-		res, err := svc.Browse(r.Context(), r.URL.Query().Get("prefix"))
-		if err != nil {
-			writeError(w, err)
-			return
+	// GET /api/v1/bundle/{path...} — the two files OKF reserves, at the
+	// paths it reserves them at (design doc 0046 §§3.7-3.8).
+	//
+	//	.../index.md   one level of the tree, as SPEC §8 lists a directory
+	//	.../log.md     the changes under that path, as SPEC §9 logs them
+	//
+	// Both are derived: ochakai already held a tree to walk and a
+	// revision ledger, and served them at addresses of its own invention
+	// (/api/v1/browse, /api/v1/revisions/{id}) in shapes of its own
+	// invention. The format had names for both all along.
+	//
+	// Accept decides the representation, not the address: markdown is the
+	// file, JSON is the same listing with the markdown left out — for the
+	// web UI's tree, which should not have to parse a document to draw a
+	// sidebar. A representation is not a second surface.
+	//
+	// PUT and DELETE are refused (405): a derived file is not one anybody
+	// writes. The rest of the bundle joins this address in a later change;
+	// today a path that is not one of the two reserved names is a 404.
+	mux.HandleFunc("GET /api/v1/bundle/{path...}", func(w http.ResponseWriter, r *http.Request) {
+		path := r.PathValue("path")
+		dir, base := splitReserved(path)
+		switch base {
+		case "index.md":
+			if wantsJSON(r) {
+				res, err := svc.Browse(r.Context(), dir)
+				if err != nil {
+					writeError(w, err)
+					return
+				}
+				writeJSON(w, http.StatusOK, res)
+				return
+			}
+			doc, err := svc.IndexDocument(r.Context(), dir)
+			if err != nil {
+				writeError(w, err)
+				return
+			}
+			writeMarkdown(w, doc)
+		case "log.md":
+			limit, err := queryInt(r.URL.Query(), "limit")
+			if err != nil {
+				writeError(w, err)
+				return
+			}
+			if wantsJSON(r) {
+				rows, err := svc.Revisions(r.Context(), dir, limit)
+				if err != nil {
+					writeError(w, err)
+					return
+				}
+				writeJSON(w, http.StatusOK, map[string]any{"revisions": rows})
+				return
+			}
+			doc, err := svc.LogDocument(r.Context(), dir, limit)
+			if err != nil {
+				writeError(w, err)
+				return
+			}
+			writeMarkdown(w, doc)
+		default:
+			// Not yet an address for everything in the bundle: the
+			// objects and concepts join it in a later change (design
+			// doc 0046 §3.5), and until then this path serves the two
+			// files the format reserves.
+			writeJSON(w, http.StatusNotFound, map[string]string{
+				"error": fmt.Sprintf("no object at %q: the bundle surface serves index.md and log.md", path),
+			})
 		}
-		writeJSON(w, http.StatusOK, res)
 	})
+
+	for _, m := range []string{"PUT", "DELETE"} {
+		mux.HandleFunc(m+" /api/v1/bundle/{path...}", func(w http.ResponseWriter, r *http.Request) {
+			writeJSON(w, http.StatusMethodNotAllowed, map[string]string{
+				"error": "index.md and log.md are generated from the bundle, not stored in it (design doc 0046 §§3.7-3.8)",
+			})
+		})
+	}
 
 	// GET /api/v1/context?q=...&type=...&status=...&tag=...&prefix=...&limit=...&budget=...
 	// The one-call read before answering a data question: full entries
@@ -297,26 +363,6 @@ func Handler(svc *service.Service) http.Handler {
 			return
 		}
 		writeJSON(w, http.StatusOK, u)
-	})
-
-	// GET /api/v1/revisions/{id...} — the entry's change history, newest
-	// first: who changed it, how, when, with full snapshots. The read
-	// surface behind "every change kept as a revision"; works for
-	// soft-deleted entries too. Lives outside /knowledge/ for the same
-	// reason /usage does: a suffix after a hierarchical {id...} would be
-	// unroutable.
-	mux.HandleFunc("GET /api/v1/revisions/{id...}", func(w http.ResponseWriter, r *http.Request) {
-		limit, err := queryInt(r.URL.Query(), "limit")
-		if err != nil {
-			writeError(w, err)
-			return
-		}
-		revs, err := svc.Revisions(r.Context(), r.PathValue("id"), limit)
-		if err != nil {
-			writeError(w, err)
-			return
-		}
-		writeJSON(w, http.StatusOK, map[string]any{"revisions": revs})
 	})
 
 	// GET /api/v1/backlinks/{id...} — live entries whose links point at
@@ -779,6 +825,29 @@ func frontmatterFilter(q url.Values) map[string]string {
 		out[name] = vals[len(vals)-1]
 	}
 	return out
+}
+
+// splitReserved cuts a bundle path into the directory it names and its
+// last segment. "index.md" is the root's listing, "a/b/log.md" is the
+// history under a/b.
+func splitReserved(path string) (dir, base string) {
+	path = strings.Trim(path, "/")
+	if i := strings.LastIndex(path, "/"); i >= 0 {
+		return path[:i], path[i+1:]
+	}
+	return "", path
+}
+
+// wantsJSON reports whether the caller asked for the structured form of
+// a derived file. Only an explicit JSON Accept counts: a browser or a
+// curl sends */* and should get the file that lives at the path.
+func wantsJSON(r *http.Request) bool {
+	return strings.Contains(r.Header.Get("Accept"), "application/json")
+}
+
+func writeMarkdown(w http.ResponseWriter, doc []byte) {
+	w.Header().Set("Content-Type", documentMediaType)
+	_, _ = w.Write(doc)
 }
 
 // wantsDocument reports whether the caller asked for the entry as a

--- a/internal/restapi/restapi_integration_test.go
+++ b/internal/restapi/restapi_integration_test.go
@@ -105,28 +105,51 @@ func TestRESTIntegration(t *testing.T) {
 			resp.StatusCode, resp.Header.Get("Ochakai-Unchanged"))
 	}
 
-	// Browse: under the run-unique top segment the "sales" directory
-	// shows, and the prefix level shows the entry (with its type as
+	// index.md: under the run-unique top segment the "sales" directory
+	// shows, and the level below shows the entry (with its type as
 	// metadata in the projection).
 	var root service.BrowseResult
-	getJSON(t, srv.URL+"/api/v1/browse?prefix="+typ, &root)
+	getJSON(t, srv.URL+"/api/v1/bundle/"+typ+"/index.md", &root)
 	if len(root.Dirs) != 1 || root.Dirs[0].Name != "sales" || root.Dirs[0].Count != 1 {
-		t.Errorf("browse root = %+v", root)
+		t.Errorf("index.md root = %+v", root)
 	}
 	var level service.BrowseResult
-	getJSON(t, srv.URL+"/api/v1/browse?prefix="+typ+"/sales", &level)
+	getJSON(t, srv.URL+"/api/v1/bundle/"+typ+"/sales/index.md", &level)
 	if len(level.Entries) != 1 || level.Entries[0].ID != id || string(level.Entries[0].Type) != typ {
-		t.Errorf("browse level = %+v", level)
+		t.Errorf("index.md level = %+v", level)
+	}
+	// And the same address without the Accept header is the file itself.
+	doc := getText(t, srv.URL+"/api/v1/bundle/"+typ+"/sales/index.md")
+	if !strings.Contains(doc, "# "+typ+"/sales") || !strings.Contains(doc, "(orders.md)") {
+		t.Errorf("generated index.md:\n%s", doc)
 	}
 
-	// Revisions: exactly the create, with a snapshot.
+	// log.md: exactly the create, in both representations.
 	var revs struct {
 		Revisions []domain.Revision `json:"revisions"`
 	}
-	getJSON(t, srv.URL+"/api/v1/revisions/"+typ+"/sales/orders", &revs)
+	getJSON(t, srv.URL+"/api/v1/bundle/"+typ+"/sales/orders/log.md", &revs)
 	if len(revs.Revisions) != 1 || revs.Revisions[0].Change != "create" ||
 		!strings.Contains(revs.Revisions[0].Document, "title: REST round trip") {
 		t.Errorf("revisions = %+v", revs.Revisions)
+	}
+	logDoc := getText(t, srv.URL+"/api/v1/bundle/"+typ+"/log.md")
+	if !strings.Contains(logDoc, "**Create**") || !strings.Contains(logDoc, "/"+id+".md") {
+		t.Errorf("generated log.md:\n%s", logDoc)
+	}
+
+	// Neither is writable: they are generated, not stored.
+	req, err := http.NewRequest(http.MethodPut, srv.URL+"/api/v1/bundle/"+typ+"/index.md", strings.NewReader("x"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("PUT index.md = %d, want 405", resp.StatusCode)
 	}
 
 	// Export: the bundle carries the entry at its canonical path.
@@ -241,7 +264,7 @@ func TestRESTIntegration(t *testing.T) {
 	}
 
 	// Delete, then the entry is gone.
-	req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/knowledge/"+typ+"/sales/orders", nil)
+	req, _ = http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/knowledge/"+typ+"/sales/orders", nil)
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -448,9 +471,35 @@ func putDoc(t *testing.T, base, id string, doc []byte, onlyIfAbsent bool) *http.
 	return resp
 }
 
-func getJSON(t *testing.T, url string, v any) {
+// getText fetches a path without asking for JSON — what a reader of the
+// bundle gets.
+func getText(t *testing.T, url string) string {
 	t.Helper()
 	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s = %d: %s", url, resp.StatusCode, body)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/markdown") {
+		t.Errorf("GET %s: content-type = %q, want markdown", url, ct)
+	}
+	return string(body)
+}
+
+func getJSON(t *testing.T, url string, v any) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The reserved paths answer with a file unless asked otherwise
+	// (design doc 0046 §§3.7-3.8); every other path ignores this.
+	req.Header.Set("Accept", "application/json")
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/restapi/restapi_test.go
+++ b/internal/restapi/restapi_test.go
@@ -57,11 +57,11 @@ func TestBadRequestValidation(t *testing.T) {
 		{"usage sort with query", "/api/v1/knowledge?sort=usage&q=revenue", "cannot be combined"},
 		{"failed sort with query", "/api/v1/knowledge?sort=failed&q=revenue", "cannot be combined"},
 		{"bad search limit", "/api/v1/knowledge?limit=abc", "invalid limit"},
-		{"bad revisions limit", "/api/v1/revisions/metrics/revenue?limit=abc", "invalid limit"},
+		{"bad log limit", "/api/v1/bundle/metrics/log.md?limit=abc", "invalid limit"},
 		{"bad backlinks limit", "/api/v1/backlinks/metrics/revenue?limit=1.5", "invalid limit"},
 		{"bad context limit", "/api/v1/context?q=x&limit=1.5", "invalid limit"},
 		{"bad min_score", "/api/v1/context?q=x&min_score=high", "invalid min_score"},
-		{"browse bad prefix", "/api/v1/browse?prefix=..%2Fescape", "invalid prefix"},
+		{"bad index prefix", "/api/v1/bundle/..%2Fescape/index.md", "invalid prefix"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/service/browse.go
+++ b/internal/service/browse.go
@@ -2,9 +2,11 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/na0fu3y/ochakai/internal/domain"
+	"github.com/na0fu3y/ochakai/internal/okf"
 	"github.com/na0fu3y/ochakai/internal/store"
 )
 
@@ -54,3 +56,92 @@ func normalizePrefix(p string) (string, error) {
 	}
 	return p, nil
 }
+
+// IndexDocument renders one directory as the index.md OKF SPEC §8
+// defines (design doc 0046 §3.7). It is the same listing Browse
+// returns — one level, subdirectories with counts, entries with their
+// descriptions, cut off at the same limit — in the shape the format
+// already has a place for.
+//
+// Two representations of one thing, at one address: a caller that wants
+// to render the tree asks for JSON, a caller that wants the file gets
+// the file. The JSON is not a second surface, it is the same listing
+// without asking a browser to parse markdown.
+func (s *Service) IndexDocument(ctx context.Context, prefix string) ([]byte, error) {
+	res, err := s.Browse(ctx, prefix)
+	if err != nil {
+		return nil, err
+	}
+	dir, err := normalizePrefix(prefix)
+	if err != nil {
+		return nil, err
+	}
+	var dirs, concepts []okf.IndexLine
+	for _, d := range res.Dirs {
+		noun := "concepts"
+		if d.Count == 1 {
+			noun = "concept"
+		}
+		dirs = append(dirs, okf.IndexLine{Text: d.Name + "/", Target: d.Name + "/index.md",
+			Description: fmt.Sprintf("%d %s", d.Count, noun)})
+	}
+	for _, e := range res.Entries {
+		name := e.ID
+		if i := strings.LastIndex(name, "/"); i >= 0 {
+			name = name[i+1:]
+		}
+		title := e.Title
+		if title == "" {
+			title = name // the filename is the name (design doc 0022)
+		}
+		concepts = append(concepts, okf.IndexLine{Text: title, Target: name + ".md", Description: e.Description})
+	}
+	var notes []string
+	if res.Truncated {
+		// The cut-off says so in the document. A listing that stops
+		// silently is a listing that misdescribes the directory
+		// (design doc 0014's decision, now visible to whoever reads
+		// the file rather than only to whoever read the JSON).
+		notes = append(notes, fmt.Sprintf("_This listing was cut off at %d entries._", store.MaxBrowseEntries))
+	}
+	return okf.IndexDocument(dir, []okf.IndexSection{{Lines: dirs}, {Lines: concepts}}, notes...), nil
+}
+
+// LogDocument renders a subtree's history as the log.md OKF SPEC §9
+// defines (design doc 0046 §3.8): date-grouped, newest first.
+//
+// It publishes an instance ledger, which is why an import skips it: the
+// history of what happened here is this instance's observation, exactly
+// as generated and verified are (design doc 0009). Publishing it makes
+// it readable by whoever holds the bundle; reading it back would make it
+// a claim anyone could assert.
+func (s *Service) LogDocument(ctx context.Context, prefix string, limit int) ([]byte, error) {
+	prefix, err := normalizePrefix(prefix)
+	if err != nil {
+		return nil, err
+	}
+	if limit <= 0 || limit > maxLogLines {
+		limit = maxLogLines
+	}
+	rows, err := s.Store.ListRevisionsUnder(ctx, prefix, limit)
+	if err != nil {
+		return nil, err
+	}
+	lines := make([]okf.LogLine, 0, len(rows))
+	for _, r := range rows {
+		lines = append(lines, okf.LogLine{
+			At: r.ChangedAt, Change: r.Change, Path: r.ID + ".md", Title: r.Title, By: r.ChangedBy,
+		})
+	}
+	title := "Update Log"
+	if prefix != "" {
+		title = prefix
+	}
+	return okf.LogDocument(title, lines), nil
+}
+
+// maxLogLines bounds a generated history the way the tree listing is
+// bounded: a log is for reading, and a directory with a hundred thousand
+// changes under it does not become more readable by containing all of
+// them. The whole ledger is still there — ask a narrower path.
+const maxLogLines = 1000

--- a/internal/service/readonly_test.go
+++ b/internal/service/readonly_test.go
@@ -26,6 +26,9 @@ func TestReadOnlyRefusesEveryWrite(t *testing.T) {
 	reads := map[string]bool{
 		"Get": true, "Search": true, "SearchOrList": true, "Context": true,
 		"Revisions": true, "Backlinks": true, "Usage": true, "Browse": true,
+		// The two derived files are reads of the same tree and ledger
+		// (design doc 0046 §§3.7-3.8).
+		"IndexDocument": true, "LogDocument": true,
 		"Export": true, "Attachment": true, "AttachmentMeta": true,
 		"FillAttachments": true, "RefuseIfCurated": true,
 		"RefuseIfRevivingCurated": true, "Close": true,

--- a/internal/store/browse.go
+++ b/internal/store/browse.go
@@ -47,15 +47,15 @@ type BrowseEntry struct {
 const browseNotRejected = `deleted_at IS NULL
 	AND NOT EXISTS (SELECT 1 FROM knowledge_rejection r WHERE r.id = knowledge.id)`
 
-// maxBrowseEntries bounds one directory listing. A directory this wide
+// MaxBrowseEntries bounds one directory listing. A directory this wide
 // is a modeling smell, not a paging problem — the caller renders a
 // truncation note instead of paginating.
-const maxBrowseEntries = 1000
+const MaxBrowseEntries = 1000
 
 // Browse returns what sits directly under prefix: the subdirectories
 // (with entry counts beneath them) and the entries at this level, both
 // in name order; truncated reports that the entry list hit
-// maxBrowseEntries. prefix is "" for the root, or segments with a
+// MaxBrowseEntries. prefix is "" for the root, or segments with a
 // trailing slash ("sales/"). Prefix matching is by string, not LIKE —
 // IDs may contain "_", which LIKE would treat as a wildcard.
 func (s *Store) Browse(ctx context.Context, prefix string) (dirs []DirCount, entries []BrowseEntry, truncated bool, err error) {
@@ -83,7 +83,7 @@ func (s *Store) Browse(ctx context.Context, prefix string) (dirs []DirCount, ent
 		WHERE `+browseNotRejected+`
 		  AND left(id, length($1::text)) = $1
 		  AND strpos(substr(id, length($1::text)+1), '/') = 0
-		ORDER BY id LIMIT %d`, maxBrowseEntries+1), prefix)
+		ORDER BY id LIMIT %d`, MaxBrowseEntries+1), prefix)
 	if err != nil {
 		return nil, nil, false, err
 	}
@@ -95,8 +95,8 @@ func (s *Store) Browse(ctx context.Context, prefix string) (dirs []DirCount, ent
 	if err != nil {
 		return nil, nil, false, err
 	}
-	if len(entries) > maxBrowseEntries {
-		entries = entries[:maxBrowseEntries]
+	if len(entries) > MaxBrowseEntries {
+		entries = entries[:MaxBrowseEntries]
 		truncated = true
 	}
 	return dirs, entries, truncated, nil

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1247,6 +1247,47 @@ func (s *Store) ListRevisions(ctx context.Context, id string, limit int) ([]doma
 	return revs, nil
 }
 
+// LogRow is one line of a subtree's history: enough to render log.md
+// (SPEC §9) and no more. The document each revision holds is
+// deliberately not selected — a history that shipped every past version
+// of every entry in a directory would be the whole knowledge base
+// several times over, and what log.md publishes is what changed and by
+// whom (design doc 0046 §3.8).
+type LogRow struct {
+	ID        string
+	Title     string
+	Change    string
+	ChangedBy domain.Actor
+	ChangedAt time.Time
+}
+
+// ListRevisionsUnder returns the newest changes anywhere under a path
+// prefix, newest first. An empty prefix is the whole bundle.
+//
+// The title comes from the entry as it stands rather than from the
+// revision: a log names what changed, and naming it by a title it has
+// since stopped having would send a reader looking for something that is
+// not there. An entry that has since been purged keeps its history and
+// loses its title, which is why the join is left.
+func (s *Store) ListRevisionsUnder(ctx context.Context, prefix string, limit int) ([]LogRow, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT r.id, COALESCE(k.title, ''), r.change,
+		        r.changed_by_kind, r.changed_by_name, r.changed_by_via, r.changed_at
+		 FROM knowledge_revision r
+		 LEFT JOIN knowledge k ON k.id = r.id
+		 WHERE $1 = '' OR r.id = $1 OR r.id LIKE $2
+		 ORDER BY r.changed_at DESC, r.id, r.rev DESC LIMIT $3`,
+		prefix, prefix+"/%", limit)
+	if err != nil {
+		return nil, err
+	}
+	return pgx.CollectRows(rows, func(row pgx.CollectableRow) (LogRow, error) {
+		var l LogRow
+		return l, row.Scan(&l.ID, &l.Title, &l.Change,
+			&l.ChangedBy.Kind, &l.ChangedBy.Name, &l.ChangedBy.Via, &l.ChangedAt)
+	})
+}
+
 func (s *Store) addRevision(ctx context.Context, tx pgx.Tx, k *domain.Knowledge, change string, actor domain.Actor) error {
 	// The full document, server-owned keys included: a revision records
 	// what the entry was, and who had confirmed it at the time is part of

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -681,18 +681,22 @@ function setReadOnly(on) {
 }
 
 async function api(path, opts = {}) {
-  const init = { method: opts.method || 'GET' };
+  // Every call here wants the structured form. It matters at the paths
+  // that serve a file by default — index.md and log.md are documents,
+  // and this page asks for the listing behind them (design doc 0046
+  // §§3.7-3.8).
+  const init = { method: opts.method || 'GET', headers: { Accept: 'application/json' } };
   if (opts.raw !== undefined) {
     init.body = opts.raw; // raw bytes (attachment upload), no JSON envelope
   } else if (opts.doc !== undefined) {
-    init.headers = { 'Content-Type': 'text/markdown' };
+    init.headers['Content-Type'] = 'text/markdown';
     init.body = opts.doc; // an OKF document — the one way to write knowledge
   } else if (opts.body !== undefined) {
-    init.headers = { 'Content-Type': 'application/json' };
+    init.headers['Content-Type'] = 'application/json';
     init.body = JSON.stringify(opts.body);
   }
   if (opts.onlyIfAbsent) {
-    init.headers = Object.assign({}, init.headers, { 'If-None-Match': '*' });
+    init.headers['If-None-Match'] = '*';
   }
   const res = await fetch(BASE + path, init);
   // A read-only deployment says so on every response (design doc 0040).
@@ -1087,7 +1091,7 @@ function knownDirs() {
 async function refreshTree() {
   const tree = $('#tree');
   try {
-    const res = await api('/api/v1/browse');
+    const res = await api('/api/v1/bundle/index.md');
     tree.innerHTML = levelHTML(res, '') || '<div class="empty">No knowledge yet.</div>';
     wireNodes(tree);
     // A deep link may have rendered before the tree existed (boot) or
@@ -1162,7 +1166,7 @@ function loadNode(d) {
     const box = d.querySelector(':scope > .children');
     const prefix = d.dataset.prefix;
     try {
-      const res = await api(`/api/v1/browse?prefix=${encodeURIComponent(prefix)}`);
+      const res = await api(`/api/v1/bundle/${idPath(prefix)}/index.md`);
       const body = levelHTML(res, prefix);
       const note = res.truncated
         ? `<div class="truncation-note">Showing the first 1000 entries at this level — a directory this wide is
@@ -1339,7 +1343,7 @@ function dirCard(prefix, d) {
 // they render as title, status, and description.
 async function loadDirIndex(container, prefix, emptyText) {
   try {
-    const res = await api('/api/v1/browse' + (prefix ? '?prefix=' + encodeURIComponent(prefix) : ''));
+    const res = await api(prefix ? `/api/v1/bundle/${idPath(prefix)}/index.md` : '/api/v1/bundle/index.md');
     if (!container.isConnected) return; // navigated away while loading
     const dirs = (res.dirs || []).map(d => dirCard(prefix, d)).join('');
     const entries = (res.entries || []).map(hitCard).join('');
@@ -1685,7 +1689,7 @@ async function viewDetail(id) {
         : '<div class="empty">Nothing links to this entry yet.</div>';
     },
     history: async () => {
-      const { revisions } = await api('/api/v1/revisions/' + idPath(entry.id) + '?limit=200');
+      const { revisions } = await api('/api/v1/bundle/' + idPath(entry.id) + '/log.md?limit=200');
       const rows = (revisions || []).map(r => `
         <tr>
           <td class="k mono">#${r.rev}</td>


### PR DESCRIPTION
Sixth in the 0046 series. One area left after this.

## Why

SPEC §3.1 reserves two filenames and defines what goes in them — §8 a directory listing, §9 an update history. ochakai has held both all along: the tree a browse walks, and the revision ledger. It served them at **addresses it invented**, in **shapes it invented**:

| ochakai's | OKF's |
|---|---|
| `GET /api/v1/browse?prefix=metrics` | `metrics/index.md` |
| `GET /api/v1/revisions/{id}` | `log.md` |

0043 §5 deferred `log.md` on the grounds that its content conventions were "the spec's to decide". §9 had already decided them.

## What lands

`GET /api/v1/bundle/{path}` serves both, generated on demand.

**Accept decides the representation, not the address.** `application/json` gets the listing or the revisions — the same JSON the two retired endpoints returned, which is what the web UI's tree needs so it does not have to parse a document. Anything else gets the file. A representation is not a second surface.

`PUT` and `DELETE` are **405**: a generated file is not one anybody writes.

## Two things the old endpoints could not do

- **A directory's log.md covers everything under it.** `/revisions/{id}` could only ever answer for one entry; "what changed under `metrics/` this week" had no answer.
- **The history becomes portable.** It is a file somebody else can read, in a format that defines it, rather than a listing only ochakai knows how to print. `ochakai log [path]` prints it.

## Publishing a ledger is not trusting one

An import skips both files, exactly as it skips `generated` and `verified`. What happened in one instance is that instance's observation; reading it back would turn it into a claim anyone could assert (design doc 0009). Same asymmetry, same reason.

## Details worth a look

- The index renderer is **shared with the exporter**, so a bundle's `index.md` does not change shape depending on whether an export wrote it or a read generated it.
- The 1000-per-level cut-off (0014) now says so **in the document** — a listing that stops silently misdescribes the directory.
- `log.md` takes the entry's *current* title, not the one the revision was written under: a log that named something by a title it has since lost sends the reader looking for something that is not there.
- The generated log is capped at 1000 lines. The ledger is all still there — ask a narrower path.
- The web UI's `api()` helper now sends `Accept: application/json` on every call, which is what it always meant.

## Checks

`scripts/check --db` passes. The REST integration test exercises both representations, both files, and the 405.

## Left

**The one address space** (0046 §§3.1-3.3, 3.5): the `object` table, attachments dissolving into path-addressed files, and concepts joining `/api/v1/bundle/{path}`. It is the largest of the six areas — it touches nearly every store query — and I would rather land it on a quiet tree than on top of this one. Notes already settled while scoping it are in #265's description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)