### PR TITLE
Key an object by the path it lives at (0046 §§2.1, 3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,25 @@ last entry.
 
 ### Changed
 
+- **The store is keyed by the bundle path** (design doc
+  [0046](docs/design/0046-bundle-address-space.md) §§2.1, 3.1). Migration
+  0028 renames `knowledge` to `object` and moves its primary key to
+  `path`, the address each object lives at; the revision ledger is
+  re-keyed the same way, so a file's history will land beside the
+  concept's instead of in a second place.
+
+  Nothing on the wire moves. The concept id is still the address a
+  concept is called by — SPEC §2's "the path with `.md` removed", which
+  every ledger joins on and every surface names an entry by — and it
+  keeps a unique index of its own. What changed is what the table is a
+  table *of*: one bundle, mapping a path to an object, with a knowledge
+  entry as one kind of object in it. Files arrive in a later change
+  (§3.13), which is where the path stops being derivable from the id.
+
+  Operators: the migration is one rename, two column additions and two
+  primary-key swaps, all in one transaction. It rewrites no content and
+  moves no timestamp.
+
 - **BREAKING**: the two files OKF reserves are served at the paths OKF
   reserves them at (design doc
   [0046](docs/design/0046-bundle-address-space.md) §§3.7-3.8).

--- a/internal/domain/knowledge.go
+++ b/internal/domain/knowledge.go
@@ -1094,3 +1094,16 @@ type ContextOutline struct {
 	Status      Status `json:"status"`
 	Bytes       int    `json:"bytes"`
 }
+
+// ConceptPath is the bundle path a concept lives at: its id with ".md"
+// on the end (OKF SPEC §2, design doc 0017). The path is what an object
+// is keyed by (design doc 0046 §3.1) and the id is the address a concept
+// is called by, so every place that has one and needs the other goes
+// through here rather than concatenating a suffix of its own.
+func ConceptPath(id string) string { return id + ".md" }
+
+// ConceptID is the inverse: the id addressed by a bundle path, and ""
+// when the path is not a markdown file and so names no concept.
+func ConceptID(path string) (string, bool) {
+	return strings.CutSuffix(path, ".md")
+}

--- a/internal/store/attachment.go
+++ b/internal/store/attachment.go
@@ -135,7 +135,7 @@ func (s *Store) ListAttachments(ctx context.Context, id string) ([]domain.Attach
 	rows, err := s.pool.Query(ctx, `SELECT `+attachmentCols+`
 		FROM attachment a
 		JOIN blob b ON b.sha256 = a.sha256
-		JOIN knowledge k ON k.id = a.knowledge_id AND k.deleted_at IS NULL
+		JOIN object k ON k.id = a.knowledge_id AND k.deleted_at IS NULL
 		WHERE a.knowledge_id=$1 ORDER BY a.name`, id)
 	if err != nil {
 		return nil, err
@@ -175,7 +175,7 @@ func (s *Store) GetAttachmentMeta(ctx context.Context, id, name string) (*domain
 	rows, err := s.pool.Query(ctx, `SELECT `+attachmentCols+`
 		FROM attachment a
 		JOIN blob b ON b.sha256 = a.sha256
-		JOIN knowledge k ON k.id = a.knowledge_id AND k.deleted_at IS NULL
+		JOIN object k ON k.id = a.knowledge_id AND k.deleted_at IS NULL
 		WHERE a.knowledge_id=$1 AND a.name=$2`, id, name)
 	if err != nil {
 		return nil, err
@@ -248,7 +248,7 @@ func (s *Store) touchAndRevise(ctx context.Context, tx pgx.Tx, k *domain.Knowled
 	// an attachment plus its revision planted on a tombstone would
 	// resurface whenever someone revived the entry.
 	tag, err := tx.Exec(ctx,
-		`UPDATE knowledge SET updated_at=$2 WHERE id=$1 AND deleted_at IS NULL`, k.ID, k.UpdatedAt)
+		`UPDATE object SET updated_at=$2 WHERE id=$1 AND deleted_at IS NULL`, k.ID, k.UpdatedAt)
 	if err != nil {
 		return err
 	}

--- a/internal/store/attachment_search_integration_test.go
+++ b/internal/store/attachment_search_integration_test.go
@@ -52,7 +52,7 @@ func TestIntegrationAttachmentSearch(t *testing.T) {
 	for _, del := range []string{
 		`DELETE FROM attachment_embedding WHERE knowledge_id LIKE 'it-attsearch%'`,
 		`DELETE FROM attachment WHERE knowledge_id LIKE 'it-attsearch%'`,
-		`DELETE FROM knowledge WHERE id LIKE 'it-attsearch%'`,
+		`DELETE FROM object WHERE id LIKE 'it-attsearch%'`,
 		`DELETE FROM knowledge_revision WHERE id LIKE 'it-attsearch%'`,
 	} {
 		if _, err := s.pool.Exec(ctx, del); err != nil {

--- a/internal/store/blob_integration_test.go
+++ b/internal/store/blob_integration_test.go
@@ -34,7 +34,7 @@ func TestIntegrationBlobStoreOnly(t *testing.T) {
 	}
 	for _, del := range []string{
 		`DELETE FROM attachment WHERE knowledge_id LIKE 'it-ext%'`,
-		`DELETE FROM knowledge WHERE id LIKE 'it-ext%'`,
+		`DELETE FROM object WHERE id LIKE 'it-ext%'`,
 		`DELETE FROM knowledge_revision WHERE id LIKE 'it-ext%'`,
 	} {
 		if _, err := s.pool.Exec(ctx, del); err != nil {
@@ -150,7 +150,7 @@ func TestIntegrationAttachRacingDeleteLoses(t *testing.T) {
 	id := fmt.Sprintf("it-attach-race-%d", time.Now().UnixNano())
 	defer func() {
 		_, _ = s.pool.Exec(ctx, `DELETE FROM attachment WHERE knowledge_id = $1`, id)
-		for _, table := range []string{"knowledge_revision", "knowledge"} {
+		for _, table := range []string{"knowledge_revision", "object"} {
 			_, _ = s.pool.Exec(ctx, `DELETE FROM `+table+` WHERE id = $1`, id)
 		}
 	}()
@@ -169,7 +169,7 @@ func TestIntegrationAttachRacingDeleteLoses(t *testing.T) {
 	}
 	defer func() { _ = del.Rollback(ctx) }()
 	if _, err := del.Exec(ctx,
-		`UPDATE knowledge SET deleted_at = now(), updated_at = now() WHERE id = $1`, id); err != nil {
+		`UPDATE object SET deleted_at = now(), updated_at = now() WHERE id = $1`, id); err != nil {
 		t.Fatal(err)
 	}
 
@@ -186,7 +186,8 @@ func TestIntegrationAttachRacingDeleteLoses(t *testing.T) {
 		var waiting int
 		if err := s.pool.QueryRow(ctx,
 			`SELECT count(*) FROM pg_stat_activity
-			  WHERE wait_event_type = 'Lock' AND query LIKE '%knowledge%'`).Scan(&waiting); err != nil {
+			  WHERE wait_event_type = 'Lock'
+			    AND (query LIKE '%object%' OR query LIKE '%knowledge%')`).Scan(&waiting); err != nil {
 			t.Fatal(err)
 		}
 		if waiting > 0 {

--- a/internal/store/browse.go
+++ b/internal/store/browse.go
@@ -45,7 +45,7 @@ type BrowseEntry struct {
 // has an id column of its own, and a bare one inside the subquery would
 // bind to it and match everything.
 const browseNotRejected = `deleted_at IS NULL
-	AND NOT EXISTS (SELECT 1 FROM knowledge_rejection r WHERE r.id = knowledge.id)`
+	AND NOT EXISTS (SELECT 1 FROM knowledge_rejection r WHERE r.id = object.id)`
 
 // MaxBrowseEntries bounds one directory listing. A directory this wide
 // is a modeling smell, not a paging problem — the caller renders a
@@ -61,7 +61,7 @@ const MaxBrowseEntries = 1000
 func (s *Store) Browse(ctx context.Context, prefix string) (dirs []DirCount, entries []BrowseEntry, truncated bool, err error) {
 	rows, err := s.pool.Query(ctx, `
 		SELECT split_part(substr(id, length($1::text)+1), '/', 1) AS dir, count(*)
-		FROM knowledge
+		FROM object
 		WHERE `+browseNotRejected+`
 		  AND left(id, length($1::text)) = $1
 		  AND strpos(substr(id, length($1::text)+1), '/') > 0
@@ -79,7 +79,7 @@ func (s *Store) Browse(ctx context.Context, prefix string) (dirs []DirCount, ent
 	}
 	rows, err = s.pool.Query(ctx, fmt.Sprintf(`
 		SELECT type, id, title, description, status, updated_at
-		FROM knowledge
+		FROM object
 		WHERE `+browseNotRejected+`
 		  AND left(id, length($1::text)) = $1
 		  AND strpos(substr(id, length($1::text)+1), '/') = 0

--- a/internal/store/browse_integration_test.go
+++ b/internal/store/browse_integration_test.go
@@ -27,7 +27,7 @@ func TestIntegrationBrowse(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, del := range []string{
-		`DELETE FROM knowledge WHERE id LIKE 'it-br-%'`,
+		`DELETE FROM object WHERE id LIKE 'it-br-%'`,
 		`DELETE FROM knowledge_revision WHERE id LIKE 'it-br-%'`,
 		`DELETE FROM knowledge_rejection WHERE id LIKE 'it-br-%'`,
 		`DELETE FROM knowledge_verification WHERE id LIKE 'it-br-%'`,

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -65,7 +65,7 @@ func (e *ExportSnapshot) Close(ctx context.Context) {
 // does not carry them.
 func (e *ExportSnapshot) IndexRows(ctx context.Context) ([]domain.Knowledge, error) {
 	rows, err := e.tx.Query(ctx,
-		`SELECT type, id, title, description FROM knowledge WHERE deleted_at IS NULL ORDER BY id`)
+		`SELECT type, id, title, description FROM object WHERE deleted_at IS NULL ORDER BY id`)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func (e *ExportSnapshot) IndexRows(ctx context.Context) ([]domain.Knowledge, err
 // memory at once.
 func (e *ExportSnapshot) ListByIDs(ctx context.Context, ids []string) ([]domain.Knowledge, error) {
 	rows, err := e.tx.Query(ctx,
-		`SELECT `+knowledgeSelectDoc+` FROM knowledge
+		`SELECT `+knowledgeSelectDoc+` FROM object
 		 WHERE deleted_at IS NULL AND id = ANY($1) ORDER BY id`, ids)
 	if err != nil {
 		return nil, err
@@ -106,7 +106,7 @@ func (e *ExportSnapshot) AttachmentMeta(ctx context.Context) ([]ExportAttachment
 	rows, err := e.tx.Query(ctx, `SELECT a.knowledge_id, `+attachmentCols+`
 		FROM attachment a
 		JOIN blob b ON b.sha256 = a.sha256
-		JOIN knowledge k ON k.id = a.knowledge_id AND k.deleted_at IS NULL
+		JOIN object k ON k.id = a.knowledge_id AND k.deleted_at IS NULL
 		ORDER BY a.knowledge_id, a.name`)
 	if err != nil {
 		return nil, err

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -134,7 +134,7 @@ func (s *Store) backfillDocuments(ctx context.Context) error {
 func (s *Store) backfillEntryDocuments(ctx context.Context) error {
 	for {
 		rows, err := s.pool.Query(ctx,
-			`SELECT `+knowledgeSelect+` FROM knowledge WHERE doc = '' ORDER BY id LIMIT $1`,
+			`SELECT `+knowledgeSelect+` FROM object WHERE doc = '' ORDER BY id LIMIT $1`,
 			backfillBatch)
 		if err != nil {
 			return err
@@ -159,7 +159,7 @@ func (s *Store) backfillEntryDocuments(ctx context.Context) error {
 				continue
 			}
 			if _, err := s.pool.Exec(ctx,
-				`UPDATE knowledge SET doc = $2, content_hash = $3 WHERE id = $1`,
+				`UPDATE object SET doc = $2, content_hash = $3 WHERE id = $1`,
 				batch[i].ID, doc, hash); err != nil {
 				return err
 			}
@@ -189,7 +189,7 @@ func (s *Store) backfillEntryDocuments(ctx context.Context) error {
 func (s *Store) backfillLinkForms(ctx context.Context) error {
 	for {
 		rows, err := s.pool.Query(ctx,
-			`SELECT `+knowledgeSelectDoc+` FROM knowledge
+			`SELECT `+knowledgeSelectDoc+` FROM object
 			 WHERE id IN (SELECT id FROM link_form_backfill) ORDER BY id LIMIT $1`,
 			backfillBatch)
 		if err != nil {
@@ -221,7 +221,7 @@ func (s *Store) backfillLinkForms(ctx context.Context) error {
 				return err
 			}
 			if _, err := s.pool.Exec(ctx,
-				`UPDATE knowledge SET body=$2, links=$3, doc=$4, content_hash=$5 WHERE id=$1`,
+				`UPDATE object SET body=$2, links=$3, doc=$4, content_hash=$5 WHERE id=$1`,
 				k.ID, k.Body, j.links, doc, hash); err != nil {
 				return err
 			}
@@ -250,7 +250,7 @@ func (s *Store) backfillLinkForms(ctx context.Context) error {
 func (s *Store) backfillFrontmatter(ctx context.Context) error {
 	for {
 		rows, err := s.pool.Query(ctx,
-			`SELECT id, doc FROM knowledge
+			`SELECT id, doc FROM object
 			 WHERE id IN (SELECT id FROM frontmatter_backfill) ORDER BY id LIMIT $1`,
 			backfillBatch)
 		if err != nil {
@@ -283,7 +283,7 @@ func (s *Store) backfillFrontmatter(ctx context.Context) error {
 				continue
 			}
 			if _, err := s.pool.Exec(ctx,
-				`UPDATE knowledge SET frontmatter = $2 WHERE id = $1`, b.id, fm); err != nil {
+				`UPDATE object SET frontmatter = $2 WHERE id = $1`, b.id, fm); err != nil {
 				return err
 			}
 		}
@@ -327,7 +327,7 @@ func anyConverted(ctx context.Context, s *Store, batch []domain.Knowledge) bool 
 	}
 	var n int
 	if err := s.pool.QueryRow(ctx,
-		`SELECT count(*) FROM knowledge WHERE id = ANY($1) AND doc <> ''`, ids).Scan(&n); err != nil {
+		`SELECT count(*) FROM object WHERE id = ANY($1) AND doc <> ''`, ids).Scan(&n); err != nil {
 		return false
 	}
 	return n > 0

--- a/internal/store/migrate_integration_test.go
+++ b/internal/store/migrate_integration_test.go
@@ -438,11 +438,11 @@ func TestMigrateConcurrent(t *testing.T) {
 	var n int
 	if err := scoped.pool.QueryRow(ctx,
 		`SELECT count(*) FROM information_schema.tables
-		  WHERE table_schema = $1 AND table_name = 'knowledge'`, schema).Scan(&n); err != nil {
+		  WHERE table_schema = $1 AND table_name = 'object'`, schema).Scan(&n); err != nil {
 		t.Fatal(err)
 	}
 	if n != 1 {
-		t.Errorf("knowledge table in %s: got %d, want 1", schema, n)
+		t.Errorf("object table in %s: got %d, want 1", schema, n)
 	}
 }
 
@@ -1094,7 +1094,7 @@ func TestBackfillComposesStoredDocuments(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
-		_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge WHERE id = $1`, id)
+		_, _ = s.pool.Exec(ctx, `DELETE FROM object WHERE id = $1`, id)
 		_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_revision WHERE id = $1`, id)
 	})
 
@@ -1108,7 +1108,7 @@ func TestBackfillComposesStoredDocuments(t *testing.T) {
 		sql  string
 		args []any
 	}{
-		{`UPDATE knowledge SET doc = '', content_hash = '' WHERE id = $1`, []any{id}},
+		{`UPDATE object SET doc = '', content_hash = '' WHERE id = $1`, []any{id}},
 		{`UPDATE knowledge_revision SET doc = '', snapshot = $2 WHERE id = $1`, []any{id, snapshot}},
 	} {
 		if _, err := s.pool.Exec(ctx, q.sql, q.args...); err != nil {
@@ -1123,7 +1123,7 @@ func TestBackfillComposesStoredDocuments(t *testing.T) {
 	var doc, hash string
 	var updatedAt time.Time
 	if err := s.pool.QueryRow(ctx,
-		`SELECT doc, content_hash, updated_at FROM knowledge WHERE id = $1`, id).
+		`SELECT doc, content_hash, updated_at FROM object WHERE id = $1`, id).
 		Scan(&doc, &hash, &updatedAt); err != nil {
 		t.Fatal(err)
 	}
@@ -1160,10 +1160,109 @@ func TestBackfillComposesStoredDocuments(t *testing.T) {
 		t.Fatal(err)
 	}
 	var again string
-	if err := s.pool.QueryRow(ctx, `SELECT doc FROM knowledge WHERE id = $1`, id).Scan(&again); err != nil {
+	if err := s.pool.QueryRow(ctx, `SELECT doc FROM object WHERE id = $1`, id).Scan(&again); err != nil {
 		t.Fatal(err)
 	}
 	if again != doc {
 		t.Error("a second backfill pass rewrote an already-composed document")
+	}
+}
+
+// Migration 0028 (design doc 0046 §§2.1, 3.1): the table of knowledge
+// entries becomes the table of bundle objects, keyed by the path each
+// one lives at. The concept id survives as the address a concept is
+// called by — every ledger joins on it — and the revision log starts
+// counting by path, so that a file's history will land beside the
+// concept's rather than in a second place.
+func TestMigrationObjectPathKey(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(s.Close)
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck // rollback is the cleanup
+
+	for _, q := range []string{
+		`CREATE SCHEMA path_scratch`,
+		`SET LOCAL search_path TO path_scratch`,
+		`CREATE TABLE knowledge (
+			id text NOT NULL, title text NOT NULL DEFAULT '',
+			CONSTRAINT knowledge_pkey PRIMARY KEY (id))`,
+		`CREATE TABLE knowledge_revision (
+			id text NOT NULL, rev int NOT NULL, change text NOT NULL,
+			CONSTRAINT knowledge_revision_pkey PRIMARY KEY (id, rev))`,
+		`INSERT INTO knowledge (id, title) VALUES
+			('metrics/revenue', '売上'), ('glossary/mau', 'MAU')`,
+		`INSERT INTO knowledge_revision (id, rev, change) VALUES
+			('metrics/revenue', 1, 'create'), ('metrics/revenue', 2, 'update'),
+			('glossary/mau', 1, 'create')`,
+	} {
+		if _, err := tx.Exec(ctx, q); err != nil {
+			t.Fatalf("scratch setup: %v\n%s", err, q)
+		}
+	}
+
+	sql, err := migrationFS.ReadFile("migrations/0028_object_path_key.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec(ctx, string(sql)); err != nil {
+		t.Fatalf("apply 0028: %v", err)
+	}
+
+	// Every concept is at its id plus ".md" (SPEC §2), and the path is
+	// what the row is keyed by.
+	var mismatched int
+	if err := tx.QueryRow(ctx,
+		`SELECT count(*) FROM object WHERE path <> id || '.md'`).Scan(&mismatched); err != nil {
+		t.Fatal(err)
+	}
+	if mismatched != 0 {
+		t.Errorf("%d rows are not at their concept's path", mismatched)
+	}
+	for _, table := range []string{"object", "knowledge_revision"} {
+		var keyed bool
+		if err := tx.QueryRow(ctx,
+			`SELECT bool_or(a.attname = 'path') FROM pg_index i
+			   JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
+			  WHERE i.indrelid = ('path_scratch.' || $1)::regclass AND i.indisprimary`,
+			table).Scan(&keyed); err != nil {
+			t.Fatalf("primary key of %s: %v", table, err)
+		}
+		if !keyed {
+			t.Errorf("%s is not keyed by its path", table)
+		}
+	}
+	// The id is still a key of its own: it is what verify, reject, usage
+	// and move are called with (design doc 0046 §3.1).
+	var unique bool
+	if err := tx.QueryRow(ctx,
+		`SELECT bool_or(i.indisunique) FROM pg_index i
+		  WHERE i.indrelid = 'path_scratch.object'::regclass
+		    AND NOT i.indisprimary`).Scan(&unique); err != nil {
+		t.Fatal(err)
+	}
+	if !unique {
+		t.Error("the concept id lost its unique index; every ledger joins on it")
+	}
+	// History is not rewritten, only re-keyed: both revisions of the
+	// entry are still there, under its path.
+	var revs int
+	if err := tx.QueryRow(ctx,
+		`SELECT count(*) FROM knowledge_revision WHERE path = 'metrics/revenue.md'`).Scan(&revs); err != nil {
+		t.Fatal(err)
+	}
+	if revs != 2 {
+		t.Errorf("revisions under the path: got %d, want 2", revs)
 	}
 }

--- a/internal/store/migrations/0028_object_path_key.sql
+++ b/internal/store/migrations/0028_object_path_key.sql
@@ -1,0 +1,63 @@
+-- The bundle path becomes the address (design doc 0046 §§2.1, 3.1).
+--
+-- ochakai has held a table of knowledge entries keyed by concept id, and
+-- a separate table of attachments keyed by (entry, filename). 0046 turns
+-- that around: what an instance holds is one bundle — a mapping from
+-- path to object — and a knowledge entry is one kind of object in it.
+-- The key of that mapping is the path, so it becomes the primary key
+-- here, and the table stops being named after one of the two kinds.
+--
+-- The concept id stays, as the derived address it always was (design doc
+-- 0017, SPEC §2: the path with ".md" removed). Every ledger keys by it —
+-- verify, reject, usage and move are called with an id and will go on
+-- being called with one (0046 §3.1) — and a unique index keeps it the
+-- key it is. The one ledger that moves is the revision log: 0046 §3.1
+-- makes a revision an event about an *object*, so that creating and
+-- deleting a file lands in the same history as editing a concept.
+--
+-- Nothing about a file arrives in this migration. Concepts are the only
+-- objects here, so path is exactly id || '.md' for every row; the next
+-- change is where the attachment rows move in and the column stops being
+-- derivable (0046 §3.13).
+
+ALTER TABLE knowledge RENAME TO object;
+
+ALTER TABLE object ADD COLUMN IF NOT EXISTS path text;
+UPDATE object SET path = id || '.md' WHERE path IS NULL OR path = '';
+ALTER TABLE object ALTER COLUMN path SET NOT NULL;
+
+-- The primary key moves to the path; the id keeps a unique index of its
+-- own, because it is what every other table joins on and what every
+-- surface calls an entry by.
+ALTER TABLE object DROP CONSTRAINT IF EXISTS knowledge_pkey;
+ALTER TABLE object DROP CONSTRAINT IF EXISTS object_pkey;
+ALTER TABLE object ADD CONSTRAINT object_pkey PRIMARY KEY (path);
+CREATE UNIQUE INDEX IF NOT EXISTS object_id ON object (id);
+
+-- A revision is an event about an object. The column is the path for the
+-- same reason the primary key is, and the (path, rev) pair replaces
+-- (id, rev) — including for the rows already written, whose entries are
+-- all concepts.
+ALTER TABLE knowledge_revision ADD COLUMN IF NOT EXISTS path text;
+UPDATE knowledge_revision SET path = id || '.md' WHERE path IS NULL OR path = '';
+ALTER TABLE knowledge_revision ALTER COLUMN path SET NOT NULL;
+ALTER TABLE knowledge_revision DROP CONSTRAINT IF EXISTS knowledge_revision_pkey;
+ALTER TABLE knowledge_revision ADD CONSTRAINT knowledge_revision_pkey PRIMARY KEY (path, rev);
+-- The id column stays for one release: a revision of a concept is still
+-- looked up by the id its surfaces call it by, and dropping the column
+-- before the read paths stop using it would take the history with it.
+CREATE INDEX IF NOT EXISTS knowledge_revision_id ON knowledge_revision (id);
+
+-- A function body is text, not a reference: renaming the table does not
+-- reach inside the one trigger function that names it (0016). The
+-- attachment trigger touches the owning entry's row so the entry's
+-- lexical haystack is recomputed from the current filenames, and it has
+-- to touch it under the name the table now has.
+CREATE OR REPLACE FUNCTION ochakai_attachment_search_text() RETURNS trigger
+LANGUAGE plpgsql AS $$
+DECLARE
+    target text := COALESCE(NEW.knowledge_id, OLD.knowledge_id);
+BEGIN
+    UPDATE object SET search_text = search_text WHERE id = target;
+    RETURN NULL;
+END $$;

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"path"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -246,14 +247,14 @@ func withoutDoc(cols string) string {
 	var kept []string
 	for _, c := range strings.Split(cols, ",") {
 		t := strings.TrimSpace(c)
-		if t == "doc" || t == "k.doc" || t == "knowledge.doc" {
+		if t == "doc" || t == "k.doc" || t == "object.doc" {
 			continue
 		}
 		// The frontmatter index is never read back either: it is a
 		// question-answering copy of what the document already carries
 		// (design doc 0046 §3.11), so every read leaves it in the
 		// database where the filters use it.
-		if t == "frontmatter" || t == "k.frontmatter" || t == "knowledge.frontmatter" {
+		if t == "frontmatter" || t == "k.frontmatter" || t == "object.frontmatter" {
 			continue
 		}
 		kept = append(kept, t)
@@ -264,12 +265,12 @@ func withoutDoc(cols string) string {
 var (
 	// knowledgeSelect and knowledgeSelectK are what a read selects: the
 	// entry's columns (minus the stored document) plus its ledgers.
-	knowledgeSelect  = withoutDoc(knowledgeCols) + ", " + ledgerCols("knowledge")
+	knowledgeSelect  = withoutDoc(knowledgeCols) + ", " + ledgerCols("object")
 	knowledgeSelectK = withoutDoc(knowledgeColsK) + ", " + ledgerCols("k")
 	// knowledgeSelectDoc is the same read with the stored document, for
 	// the paths that hand one out (design doc 0046 §2.2): a single get,
 	// an export, and the move that rewrites a body in place.
-	knowledgeSelectDoc = withoutFrontmatter(knowledgeCols) + ", " + ledgerCols("knowledge")
+	knowledgeSelectDoc = withoutFrontmatter(knowledgeCols) + ", " + ledgerCols("object")
 )
 
 // sortedKeys orders a filter's frontmatter keys so a query's arguments —
@@ -554,7 +555,7 @@ func (s *Store) getOneFrom(ctx context.Context, q querier, id string, deleted bo
 		cond = "deleted_at IS NOT NULL"
 	}
 	rows, err := q.Query(ctx,
-		`SELECT `+knowledgeSelectDoc+` FROM knowledge WHERE id = $1 AND `+cond, id)
+		`SELECT `+knowledgeSelectDoc+` FROM object WHERE id = $1 AND `+cond, id)
 	if err != nil {
 		return nil, err
 	}
@@ -604,7 +605,7 @@ func (s *Store) listLinkingTo(ctx context.Context, id string, limit int, cols st
 	scan func(pgx.CollectableRow) (domain.Knowledge, error),
 ) ([]domain.Knowledge, error) {
 	rows, err := s.pool.Query(ctx,
-		`SELECT `+cols+` FROM knowledge
+		`SELECT `+cols+` FROM object
 		 WHERE deleted_at IS NULL AND links @> $1
 		 ORDER BY updated_at DESC LIMIT $2`,
 		fmt.Sprintf(`[{"target": %q}]`, id),
@@ -631,7 +632,7 @@ func (s *Store) Create(ctx context.Context, k *domain.Knowledge, keepCuratedTomb
 	// instead of being erased by it.
 	revive := ""
 	if keepCuratedTombstones {
-		revive = " AND " + notCurated("knowledge")
+		revive = " AND " + notCurated("object")
 	}
 	return s.withTx(ctx, func(tx pgx.Tx) error {
 		j, err := marshalJSONFields(k)
@@ -664,10 +665,16 @@ func (s *Store) Create(ctx context.Context, k *domain.Knowledge, keepCuratedTomb
 			k.UpdatedBy.Kind, k.UpdatedBy.Name, k.UpdatedBy.Via,
 			j.links, j.attrs, k.Body, k.CreatedAt, k.UpdatedAt, k.ContentChangedAt, doc, fm, hash,
 		}
-		tag, err := tx.Exec(ctx, `INSERT INTO knowledge (`+knowledgeCols+`)
-			VALUES (`+knowledgeParams+`)
+		// The path is the row's key (design doc 0046 §3.1) and the id is
+		// the concept's address within it, so a concept write states both.
+		// ON CONFLICT still names the id: reviving a tombstone is about the
+		// entry at that address, and for a concept the two keys move
+		// together.
+		args = append(args, domain.ConceptPath(k.ID))
+		tag, err := tx.Exec(ctx, `INSERT INTO object (`+knowledgeCols+`, path)
+			VALUES (`+knowledgeParams+`, $`+strconv.Itoa(len(args))+`)
 			ON CONFLICT (id) DO UPDATE SET `+knowledgeExcluded+`, deleted_at=NULL
-			WHERE knowledge.deleted_at IS NOT NULL`+revive,
+			WHERE object.deleted_at IS NOT NULL`+revive,
 			args...)
 		if err != nil {
 			return err
@@ -745,7 +752,7 @@ func (s *Store) Update(ctx context.Context, k *domain.Knowledge, actor domain.Ac
 			args = append(args, *ifMatch)
 			cond = fmt.Sprintf(" AND content_hash=$%d", len(args))
 		}
-		tag, err := tx.Exec(ctx, `UPDATE knowledge SET
+		tag, err := tx.Exec(ctx, `UPDATE object SET
 			type=$2, title=$3, description=$4, resource=$5, tags=$6, status=$7, status_note=$8, stale_after=$9,
 			sources=$10, usage_window=$11, runtime=$12, parameters=$13, computation=$14, executor=$15, attester=$16,
 			updated_by_kind=$17, updated_by_name=$18, updated_by_via=$19,
@@ -761,7 +768,7 @@ func (s *Store) Update(ctx context.Context, k *domain.Knowledge, actor domain.Ac
 			if ifMatch != nil {
 				var live bool
 				if err := tx.QueryRow(ctx,
-					`SELECT EXISTS (SELECT 1 FROM knowledge WHERE id=$1 AND deleted_at IS NULL)`,
+					`SELECT EXISTS (SELECT 1 FROM object WHERE id=$1 AND deleted_at IS NULL)`,
 					k.ID).Scan(&live); err != nil {
 					return err
 				}
@@ -812,7 +819,7 @@ func (s *Store) Verify(ctx context.Context, id string, actor domain.Actor) (*dom
 		err := tx.QueryRow(ctx, `INSERT INTO knowledge_verification (id, seq, by_kind, by_name, by_via, at)
 			SELECT $1, COALESCE((SELECT MAX(seq) FROM knowledge_verification WHERE id=$1), 0) + 1,
 				$2, $3, $4, now()
-			WHERE EXISTS (SELECT 1 FROM knowledge WHERE id=$1 AND deleted_at IS NULL)
+			WHERE EXISTS (SELECT 1 FROM object WHERE id=$1 AND deleted_at IS NULL)
 			RETURNING at`,
 			id, actor.Kind, actor.Name, actor.Via).Scan(&at)
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -850,7 +857,7 @@ func (s *Store) Reject(ctx context.Context, id string, actor domain.Actor, note 
 	err := s.withTx(ctx, func(tx pgx.Tx) error {
 		tag, err := tx.Exec(ctx, `INSERT INTO knowledge_rejection (id, by_kind, by_name, by_via, at, note)
 			SELECT $1, $2, $3, $4, now(), $5
-			WHERE EXISTS (SELECT 1 FROM knowledge WHERE id=$1 AND deleted_at IS NULL)
+			WHERE EXISTS (SELECT 1 FROM object WHERE id=$1 AND deleted_at IS NULL)
 			ON CONFLICT (id) DO UPDATE SET
 				by_kind=EXCLUDED.by_kind, by_name=EXCLUDED.by_name, by_via=EXCLUDED.by_via,
 				at=EXCLUDED.at, note=EXCLUDED.note`,
@@ -880,7 +887,7 @@ func (s *Store) LiftRejection(ctx context.Context, id string, actor domain.Actor
 	err := s.withTx(ctx, func(tx pgx.Tx) error {
 		tag, err := tx.Exec(ctx, `DELETE FROM knowledge_rejection r
 			WHERE r.id = $1
-			  AND EXISTS (SELECT 1 FROM knowledge WHERE id=$1 AND deleted_at IS NULL)`, id)
+			  AND EXISTS (SELECT 1 FROM object WHERE id=$1 AND deleted_at IS NULL)`, id)
 		if err != nil {
 			return err
 		}
@@ -910,7 +917,7 @@ func (s *Store) SoftDelete(ctx context.Context, id string, actor domain.Actor) e
 		// Get above ran outside this transaction, and a double delete must
 		// not record a second "delete" revision.
 		tag, err := tx.Exec(ctx,
-			`UPDATE knowledge SET deleted_at = now(), updated_at = now()
+			`UPDATE object SET deleted_at = now(), updated_at = now()
 			 WHERE id=$1 AND deleted_at IS NULL`, id)
 		if err != nil {
 			return err
@@ -955,7 +962,7 @@ func (s *Store) Purge(ctx context.Context, id string, actor domain.Actor) error 
 		// same id, which would otherwise both log an audit row.
 		var deleted bool
 		err := tx.QueryRow(ctx,
-			`SELECT deleted_at IS NOT NULL FROM knowledge WHERE id=$1 FOR UPDATE`, id).Scan(&deleted)
+			`SELECT deleted_at IS NOT NULL FROM object WHERE id=$1 FOR UPDATE`, id).Scan(&deleted)
 		if errors.Is(err, pgx.ErrNoRows) {
 			return ErrNotFound
 		}
@@ -970,7 +977,7 @@ func (s *Store) Purge(ctx context.Context, id string, actor domain.Actor) error 
 			SELECT k.id, k.type, k.title,
 			       (SELECT count(*) FROM knowledge_revision r WHERE r.id = k.id),
 			       $2, $3, $4
-			  FROM knowledge k WHERE k.id = $1`,
+			  FROM object k WHERE k.id = $1`,
 			id, actor.Kind, actor.Name, actor.Via); err != nil {
 			return err
 		}
@@ -990,7 +997,7 @@ func (s *Store) Purge(ctx context.Context, id string, actor domain.Actor) error 
 		// statement carries the precondition itself, not just the lock
 		// taken above: a purge that would hit a live row aborts the
 		// transaction instead of erasing it.
-		tag, err := tx.Exec(ctx, `DELETE FROM knowledge WHERE id=$1 AND deleted_at IS NOT NULL`, id)
+		tag, err := tx.Exec(ctx, `DELETE FROM object WHERE id=$1 AND deleted_at IS NOT NULL`, id)
 		if err != nil {
 			return err
 		}
@@ -1039,7 +1046,7 @@ func (s *Store) Move(ctx context.Context, oldID, newID string, actor domain.Acto
 		// blocked forever.
 		var occupied, occupantDeleted bool
 		if err := tx.QueryRow(ctx,
-			`SELECT true, deleted_at IS NOT NULL FROM knowledge WHERE id=$1`, newID).
+			`SELECT true, deleted_at IS NOT NULL FROM object WHERE id=$1`, newID).
 			Scan(&occupied, &occupantDeleted); err != nil && !errors.Is(err, pgx.ErrNoRows) {
 			return err
 		}
@@ -1053,10 +1060,10 @@ func (s *Store) Move(ctx context.Context, oldID, newID string, actor domain.Acto
 		// exactly as in SoftDelete: the Get above ran outside this
 		// transaction.
 		tag, err := tx.Exec(ctx,
-			`UPDATE knowledge SET id=$2, updated_at=$3, content_changed_at=$3,
+			`UPDATE object SET id=$2, path=$7, updated_at=$3, content_changed_at=$3,
 			 updated_by_kind=$4, updated_by_name=$5, updated_by_via=$6
 			 WHERE id=$1 AND deleted_at IS NULL`,
-			oldID, newID, k.UpdatedAt, actor.Kind, actor.Name, actor.Via)
+			oldID, newID, k.UpdatedAt, actor.Kind, actor.Name, actor.Via, domain.ConceptPath(newID))
 		if isUniqueViolation(err) {
 			// The probe above found the destination free, but it took no
 			// lock — a create can land on newID in the window. The primary
@@ -1072,7 +1079,7 @@ func (s *Store) Move(ctx context.Context, oldID, newID string, actor domain.Acto
 			return ErrNotFound
 		}
 		for _, q := range []string{
-			`UPDATE knowledge_revision SET id=$2 WHERE id=$1`,
+			`UPDATE knowledge_revision SET id=$2, path=$2 || '.md' WHERE id=$1`,
 			`UPDATE knowledge_verification SET id=$2 WHERE id=$1`,
 			`UPDATE knowledge_rejection SET id=$2 WHERE id=$1`,
 			`UPDATE attachment SET knowledge_id=$2 WHERE knowledge_id=$1`,
@@ -1132,7 +1139,7 @@ func (s *Store) rewriteReferences(ctx context.Context, tx pgx.Tx, oldID string, 
 	// was lost. ORDER BY id gives concurrent moves one lock order, so they
 	// queue instead of deadlocking.
 	rows, err := tx.Query(ctx,
-		`SELECT `+knowledgeSelectDoc+` FROM knowledge
+		`SELECT `+knowledgeSelectDoc+` FROM object
 		 WHERE deleted_at IS NULL AND (links @> $1 OR attrs->>'model' = $2 OR id = $3)
 		 ORDER BY id FOR UPDATE`,
 		fmt.Sprintf(`[{"target": %q}]`, oldID),
@@ -1221,7 +1228,7 @@ func (s *Store) rewriteReferences(ctx context.Context, tx pgx.Tx, oldID string, 
 		}
 		r.ContentHash = hash
 		tag, err := tx.Exec(ctx,
-			`UPDATE knowledge SET links=$2, attrs=$3, body=$4, updated_at=$5,
+			`UPDATE object SET links=$2, attrs=$3, body=$4, updated_at=$5,
 			 updated_by_kind=$6, updated_by_name=$7, updated_by_via=$8,
 			 doc=$9, content_hash=$10, content_changed_at=$11, frontmatter=$12
 			 WHERE id=$1 AND deleted_at IS NULL`,
@@ -1306,7 +1313,7 @@ func (s *Store) ListRevisionsUnder(ctx context.Context, prefix string, limit int
 		`SELECT r.id, COALESCE(k.title, ''), r.change,
 		        r.changed_by_kind, r.changed_by_name, r.changed_by_via, r.changed_at
 		 FROM knowledge_revision r
-		 LEFT JOIN knowledge k ON k.id = r.id
+		 LEFT JOIN object k ON k.id = r.id
 		 WHERE $1 = '' OR r.id = $1 OR r.id LIKE $2
 		 ORDER BY r.changed_at DESC, r.id, r.rev DESC LIMIT $3`,
 		prefix, prefix+"/%", limit)
@@ -1328,9 +1335,12 @@ func (s *Store) addRevision(ctx context.Context, tx pgx.Tx, k *domain.Knowledge,
 	if err != nil {
 		return err
 	}
-	_, err = tx.Exec(ctx, `INSERT INTO knowledge_revision (id, rev, change, changed_by_kind, changed_by_name, changed_by_via, doc)
-		VALUES ($1, (SELECT COALESCE(MAX(rev), 0) + 1 FROM knowledge_revision WHERE id=$1), $2, $3, $4, $5, $6)`,
-		k.ID, change, actor.Kind, actor.Name, actor.Via, string(doc))
+	// A revision is an event about an object, so the ledger counts by
+	// path (design doc 0046 §3.1): when a file's create and delete land
+	// here too, they share one history with the concept beside them.
+	_, err = tx.Exec(ctx, `INSERT INTO knowledge_revision (path, id, rev, change, changed_by_kind, changed_by_name, changed_by_via, doc)
+		VALUES ($1, $2, (SELECT COALESCE(MAX(rev), 0) + 1 FROM knowledge_revision WHERE path=$1), $3, $4, $5, $6, $7)`,
+		domain.ConceptPath(k.ID), k.ID, change, actor.Kind, actor.Name, actor.Via, string(doc))
 	return err
 }
 
@@ -1542,14 +1552,14 @@ func (s *Store) SearchLexical(ctx context.Context, query string, f Filter, limit
 						CASE WHEN k.search_text ILIKE $%[5]d THEN 0.3 ELSE 0 END AS whole,
 						CASE WHEN EXISTS (SELECT 1 FROM knowledge_verification v
 							WHERE v.id = k.id) THEN 0.05 ELSE 0 END AS verified
-					FROM knowledge k
+					FROM object k
 					WHERE (%[6]s) AND %[7]s
 				) c
 			) w
 			ORDER BY score DESC LIMIT %[8]d
 		)
 		SELECT `+knowledgeSelectK+`, scored.score
-		FROM knowledge k JOIN scored ON scored.id = k.id
+		FROM object k JOIN scored ON scored.id = k.id
 		ORDER BY scored.score DESC`,
 		strings.Join(weighted, " + "), strings.Join(weights, " + "),
 		strings.Join(weight, ", "), strings.Join(hit, ", "), wholeParam,
@@ -1575,7 +1585,7 @@ func (s *Store) SearchVector(ctx context.Context, vec []float32, model string, f
 	args = append(args, model)
 	q := fmt.Sprintf(`
 		SELECT `+knowledgeSelectK+`, 1 - (e.embedding <=> $%d::vector) AS score
-		FROM knowledge k JOIN knowledge_embedding e ON k.id = e.id AND e.model = $%d
+		FROM object k JOIN knowledge_embedding e ON k.id = e.id AND e.model = $%d
 		WHERE %s
 		ORDER BY e.embedding <=> $%d::vector LIMIT %d`, vecParam, len(args), where, vecParam, limit)
 	return s.annSearch(ctx, limit, q, args)
@@ -1593,7 +1603,7 @@ func (s *Store) SearchVectorAttachments(ctx context.Context, vec []float32, mode
 	q := fmt.Sprintf(`
 		SELECT `+withoutDoc(knowledgeCols)+", "+ledgerCols("best")+`, score FROM (
 			SELECT DISTINCT ON (k.id) k.*, 1 - (e.embedding <=> $%d::vector) AS score
-			FROM knowledge k JOIN attachment_embedding e ON k.id = e.knowledge_id AND e.model = $%d
+			FROM object k JOIN attachment_embedding e ON k.id = e.knowledge_id AND e.model = $%d
 			WHERE %s
 			ORDER BY k.id, e.embedding <=> $%d::vector
 		) best
@@ -1704,7 +1714,7 @@ func (f Filter) buildWhere(prefix string) (string, []any) {
 	// — true for every row, which silently empties every unaliased query.
 	outer := prefix
 	if outer == "" {
-		outer = "knowledge."
+		outer = "object."
 	}
 	rejectedExists := fmt.Sprintf(
 		"EXISTS (SELECT 1 FROM knowledge_rejection r WHERE r.id = %sid)", outer)
@@ -1809,7 +1819,7 @@ func sourceContainment(resource string) []byte {
 // order beats a relevance score nothing computed.
 func (s *Store) ListBySource(ctx context.Context, f Filter, limit int) ([]domain.Knowledge, error) {
 	where, args := f.buildWhere("")
-	return s.queryKnowledge(ctx, fmt.Sprintf(`SELECT `+knowledgeSelect+` FROM knowledge WHERE %s
+	return s.queryKnowledge(ctx, fmt.Sprintf(`SELECT `+knowledgeSelect+` FROM object WHERE %s
 		ORDER BY id LIMIT %d`, where, limit), args...)
 }
 
@@ -1832,7 +1842,7 @@ func (s *Store) ListByStaleAfter(ctx context.Context, f Filter, limit int) ([]do
 	// doc 0036 §3.9), and current_date would hand that decision to
 	// whatever TimeZone the database session happens to carry — the same
 	// entry would be stale on one deployment and not on another.
-	return s.queryKnowledge(ctx, fmt.Sprintf(`SELECT `+knowledgeSelect+` FROM knowledge WHERE %s
+	return s.queryKnowledge(ctx, fmt.Sprintf(`SELECT `+knowledgeSelect+` FROM object WHERE %s
 		AND stale_after IS NOT NULL AND stale_after <= (now() AT TIME ZONE 'UTC')::date
 		ORDER BY stale_after ASC, id LIMIT %d`, where, limit), args...)
 }
@@ -1842,8 +1852,8 @@ func (s *Store) ListByStaleAfter(ctx context.Context, f Filter, limit int) ([]do
 // query canary runs: "which verified queries have gone longest unchecked".
 func (s *Store) ListByVerifiedAt(ctx context.Context, f Filter, limit int) ([]domain.Knowledge, error) {
 	where, args := f.buildWhere("")
-	return s.queryKnowledge(ctx, fmt.Sprintf(`SELECT `+knowledgeSelect+` FROM knowledge WHERE %s
-		ORDER BY `+lastVerifiedAt("knowledge")+` ASC NULLS LAST, id LIMIT %d`, where, limit), args...)
+	return s.queryKnowledge(ctx, fmt.Sprintf(`SELECT `+knowledgeSelect+` FROM object WHERE %s
+		ORDER BY `+lastVerifiedAt("object")+` ASC NULLS LAST, id LIMIT %d`, where, limit), args...)
 }
 
 // usageLateral aggregates a knowledge entry's per-event running totals
@@ -1874,7 +1884,7 @@ func (s *Store) ListByUsage(ctx context.Context, f Filter, limit int) ([]domain.
 	q := fmt.Sprintf(`
 		SELECT `+knowledgeSelectK+`,
 			u.search_hits, u.fetches, u.worked, u.failed, u.last_used_at
-		FROM knowledge k`+usageLateral+`
+		FROM object k`+usageLateral+`
 		WHERE %s
 		ORDER BY u.search_hits DESC, k.created_at ASC, k.id LIMIT %d`, where, limit)
 	rows, err := s.pool.Query(ctx, q, args...)
@@ -1908,7 +1918,7 @@ func (s *Store) ListByFailed(ctx context.Context, f Filter, limit int) ([]domain
 	q := fmt.Sprintf(`
 		SELECT `+knowledgeSelectK+`,
 			u.search_hits, u.fetches, u.worked, u.failed, u.last_used_at
-		FROM knowledge k`+usageLateral+`
+		FROM object k`+usageLateral+`
 		WHERE %s AND u.failed > 0
 			AND (%[2]s IS NULL OR u.last_failed_at > %[2]s)
 		ORDER BY u.failed DESC, u.worked ASC, %[2]s ASC NULLS LAST, k.id LIMIT %[3]d`,
@@ -1952,7 +1962,7 @@ func scanUsageHit(row pgx.CollectableRow) (domain.SearchHit, error) {
 // nothing — never reaches the rest of the corpus.
 func (s *Store) ListUnembedded(ctx context.Context, model, after string, limit int) ([]string, error) {
 	rows, err := s.pool.Query(ctx,
-		`SELECT k.id FROM knowledge k
+		`SELECT k.id FROM object k
 		 LEFT JOIN knowledge_embedding e ON e.id = k.id AND e.model = $1
 		 WHERE k.deleted_at IS NULL AND e.id IS NULL AND ($2 = '' OR k.id > $2)
 		 ORDER BY k.id LIMIT $3`, model, after, limit)
@@ -1976,7 +1986,7 @@ type UnembeddedAttachment struct {
 func (s *Store) ListUnembeddedAttachments(ctx context.Context, model, afterID, afterName string, limit int) ([]UnembeddedAttachment, error) {
 	rows, err := s.pool.Query(ctx,
 		`SELECT a.knowledge_id, a.name FROM attachment a
-		 JOIN knowledge k ON k.id = a.knowledge_id AND k.deleted_at IS NULL
+		 JOIN object k ON k.id = a.knowledge_id AND k.deleted_at IS NULL
 		 LEFT JOIN attachment_embedding e
 		   ON e.knowledge_id = a.knowledge_id AND e.name = a.name AND e.model = $1
 		 WHERE e.knowledge_id IS NULL
@@ -2004,7 +2014,7 @@ func (s *Store) CountUnembeddedAttachments(ctx context.Context, model string) (i
 	var n int
 	err := s.pool.QueryRow(ctx,
 		`SELECT count(*) FROM attachment a
-		 JOIN knowledge k ON k.id = a.knowledge_id AND k.deleted_at IS NULL
+		 JOIN object k ON k.id = a.knowledge_id AND k.deleted_at IS NULL
 		 LEFT JOIN attachment_embedding e
 		   ON e.knowledge_id = a.knowledge_id AND e.name = a.name AND e.model = $1
 		 WHERE e.knowledge_id IS NULL`, model).Scan(&n)
@@ -2020,7 +2030,7 @@ func (s *Store) CountUnembeddedAttachments(ctx context.Context, model string) (i
 func (s *Store) CountUnembedded(ctx context.Context, model string) (int, error) {
 	var n int
 	err := s.pool.QueryRow(ctx,
-		`SELECT count(*) FROM knowledge k
+		`SELECT count(*) FROM object k
 		 LEFT JOIN knowledge_embedding e ON e.id = k.id AND e.model = $1
 		 WHERE k.deleted_at IS NULL AND e.id IS NULL`, model).Scan(&n)
 	return n, err

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -54,7 +54,7 @@ func TestIntegration(t *testing.T) {
 	}
 	// Hard-delete leftovers from prior runs (soft-deleted rows still
 	// conflict on the primary key).
-	for _, table := range []string{"knowledge", "knowledge_revision", "knowledge_embedding"} {
+	for _, table := range []string{"object", "knowledge_revision", "knowledge_embedding"} {
 		if _, err := s.pool.Exec(ctx, `DELETE FROM `+table+` WHERE id LIKE 'it-%'`); err != nil {
 			t.Fatal(err)
 		}
@@ -444,7 +444,7 @@ func TestIntegrationListLinkingTo(t *testing.T) {
 	if err := s.Migrate(ctx, 0); err != nil {
 		t.Fatal(err)
 	}
-	for _, table := range []string{"knowledge", "knowledge_revision"} {
+	for _, table := range []string{"object", "knowledge_revision"} {
 		if _, err := s.pool.Exec(ctx, `DELETE FROM `+table+` WHERE id LIKE 'it-link-%'`); err != nil {
 			t.Fatal(err)
 		}
@@ -505,7 +505,7 @@ func TestIntegrationPrefixFilterMatchesSegments(t *testing.T) {
 	}
 	// Both families this test creates, or a second run trips over its own
 	// leftovers: soft-deleted rows still hold the primary key.
-	for _, table := range []string{"knowledge", "knowledge_revision"} {
+	for _, table := range []string{"object", "knowledge_revision"} {
 		if _, err := s.pool.Exec(ctx,
 			`DELETE FROM `+table+` WHERE id LIKE 'it-scope%' OR id LIKE 'it-elsewhere%'`); err != nil {
 			t.Fatal(err)
@@ -597,7 +597,7 @@ func TestIntegrationSearchLexicalWildcardEscape(t *testing.T) {
 	if err := s.Migrate(ctx, 0); err != nil {
 		t.Fatal(err)
 	}
-	for _, table := range []string{"knowledge", "knowledge_revision"} {
+	for _, table := range []string{"object", "knowledge_revision"} {
 		if _, err := s.pool.Exec(ctx, `DELETE FROM `+table+` WHERE id LIKE 'it-wild-%'`); err != nil {
 			t.Fatal(err)
 		}
@@ -653,7 +653,7 @@ func TestIntegrationUsageBuffering(t *testing.T) {
 	if err := s.Migrate(ctx, 0); err != nil {
 		t.Fatal(err)
 	}
-	for _, table := range []string{"knowledge", "knowledge_revision"} {
+	for _, table := range []string{"object", "knowledge_revision"} {
 		if _, err := s.pool.Exec(ctx, `DELETE FROM `+table+` WHERE id LIKE 'it-buf-%'`); err != nil {
 			t.Fatal(err)
 		}
@@ -713,7 +713,7 @@ func TestIntegrationMove(t *testing.T) {
 		t.Fatal(err)
 	}
 	s.UseBlobStore(newFakeBlobStore())
-	for _, table := range []string{"knowledge", "knowledge_revision", "knowledge_embedding"} {
+	for _, table := range []string{"object", "knowledge_revision", "knowledge_embedding"} {
 		if _, err := s.pool.Exec(ctx, `DELETE FROM `+table+` WHERE id LIKE 'it-move-%'`); err != nil {
 			t.Fatal(err)
 		}
@@ -883,7 +883,7 @@ func TestIntegrationCreateRevivesSoftDeleted(t *testing.T) {
 	if err := s.Migrate(ctx, 0); err != nil {
 		t.Fatal(err)
 	}
-	for _, table := range []string{"knowledge", "knowledge_revision"} {
+	for _, table := range []string{"object", "knowledge_revision"} {
 		if _, err := s.pool.Exec(ctx, `DELETE FROM `+table+` WHERE id LIKE 'it-revive-%'`); err != nil {
 			t.Fatal(err)
 		}
@@ -993,7 +993,7 @@ func TestIntegrationAttachments(t *testing.T) {
 	}
 	for _, del := range []string{
 		`DELETE FROM attachment WHERE knowledge_id LIKE 'it-att%'`,
-		`DELETE FROM knowledge WHERE id LIKE 'it-att%'`,
+		`DELETE FROM object WHERE id LIKE 'it-att%'`,
 		`DELETE FROM knowledge_revision WHERE id LIKE 'it-att%'`,
 	} {
 		if _, err := s.pool.Exec(ctx, del); err != nil {
@@ -1102,7 +1102,7 @@ func TestIntegrationListRevisions(t *testing.T) {
 	if err := s.Migrate(ctx, 0); err != nil {
 		t.Fatal(err)
 	}
-	for _, table := range []string{"knowledge", "knowledge_revision"} {
+	for _, table := range []string{"object", "knowledge_revision"} {
 		if _, err := s.pool.Exec(ctx, `DELETE FROM `+table+` WHERE id LIKE 'it-revs-%'`); err != nil {
 			t.Fatal(err)
 		}
@@ -1213,7 +1213,7 @@ func TestIntegrationSearchTextFollowsAttachmentsAndMoves(t *testing.T) {
 
 	searchText := func(id string) string {
 		var got string
-		if err := s.pool.QueryRow(ctx, `SELECT search_text FROM knowledge WHERE id = $1`, id).Scan(&got); err != nil {
+		if err := s.pool.QueryRow(ctx, `SELECT search_text FROM object WHERE id = $1`, id).Scan(&got); err != nil {
 			t.Fatalf("read search_text for %s: %v", id, err)
 		}
 		return got
@@ -1221,7 +1221,7 @@ func TestIntegrationSearchTextFollowsAttachmentsAndMoves(t *testing.T) {
 
 	const id, moved = "it-haystack", "it-haystack-moved"
 	for _, dead := range []string{id, moved} {
-		_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge WHERE id = $1`, dead)
+		_, _ = s.pool.Exec(ctx, `DELETE FROM object WHERE id = $1`, dead)
 		_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_revision WHERE id = $1`, dead)
 	}
 	k := &domain.Knowledge{
@@ -1286,7 +1286,7 @@ func TestIntegrationPurgeFreesIDForMove(t *testing.T) {
 
 	const src, dst = "it-purge-src", "it-purge-dst"
 	for _, id := range []string{src, dst} {
-		_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge WHERE id = $1`, id)
+		_, _ = s.pool.Exec(ctx, `DELETE FROM object WHERE id = $1`, id)
 		_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_revision WHERE id = $1`, id)
 	}
 	create := func(id string) {
@@ -1364,7 +1364,7 @@ func TestIntegrationPurgeFreesIDForMove(t *testing.T) {
 	if moved.ID != dst {
 		t.Errorf("moved entry id = %q, want %q", moved.ID, dst)
 	}
-	_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge WHERE id = $1`, dst)
+	_, _ = s.pool.Exec(ctx, `DELETE FROM object WHERE id = $1`, dst)
 	_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_revision WHERE id = $1`, dst)
 }
 
@@ -1392,7 +1392,7 @@ func TestIntegrationPurgeLosesToRevival(t *testing.T) {
 
 	const id = "it-purge-race"
 	cleanup := func() {
-		_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge WHERE id = $1`, id)
+		_, _ = s.pool.Exec(ctx, `DELETE FROM object WHERE id = $1`, id)
 		_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_revision WHERE id = $1`, id)
 		_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_purge WHERE id = $1`, id)
 	}
@@ -1417,7 +1417,7 @@ func TestIntegrationPurgeLosesToRevival(t *testing.T) {
 	}
 	defer func() { _ = revive.Rollback(ctx) }()
 	if _, err := revive.Exec(ctx,
-		`UPDATE knowledge SET deleted_at = NULL, updated_at = now() WHERE id = $1`, id); err != nil {
+		`UPDATE object SET deleted_at = NULL, updated_at = now() WHERE id = $1`, id); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1432,7 +1432,8 @@ func TestIntegrationPurgeLosesToRevival(t *testing.T) {
 		var waiting int
 		if err := s.pool.QueryRow(ctx,
 			`SELECT count(*) FROM pg_stat_activity
-			  WHERE wait_event_type = 'Lock' AND query LIKE '%knowledge%'`).Scan(&waiting); err != nil {
+			  WHERE wait_event_type = 'Lock'
+			    AND (query LIKE '%object%' OR query LIKE '%knowledge%')`).Scan(&waiting); err != nil {
 			t.Fatal(err)
 		}
 		if waiting > 0 {
@@ -1488,7 +1489,7 @@ func TestIntegrationCloseFlushesBufferedUsage(t *testing.T) {
 		t.Fatal(err)
 	}
 	const id = "it-flush-on-close"
-	_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge WHERE id = $1`, id)
+	_, _ = s.pool.Exec(ctx, `DELETE FROM object WHERE id = $1`, id)
 	_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_revision WHERE id = $1`, id)
 	_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_usage WHERE knowledge_id = $1`, id)
 	_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_event WHERE knowledge_id = $1`, id)
@@ -1519,7 +1520,7 @@ func TestIntegrationCloseFlushesBufferedUsage(t *testing.T) {
 	if u.Fetches != 1 {
 		t.Errorf("fetches = %d after Close, want 1 — the buffer was dropped", u.Fetches)
 	}
-	_, _ = verify.pool.Exec(ctx, `DELETE FROM knowledge WHERE id = $1`, id)
+	_, _ = verify.pool.Exec(ctx, `DELETE FROM object WHERE id = $1`, id)
 	_, _ = verify.pool.Exec(ctx, `DELETE FROM knowledge_revision WHERE id = $1`, id)
 	_, _ = verify.pool.Exec(ctx, `DELETE FROM knowledge_usage WHERE knowledge_id = $1`, id)
 	_, _ = verify.pool.Exec(ctx, `DELETE FROM knowledge_event WHERE knowledge_id = $1`, id)
@@ -1546,7 +1547,7 @@ func TestIntegrationDelegatedProvenance(t *testing.T) {
 	}
 
 	const id = "it-delegated"
-	_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge WHERE id = $1`, id)
+	_, _ = s.pool.Exec(ctx, `DELETE FROM object WHERE id = $1`, id)
 	_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_revision WHERE id = $1`, id)
 	via := "process:insightflow@example.iam.gserviceaccount.com"
 	delegated := domain.Actor{Kind: domain.ActorHuman, Name: "tanaka@example.co.jp", Via: via}
@@ -1602,7 +1603,7 @@ func TestIntegrationDelegatedProvenance(t *testing.T) {
 		t.Errorf("revision changed_by lost the delegation: %+v", create.ChangedBy)
 	}
 
-	_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge WHERE id = $1`, id)
+	_, _ = s.pool.Exec(ctx, `DELETE FROM object WHERE id = $1`, id)
 	_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_revision WHERE id = $1`, id)
 }
 
@@ -1660,7 +1661,7 @@ func TestIntegrationLexicalSearchAnswersQuestions(t *testing.T) {
 	}
 	clean := func() {
 		for _, id := range ids {
-			_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge WHERE id = $1`, id)
+			_, _ = s.pool.Exec(ctx, `DELETE FROM object WHERE id = $1`, id)
 			_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_revision WHERE id = $1`, id)
 		}
 	}
@@ -1756,7 +1757,7 @@ func TestIntegrationVerifyClearsTheReviewFeed(t *testing.T) {
 		t.Fatal(err)
 	}
 	const id = "it-verify-feed"
-	for _, table := range []string{"knowledge", "knowledge_revision", "knowledge_verification", "knowledge_rejection"} {
+	for _, table := range []string{"object", "knowledge_revision", "knowledge_verification", "knowledge_rejection"} {
 		if _, err := s.pool.Exec(ctx, `DELETE FROM `+table+` WHERE id = $1`, id); err != nil {
 			t.Fatal(err)
 		}
@@ -1873,7 +1874,7 @@ func TestIntegrationMoveKeepsOutboundRelativeLinks(t *testing.T) {
 	if err := s.Migrate(ctx, 0); err != nil {
 		t.Fatal(err)
 	}
-	for _, table := range []string{"knowledge", "knowledge_revision"} {
+	for _, table := range []string{"object", "knowledge_revision"} {
 		if _, err := s.pool.Exec(ctx, `DELETE FROM `+table+` WHERE id LIKE 'it-relmove%'`); err != nil {
 			t.Fatal(err)
 		}
@@ -1894,7 +1895,7 @@ func TestIntegrationMoveKeepsOutboundRelativeLinks(t *testing.T) {
 		}
 	}
 	t.Cleanup(func() {
-		for _, table := range []string{"knowledge", "knowledge_revision"} {
+		for _, table := range []string{"object", "knowledge_revision"} {
 			_, _ = s.pool.Exec(ctx, `DELETE FROM `+table+` WHERE id LIKE 'it-relmove%'`)
 		}
 	})
@@ -1946,13 +1947,13 @@ func TestIntegrationMoveSelfRewriteIsOneRevision(t *testing.T) {
 	if err := s.Migrate(ctx, 0); err != nil {
 		t.Fatal(err)
 	}
-	for _, table := range []string{"knowledge", "knowledge_revision"} {
+	for _, table := range []string{"object", "knowledge_revision"} {
 		if _, err := s.pool.Exec(ctx, `DELETE FROM `+table+` WHERE id LIKE 'it-selfmove%'`); err != nil {
 			t.Fatal(err)
 		}
 	}
 	defer func() {
-		for _, table := range []string{"knowledge", "knowledge_revision"} {
+		for _, table := range []string{"object", "knowledge_revision"} {
 			_, _ = s.pool.Exec(ctx, `DELETE FROM `+table+` WHERE id LIKE 'it-selfmove%'`)
 		}
 	}()
@@ -2057,7 +2058,7 @@ func TestIntegrationExportSnapshotIsConsistent(t *testing.T) {
 		t.Fatal(err)
 	}
 	const doomed = "it-exportsnap/doomed"
-	for _, table := range []string{"knowledge", "knowledge_revision"} {
+	for _, table := range []string{"object", "knowledge_revision"} {
 		if _, err := s.pool.Exec(ctx, `DELETE FROM `+table+` WHERE id LIKE 'it-exportsnap%'`); err != nil {
 			t.Fatal(err)
 		}
@@ -2068,7 +2069,7 @@ func TestIntegrationExportSnapshotIsConsistent(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
-		for _, table := range []string{"knowledge", "knowledge_revision"} {
+		for _, table := range []string{"object", "knowledge_revision"} {
 			_, _ = s.pool.Exec(ctx, `DELETE FROM `+table+` WHERE id LIKE 'it-exportsnap%'`)
 		}
 	})
@@ -2246,7 +2247,7 @@ func TestIntegrationMoveDoesNotClobberAConcurrentEdit(t *testing.T) {
 	moved := fmt.Sprintf("it-clobber-%d/renamed", stamp)
 	referrer := fmt.Sprintf("it-clobber-%d/insight", stamp)
 	cleanup := func() {
-		for _, table := range []string{"knowledge", "knowledge_revision"} {
+		for _, table := range []string{"object", "knowledge_revision"} {
 			_, _ = s.pool.Exec(ctx, `DELETE FROM `+table+` WHERE id LIKE $1`,
 				fmt.Sprintf("it-clobber-%d%%", stamp))
 		}
@@ -2273,7 +2274,7 @@ func TestIntegrationMoveDoesNotClobberAConcurrentEdit(t *testing.T) {
 	defer func() { _ = edit.Rollback(ctx) }()
 	const added = "A sentence the move must not eat."
 	if _, err := edit.Exec(ctx,
-		`UPDATE knowledge SET body = body || $2, updated_at = now() WHERE id = $1`,
+		`UPDATE object SET body = body || $2, updated_at = now() WHERE id = $1`,
 		referrer, "\n\n"+added); err != nil {
 		t.Fatal(err)
 	}
@@ -2290,7 +2291,8 @@ func TestIntegrationMoveDoesNotClobberAConcurrentEdit(t *testing.T) {
 		var waiting int
 		if err := s.pool.QueryRow(ctx,
 			`SELECT count(*) FROM pg_stat_activity
-			  WHERE wait_event_type = 'Lock' AND query LIKE '%knowledge%'`).Scan(&waiting); err != nil {
+			  WHERE wait_event_type = 'Lock'
+			    AND (query LIKE '%object%' OR query LIKE '%knowledge%')`).Scan(&waiting); err != nil {
 			t.Fatal(err)
 		}
 		if waiting > 0 {
@@ -2631,10 +2633,10 @@ func TestIntegrationStoredDocumentMatchesTheIndex(t *testing.T) {
 	if err := s.Create(ctx, k, false); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { _, _ = s.pool.Exec(ctx, `DELETE FROM knowledge WHERE id = $1`, id) })
+	t.Cleanup(func() { _, _ = s.pool.Exec(ctx, `DELETE FROM object WHERE id = $1`, id) })
 
 	var stored string
-	if err := s.pool.QueryRow(ctx, `SELECT doc FROM knowledge WHERE id = $1`, id).Scan(&stored); err != nil {
+	if err := s.pool.QueryRow(ctx, `SELECT doc FROM object WHERE id = $1`, id).Scan(&stored); err != nil {
 		t.Fatal(err)
 	}
 	read, err := s.Get(ctx, id)
@@ -2695,7 +2697,7 @@ func TestIntegrationProducerKeysInsideObjectsSurviveStorage(t *testing.T) {
 	if err := s.Create(ctx, k, false); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { _, _ = s.pool.Exec(ctx, `DELETE FROM knowledge WHERE id = $1`, id) })
+	t.Cleanup(func() { _, _ = s.pool.Exec(ctx, `DELETE FROM object WHERE id = $1`, id) })
 
 	got, err := s.Get(ctx, id)
 	if err != nil {
@@ -2711,7 +2713,7 @@ func TestIntegrationProducerKeysInsideObjectsSurviveStorage(t *testing.T) {
 	// changes nothing else is still a no-op, so they are part of the
 	// content the hash is over.
 	var doc string
-	if err := s.pool.QueryRow(ctx, `SELECT doc FROM knowledge WHERE id = $1`, id).Scan(&doc); err != nil {
+	if err := s.pool.QueryRow(ctx, `SELECT doc FROM object WHERE id = $1`, id).Scan(&doc); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(doc, "license: CC-BY") {
@@ -2768,7 +2770,7 @@ func TestIntegrationFrontmatterFilter(t *testing.T) {
 		if err := s.Create(ctx, &d.Knowledge, false); err != nil {
 			t.Fatal(err)
 		}
-		t.Cleanup(func() { _, _ = s.pool.Exec(ctx, `DELETE FROM knowledge WHERE id = $1`, d.ID) })
+		t.Cleanup(func() { _, _ = s.pool.Exec(ctx, `DELETE FROM object WHERE id = $1`, d.ID) })
 	}
 
 	find := func(fm map[string]string) []string {
@@ -2806,5 +2808,78 @@ func TestIntegrationFrontmatterFilter(t *testing.T) {
 				t.Errorf("fm=%v matched %v, want %v", tc.fm, got, tc.want)
 			}
 		})
+	}
+}
+
+// A row is at the path its concept lives at, and stays there through a
+// move (design doc 0046 §§2.1, 3.1). The path is the key of the bundle,
+// so a write that set the id and left the path behind would put the
+// entry at an address nothing resolves — and the revision ledger, which
+// counts by path now, would start a second history for it.
+func TestIntegrationObjectIsKeyedByBundlePath(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	actor := domain.Actor{Kind: domain.ActorHuman, Name: "t"}
+	id := fmt.Sprintf("it-path-%d/revenue", time.Now().UnixNano())
+	moved := id + "-moved"
+	defer func() {
+		for _, i := range []string{id, moved} {
+			_, _ = s.pool.Exec(ctx, `DELETE FROM object WHERE id = $1`, i)
+			_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_revision WHERE id = $1`, i)
+		}
+	}()
+
+	k := &domain.Knowledge{Type: domain.TypeMetrics, ID: id, Title: "売上",
+		Status: domain.StatusDraft, Body: "受注合計。", CreatedBy: actor, UpdatedBy: actor}
+	if err := s.Create(ctx, k, false); err != nil {
+		t.Fatal(err)
+	}
+	pathOf := func(id string) string {
+		t.Helper()
+		var p string
+		if err := s.pool.QueryRow(ctx, `SELECT path FROM object WHERE id = $1`, id).Scan(&p); err != nil {
+			t.Fatalf("no row at id %s: %v", id, err)
+		}
+		return p
+	}
+	if got, want := pathOf(id), domain.ConceptPath(id); got != want {
+		t.Errorf("created at path %q, want %q", got, want)
+	}
+
+	if _, err := s.Move(ctx, id, moved, actor); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := pathOf(moved), domain.ConceptPath(moved); got != want {
+		t.Errorf("after the move the row is at %q, want %q", got, want)
+	}
+	// One history, carried to the new path rather than restarted there.
+	var revs int
+	if err := s.pool.QueryRow(ctx,
+		`SELECT count(*) FROM knowledge_revision WHERE path = $1`,
+		domain.ConceptPath(moved)).Scan(&revs); err != nil {
+		t.Fatal(err)
+	}
+	if revs != 2 { // create, move
+		t.Errorf("revisions at the new path: got %d, want 2", revs)
+	}
+	var stale int
+	if err := s.pool.QueryRow(ctx,
+		`SELECT count(*) FROM knowledge_revision WHERE path = $1`,
+		domain.ConceptPath(id)).Scan(&stale); err != nil {
+		t.Fatal(err)
+	}
+	if stale != 0 {
+		t.Errorf("%d revisions were left at the old path", stale)
 	}
 }


### PR DESCRIPTION
#267 item 2, first half. 0046 §3.1 folds `knowledge` and `attachment` into one table of bundle objects; this is the half that moves the key, and the next one is where the attachment rows move in.

## What changes

`knowledge` becomes `object`, and its primary key becomes `path` — the address the object lives at. The revision ledger is re-keyed the same way.

That second part is the reason to do this now rather than with the attachment rows: 0046 §3.1 makes a revision an event about an *object*, not about an entry. When creating and deleting a file starts landing in a history, it has to be the history the concept beside it already has, and a ledger keyed by concept id has nowhere to put it.

## What does not change

Nothing on the wire, and nothing in any surface. The concept id is still the address a concept is called by — SPEC §2's "the path with `.md` removed" — so:

- it keeps a unique index of its own, and every read still finds rows by it;
- `verify`, `reject`, `usage` and `move` go on being called with an id, which is what 0046 §3.1 says they should;
- `ON CONFLICT (id)` still expresses "revive the tombstone at this address".

Both keys are written by the same write, through `domain.ConceptPath`, so no caller concatenates a suffix of its own. For a concept the two move together; for a file, next PR, only one of them exists.

## The one thing a rename does not reach

A function body is text, not a reference. `ochakai_attachment_search_text()` — the trigger that touches an entry's row so its lexical haystack is recomputed from the current filenames — names the table inside its body, so the migration recreates it. Without that, every attach and detach fails with `relation "knowledge" does not exist`, which is exactly what the attachment integration tests said before this line existed.

## Tests

- `TestMigrationObjectPathKey` applies 0028 alone to a scratch schema holding the legacy shape: every row lands at its concept's path, both tables end up keyed by path, the id keeps a unique index, and the two revisions of an entry are re-keyed rather than rewritten.
- `TestIntegrationObjectIsKeyedByBundlePath` runs the live path: a create puts the row at `<id>.md`, a move carries it, and the history moves with it instead of restarting at the new address.

`scripts/check --db` is clean.
