### PR TITLE
Say why a bundle write is refused, per path (0046 §3.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,11 @@ last entry.
   [0046](docs/design/0046-bundle-address-space.md) §§3.7-3.8).
   `GET /api/v1/bundle/{path}` answers `index.md` (SPEC §8's directory
   listing) and `log.md` (SPEC §9's update history); both are generated
-  from the bundle, so `PUT` and `DELETE` are `405`.
+  from the bundle, so `PUT` and `DELETE` against either are `409`.
+  Any other path under `/api/v1/bundle/` is `404` on read and `501` on
+  write: the rest of the bundle joins this address in a later change
+  (0046 §3.5), and a refusal there says so rather than explaining
+  itself in terms of two files the caller never named.
 
   - **`GET /api/v1/browse` is gone.** A directory listing is what
     `index.md` is, and ochakai was serving it at an address of its own

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -332,10 +332,10 @@ paths:
         names. Two representations of one thing, at one address — the
         JSON is what a web UI's tree needs, not a second surface.
 
-        PUT and DELETE are 405: a generated file is not one anybody
-        writes. Paths other than the two reserved names are 404 for now —
-        the rest of the bundle joins this address in a later change
-        (0046 §3.5).
+        PUT and DELETE against these two names are 409: a generated file
+        is not one anybody writes. Paths other than the two reserved
+        names are 404 on read and 501 on write for now — the rest of the
+        bundle joins this address in a later change (0046 §3.5).
       parameters:
         - name: path
           in: path
@@ -418,28 +418,74 @@ paths:
                         updated_at: "2026-07-14T02:33:41.019778Z"
         "400": { $ref: "#/components/responses/Error" }
         "403": { $ref: "#/components/responses/Forbidden" }
-    put:
-      operationId: putBundleFile
-      summary: Refused — the reserved files are generated
-      description: >
-        index.md and log.md are derived from the bundle (design doc 0046
-        §§3.7-3.8), so neither is written. The same goes for DELETE.
-      responses:
-        "405":
-          description: A generated file is not one anybody writes.
+        "404":
+          description: >
+            No object at this path. Today that is every path but the two
+            reserved names: the concepts and files join this address in a
+            later change (design doc 0046 §3.5).
+          headers:
+            Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
           content:
             application/json:
               schema:
                 type: object
                 properties:
                   error: { type: string }
+              example:
+                error: 'no object at "metrics/revenue.md": the bundle surface serves index.md and log.md'
+    put:
+      operationId: putBundleFile
+      summary: Refused — generated at the reserved names, not built yet elsewhere
+      description: >
+        Two refusals, and the path decides which. index.md and log.md are
+        derived from the bundle (design doc 0046 §§3.7-3.8), so a write
+        there is a conflict with what the address is: 409. Every other
+        path is the write face 0046 §3.5 describes, which lands in a
+        later change: 501. The same goes for DELETE.
+      responses:
+        "409":
+          description: A generated file is not one anybody writes.
+          headers:
+            Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error: { type: string }
+              example:
+                error: index.md is generated from the bundle, not stored in it (design doc 0046 §§3.7-3.8)
+        "501":
+          description: The bundle write surface is not built yet.
+          headers:
+            Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error: { type: string }
+              example:
+                error: the bundle write surface lands in a later change (design doc 0046 §3.5)
     delete:
       operationId: deleteBundleFile
-      summary: Refused — the reserved files are generated
+      summary: Refused — generated at the reserved names, not built yet elsewhere
       description: See PUT.
       responses:
-        "405":
-          description: A generated file is not one anybody writes.
+        "409":
+          description: A generated file is not one anybody deletes.
+          headers:
+            Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error: { type: string }
+        "501":
+          description: The bundle write surface is not built yet.
+          headers:
+            Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
           content:
             application/json:
               schema:

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -91,9 +91,9 @@ func Handler(svc *service.Service) http.Handler {
 	// web UI's tree, which should not have to parse a document to draw a
 	// sidebar. A representation is not a second surface.
 	//
-	// PUT and DELETE are refused (405): a derived file is not one anybody
-	// writes. The rest of the bundle joins this address in a later change;
-	// today a path that is not one of the two reserved names is a 404.
+	// PUT and DELETE are refused, for two different reasons (below). The
+	// rest of the bundle joins this address in a later change; today a
+	// path that is not one of the two reserved names is a 404 on read.
 	mux.HandleFunc("GET /api/v1/bundle/{path...}", func(w http.ResponseWriter, r *http.Request) {
 		path := r.PathValue("path")
 		dir, base := splitReserved(path)
@@ -146,10 +146,26 @@ func Handler(svc *service.Service) http.Handler {
 		}
 	})
 
+	// PUT and DELETE /api/v1/bundle/{path...} — two refusals, and which
+	// one the caller gets depends on the path.
+	//
+	// The reserved names are generated from the bundle rather than stored
+	// in it, so a write is a conflict with what the address is: 409, as
+	// design doc 0046 §3.5 says. Every other path is the write face that
+	// same section describes, and it lands in a later change: 501, which
+	// is what "not built yet" means. Answering the reserved-file reason
+	// there would explain a refusal in terms of two files the caller never
+	// named.
 	for _, m := range []string{"PUT", "DELETE"} {
 		mux.HandleFunc(m+" /api/v1/bundle/{path...}", func(w http.ResponseWriter, r *http.Request) {
-			writeJSON(w, http.StatusMethodNotAllowed, map[string]string{
-				"error": "index.md and log.md are generated from the bundle, not stored in it (design doc 0046 §§3.7-3.8)",
+			if _, base := splitReserved(r.PathValue("path")); isReserved(base) {
+				writeJSON(w, http.StatusConflict, map[string]string{
+					"error": fmt.Sprintf("%s is generated from the bundle, not stored in it (design doc 0046 §§3.7-3.8)", base),
+				})
+				return
+			}
+			writeJSON(w, http.StatusNotImplemented, map[string]string{
+				"error": "the bundle write surface lands in a later change (design doc 0046 §3.5)",
 			})
 		})
 	}
@@ -836,6 +852,12 @@ func splitReserved(path string) (dir, base string) {
 		return path[:i], path[i+1:]
 	}
 	return "", path
+}
+
+// isReserved reports whether a bundle path's last segment is one of the
+// two filenames OKF reserves (SPEC §3.1) — the generated ones.
+func isReserved(base string) bool {
+	return base == "index.md" || base == "log.md"
 }
 
 // wantsJSON reports whether the caller asked for the structured form of

--- a/internal/restapi/restapi_integration_test.go
+++ b/internal/restapi/restapi_integration_test.go
@@ -138,7 +138,8 @@ func TestRESTIntegration(t *testing.T) {
 		t.Errorf("generated log.md:\n%s", logDoc)
 	}
 
-	// Neither is writable: they are generated, not stored.
+	// Neither is writable: they are generated, not stored, so a write to
+	// one conflicts with what the address is (design doc 0046 §3.5).
 	req, err := http.NewRequest(http.MethodPut, srv.URL+"/api/v1/bundle/"+typ+"/index.md", strings.NewReader("x"))
 	if err != nil {
 		t.Fatal(err)
@@ -148,8 +149,8 @@ func TestRESTIntegration(t *testing.T) {
 		t.Fatal(err)
 	}
 	resp.Body.Close()
-	if resp.StatusCode != http.StatusMethodNotAllowed {
-		t.Errorf("PUT index.md = %d, want 405", resp.StatusCode)
+	if resp.StatusCode != http.StatusConflict {
+		t.Errorf("PUT index.md = %d, want 409", resp.StatusCode)
 	}
 
 	// Export: the bundle carries the entry at its canonical path.

--- a/internal/restapi/restapi_test.go
+++ b/internal/restapi/restapi_test.go
@@ -3,6 +3,7 @@ package restapi
 import (
 	"bytes"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -72,6 +73,60 @@ func TestBadRequestValidation(t *testing.T) {
 			}
 			if !strings.Contains(rec.Body.String(), c.wantSubstr) {
 				t.Errorf("GET %s body %q does not mention %q", c.url, rec.Body, c.wantSubstr)
+			}
+		})
+	}
+}
+
+// TestBundleAddressesRefuseByPath pins what /api/v1/bundle answers for
+// the paths it does not serve yet. Three different refusals, and which
+// one a caller gets is the whole point: a reserved name is a generated
+// file and never writable (409), any other path is the write face design
+// doc 0046 §3.5 describes and simply has not landed (501), and reading
+// one of those is a 404 for as long as that is true. One reason for all
+// three — "index.md and log.md are generated" — would answer a request
+// about metrics/revenue.md by talking about two files it never named.
+//
+// Through checkedServer, so each status is one the contract declares:
+// the spec only covers what a test exercises, and until this one there
+// was no request here to cover the refusals at all (issue #270).
+func TestBundleAddressesRefuseByPath(t *testing.T) {
+	srv := checkedServer(t, Handler(&service.Service{}))
+	defer srv.Close()
+
+	cases := []struct {
+		name, method, path string
+		want               int
+		wantSubstr         string
+	}{
+		{"put index.md", http.MethodPut, "index.md", http.StatusConflict, "generated from the bundle"},
+		{"put nested log.md", http.MethodPut, "metrics/log.md", http.StatusConflict, "log.md is generated"},
+		{"delete index.md", http.MethodDelete, "index.md", http.StatusConflict, "index.md is generated"},
+		{"put a concept", http.MethodPut, "metrics/revenue.md", http.StatusNotImplemented, "later change"},
+		{"delete a concept", http.MethodDelete, "metrics/revenue.md", http.StatusNotImplemented, "later change"},
+		{"put a file", http.MethodPut, "metrics/revenue/chart.png", http.StatusNotImplemented, "later change"},
+		{"get a concept", http.MethodGet, "metrics/revenue.md", http.StatusNotFound, "no object at"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req, err := http.NewRequest(c.method, srv.URL+"/api/v1/bundle/"+c.path, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if resp.StatusCode != c.want {
+				t.Fatalf("%s %s = %d, want %d (body: %s)", c.method, c.path, resp.StatusCode, c.want, body)
+			}
+			if !strings.Contains(string(body), c.wantSubstr) {
+				t.Errorf("%s %s said %q, which does not mention %q", c.method, c.path, body, c.wantSubstr)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #270.

## What and why

`PUT` and `DELETE` were registered for the whole `/api/v1/bundle/{path...}`
wildcard and answered one 405 for every path: *"index.md and log.md are
generated from the bundle"*. Two things were wrong with that.

- **A path that is not one of the reserved names got a reason about two files
  the caller never named.** `PUT /api/v1/bundle/metrics/revenue.md` is the
  write face 0046 §3.5 describes, and it lands in a later change — which is
  what **501** means, so it now says so: *"the bundle write surface lands in a
  later change (design doc 0046 §3.5)"*.
- **The status for the reserved names disagreed with the design.** 0046 §3.5
  says a write to a generated file is **409**, not 405. The message now names
  the file the caller actually addressed (`index.md is generated from the
  bundle, not stored in it`), so a write to `metrics/log.md` explains itself in
  terms of `log.md`.

Both statuses were missing from `api/openapi.yaml`, along with the **404** the
read has always answered for a non-reserved path. The contract test only sees
what some test exercises, so nothing caught the gap; the new refusal test goes
through `checkedServer`, which puts all three under the contract.

`GET` keeps its 404 — the read is now declared rather than changed. Read-only
deployments are untouched: these refusals never reach the service, so they are
the same on every deployment.

## Checks

- [x] `scripts/check` is clean — `scripts/check core` passes; `--db` could not
      run here (no Docker daemon in this environment), and the store is
      untouched by this change. The one integration-test assertion that
      expected 405 is updated to 409.
- [x] Behavior changes come with tests — `TestBundleAddressesRefuseByPath`
      covers 409 (PUT/DELETE on `index.md`, nested `log.md`), 501 (PUT/DELETE
      on a concept path and on a file path) and 404 (GET on a concept path).

## Surfaces and contract

- [x] `api/openapi.yaml` now declares 409 and 501 on `putBundleFile` /
      `deleteBundleFile` and 404 on `getBundleFile`, with examples matching the
      strings the handler writes. `internal/mcpserver` and
      `internal/apiclient` only read this address, so neither changes.
- [x] REST is the only surface with a bundle write face today, and this PR does
      not add one — it corrects how the absent one refuses. CLI, MCP and Web UI
      have nothing to mirror yet (design doc 0015).

## Design docs

- [x] Not applicable: this makes the implementation agree with an accepted
      decision (0046 §3.5 already says 409), and 501 for a surface that has not
      landed is not a new decision. The CHANGELOG's unreleased entry — the
      behavior has not shipped — is corrected in place.
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHBfFSQq5oTRGmFbFxqXbR)_