### PR TITLE
Name the statuses there are, when a status is refused (0043 §§3.2-3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,17 @@ last entry.
 
 ### Fixed
 
+- The invalid-status error names the statuses there are. It offered
+  `draft, verified, deprecated, rejected` — two of which stopped being
+  statuses when design doc
+  [0043](docs/design/0043-document-first.md) §§3.2-3.3 moved confirmation
+  into the verification ledger and rejection into a ruling — and omitted
+  `stable`, the value the writer usually wants. A caller who wrote
+  `status: published` was told to retry with `verified`, which fails the
+  same way. It now renders `domain.Statuses` like every other
+  enumeration, and a test reads the whole tree for a lifecycle list
+  spelled by hand, so this copy cannot come back.
+
 - Producer-defined keys **inside** a `sources` entry, a `parameter`, an
   `executor` or an `attester` are kept rather than dropped (SPEC §4.1,
   design doc [0043](docs/design/0043-document-first.md) §3.6). They ride

--- a/internal/domain/knowledge.go
+++ b/internal/domain/knowledge.go
@@ -170,6 +170,19 @@ func ValidStatus(s Status) bool {
 	return slices.Contains(Statuses, s)
 }
 
+// StatusesHint renders the lifecycle vocabulary for help and error text,
+// so no surface keeps a copy of the list to fall behind. The write path's
+// invalid-status error did, and named `verified` and `rejected` for years
+// after they stopped being statuses (design doc 0043 §§3.2-3.3) — telling
+// a caller to retry with a value that fails the same way.
+func StatusesHint() string {
+	names := make([]string, len(Statuses))
+	for i, s := range Statuses {
+		names[i] = string(s)
+	}
+	return strings.Join(names, ", ")
+}
+
 // Trust is the tier a consumer derives from an entry's verification
 // ledger, in OKF's own vocabulary (SPEC §5.3). It is not a lifecycle
 // value and not a field a writer can set: status says whether the entry

--- a/internal/domain/vocabulary_test.go
+++ b/internal/domain/vocabulary_test.go
@@ -1,0 +1,121 @@
+package domain
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// A lifecycle vocabulary spelled anywhere but Statuses can only fall
+// behind, and nothing fails when it does: the list is prose to the
+// compiler. The write path's invalid-status error proved it — it went on
+// offering `verified` and `rejected` long after design doc 0043 §§3.2-3.3
+// moved confirmation into the verification ledger and rejection into the
+// rejection ledger, and it never named `stable`, the value a writer who
+// hit the error most likely wanted. A caller told to retry with `verified`
+// fails the same way, twice.
+//
+// So this walks the tree and reads every run that begins with `draft` as a
+// claim about the vocabulary: a hand-written list, an enum, a JSON Schema
+// tag the compiler will not let us interpolate into. Each one has to name
+// Statuses, in order. Prose is left alone — "promote a draft to stable"
+// names no list — and a run that starts anywhere else is some other
+// sentence ("verified, rejected, or deprecated" is the curation guards'
+// three rulings, not three statuses).
+//
+// TestTypeVocabularyMatchesDomain does this for types on the one page that
+// carries a copy; the lifecycle values are short, ordinary English words,
+// so they turn up in far more places and are worth catching everywhere.
+func TestNoSurfaceSpellsItsOwnStatusVocabulary(t *testing.T) {
+	root := repoRoot(t)
+	for _, f := range vocabularyFiles(t, root) {
+		content, err := os.ReadFile(filepath.Join(root, f))
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		s := string(content)
+		for _, m := range statusRun.FindAllStringIndex(s, -1) {
+			run := s[m[0]:m[1]]
+			got := strings.ToLower(strings.Join(statusWord.FindAllString(run, -1), ", "))
+			if got == StatusesHint() {
+				continue
+			}
+			t.Errorf("%s:%d spells a lifecycle vocabulary of its own — %q, where Statuses says %q.\n"+
+				"Render it from domain.Statuses (StatusesHint) so it cannot fall behind again.",
+				f, 1+strings.Count(s[:m[0]], "\n"), run, StatusesHint())
+		}
+	}
+}
+
+// A run of lifecycle-ish words beginning with draft: comma-, pipe-, slash-
+// or "or"/"and"-separated, tolerating the quotes a JS array or a YAML enum
+// puts around each value. The words include the ones that are no longer
+// statuses, which is the point — a stale list has to match here to be
+// reported as stale.
+var (
+	statusWord = regexp.MustCompile(`(?i)\b(?:draft|stable|deprecated|verified|rejected|retired|published|archived|approved|active)\b`)
+	statusRun  = regexp.MustCompile(`(?i)\bdraft\b(?:['"` + "`" +
+		`]?\s*(?:[,|/]\s*(?:or\s+|and\s+)?|(?:or|and)\s+)['"` + "`" +
+		`]?(?:draft|stable|deprecated|verified|rejected|retired|published|archived|approved|active)\b)+`)
+)
+
+// vocabularyFiles lists the files that carry text a user reads: the
+// program's own sources, the wire contract, and the single-page web UI.
+// Design docs are excluded — a decision record says what was decided when
+// it was decided, and stays as written (docs/design/README.md).
+func vocabularyFiles(t *testing.T, root string) []string {
+	t.Helper()
+	var files []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		if d.IsDir() {
+			switch {
+			case rel == ".":
+				return nil
+			case strings.HasPrefix(d.Name(), "."), d.Name() == "testdata":
+				return fs.SkipDir
+			case rel == filepath.Join("docs", "design"):
+				return fs.SkipDir
+			}
+			return nil
+		}
+		switch {
+		case rel == filepath.Join("internal", "domain", "vocabulary_test.go"):
+			// This file spells the retired values on purpose.
+		case strings.HasSuffix(rel, ".go"),
+			rel == filepath.Join("api", "openapi.yaml"),
+			rel == filepath.Join("internal", "webui", "index.html"):
+			files = append(files, rel)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	// A guard that silently walks nothing passes forever.
+	if len(files) < 50 {
+		t.Fatalf("only %d files to check under %s; the walk is not seeing the tree", len(files), root)
+	}
+	return files
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
+		t.Fatalf("no go.mod at %s: %v", root, err)
+	}
+	return root
+}

--- a/internal/okf/parse.go
+++ b/internal/okf/parse.go
@@ -257,7 +257,7 @@ func parseDoc(doc []byte) (*Doc, string, []string, error) {
 	status, known := domain.StatusFromOKF(strings.TrimSpace(fm.status))
 	if !known {
 		notes = append(notes, fmt.Sprintf("status %q is not an OKF lifecycle value (%s); read as %s",
-			fm.status, statusesHint(), status))
+			fm.status, domain.StatusesHint(), status))
 	}
 	if !domain.ValidStaleAfter(fm.staleAfter) {
 		notes = append(notes, fmt.Sprintf("stale_after %q is not a YYYY-MM-DD date; dropped", fm.staleAfter))
@@ -306,16 +306,6 @@ func parseDoc(doc []byte) (*Doc, string, []string, error) {
 		// §2.2), and the fields above are the index derived from it.
 		Doc: string(StripServerKeys(NormalizeText([]byte(s)))),
 	}}, fm.typ, notes, nil
