### PR TITLE
Serve a file the way its media type deserves (0046 §3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,29 @@ last entry.
   (`… 0 skipped, 0 notes`), because a count that only appears in the
   scrollback is a count nobody reads.
 
+### Security
+
+- **A file is served the way its media type deserves** (design doc
+  [0046](docs/design/0046-bundle-address-space.md) §3.2). An image, a PDF
+  or plain text is served `inline` as before; anything else now goes out
+  as a download, under `Content-Security-Policy: sandbox`, and
+  `X-Content-Type-Options: nosniff` is set on both.
+
+  Nothing stored today takes the second branch — the write path still
+  refuses every media type but those (design doc
+  [0013](docs/design/0013-attachment-files-gcs-only.md)), and it refuses
+  `text/html` and `image/svg+xml` by name. That is exactly why the rule
+  belongs on the way out as well: an SVG is an image by every convention
+  and a document that carries script by specification, and the only thing
+  standing between one and the web UI's own origin was a sniffer check at
+  write time. A row written before that check, or bytes a browser reads
+  differently than `http.DetectContentType` did, had nothing behind it.
+
+  It is also the half that has to exist first. 0046 §3.2 stops refusing
+  media types on the way in — a bundle whose files come back missing does
+  not round-trip — and "receive it, do not render it" is only a policy
+  once the second half is true.
+
 ### Fixed
 
 - Producer-defined keys **inside** a `sources` entry, a `parameter`, an

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1765,11 +1765,34 @@ paths:
         no-cache: names are mutable (replace-by-name), so clients
         revalidate every time. Fetching the bytes records a usage event
         against the owning entry; a 304 revalidation does not.
+
+        The bytes were uploaded by somebody, so what a browser may do
+        with them is decided here (design doc 0046 §3.2). An image, a
+        PDF or plain text is served `inline`; anything else — an SVG and
+        an HTML file above all, which are documents that carry script —
+        is served as an `attachment` under
+        `Content-Security-Policy: sandbox`, so it has no origin to run
+        in. `X-Content-Type-Options: nosniff` is set either way, because
+        the media type was decided by sniffing the bytes and a browser
+        must not decide it again.
       responses:
         "200":
           description: The attachment bytes.
           headers:
             Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
+            Content-Disposition:
+              description: >
+                `inline` for an image, a PDF or plain text; `attachment`
+                for everything else (design doc 0046 §3.2).
+              schema: { type: string }
+            Content-Security-Policy:
+              description: >
+                `sandbox`, on the responses that are not served inline —
+                bytes that could carry script get no origin to run in.
+              schema: { type: string }
+            X-Content-Type-Options:
+              description: "`nosniff`, always."
+              schema: { type: string }
           content:
             "*/*":
               schema: { type: string, format: binary }

--- a/internal/domain/attachment.go
+++ b/internal/domain/attachment.go
@@ -50,6 +50,33 @@ var attachmentMediaTypes = map[string]bool{
 	"text/plain":      true,
 }
 
+// InlineServable reports whether bytes of this media type may be handed
+// to a browser to render in place. Images (bar SVG), PDFs and plain text
+// may; everything else is served as a download instead (design doc 0046
+// §3.2).
+//
+// The rule is on the delivery side because that is where it belongs. A
+// write-time allowlist decides what a knowledge base may hold, and the
+// two questions are not the same one: 0046 §3.2 stops refusing media
+// types, on the grounds that a bundle whose files come back missing is
+// not a bundle that round-trips — "receive it, do not render it". Even
+// while the write side still refuses (design doc 0013), this is the
+// check that has to be true: a row written before that allowlist, or a
+// sniffer that reads one byte differently than a browser does, is a
+// script in the web UI's origin if the only guard is upstream.
+//
+// SVG is the case worth naming. It is an image by every convention and
+// an executable document by specification, so it is served the way an
+// executable document has to be: never inline.
+func InlineServable(mediaType string) bool {
+	mt, _, _ := strings.Cut(mediaType, ";")
+	mt = strings.ToLower(strings.TrimSpace(mt))
+	if mt == "image/svg+xml" || mt == "text/html" {
+		return false
+	}
+	return strings.HasPrefix(mt, "image/") || mt == "application/pdf" || mt == "text/plain"
+}
+
 // ValidAttachmentName reports whether name can be an attachment filename:
 // one path segment (so it embeds in bundle paths and URLs unchanged, with
 // the same path-safety-only character rule as ID segments, design doc

--- a/internal/domain/attachment_test.go
+++ b/internal/domain/attachment_test.go
@@ -75,3 +75,39 @@ func TestValidateAttachment(t *testing.T) {
 		t.Error(".md attachment accepted")
 	}
 }
