### PR TITLE
Hand back the document that was written, on every read (0046 §2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,15 @@ last entry.
     (design doc [0038](docs/design/0038-type-vocabulary-realignment.md)),
     and rewriting it would also leave the index disagreeing with the
     document it is derived from.
+  - **A read hands those bytes back.** The `document` field of a read —
+    what `ochakai get` prints, what the web UI's editor loads, what
+    `get_knowledge` returns — is the stored document, not a rendering of
+    it. Storing the bytes and rendering them back would have kept the
+    promise only for callers that asked for `text/markdown`, and every
+    edit through the UI or the CLI would have reformatted the entry on
+    its way past. The server-owned keys stay out of that field, as they
+    always were: `observed` is where they are, which is what makes the
+    field editable and sendable back as it came.
   - The canonical rendering stays as the form ochakai writes when it
     composes a document itself, and as what a write path falls back to
     when a caller changes an entry's fields rather than its document.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -750,9 +750,10 @@ paths:
       operationId: getKnowledge
       summary: Get one knowledge entry
       description: >
-        Answers a View by default: the entry's canonical document, the
-        projection to read it by, and what this instance observed about
-        it (design doc 0043 §3.5).
+        Answers a View by default: the entry's document as it was
+        written, the projection to read it by, and what this instance
+        observed about it (design docs 0043 §3.5, 0046 §2.2). Comments,
+        key order and quoting style are the writer's, and stay theirs.
 
         With "Accept: text/markdown" it answers a document instead — the
         export form, keys the server owns included, which is what a
@@ -1054,9 +1055,9 @@ paths:
                     wrote the entry. The verifications ledger is untouched
                     — a PUT edits the document and rules on nothing;
                     POST /api/v1/verify/{id} is what confirms an entry.
-                    `document` comes back canonical: key order normalized,
-                    and no server-owned keys to strip before the next
-                    edit.
+                    `document` comes back as it was written — the bytes
+                    that were stored (design doc 0046 §2.2), with no
+                    server-owned keys to strip before the next edit.
                   value:
                     id: metrics/revenue
                     document: |
@@ -1949,15 +1950,15 @@ components:
   headers:
     ETag:
       description: >
-        The entry's version — the hash of its canonical OKF document,
+        The entry's version — the hash of the document as stored,
         quoted, and the same value as the body's summary.content_hash
-        (design doc 0043 §3.4). A client echoes it in If-Match on a later update
-        to write only if nothing changed meanwhile (design doc 0030).
-        It is a hash of the content alone, so it moves when the entry's
-        content moves and at no other time: verifying, rejecting or
-        attaching a file all leave a held precondition valid. Treat it as
-        opaque — two entries that say the same thing carry the same
-        version.
+        (design docs 0043 §3.4, 0046 §3.4). A client echoes it in
+        If-Match on a later update to write only if nothing changed
+        meanwhile (design doc 0030). It covers the document and nothing
+        else, so verifying, rejecting or attaching a file all leave a
+        held precondition valid — while reformatting the entry moves it,
+        because the file did change (what the entry *says* did not, which
+        is what observed.generated.at reports). Treat it as opaque.
       schema: { type: string }
     Note:
       description: >
@@ -2253,12 +2254,12 @@ components:
         content_hash:
           type: string
           description: >
-            The entry's version: the hash of its canonical OKF document,
-            and the same value the ETag header carries (design doc 0043
-            §3.4). Send it back as If-Match to write only if nothing
-            changed meanwhile. Opaque — it moves when the content moves
-            and at no other time, so a verification or an attachment
-            leaves a held precondition valid.
+            The entry's version: the hash of the document as stored, and
+            the same value the ETag header carries (design docs 0043
+            §3.4, 0046 §3.4). Send it back as If-Match to write only if
+            nothing changed meanwhile. Opaque — it covers the document
+            alone, so a verification or an attachment leaves a held
+            precondition valid, while a reformat moves it.
         created_at: { type: string, format: date-time }
         updated_at:
           type: string

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -161,11 +161,12 @@ level and inside a `sources` entry, a parameter, the executor or the
 attester, because a key discarded on the way in is a key no later
 release can recover.
 
-An entry's version is the hash of its canonical document, which a read
+An entry's version is the hash of the document as stored, which a read
 returns as an `ETag` and a write takes back as `If-Match`. Being a hash
-of the content alone, it moves when the entry's content moves and at no
-other time — confirming an entry, rejecting it or attaching a file to it
-all leave a held precondition valid.
+of the document alone, confirming an entry, rejecting it or attaching a
+file to it all leave a held precondition valid; reformatting the entry
+moves it, because the file did change — what the entry *says* did not,
+and that is what `generated.at` reports.
 
 What this instance *observed* about an entry travels beside the document
 rather than inside it: who created it, who last changed it, every
@@ -291,7 +292,7 @@ memory and flushed periodically, statistics are documented as
 best-effort, an overrun is dropped rather than backing up the request,
 and shutdown drains before a final flush (design doc
 [0029](design/0029-usage-recording-off-the-read-path.md)). Concurrent
-edits are handled by optional optimistic locking — the canonical
+edits are handled by optional optimistic locking — the stored
 document's hash as the version, exposed as an ETag with `If-Match`
 (design doc
 [0030](design/0030-optimistic-locking.md)).

--- a/internal/domain/knowledge.go
+++ b/internal/domain/knowledge.go
@@ -991,6 +991,12 @@ func ObservedOf(k *Knowledge) Observed {
 
 // View is a read of one entry: the document it is, the projection to read
 // it by, and what this instance observed about it (design doc 0043 §3.5).
+//
+// Document is the stored document — the writer's own bytes (design doc
+// 0046 §2.2), without the keys this instance owns, which Observed carries
+// instead. It is what the editing surfaces read and write back, so it has
+// to be the thing that was written: a rendering here would mean every
+// edit through the web UI or `ochakai get` silently reformatted the entry.
 type View struct {
 	ID          string       `json:"id"`
 	Document    string       `json:"document"`

--- a/internal/okf/okf.go
+++ b/internal/okf/okf.go
@@ -378,7 +378,11 @@ func sourcesOut(in []domain.Source) []source {
 // the keys this instance owns and only ever writes — generated and
 // verified (SPEC §5.2), and ochakai's created_by / rejected_* extensions.
 // This is what an export writes, what a read with Accept: text/markdown
-// returns, and what `ochakai get` hands to an editor.
+// returns, and what a revision records.
+//
+// The editing surfaces read ViewOf instead, which hands back the same
+// stored bytes without the owned keys: a document beside an Observed
+// that already says who wrote and confirmed the entry.
 //
 // The stored document is the writer's own bytes (design doc 0046 §2.2),
 // so the keys are appended to its frontmatter rather than merged into a
@@ -495,19 +499,30 @@ func render(k *domain.Knowledge, serverKeys bool) ([]byte, error) {
 	return []byte(b.String()), nil
 }
 
-// ViewOf assembles a read of one entry: the canonical document it is,
-// the projection to read it by, and what this instance observed about it
+// ViewOf assembles a read of one entry: the document it is, the
+// projection to read it by, and what this instance observed about it
 // (design doc 0043 §3.5).
 //
-// The document is rendered rather than fetched. It is a pure function of
-// the columns a read already returns, and the store pins that rendering
-// against the stored bytes — so re-rendering here reproduces what is
-// stored, and no read has to carry the document twice over the wire from
-// the database.
+// The document is the stored one — the writer's own bytes, comments, key
+// order and all (design doc 0046 §2.2). It has to be: this is the shape
+// the web UI's editor and `ochakai get` hand to whoever edits the entry,
+// so a rendering here would be a rewrite there, and the promise that a
+// document survives a round trip would hold only for the callers that
+// asked for text/markdown.
+//
+// Server-owned keys stay out of it. They are what Observed carries, and
+// putting them in the document too would hand an editor keys it is not
+// allowed to set — Document is the export form, and this is not it.
+//
+// The canonical rendering is the fallback for an entry with no stored
+// bytes: one composed in memory, or a row read for a listing.
 func ViewOf(k *domain.Knowledge) (domain.View, error) {
-	doc, err := Canonical(k)
-	if err != nil {
-		return domain.View{}, err
+	doc := []byte(k.Doc)
+	if len(doc) == 0 {
+		var err error
+		if doc, err = Canonical(k); err != nil {
+			return domain.View{}, err
+		}
 	}
 	return domain.View{
 		ID:          k.ID,

--- a/internal/okf/okf_test.go
+++ b/internal/okf/okf_test.go
@@ -556,3 +556,58 @@ attester:
 		t.Errorf("round trip changed the entry:\n got %+v\nwant %+v", back.Knowledge, d.Knowledge)
 	}
 }
+
+// A read hands back the document that was stored, not a rendering of it
+// (design docs 0046 §2.2, 0043 §3.5). The editing surfaces — the web UI's
+// editor, `ochakai get` — read this field and write it back, so a
+// rendering here would reformat every entry they touch: the comment
+// below would go, the key order would settle, and a status the writer
+// never wrote would appear.
+func TestViewOfHandsBackTheStoredDocument(t *testing.T) {
+	const stored = "---\ntype: Metric\n# 定義は財務の合意による\ntitle: 売上\nowner: finance\n---\n\n受注合計。\n"
+	k := domain.Knowledge{
+		Type: domain.TypeMetrics, ID: "metrics/revenue", Title: "売上",
+		Status: domain.StatusStable, Body: "受注合計。", Doc: stored,
+		CreatedBy: domain.Actor{Kind: domain.ActorHuman, Name: "na0"},
+		UpdatedBy: domain.Actor{Kind: domain.ActorHuman, Name: "na0"},
+	}
+	v, err := ViewOf(&k)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.Document != stored {
+		t.Errorf("the view rewrote the stored document:\n got %q\nwant %q", v.Document, stored)
+	}
+	// The projection still applies OKF's default to a document that names
+	// no status (SPEC §5.4) — the reading is the projection's job, and it
+	// is not written into the document (design doc 0046 §3.9).
+	if v.Summary.Status != domain.StatusStable {
+		t.Errorf("summary status = %q, want stable", v.Summary.Status)
+	}
+	if strings.Contains(v.Document, "status:") {
+		t.Errorf("the view wrote a status the document does not carry:\n%s", v.Document)
+	}
+	// Server-owned keys stay in observed, so what comes back can be sent
+	// straight back as a write.
+	for _, owned := range []string{"generated:", "created_by:", "verified:"} {
+		if strings.Contains(v.Document, owned) {
+			t.Errorf("the view's document carries the server-owned key %q:\n%s", owned, v.Document)
+		}
+	}
+
+	// An entry with no stored bytes — one composed in memory, or a row
+	// read for a listing — falls back to the canonical rendering, which
+	// is the only document it has.
+	k.Doc = ""
+	v, err = ViewOf(&k)
+	if err != nil {
+		t.Fatal(err)
+	}
+	canon, err := Canonical(&k)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.Document != string(canon) {
+		t.Errorf("an entry with no document did not fall back to the canonical form:\n%s", v.Document)
+	}
+}

--- a/internal/restapi/restapi_integration_test.go
+++ b/internal/restapi/restapi_integration_test.go
@@ -1049,9 +1049,9 @@ func TestRESTIntegrationDocumentWrites(t *testing.T) {
 	if back.Observed.CreatedBy.Name != created.Observed.CreatedBy.Name {
 		t.Errorf("a document's created_by was read back as provenance: %+v", back.Observed.CreatedBy)
 	}
-	// The view's document is canonical: the server-owned keys the
+	// The view's document is the stored one: the server-owned keys the
 	// text/markdown read carries are not in it, so it needs no stripping
-	// before the next edit (design doc 0043 §3.5).
+	// before the next edit (design docs 0043 §3.5, 0046 §2.2).
 	if strings.Contains(back.Document, "generated:") || strings.Contains(back.Document, "created_by:") {
 		t.Errorf("the view's document carries server-owned keys:\n%s", back.Document)
 	}
@@ -1067,5 +1067,108 @@ func TestRESTIntegrationDocumentWrites(t *testing.T) {
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusPreconditionFailed {
 		t.Errorf("stale If-Match = %d, want 412", resp.StatusCode)
+	}
+}
+
+// TestRESTIntegrationDocumentSurvivesTheRoundTrip pins design doc 0046
+// §2.2 at the surface: what a read hands back is what was written.
+//
+// Storing the bytes is only half of it. The web UI's editor and
+// `ochakai get` read the JSON view's document and write it back, so a
+// canonical rendering there would reformat every entry those surfaces
+// touch — comments gone, key order settled, a status the writer never
+// wrote appearing — and the promise would hold only for the callers that
+// asked for text/markdown. The property is stated as a round trip
+// because that is how it is broken: read, send back, nothing happened.
+func TestRESTIntegrationDocumentSurvivesTheRoundTrip(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := store.New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	svc := &service.Service{Store: s, Log: slog.New(slog.NewTextHandler(os.Stderr, nil))}
+	srv := checkedServer(t, Handler(svc))
+	defer srv.Close()
+
+	id := fmt.Sprintf("restbytes%d/revenue", time.Now().UnixNano())
+	// Cleaned up at the end of the body rather than from t.Cleanup: the
+	// cleanups run after this function's defers, so the server the
+	// request would go to is already closed by then.
+	defer func() {
+		for _, u := range []string{"", "?purge=true"} {
+			req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/knowledge/"+id+u, nil)
+			if resp, err := http.DefaultClient.Do(req); err == nil {
+				resp.Body.Close()
+			}
+		}
+	}()
+
+	// Everything a rendering would quietly normalize: a comment, the
+	// title after a producer key, a lowercase recommended type, and no
+	// status at all.
+	const written = "---\ntype: metric\n# 定義は財務の合意による\nowner: finance\ntitle: 売上\n---\n\n受注合計。\n"
+
+	resp := putDoc(t, srv.URL, id, []byte(written), true)
+	var created domain.View
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create = %d", resp.StatusCode)
+	}
+	if created.Document != written {
+		t.Errorf("the write rewrote the document:\n got %q\nwant %q", created.Document, written)
+	}
+
+	var read domain.View
+	getJSON(t, srv.URL+"/api/v1/knowledge/"+id, &read)
+	if read.Document != written {
+		t.Errorf("the read rewrote the document:\n got %q\nwant %q", read.Document, written)
+	}
+	// The projection applies OKF's default to a silent document (SPEC
+	// §5.4) without the document gaining a key (design doc 0046 §3.9),
+	// and the writer's casing is the stored casing.
+	if read.Summary.Status != domain.StatusStable {
+		t.Errorf("summary status = %q, want stable", read.Summary.Status)
+	}
+	if strings.Contains(read.Document, "status:") {
+		t.Errorf("a status was written into a document that named none:\n%s", read.Document)
+	}
+	if read.Summary.Type != "metric" {
+		t.Errorf("type = %q, want the writer's casing", read.Summary.Type)
+	}
+
+	// The markdown representation is the same bytes with this instance's
+	// observations appended — the export form, not a second document.
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/v1/knowledge/"+id, nil)
+	req.Header.Set("Accept", "text/markdown")
+	mdResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	served, _ := io.ReadAll(mdResp.Body)
+	mdResp.Body.Close()
+	for _, want := range []string{"# 定義は財務の合意による", "type: metric", "generated:", "created_by:"} {
+		if !strings.Contains(string(served), want) {
+			t.Errorf("the served document is missing %q:\n%s", want, served)
+		}
+	}
+
+	// And the loop closes: what the read handed over, sent back, is not
+	// a change.
+	resp = putDoc(t, srv.URL, id, []byte(read.Document), false)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK || resp.Header.Get("Ochakai-Unchanged") != "true" {
+		t.Errorf("sending back what was read = %d, Ochakai-Unchanged = %q",
+			resp.StatusCode, resp.Header.Get("Ochakai-Unchanged"))
 	}
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -791,7 +791,7 @@ func (s *Service) Context(ctx context.Context, req ContextRequest) (*ContextResu
 		for _, l := range entries[i].Links {
 			add(l.Target)
 		}
-		linking, err := s.Store.ListLinkingTo(ctx, entries[i].ID, 2*limit)
+		linking, err := s.Store.ListLinkingToDocs(ctx, entries[i].ID, 2*limit)
 		if err != nil {
 			s.Log.Warn("backlink lookup failed", "id", entries[i].ID, "error", err)
 			continue

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -587,12 +587,32 @@ func (s *Store) GetTombstone(ctx context.Context, id string) (*domain.Knowledge,
 // round. A stored target is always the resolved id, whichever of SPEC
 // §6's two forms the body wrote it in.
 func (s *Store) ListLinkingTo(ctx context.Context, id string, limit int) ([]domain.Knowledge, error) {
-	return s.queryKnowledge(ctx,
-		`SELECT `+knowledgeSelect+` FROM knowledge
+	return s.listLinkingTo(ctx, id, limit, knowledgeSelect, scanKnowledge)
+}
+
+// ListLinkingToDocs is ListLinkingTo for the caller that hands the
+// entries over rather than naming them: a context pack delivers its
+// companions as documents, and a companion read without one would come
+// back rendered while the entries beside it came back as written (design
+// doc 0046 §2.2). Backlinks stays on the lighter read — a row there is a
+// projection, and the document would be paid for and dropped.
+func (s *Store) ListLinkingToDocs(ctx context.Context, id string, limit int) ([]domain.Knowledge, error) {
+	return s.listLinkingTo(ctx, id, limit, knowledgeSelectDoc, scanKnowledgeDoc)
+}
+
+func (s *Store) listLinkingTo(ctx context.Context, id string, limit int, cols string,
+	scan func(pgx.CollectableRow) (domain.Knowledge, error),
+) ([]domain.Knowledge, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT `+cols+` FROM knowledge
 		 WHERE deleted_at IS NULL AND links @> $1
 		 ORDER BY updated_at DESC LIMIT $2`,
 		fmt.Sprintf(`[{"target": %q}]`, id),
 		limit)
+	if err != nil {
+		return nil, err
+	}
+	return pgx.CollectRows(rows, scan)
 }
 
 // Create inserts a new entry. A live entry with the same id is
@@ -630,7 +650,13 @@ func (s *Store) Create(ctx context.Context, k *domain.Knowledge, keepCuratedTomb
 		if err != nil {
 			return err
 		}
-		k.ContentHash = hash
+		// The row's bytes go back onto the entry, so what a write returns
+		// is what a later read returns (design doc 0046 §2.2). The two
+		// differ whenever storedDoc fell back to the canonical form — a
+		// caller that changed fields rather than a document — and a
+		// surface rendering the payload back would show bytes nothing
+		// stored.
+		k.Doc, k.ContentHash = doc, hash
 		args := []any{
 			k.Type, k.ID, k.Title, k.Description, k.Resource, k.Tags, k.Status, k.StatusNote, staleAfter,
 			j.sources, j.usageWindow, k.Runtime, j.parameters, k.Computation, j.executor, j.attester,
@@ -703,7 +729,13 @@ func (s *Store) Update(ctx context.Context, k *domain.Knowledge, actor domain.Ac
 		if err != nil {
 			return err
 		}
-		k.ContentHash = hash
+		// The row's bytes go back onto the entry, so what a write returns
+		// is what a later read returns (design doc 0046 §2.2). The two
+		// differ whenever storedDoc fell back to the canonical form — a
+		// caller that changed fields rather than a document — and a
+		// surface rendering the payload back would show bytes nothing
+		// stored.
+		k.Doc, k.ContentHash = doc, hash
 		cond := ""
 		args := []any{k.ID, k.Type, k.Title, k.Description, k.Resource, k.Tags, k.Status, k.StatusNote, staleAfter,
 			j.sources, j.usageWindow, k.Runtime, j.parameters, k.Computation, j.executor, j.attester,

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -1797,19 +1797,28 @@ async function viewDetail(id) {
   });
 }
 
-// withStatus returns doc with its status line set. A canonical document
-// always carries one — the server writes status unconditionally — so this
-// is a line replacement on text ochakai itself produced, not a parser
-// (design doc 0044 §2.1 refuses the parser; this refuses to need one).
+// withStatus returns doc with its status line set: the line replaced when
+// the document has one, and appended to the frontmatter when it does not.
+// A writer who named no status leaves the key absent, and the server does
+// not fill it in (design doc 0046 §3.9) — so promoting such an entry has
+// to add the line, or the button would report success and change nothing.
 //
-// The alternative, rebuilding a document from the fields the page holds,
-// is what erased data before: the page holds the projection, and a
-// document assembled from it would drop everything the projection does
-// not carry — the citations, the contract, the body (design doc 0035 §4
-// is the same bug with fewer fields).
+// Still a line edit rather than a parser (design doc 0044 §2.1 refuses
+// the parser; this refuses to need one). The alternative, rebuilding a
+// document from the fields the page holds, is what erased data before:
+// the page holds the projection, and a document assembled from it would
+// drop everything the projection does not carry — the citations, the
+// contract, the body (design doc 0035 §4 is the same bug with fewer
+// fields).
 function withStatus(doc, status) {
   const line = 'status: ' + status;
-  return /^status:.*$/m.test(doc) ? doc.replace(/^status:.*$/m, line) : doc;
+  if (/^status:.*$/m.test(doc)) return doc.replace(/^status:.*$/m, line);
+  // Append inside the frontmatter block: after the opening delimiter's
+  // line, before the closing one. A document with no frontmatter is not
+  // one this UI can write, so it is handed back untouched and the PUT
+  // fails with the server's own message.
+  const m = doc.match(/^(---\r?\n[\s\S]*?)(---\r?\n[\s\S]*)$/);
+  return m ? m[1] + line + '\n' + m[2] : doc;
 }
 
 // Apply a status transition (full-replacement PUT), prompting for a

--- a/internal/webui/webui_test.go
+++ b/internal/webui/webui_test.go
@@ -80,6 +80,14 @@ func TestAStatusChangeEditsTheDocumentRatherThanRebuildingIt(t *testing.T) {
 	if strings.Contains(page, "function toDocument(") || strings.Contains(page, "const WRITABLE") {
 		t.Error("the page rebuilds a document from fields again; a projection cannot be rebuilt into an entry")
 	}
+	// A document that names no status has to gain one. The server does
+	// not write a status its writer left out (design doc 0046 §3.9), and
+	// the document a read hands back is the one that was written (§2.2) —
+	// so a replace-only edit would report success and change nothing.
+	fn := section(t, page, "function withStatus(doc, status)", "\n}")
+	if !strings.Contains(fn, "doc.match(") {
+		t.Error("withStatus only replaces a status line; a document that names none would come back unchanged")
+	}
 }
 
 // "Stale" already meant two different things on this page — the


### PR DESCRIPTION
0046 §2.2 says the server does not rewrite the document it was handed. #257 made that true of storage. It was not true of reads, and reads are where the surfaces that *edit* an entry get their text.

`ViewOf` rendered the canonical form. The web UI's editor loads that field into its textarea, `ochakai get` prints it, `get_knowledge` returns it — and all three write it back. So one save through the web UI reformatted the entry: the frontmatter comment gone, the key order settled, and a `status: stable` the writer never wrote now in the file (0046 §3.9 says ochakai does not write that key; the canonical rendering always does). The promise held only for a caller that asked for `text/markdown`. It is the same failure 0046 §3.14 describes when it says the form sugar "rewrites the document into the canonical form on every save" — arriving through the text editor 0044 replaced the sugar with.

## What changed

- **`okf.ViewOf` hands back the stored bytes**, falling back to the canonical form for an entry that has none — one composed in memory, or a row read for a listing. The server-owned keys stay out of the field, exactly where they were: `observed` carries them, and that is what makes the document editable and sendable straight back.
- **A write puts the row's bytes back onto the entry it returns** (`store.Create`, `store.Update`), so a write and a later read agree even when `storedDoc` fell back to the canonical form.
- **A context pack reads its link companions with their documents** (`ListLinkingToDocs`), so entries in one response are not half as-written and half rendered. `backlinks` stays on the lighter read: a row there is a projection, and the document would be paid for and dropped.
- **The web UI's status change grew the case it never had.** `withStatus` replaced a status line and left a document that named none untouched — safe while the canonical form always carried one, and a silent no-op now. It appends the key inside the frontmatter instead. Still a line edit, not a parser (0044 §2.1).
- **Four descriptions of the ETag** still said "the hash of its canonical OKF document" (OpenAPI ×2, `docs/architecture.md` ×2). 0046 §3.4 made it the hash of the stored bytes, which is also why a reformat moves it while `generated.at` stays put.

## Tests

Both fail on `main` and pass here:

- `TestViewOfHandsBackTheStoredDocument` — the unit property, no database.
- `TestRESTIntegrationDocumentSurvivesTheRoundTrip` — the whole loop over REST: a document with a comment, a producer key before the title, a lowercase `type` and no `status` at all is written, read back byte-identical, and sent back as `Ochakai-Unchanged: true`. It also pins what the round trip is *not*: the `text/markdown` read of the same entry carries `generated:` and `created_by:`, and the summary reads `stable` from a document that never says so.

The web UI's line edit is guarded where the page's other invariants are, in `TestAStatusChangeEditsTheDocumentRatherThanRebuildingIt`.

`scripts/check --db` is clean.

Found while reviewing 0046's implementation against the design; the rest of that review is #267 and #268-#278.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