-}
-
-// statusesHint renders the lifecycle vocabulary for a note, from the one
-// place it is spelled.
-func statusesHint() string {
-	names := make([]string, len(domain.Statuses))
-	for i, st := range domain.Statuses {
-		names[i] = string(st)
-	}
-	return strings.Join(names, ", ")
 }
 
 // The v0.2 family readers. All of them follow the same rule: never reject

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -555,7 +555,7 @@ func validate(k *domain.Knowledge) error {
 		return Invalidf(`invalid id %q (path segments separated by "/", e.g. sales/orders; segments must not start with "." and the last must not be "index" or "log")`, k.ID)
 	}
 	if k.Status != "" && !domain.ValidStatus(k.Status) {
-		return Invalidf("invalid status %q (valid: draft, verified, deprecated, rejected)", k.Status)
+		return Invalidf("invalid status %q (valid: %s)", k.Status, domain.StatusesHint())
 	}
 	if !domain.ValidStaleAfter(k.StaleAfter) {
 		return Invalidf("invalid stale_after %q (an absolute date, YYYY-MM-DD, e.g. 2026-12-31)", k.StaleAfter)

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -277,6 +277,25 @@ func TestValidateRejectsBadInput(t *testing.T) {
 			t.Errorf("%s: want InvalidInputError, got %v", name, err)
 		}
 	}