+
+// What a browser may render in place, and what it may only be handed
+// (design doc 0046 §3.2). The write path still refuses most of these
+// media types (design doc 0013); the delivery rule must not depend on
+// that, because a row written before the rule — or bytes that sniff
+// differently in a browser than they did here — reaches this function
+// either way.
+func TestInlineServable(t *testing.T) {
+	for _, tc := range []struct {
+		mediaType string
+		inline    bool
+	}{
+		{"image/png", true},
+		{"image/jpeg", true},
+		{"image/webp", true},
+		{"image/gif", true}, // not writable, but nothing executable about it
+		{"application/pdf", true},
+		{"text/plain", true},
+		{"text/plain; charset=utf-8", true},
+		{"TEXT/PLAIN", true},
+		// The two that carry script, and the reason this rule exists: an
+		// SVG is an image by every convention and a document by spec.
+		{"image/svg+xml", false},
+		{"IMAGE/SVG+XML", false},
+		{"image/svg+xml; charset=utf-8", false},
+		{"text/html", false},
+		{"application/xhtml+xml", false},
+		{"application/zip", false},
+		{"application/octet-stream", false},
+		{"", false},
+	} {
+		if got := InlineServable(tc.mediaType); got != tc.inline {
+			t.Errorf("InlineServable(%q) = %v, want %v", tc.mediaType, got, tc.inline)
+		}
+	}
+}

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -470,12 +470,7 @@ func Handler(svc *service.Service) http.Handler {
 			ct = "text/plain; charset=utf-8"
 		}
 		w.Header().Set("Content-Type", ct)
-		// The bytes are user-uploaded and served inline; the media type is
-		// sniffed and allowlisted (design doc 0013 — nothing executable, no
-		// text/html, no image/svg+xml), but nosniff keeps a browser from
-		// overriding that and interpreting them as anything else.
-		w.Header().Set("X-Content-Type-Options", "nosniff")
-		w.Header().Set("Content-Disposition", `inline; filename="`+att.Name+`"`)
+		serveDefensively(w, att.MediaType, att.Name)
 		_, _ = w.Write(data)
 	})
 
@@ -1022,6 +1017,39 @@ func queryFloat(q url.Values, name string) (float64, error) {
 		return 0, service.Invalidf("invalid %s %q (want a number)", name, s)
 	}
 	return f, nil
+}
+
+// serveDefensively sets the headers that decide what a browser is
+// allowed to do with bytes somebody uploaded (design doc 0046 §3.2).
+//
+// nosniff on everything: the media type is decided here, by sniffing the
+// bytes, and a browser that overrides it would be deciding it again from
+// a filename or a guess.
+//
+// What may render in place is an image, a PDF or plain text
+// (domain.InlineServable). Anything else is handed over as a download,
+// under a sandbox with no origin, so that a document which happens to
+// carry script — an SVG, an HTML file — has nowhere to run even if it
+// arrives here. The web UI is served from this same origin, so "nowhere
+// to run" is the whole of the protection: an inline SVG would be script
+// in the origin holding the reader's IAP session.
+//
+// This is the delivery half of "receive it, do not render it". The write
+// half still refuses those media types (design doc 0013), and this does
+// not depend on it: a row written before that rule, or one whose bytes
+// sniff differently here than in a browser, is covered either way.
+func serveDefensively(w http.ResponseWriter, mediaType, name string) {
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	disposition := "inline"
+	if !domain.InlineServable(mediaType) {
+		disposition = "attachment"
+		w.Header().Set("Content-Security-Policy", "sandbox")
+	}
+	// The name is one path segment with no control characters
+	// (domain.ValidAttachmentName), so the only character left that could
+	// end the quoted string early is the quote itself.
+	w.Header().Set("Content-Disposition",
+		disposition+`; filename="`+strings.ReplaceAll(name, `"`, `\"`)+`"`)
 }
 
 // splitAttachmentPath cuts "{id...}/{name}" at the final slash: attachment