+
+	// Rejecting is half the job: the message has to name the vocabulary
+	// the writer can use. It named `verified` and `rejected` — a ledger
+	// and a ruling since design doc 0043 §§3.2-3.3, not statuses — and
+	// never named `stable`, so whoever wrote `published` was told to retry
+	// with a value that fails exactly the same way.
+	bad := base()
+	bad.Status = "published"
+	msg := validate(bad).Error()
+	for _, s := range domain.Statuses {
+		if !strings.Contains(msg, string(s)) {
+			t.Errorf("the invalid-status error never names %q: %s", s, msg)
+		}
+	}
+	for _, retired := range []string{"verified", "rejected"} {
+		if strings.Contains(msg, retired) {
+			t.Errorf("the invalid-status error still offers %q, not a status since design doc 0043: %s", retired, msg)
+		}
+	}
 }
 
 // A write payload's byte-compared keys — the id, and the link targets


### PR DESCRIPTION
Fixes #274.

## What and why

The write path refused an unknown status with a list it kept itself:
`invalid status "published" (valid: draft, verified, deprecated, rejected)`.
Two of those four stopped being statuses when design doc
[0043](docs/design/0043-document-first.md) §§3.2-3.3 moved confirmation into
the verification ledger and rejection into a ruling this instance records,
and the one a writer most likely wants — `stable` — was never in it. So a
caller who sent `status: published` was told to retry with `verified`, and
the retry failed exactly the same way.

Every other enumeration in the tree is rendered from `domain.Statuses`. This
one was a hand copy, and nothing failed when the vocabulary moved underneath
it: to the compiler the list is prose.

- `domain.StatusesHint()` joins `TypesHint` and `TrustsHint` beside the list
  it renders; the error text calls it, and `internal/okf`'s private copy of
  the same three-line function goes.
- `TestValidateRejectsBadInput` now reads the message it gets for
  `status: published`: it must name every current status and neither retired
  one.
- `TestNoSurfaceSpellsItsOwnStatusVocabulary` is the guard the issue asks
  for. It reads the tree for a lifecycle list spelled by hand — every run of
  status words beginning with `draft`, in a Go string, in a `jsonschema` tag
  the compiler will not let us interpolate into, in the web UI's `STATUSES`
  array, in the OpenAPI enum — and requires it to name `domain.Statuses`, in
  order. Pointed at the old line it reports exactly that line; today it holds
  the eight spellings that are correct. Prose is untouched ("promote a draft
  to stable" names no list), and a run that starts elsewhere is a different
  sentence ("verified, rejected, or deprecated" is the curation guards' three
  rulings). `docs/design` is excluded — a decision record says what was
  decided when it was decided.

## Checks

- [x] `scripts/check` is clean — `core` and `lint` both pass (`0 issues`);
      the change does not touch the store, so `--db` adds nothing here
- [x] Behavior changes come with tests

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — the message is produced once
      in `internal/service`, so REST, MCP and the CLI all get the corrected
      text; no endpoint or schema changed
- [x] The change lands on every surface it belongs on — the new guard covers
      the web UI page and the OpenAPI enum as well as the Go sources, so the
      vocabulary stays one list across all four (design doc 0015)

## Design docs

- [x] Not applicable: this restores what 0043 §§3.2-3.3 already decided; no
      accepted decision changes
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01CByhcfuXKZgeUkJXt4hNLq)_