--- a/internal/restapi/restapi_integration_test.go
+++ b/internal/restapi/restapi_integration_test.go
@@ -352,6 +352,19 @@ func TestRESTIntegrationAttachments(t *testing.T) {
 	if resp.Header.Get("ETag") != `"`+sum+`"` || resp.Header.Get("Cache-Control") != "private, no-cache" {
 		t.Errorf("caching headers = %q / %q", resp.Header.Get("ETag"), resp.Header.Get("Cache-Control"))
 	}
+	// A PNG renders in place, and says so with no sandbox on it; the
+	// sniffed type is never re-decided by the browser (design doc 0046
+	// §3.2, and serveDefensively for the half this entry cannot exercise —
+	// the write path still refuses the media types that would).
+	if d := resp.Header.Get("Content-Disposition"); !strings.HasPrefix(d, "inline;") {
+		t.Errorf("Content-Disposition = %q, want inline for an image", d)
+	}
+	if resp.Header.Get("X-Content-Type-Options") != "nosniff" {
+		t.Errorf("X-Content-Type-Options = %q", resp.Header.Get("X-Content-Type-Options"))
+	}
+	if csp := resp.Header.Get("Content-Security-Policy"); csp != "" {
+		t.Errorf("Content-Security-Policy = %q on an image served inline", csp)
+	}
 
 	// Conditional GET with the current hash: 304, no body.
 	req, _ = http.NewRequest(http.MethodGet, attURL, nil)


### PR DESCRIPTION
First item of #267, and the one with an ordering constraint: this is the delivery half of 0046 §3.2's "receive it, do not render it", and it has to exist before the write half stops refusing media types.

An image, a PDF or plain text is served `inline`, as before. Anything else goes out as a download, under `Content-Security-Policy: sandbox`, with `X-Content-Type-Options: nosniff` on both.

## Why now, when nothing can reach the new branch

Nothing stored today takes it. The write path refuses every media type but those four, `text/html` and `image/svg+xml` by name (0013). That is the reason to put the rule here **as well**, rather than instead:

- An SVG is an image by every convention and a document that carries script by specification. The only thing between one and the web UI's own origin — the origin holding the reader's IAP session — was a sniffer check at write time.
- `http.DetectContentType` and a browser do not have to agree on every byte sequence. Where they disagree, the write-time check passes something the read serves as its own idea of the type.
- A row written before 0013 landed answers to no check at all.

And it is the half that must land first: 0046 §3.2 stops refusing media types on the way in, because a bundle whose files come back missing is not a bundle that round-trips. Relaxing that first would open the window this closes.

## Shape

The decision is `domain.InlineServable`, not a check inside the handler, because §3.3 gives files their own bundle address and the surface that serves them will ask the same question. `serveDefensively` in `internal/restapi` sets the three headers from it.

## Tests

- `TestInlineServable` covers the media types the write path will not accept yet — `image/svg+xml` in three spellings, `text/html`, `application/zip`, the empty type — which is the whole point of testing the predicate rather than the endpoint.
- The attachment integration test now asserts the headers on a real response: `inline`, `nosniff`, and no CSP on an image.
- `api/openapi.yaml` declares the three headers, so the contract test sees them.

`scripts/check --db` is clean.
