### PR TITLE
Make a file an object in the bundle (0046 §§3.3, 3.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,33 @@ last entry.
 
 ### Changed
 
+- **A file is an object in the bundle** (design doc
+  [0046](docs/design/0046-bundle-address-space.md) §§3.3, 3.13). Migration
+  0029 moves every `attachment` row into `object`, at the path the file
+  lives at, and attribution stops being stored: a file belongs to the
+  entry whose `<id>/` namespace it sits directly under, or to the entry
+  whose body points at it.
+
+  A bundle has nowhere to write ownership down, and it needs nowhere —
+  what makes a diagram the metric's diagram is that the metric's document
+  shows it. So the entry's file references are derived from its body on
+  every write, the way its links have been since 0024, and the two halves
+  of the derivation are one predicate every read goes through.
+
+  Nothing on the wire moves: a file is still fetched, attached and
+  detached by `(entry, filename)`, and `okf_path` still reports a file
+  that lives somewhere other than the canonical `<id>/<name>` — derived
+  now from the path rather than stored beside it. Two behaviours follow
+  from the derivation rather than from a column, and both are what the
+  design asks for: moving an entry carries the files under its namespace
+  with it, and attaching a file at a path the entry's body says nothing
+  about stores it at `<id>/<name>` instead of orphaning it.
+
+  Operators: `attachment` and `attachment_embedding` keep their rows —
+  the read paths move in this release and the tables go in a later one,
+  the way 0024 kept `knowledge_revision.snapshot`. A file's bytes do not
+  move; only the row that names them does.
+
 - **The store is keyed by the bundle path** (design doc
   [0046](docs/design/0046-bundle-address-space.md) §§2.1, 3.1). Migration
   0028 renames `knowledge` to `object` and moves its primary key to

--- a/internal/domain/links.go
+++ b/internal/domain/links.go
@@ -260,3 +260,60 @@ func rewriteLine(line string, rewriteTarget func(string) string) string {
 	}
 	return line
 }
+
+// FilesFromBody extracts the bundle paths of the non-concept objects an
+// entry's body points at: the images it embeds and the links it makes to
+// files rather than to other concepts. id is the entry's own id, which
+// relative targets resolve against.
+//
+// This is one half of how a file is attributed to an entry (design doc
+// 0046 §3.3) — the other half is living under the entry's own `<id>/`
+// namespace, which is a question about the path and needs no parsing.
+// Attribution is derived rather than recorded because a bundle carries
+// no place to record it: what says a diagram belongs to a metric is that
+// the metric's document shows it.
+//
+// LinksFromBody is the same walk over the same prose, keeping what this
+// one drops. The two are separate functions rather than one returning
+// both because their results mean different things — an edge between
+// concepts is knowledge, and a file reference is an ingredient — and
+// they are indexed and asked about separately.
+func FilesFromBody(id, body string) []string {
+	var files []string
+	seen := map[string]bool{}
+	for _, line := range proseLines(body) {
+		for _, m := range mdLinkRe.FindAllStringSubmatch(line, -1) {
+			p := resolveFileTarget(id, m[3])
+			if p == "" || seen[p] {
+				continue
+			}
+			seen[p] = true
+			files = append(files, p)
+		}
+	}
+	return files
+}
+
+// resolveFileTarget turns one link target into the bundle path of a file,
+// or "" when the target is not one: an external URL, an anchor, or a
+// markdown document (which addresses a concept, and is LinksFromBody's).
+func resolveFileTarget(id, target string) string {
+	if i := strings.IndexAny(target, "#?"); i >= 0 {
+		target = target[:i]
+	}
+	if target == "" || schemeRe.MatchString(target) || strings.HasSuffix(target, ".md") {
+		return ""
+	}
+	if strings.HasPrefix(target, "/") {
+		return Normalize(strings.Trim(target, "/"))
+	}
+	dir := path.Dir(id)
+	if dir == "." {
+		dir = ""
+	}
+	joined := path.Join(dir, target)
+	if joined == "." || strings.HasPrefix(joined, "..") {
+		return ""
+	}
+	return Normalize(joined)
+}

--- a/internal/domain/links_test.go
+++ b/internal/domain/links_test.go
@@ -223,3 +223,36 @@ func TestLinkDisplayText(t *testing.T) {
 		t.Errorf("DisplayText = %q, want the target's last segment", got)
 	}
 }
+
+// The non-concept half of what a body points at (design doc 0046 §3.3):
+// the images it shows and the files it links, resolved to bundle paths.
+// A markdown target is a concept and belongs to LinksFromBody, and a
+// target outside the bundle belongs to neither.
+func TestFilesFromBody(t *testing.T) {
+	const id = "metrics/revenue"
+	body := "見た目は ![chart](revenue/chart.png)。\n" +
+		"定義は [方針](/policies/revenue.md) に従う。\n" +
+		"元データは [CSV](/seeds/orders.csv)、控えは [同じ](revenue/chart.png)。\n" +
+		"外部は [外](https://example.com/a.png) と [印](mailto:a@example.com)。\n" +
+		"上には [出ない](../../etc/passwd)。\n" +
+		"`![例](code/only.png)` は例示。\n"
+	got := FilesFromBody(id, body)
+	want := []string{"metrics/revenue/chart.png", "seeds/orders.csv"}
+	if len(got) != len(want) {
+		t.Fatalf("files = %q, want %q", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("files[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+	// The two halves partition what the body points at: nothing is in
+	// both, and the concept link is only in the other one.
+	for _, l := range LinksFromBody(id, body) {
+		for _, f := range got {
+			if l.Target == f {
+				t.Errorf("%q is both a concept link and a file", f)
+			}
+		}
+	}
+}

--- a/internal/store/attachment.go
+++ b/internal/store/attachment.go
@@ -6,6 +6,8 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -13,30 +15,94 @@ import (
 	"github.com/na0fu3y/ochakai/internal/domain"
 )
 
-// Attachment persistence (design docs 0008, 0013). Bytes are content-
-// addressed and immutable — attaching the same file twice stores it once,
-// and revisions can name any historical content by hash. The blob row
-// keeps the metadata (media_type, size) and the attachment row maps
-// entry + filename to a blob; the bytes themselves live only in the
-// external blob store (GCS, design doc 0013 — the bytea column of design
-// doc 0008 is gone). Blobs are never deleted: like knowledge revisions,
-// history is retained. Without a configured blob store, attachments are
-// unsupported — writes fail with errNoBlobStore.
+// Files (design docs 0008, 0013, 0046 §§3.3, 3.13). A file is an object
+// in the bundle, at a path, beside the concepts — not a property of an
+// entry. Bytes stay content-addressed and immutable in the external blob
+// store (GCS): attaching the same file twice stores it once, and a
+// revision can name any historical content by hash. Blobs are never
+// deleted, so the bucket only grows. Without a configured blob store,
+// files are unsupported — writes fail with errNoBlobStore.
+//
+// Which entry a file belongs to is derived rather than recorded (0046
+// §3.3): it is the entry whose <id>/ namespace the file sits directly
+// under, or the entry whose body points at it. A bundle has nowhere to
+// write ownership down, and it does not need one — what makes a diagram
+// the metric's diagram is that the metric's document shows it.
+//
+// The two halves are one SQL predicate, attributedTo, which every read
+// here goes through. The name a surface calls a file by is the last
+// segment of its path, and okf_path is that path when it is not the
+// canonical <id>/<name> — both derived on the way out, so the wire is
+// unchanged while the storage underneath it is a bundle.
 
-const attachmentCols = `a.name, b.media_type, b.size, a.sha256, a.okf_path,
-	a.created_by_kind, a.created_by_name, a.created_at`
+// attributedTo is the predicate joining file objects f to the entry row
+// k: living directly under the entry's namespace (no further slash), or
+// named by the entry's own body. Both halves are indexed —
+// object_concept keeps concepts out of the path scan, object_files is
+// the GIN index behind the containment test.
+const attributedTo = `f.id IS NULL AND f.deleted_at IS NULL
+	AND (f.path LIKE k.id || '/%' AND strpos(substr(f.path, length(k.id) + 2), '/') = 0
+	     OR k.files ? f.path)`
 
-// attachmentDests returns the scan destinations matching attachmentCols,
-// in column order — the one place the two lists are paired.
-func attachmentDests(a *domain.Attachment) []any {
-	return []any{&a.Name, &a.MediaType, &a.Size, &a.SHA256, &a.OKFPath,
-		&a.CreatedBy.Kind, &a.CreatedBy.Name, &a.CreatedAt}
+// fileCols is one file object as an attachment is read: the path is what
+// the name and okf_path are derived from, so it is selected rather than
+// either of them.
+const fileCols = `f.path, f.media_type, f.size, f.blob_hash,
+	f.created_by_kind, f.created_by_name, f.created_at`
+
+// asAttachment renders one file object the way the surfaces name it.
+// ownerID decides whether the path is the canonical <id>/<name>, in
+// which case there is no okf_path to report: okf_path means "this file
+// is not where ochakai would have put it" (design doc 0013), and after
+// 0046 §3.3 that is a fact about the path rather than a stored column.
+func asAttachment(ownerID, path, mediaType string, size int64, hash string,
+	by domain.Actor, at time.Time,
+) domain.Attachment {
+	name := path[strings.LastIndex(path, "/")+1:]
+	okfPath := path
+	if path == ownerID+"/"+name {
+		okfPath = ""
+	}
+	return domain.Attachment{
+		Name: name, MediaType: mediaType, Size: size, SHA256: hash,
+		OKFPath: okfPath, CreatedBy: by, CreatedAt: at,
+	}
 }
 
-func scanAttachment(row pgx.CollectableRow) (domain.Attachment, error) {
-	var a domain.Attachment
-	err := row.Scan(attachmentDests(&a)...)
-	return a, err
+// scanFile pairs fileCols with asAttachment, for the reads that know
+// whose file it is.
+func scanFile(ownerID string) func(pgx.CollectableRow) (domain.Attachment, error) {
+	return func(row pgx.CollectableRow) (domain.Attachment, error) {
+		var path, mediaType, hash string
+		var size int64
+		var by domain.Actor
+		var at time.Time
+		if err := row.Scan(&path, &mediaType, &size, &hash, &by.Kind, &by.Name, &at); err != nil {
+			return domain.Attachment{}, err
+		}
+		return asAttachment(ownerID, path, mediaType, size, hash, by, at), nil
+	}
+}
+
+// filePath is where a file with this name, written against this entry,
+// lives: the path it arrived at when the entry's own body points there,
+// and the canonical <id>/<name> otherwise.
+//
+// The body is what decides, because the body is what attributes the file
+// (design doc 0046 §3.3). A caller naming a path the entry says nothing
+// about would otherwise write a file nothing points at — an orphan the
+// moment it lands, and one no export would put back where it was asked
+// for. Under the entry's own namespace it needs no mention: the path
+// says whose it is.
+func filePath(k *domain.Knowledge, name, okfPath string) string {
+	canonical := k.ID + "/" + name
+	if okfPath == "" || okfPath == canonical {
+		return canonical
+	}
+	if slices.Contains(domain.FilesFromBody(k.ID, k.Body), okfPath) {
+		return okfPath
+	}
+	return canonical
 }
 
 // PutAttachment stores data as an attachment of a live entry, replacing
@@ -69,32 +135,40 @@ func (s *Store) PutAttachment(ctx context.Context, id, name, mediaType, okfPath 
 		if err != nil {
 			return err
 		}
+		path := filePath(k, name, okfPath)
 		var count int
-		if err := tx.QueryRow(ctx,
-			`SELECT count(*) FROM attachment WHERE knowledge_id=$1 AND name<>$2`,
-			id, name).Scan(&count); err != nil {
+		if err := tx.QueryRow(ctx, `SELECT count(*)
+			FROM object k JOIN object f ON `+attributedTo+`
+			WHERE k.id=$1 AND f.path<>$2`, id, path).Scan(&count); err != nil {
 			return err
 		}
 		if count >= domain.MaxAttachmentsPerEntry {
 			return fmt.Errorf("invalid attachment: entry already has %d attachments (max %d)", count, domain.MaxAttachmentsPerEntry)
 		}
+		// The blob row is metadata only now — the object row carries the
+		// media type and size a read answers with — but it stays the
+		// registry of which content exists, and a revision names bytes by
+		// hash alone.
 		if _, err := tx.Exec(ctx, `INSERT INTO blob (sha256, media_type, size)
 			VALUES ($1, $2, $3) ON CONFLICT (sha256) DO NOTHING`,
 			att.SHA256, att.MediaType, att.Size); err != nil {
 			return err
 		}
-		if _, err := tx.Exec(ctx, `INSERT INTO attachment
-			(knowledge_id, name, sha256, okf_path, created_by_kind, created_by_name, created_at)
-			VALUES ($1,$2,$3,$4,$5,$6,$7)
-			ON CONFLICT (knowledge_id, name) DO UPDATE SET
-				sha256=EXCLUDED.sha256, okf_path=EXCLUDED.okf_path,
-				created_by_kind=EXCLUDED.created_by_kind, created_by_name=EXCLUDED.created_by_name,
-				created_at=EXCLUDED.created_at`,
-			id, att.Name, att.SHA256, att.OKFPath, actor.Kind, actor.Name, att.CreatedAt); err != nil {
+		if _, err := tx.Exec(ctx, `INSERT INTO object
+			(path, type, title, body, blob_hash, size, media_type,
+			 created_by_kind, created_by_name, updated_by_kind, updated_by_name,
+			 created_at, updated_at, content_changed_at)
+			VALUES ($1,'','','',$2,$3,$4,$5,$6,$5,$6,$7,$7,$7)
+			ON CONFLICT (path) DO UPDATE SET
+				blob_hash=EXCLUDED.blob_hash, size=EXCLUDED.size, media_type=EXCLUDED.media_type,
+				updated_by_kind=EXCLUDED.updated_by_kind, updated_by_name=EXCLUDED.updated_by_name,
+				updated_at=EXCLUDED.updated_at
+			WHERE object.id IS NULL`,
+			path, att.SHA256, att.Size, att.MediaType, actor.Kind, actor.Name, att.CreatedAt); err != nil {
 			return err
 		}
-		// A replaced attachment's vector describes the old bytes; drop it
-		// here and let the service re-embed after commit (design doc 0020).
+		// A replaced file's vector describes the old bytes; drop it here
+		// and let the service re-embed after commit (design doc 0020).
 		if err := execTolerateMissingTable(ctx, tx,
 			`DELETE FROM attachment_embedding WHERE knowledge_id=$1 AND name=$2`, id, att.Name); err != nil {
 			return err
@@ -129,58 +203,63 @@ func (s *Store) GetAttachment(ctx context.Context, id, name string) (*domain.Att
 	return att, data, nil
 }
 
-// ListAttachments returns the metadata (no bytes) of a live entry's
-// attachments, in name order.
+// ListAttachments returns the metadata (no bytes) of the files a live
+// entry is shown by, in name order.
 func (s *Store) ListAttachments(ctx context.Context, id string) ([]domain.Attachment, error) {
-	rows, err := s.pool.Query(ctx, `SELECT `+attachmentCols+`
-		FROM attachment a
-		JOIN blob b ON b.sha256 = a.sha256
-		JOIN object k ON k.id = a.knowledge_id AND k.deleted_at IS NULL
-		WHERE a.knowledge_id=$1 ORDER BY a.name`, id)
+	rows, err := s.pool.Query(ctx, `SELECT `+fileCols+`
+		FROM object k JOIN object f ON `+attributedTo+`
+		WHERE k.id=$1 AND k.deleted_at IS NULL ORDER BY f.path`, id)
 	if err != nil {
 		return nil, err
 	}
-	return pgx.CollectRows(rows, scanAttachment)
+	return pgx.CollectRows(rows, scanFile(id))
 }
 
-// ListAttachmentsBatch returns attachment metadata for a set of entries
-// in one query, keyed by entry id. Entries without attachments have no
-// key. The callers pass entries they already know are live (search
-// hits, backlinks), so no liveness join is needed.
+// ListAttachmentsBatch returns file metadata for a set of entries in one
+// query, keyed by entry id. Entries with no files have no key. The
+// callers pass entries they already know are live (search hits,
+// backlinks), so no liveness join is needed.
 func (s *Store) ListAttachmentsBatch(ctx context.Context, ids []string) (map[string][]domain.Attachment, error) {
-	rows, err := s.pool.Query(ctx, `SELECT a.knowledge_id, `+attachmentCols+`
-		FROM attachment a
-		JOIN blob b ON b.sha256 = a.sha256
-		JOIN unnest($1::text[]) AS want(id) ON a.knowledge_id = want.id
-		ORDER BY a.knowledge_id, a.name`, ids)
+	rows, err := s.pool.Query(ctx, `SELECT k.id, `+fileCols+`
+		FROM object k
+		JOIN unnest($1::text[]) AS want(id) ON k.id = want.id
+		JOIN object f ON `+attributedTo+`
+		ORDER BY k.id, f.path`, ids)
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	out := map[string][]domain.Attachment{}
 	for rows.Next() {
-		var id string
-		var a domain.Attachment
-		if err := rows.Scan(append([]any{&id}, attachmentDests(&a)...)...); err != nil {
+		var owner, path, mediaType, hash string
+		var size int64
+		var by domain.Actor
+		var at time.Time
+		if err := rows.Scan(&owner, &path, &mediaType, &size, &hash, &by.Kind, &by.Name, &at); err != nil {
 			return nil, err
 		}
-		out[id] = append(out[id], a)
+		out[owner] = append(out[owner], asAttachment(owner, path, mediaType, size, hash, by, at))
 	}
 	return out, rows.Err()
 }
 
-// GetAttachmentMeta returns one attachment's metadata without touching
-// the blob store — enough to answer a conditional GET (the ETag is the
+// GetAttachmentMeta returns one file's metadata without touching the
+// blob store — enough to answer a conditional GET (the ETag is the
 // content hash) before deciding whether the bytes are needed.
+//
+// The name is the last segment of a path, so a file the entry shows from
+// elsewhere in the bundle answers to its filename here, which is the
+// name every surface has always called it by.
 func (s *Store) GetAttachmentMeta(ctx context.Context, id, name string) (*domain.Attachment, error) {
-	rows, err := s.pool.Query(ctx, `SELECT `+attachmentCols+`
-		FROM attachment a
-		JOIN blob b ON b.sha256 = a.sha256
-		JOIN object k ON k.id = a.knowledge_id AND k.deleted_at IS NULL
-		WHERE a.knowledge_id=$1 AND a.name=$2`, id, name)
+	rows, err := s.pool.Query(ctx, `SELECT `+fileCols+`
+		FROM object k JOIN object f ON `+attributedTo+`
+		WHERE k.id=$1 AND k.deleted_at IS NULL
+		  AND substr(f.path, length(f.path) - length($2)) = '/' || $2
+		ORDER BY f.path LIMIT 1`, id, name)
 	if err != nil {
 		return nil, err
 	}
-	att, err := pgx.CollectExactlyOneRow(rows, scanAttachment)
+	att, err := pgx.CollectExactlyOneRow(rows, scanFile(id))
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, ErrNotFound
 	}
@@ -200,8 +279,12 @@ func (s *Store) DeleteAttachment(ctx context.Context, id, name string, actor dom
 		if err != nil {
 			return err
 		}
-		tag, err := tx.Exec(ctx,
-			`DELETE FROM attachment WHERE knowledge_id=$1 AND name=$2`, id, name)
+		att, err := s.GetAttachmentMeta(ctx, id, name)
+		if err != nil {
+			return err
+		}
+		path := filePath(k, att.Name, att.OKFPath)
+		tag, err := tx.Exec(ctx, `DELETE FROM object WHERE path=$1 AND id IS NULL`, path)
 		if err != nil {
 			return err
 		}
@@ -209,7 +292,7 @@ func (s *Store) DeleteAttachment(ctx context.Context, id, name string, actor dom
 			return ErrNotFound
 		}
 		if err := execTolerateMissingTable(ctx, tx,
-			`DELETE FROM attachment_embedding WHERE knowledge_id=$1 AND name=$2`, id, name); err != nil {
+			`DELETE FROM attachment_embedding WHERE knowledge_id=$1 AND name=$2`, id, att.Name); err != nil {
 			return err
 		}
 		return s.touchAndRevise(ctx, tx, k, "detach", actor)
@@ -263,14 +346,14 @@ func (s *Store) touchAndRevise(ctx context.Context, tx pgx.Tx, k *domain.Knowled
 	return s.addRevision(ctx, tx, k, change, actor)
 }
 
-// listAttachmentsTx reads the attachment list inside the writing
-// transaction, so the revision snapshot sees the change it records.
+// listAttachmentsTx reads the file list inside the writing transaction,
+// so the revision snapshot sees the change it records.
 func listAttachmentsTx(ctx context.Context, tx pgx.Tx, id string) ([]domain.Attachment, error) {
-	rows, err := tx.Query(ctx, `SELECT `+attachmentCols+`
-		FROM attachment a JOIN blob b ON b.sha256 = a.sha256
-		WHERE a.knowledge_id=$1 ORDER BY a.name`, id)
+	rows, err := tx.Query(ctx, `SELECT `+fileCols+`
+		FROM object k JOIN object f ON `+attributedTo+`
+		WHERE k.id=$1 ORDER BY f.path`, id)
 	if err != nil {
 		return nil, err
 	}
-	return pgx.CollectRows(rows, scanAttachment)
+	return pgx.CollectRows(rows, scanFile(id))
 }

--- a/internal/store/browse.go
+++ b/internal/store/browse.go
@@ -44,7 +44,10 @@ type BrowseEntry struct {
 // a status (design doc 0043 §3.3), so the id is qualified — the ledger
 // has an id column of its own, and a bare one inside the subquery would
 // bind to it and match everything.
-const browseNotRejected = `deleted_at IS NULL
+// id IS NOT NULL keeps files out: browsing lists the concepts in a
+// directory, and a file in the same directory is listed as a file
+// (design doc 0046 §3.7), not as an entry with no title.
+const browseNotRejected = `deleted_at IS NULL AND id IS NOT NULL
 	AND NOT EXISTS (SELECT 1 FROM knowledge_rejection r WHERE r.id = object.id)`
 
 // MaxBrowseEntries bounds one directory listing. A directory this wide

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -65,7 +66,8 @@ func (e *ExportSnapshot) Close(ctx context.Context) {
 // does not carry them.
 func (e *ExportSnapshot) IndexRows(ctx context.Context) ([]domain.Knowledge, error) {
 	rows, err := e.tx.Query(ctx,
-		`SELECT type, id, title, description FROM object WHERE deleted_at IS NULL ORDER BY id`)
+		`SELECT type, id, title, description FROM object
+		  WHERE deleted_at IS NULL AND id IS NOT NULL ORDER BY id`)
 	if err != nil {
 		return nil, err
 	}
@@ -103,19 +105,24 @@ func (e *ExportSnapshot) ListByIDs(ctx context.Context, ids []string) ([]domain.
 // makes that failure visible as a missing file rather than as an archive
 // quietly disagreeing with its own index.
 func (e *ExportSnapshot) AttachmentMeta(ctx context.Context) ([]ExportAttachment, error) {
-	rows, err := e.tx.Query(ctx, `SELECT a.knowledge_id, `+attachmentCols+`
-		FROM attachment a
-		JOIN blob b ON b.sha256 = a.sha256
-		JOIN object k ON k.id = a.knowledge_id AND k.deleted_at IS NULL
-		ORDER BY a.knowledge_id, a.name`)
+	rows, err := e.tx.Query(ctx, `SELECT k.id, `+fileCols+`
+		FROM object k JOIN object f ON `+attributedTo+`
+		WHERE k.id IS NOT NULL AND k.deleted_at IS NULL
+		ORDER BY k.id, f.path`)
 	if err != nil {
 		return nil, err
 	}
 	atts, err := pgx.CollectRows(rows, func(row pgx.CollectableRow) (ExportAttachment, error) {
 		var a ExportAttachment
-		err := row.Scan(&a.ID, &a.Att.Name, &a.Att.MediaType, &a.Att.Size, &a.Att.SHA256, &a.Att.OKFPath,
-			&a.Att.CreatedBy.Kind, &a.Att.CreatedBy.Name, &a.Att.CreatedAt)
-		return a, err
+		var path, mediaType, hash string
+		var size int64
+		var by domain.Actor
+		var at time.Time
+		if err := row.Scan(&a.ID, &path, &mediaType, &size, &hash, &by.Kind, &by.Name, &at); err != nil {
+			return a, err
+		}
+		a.Att = asAttachment(a.ID, path, mediaType, size, hash, by, at)
+		return a, nil
 	})
 	if err != nil {
 		return nil, err

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -134,7 +134,10 @@ func (s *Store) backfillDocuments(ctx context.Context) error {
 func (s *Store) backfillEntryDocuments(ctx context.Context) error {
 	for {
 		rows, err := s.pool.Query(ctx,
-			`SELECT `+knowledgeSelect+` FROM object WHERE doc = '' ORDER BY id LIMIT $1`,
+			// id IS NOT NULL: a file object has no document to compose
+			// and no id to scan into (design doc 0046 §3.13).
+			`SELECT `+knowledgeSelect+` FROM object
+			 WHERE doc = '' AND id IS NOT NULL ORDER BY id LIMIT $1`,
 			backfillBatch)
 		if err != nil {
 			return err

--- a/internal/store/migrations/0029_files_become_objects.sql
+++ b/internal/store/migrations/0029_files_become_objects.sql
@@ -1,0 +1,147 @@
+-- A file is an object in the bundle, not a property of an entry
+-- (design doc 0046 §§2.1, 3.3, 3.13).
+--
+-- An attachment row was a mapping from (entry, filename) to a blob: the
+-- file existed only as something an entry had. That is not what a bundle
+-- is. A bundle is a directory tree, a diagram in it is a file at a path,
+-- and what makes it "the metric's diagram" is that the metric's document
+-- shows it. So the rows move into the object table, at the path each
+-- file lives at, and attribution becomes derived.
+--
+-- Derived from two things, which is what the columns added here are for:
+-- a file directly under the entry's own <id>/ namespace belongs to it
+-- (that is a question about the path alone), and so does a file the
+-- entry's body points at (the files column, maintained beside links the
+-- way links are maintained beside the body — design doc 0024).
+--
+-- The seeding of files below is exact rather than a re-parse: the
+-- attachment table records precisely which entry each file belonged to,
+-- and that mapping is the answer this column would otherwise have to
+-- rediscover. A file at the canonical <id>/<name> needs no entry there —
+-- the path already says it.
+--
+-- attachment and attachment_embedding keep their rows. The read paths
+-- move to object in this release and the tables go in a later one, the
+-- way 0024 kept knowledge_revision.snapshot until the history had been
+-- read out of it: dropping the only copy before anything has been
+-- verified against it costs more than a release of untidiness.
+
+ALTER TABLE object ADD COLUMN IF NOT EXISTS blob_hash  text   NOT NULL DEFAULT '';
+ALTER TABLE object ADD COLUMN IF NOT EXISTS size       bigint NOT NULL DEFAULT 0;
+ALTER TABLE object ADD COLUMN IF NOT EXISTS media_type text   NOT NULL DEFAULT '';
+ALTER TABLE object ADD COLUMN IF NOT EXISTS files      jsonb  NOT NULL DEFAULT '[]';
+
+-- A file has no concept id: an id is the address of a concept, and the
+-- path with ".md" removed is not one for a .png. NULL rather than '' so
+-- the unique index on id keeps meaning what it means — Postgres lets
+-- NULLs repeat and would refuse a second empty string.
+ALTER TABLE object ALTER COLUMN id DROP NOT NULL;
+
+-- Where each file lands. Its own path when it has one and nothing is
+-- there already, and the canonical <id>/<name> otherwise: an imported
+-- bundle's file goes back where it came from (design doc 0046 §3.2, so
+-- the bundle round-trips), while a collision moves the loser rather than
+-- dropping it (§3.13 — losing one of two files is the worse answer).
+CREATE TEMP TABLE object_from_attachment ON COMMIT DROP AS
+SELECT a.knowledge_id, a.name, a.sha256, b.media_type, b.size,
+       a.created_by_kind, a.created_by_name, a.created_at,
+       CASE
+           WHEN a.okf_path <> ''
+            AND NOT EXISTS (SELECT 1 FROM object o WHERE o.path = a.okf_path)
+            AND (SELECT count(*) FROM attachment x WHERE x.okf_path = a.okf_path) = 1
+           THEN a.okf_path
+           ELSE a.knowledge_id || '/' || a.name
+       END AS path
+  FROM attachment a
+  JOIN blob b ON b.sha256 = a.sha256;
+
+-- Attribution first, while the object table still says what was there
+-- before this migration ran: every file whose path is not the entry's
+-- own <id>/<name> is named by the entry it belonged to.
+UPDATE object o SET files = COALESCE((
+    SELECT jsonb_agg(DISTINCT m.path)
+      FROM object_from_attachment m
+     WHERE m.knowledge_id = o.id
+       AND m.path <> m.knowledge_id || '/' || m.name
+), '[]'::jsonb)
+WHERE EXISTS (SELECT 1 FROM object_from_attachment m WHERE m.knowledge_id = o.id);
+
+INSERT INTO object (path, type, title, body, blob_hash, size, media_type,
+                    created_by_kind, created_by_name, updated_by_kind, updated_by_name,
+                    created_at, updated_at, content_changed_at)
+SELECT m.path, '', '', '', m.sha256, m.size, m.media_type,
+       m.created_by_kind, m.created_by_name, m.created_by_kind, m.created_by_name,
+       m.created_at, m.created_at, m.created_at
+  FROM object_from_attachment m
+ON CONFLICT (path) DO NOTHING;
+
+-- Everything that reads entries reads them by their concept id, and a
+-- file has none: the partial index keeps those reads on an index that
+-- holds only concepts, so a bundle full of files costs them nothing.
+CREATE INDEX IF NOT EXISTS object_concept ON object (updated_at DESC) WHERE id IS NOT NULL;
+
+-- The files an entry points at, asked from the other end: "which entry
+-- shows this file?" is the containment query the derivation needs.
+CREATE INDEX IF NOT EXISTS object_files ON object USING gin (files);
+
+-- The lexical haystack follows the files (design doc 0020: a filename is
+-- a name the entry can be found by). Two things change with them.
+--
+-- A file row has no id, and 0016's trigger would compute NULL for it and
+-- fail the NOT NULL — a file is found by its path, not by a haystack, so
+-- it gets an empty one and returns early.
+CREATE OR REPLACE FUNCTION ochakai_knowledge_search_text() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+    IF NEW.id IS NULL THEN
+        NEW.search_text := '';
+        RETURN NEW;
+    END IF;
+    NEW.search_text := ochakai_search_text(NEW.id, NEW.title, NEW.description, NEW.tags, NEW.body)
+        || ' ' || COALESCE((SELECT string_agg(regexp_replace(x, '^.*/', ''), ' ')
+                              FROM jsonb_array_elements_text(NEW.files) x), '');
+    RETURN NEW;
+END $$;
+
+-- And the names come from the objects under the entry's namespace rather
+-- than from the attachment table.
+CREATE OR REPLACE FUNCTION ochakai_search_text(
+    p_id text, p_title text, p_description text, p_tags text[], p_body text
+) RETURNS text LANGUAGE sql STABLE AS $$
+    SELECT p_id || ' ' || p_title || ' ' || p_description || ' '
+        || array_to_string(p_tags, ' ') || ' ' || p_body || ' '
+        || COALESCE((SELECT string_agg(regexp_replace(f.path, '^.*/', ''), ' ')
+                       FROM object f
+                      WHERE f.id IS NULL AND f.deleted_at IS NULL
+                        AND f.path LIKE p_id || '/%'
+                        AND strpos(substr(f.path, length(p_id) + 2), '/') = 0), '')
+$$;
+
+-- Writing a file refreshes the haystack of whoever it is attributed to:
+-- the entry whose namespace it sits in, and any entry whose body names
+-- it. The UPDATE fires the row trigger above, which recomputes from the
+-- files that exist at that moment, so nothing is assigned here.
+CREATE OR REPLACE FUNCTION ochakai_file_search_text() RETURNS trigger
+LANGUAGE plpgsql AS $$
+DECLARE
+    p text := COALESCE(NEW.path, OLD.path);
+BEGIN
+    UPDATE object SET search_text = search_text
+     WHERE id IS NOT NULL AND (id = regexp_replace(p, '/[^/]*$', '') OR files ? p);
+    RETURN NULL;
+END $$;
+
+-- Two triggers rather than one: a DELETE trigger's WHEN condition may
+-- not mention NEW, so the condition is written against the row each
+-- event actually has.
+DROP TRIGGER IF EXISTS object_file_search_text ON object;
+DROP TRIGGER IF EXISTS object_file_written ON object;
+DROP TRIGGER IF EXISTS object_file_removed ON object;
+CREATE TRIGGER object_file_written AFTER INSERT OR UPDATE ON object
+    FOR EACH ROW WHEN (NEW.id IS NULL) EXECUTE FUNCTION ochakai_file_search_text();
+CREATE TRIGGER object_file_removed AFTER DELETE ON object
+    FOR EACH ROW WHEN (OLD.id IS NULL) EXECUTE FUNCTION ochakai_file_search_text();
+
+-- The old attachment trigger has nothing left to fire on: nothing writes
+-- the attachment table now. It goes with the table, a release from now.
+UPDATE object SET search_text = '' WHERE id IS NULL;

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -549,6 +549,24 @@ func (s *Store) getOneTx(ctx context.Context, tx pgx.Tx, id string, deleted bool
 }
 
 // querier is the part of pgxpool.Pool and pgx.Tx that reads.
+
+// bodyFiles is the paths of the non-concept objects an entry's body
+// points at, as the column stores them (design doc 0046 §3.3). It is
+// derived on every write for the same reason links are (design doc
+// 0024): the body is the record, and a list beside it that a writer
+// could edit separately would be a second one to keep true.
+func bodyFiles(k *domain.Knowledge) []byte {
+	files := domain.FilesFromBody(k.ID, k.Body)
+	if files == nil {
+		files = []string{}
+	}
+	b, err := json.Marshal(files)
+	if err != nil { // a []string never fails to marshal
+		return []byte("[]")
+	}
+	return b
+}
+
 type querier interface {
 	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
 }
@@ -674,10 +692,10 @@ func (s *Store) Create(ctx context.Context, k *domain.Knowledge, keepCuratedTomb
 		// ON CONFLICT still names the id: reviving a tombstone is about the
 		// entry at that address, and for a concept the two keys move
 		// together.
-		args = append(args, domain.ConceptPath(k.ID))
-		tag, err := tx.Exec(ctx, `INSERT INTO object (`+knowledgeCols+`, path)
-			VALUES (`+knowledgeParams+`, $`+strconv.Itoa(len(args))+`)
-			ON CONFLICT (id) DO UPDATE SET `+knowledgeExcluded+`, deleted_at=NULL
+		args = append(args, domain.ConceptPath(k.ID), bodyFiles(k))
+		tag, err := tx.Exec(ctx, `INSERT INTO object (`+knowledgeCols+`, path, files)
+			VALUES (`+knowledgeParams+`, $`+strconv.Itoa(len(args)-1)+`, $`+strconv.Itoa(len(args))+`)
+			ON CONFLICT (id) DO UPDATE SET `+knowledgeExcluded+`, files=EXCLUDED.files, deleted_at=NULL
 			WHERE object.deleted_at IS NOT NULL`+revive,
 			args...)
 		if err != nil {
@@ -751,7 +769,7 @@ func (s *Store) Update(ctx context.Context, k *domain.Knowledge, actor domain.Ac
 		args := []any{k.ID, k.Type, k.Title, k.Description, k.Resource, k.Tags, k.Status, k.StatusNote, staleAfter,
 			j.sources, j.usageWindow, k.Runtime, j.parameters, k.Computation, j.executor, j.attester,
 			k.UpdatedBy.Kind, k.UpdatedBy.Name, k.UpdatedBy.Via,
-			j.links, j.attrs, k.Body, k.UpdatedAt, k.ContentChangedAt, doc, fm, hash}
+			j.links, j.attrs, k.Body, k.UpdatedAt, k.ContentChangedAt, doc, fm, hash, bodyFiles(k)}
 		if ifMatch != nil {
 			args = append(args, *ifMatch)
 			cond = fmt.Sprintf(" AND content_hash=$%d", len(args))
@@ -761,7 +779,7 @@ func (s *Store) Update(ctx context.Context, k *domain.Knowledge, actor domain.Ac
 			sources=$10, usage_window=$11, runtime=$12, parameters=$13, computation=$14, executor=$15, attester=$16,
 			updated_by_kind=$17, updated_by_name=$18, updated_by_via=$19,
 			links=$20, attrs=$21, body=$22, updated_at=$23, content_changed_at=$24,
-			doc=$25, frontmatter=$26, content_hash=$27
+			doc=$25, frontmatter=$26, content_hash=$27, files=$28
 			WHERE id=$1 AND deleted_at IS NULL`+cond, args...)
 		if err != nil {
 			return err
@@ -986,6 +1004,7 @@ func (s *Store) Purge(ctx context.Context, id string, actor domain.Actor) error 
 			return err
 		}
 		for _, q := range []string{
+			`DELETE FROM object f WHERE f.id IS NULL AND f.path LIKE $1 || '/%'`,
 			`DELETE FROM attachment WHERE knowledge_id=$1`,
 			`DELETE FROM knowledge_usage WHERE knowledge_id=$1`,
 			`DELETE FROM knowledge_event WHERE knowledge_id=$1`,
@@ -1083,6 +1102,21 @@ func (s *Store) Move(ctx context.Context, oldID, newID string, actor domain.Acto
 			return ErrNotFound
 		}
 		for _, q := range []string{
+			// The entry's namespace moves with it (design doc 0046 §3.3):
+			// the address is part of what a file is, and leaving the
+			// files behind would leave them under a directory whose
+			// concept is gone. Only the files — a concept under there has
+			// an id, an address and a history of its own, and moves when
+			// somebody moves it.
+			`UPDATE object SET path = $2 || substr(path, length($1) + 1)
+			 WHERE id IS NULL AND path LIKE $1 || '/%'`,
+			// The naming follows the files it names.
+			`UPDATE object SET files = (
+			     SELECT COALESCE(jsonb_agg(
+			         CASE WHEN x LIKE $1 || '/%' THEN $2 || substr(x, length($1) + 1) ELSE x END), '[]'::jsonb)
+			       FROM jsonb_array_elements_text(files) x)
+			 WHERE id IS NOT NULL
+			   AND EXISTS (SELECT 1 FROM jsonb_array_elements_text(files) x WHERE x LIKE $1 || '/%')`,
 			`UPDATE knowledge_revision SET id=$2, path=$2 || '.md' WHERE id=$1`,
 			`UPDATE knowledge_verification SET id=$2 WHERE id=$1`,
 			`UPDATE knowledge_rejection SET id=$2 WHERE id=$1`,
@@ -1687,7 +1721,12 @@ func scanHit(row pgx.CollectableRow) (domain.SearchHit, error) {
 // answers, but remains queryable on request so agents can check whether a
 // proposal was already rejected.
 func (f Filter) buildWhere(prefix string) (string, []any) {
-	conds := []string{prefix + "deleted_at IS NULL"}
+	// A file is an object in the same table now (design doc 0046 §3.13),
+	// and it is not an entry: no type, no title, nothing to rank. The id
+	// is what a concept has and a file has not, so every scan that
+	// returns entries says so here — once, where every filtered read goes
+	// through, rather than in each of them.
+	conds := []string{prefix + "deleted_at IS NULL", prefix + "id IS NOT NULL"}
 	var args []any
 	if len(f.Types) > 0 {
 		// Types match case-insensitively (design doc 0023 §3.3): the stored
@@ -2034,7 +2073,7 @@ func (s *Store) ListUnembedded(ctx context.Context, model, after string, limit i
 	rows, err := s.pool.Query(ctx,
 		`SELECT k.id FROM object k
 		 LEFT JOIN knowledge_embedding e ON e.id = k.id AND e.model = $1
-		 WHERE k.deleted_at IS NULL AND e.id IS NULL AND ($2 = '' OR k.id > $2)
+		 WHERE k.deleted_at IS NULL AND k.id IS NOT NULL AND e.id IS NULL AND ($2 = '' OR k.id > $2)
 		 ORDER BY k.id LIMIT $3`, model, after, limit)
 	if err != nil {
 		return nil, err
@@ -2055,13 +2094,15 @@ type UnembeddedAttachment struct {
 // cursor is the (knowledge_id, name) pair, for the same reason.
 func (s *Store) ListUnembeddedAttachments(ctx context.Context, model, afterID, afterName string, limit int) ([]UnembeddedAttachment, error) {
 	rows, err := s.pool.Query(ctx,
-		`SELECT a.knowledge_id, a.name FROM attachment a
-		 JOIN object k ON k.id = a.knowledge_id AND k.deleted_at IS NULL
-		 LEFT JOIN attachment_embedding e
-		   ON e.knowledge_id = a.knowledge_id AND e.name = a.name AND e.model = $1
-		 WHERE e.knowledge_id IS NULL
-		   AND ($2 = '' OR (a.knowledge_id, a.name) > ($2, $3))
-		 ORDER BY a.knowledge_id, a.name LIMIT $4`, model, afterID, afterName, limit)
+		`SELECT k.id, split_part(f.path, '/', array_length(string_to_array(f.path, '/'), 1))
+		   FROM object k JOIN object f ON `+attributedTo+`
+		   LEFT JOIN attachment_embedding e
+		     ON e.knowledge_id = k.id
+		    AND e.name = split_part(f.path, '/', array_length(string_to_array(f.path, '/'), 1))
+		    AND e.model = $1
+		  WHERE k.id IS NOT NULL AND k.deleted_at IS NULL AND e.knowledge_id IS NULL
+		    AND ($2 = '' OR (k.id, f.path) > ($2, $3))
+		  ORDER BY k.id, f.path LIMIT $4`, model, afterID, afterName, limit)
 	if err != nil {
 		if isUndefinedTable(err) {
 			return nil, nil // embedding tables appear with semantic search
@@ -2083,11 +2124,13 @@ func (s *Store) ListUnembeddedAttachments(ctx context.Context, model, afterID, a
 func (s *Store) CountUnembeddedAttachments(ctx context.Context, model string) (int, error) {
 	var n int
 	err := s.pool.QueryRow(ctx,
-		`SELECT count(*) FROM attachment a
-		 JOIN object k ON k.id = a.knowledge_id AND k.deleted_at IS NULL
-		 LEFT JOIN attachment_embedding e
-		   ON e.knowledge_id = a.knowledge_id AND e.name = a.name AND e.model = $1
-		 WHERE e.knowledge_id IS NULL`, model).Scan(&n)
+		`SELECT count(*)
+		   FROM object k JOIN object f ON `+attributedTo+`
+		   LEFT JOIN attachment_embedding e
+		     ON e.knowledge_id = k.id
+		    AND e.name = split_part(f.path, '/', array_length(string_to_array(f.path, '/'), 1))
+		    AND e.model = $1
+		  WHERE k.id IS NOT NULL AND k.deleted_at IS NULL AND e.knowledge_id IS NULL`, model).Scan(&n)
 	if err != nil && isUndefinedTable(err) {
 		return 0, nil
 	}
@@ -2102,7 +2145,7 @@ func (s *Store) CountUnembedded(ctx context.Context, model string) (int, error) 
 	err := s.pool.QueryRow(ctx,
 		`SELECT count(*) FROM object k
 		 LEFT JOIN knowledge_embedding e ON e.id = k.id AND e.model = $1
-		 WHERE k.deleted_at IS NULL AND e.id IS NULL`, model).Scan(&n)
+		 WHERE k.deleted_at IS NULL AND k.id IS NOT NULL AND e.id IS NULL`, model).Scan(&n)
 	return n, err
 }
 

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -2902,3 +2902,116 @@ func TestIntegrationObjectIsKeyedByBundlePath(t *testing.T) {
 		t.Errorf("%d revisions were left at the old path", stale)
 	}
 }
+
+// A file is an object in the bundle, and which entry it belongs to is
+// derived (design doc 0046 §§3.3, 3.13): from the path when it sits
+// under the entry's own namespace, and from the body when the entry
+// points at it. Both halves, and the two things that must not happen —
+// a file showing up where entries are listed, and a file outliving the
+// entry whose namespace it was in.
+func TestIntegrationFilesAreObjectsAttributedByPathOrBody(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	s.UseBlobStore(newFakeBlobStore())
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	actor := domain.Actor{Kind: domain.ActorHuman, Name: "t"}
+	base := fmt.Sprintf("it-files-%d", time.Now().UnixNano())
+	id := base + "/revenue"
+	defer func() {
+		_, _ = s.pool.Exec(ctx, `DELETE FROM object WHERE path LIKE $1 || '%'`, base)
+		_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_revision WHERE path LIKE $1 || '%'`, base)
+	}()
+
+	// The body shows one file from the entry's own namespace and links
+	// one that lives elsewhere in the bundle.
+	body := fmt.Sprintf("![chart](revenue/chart.png)\n\n元データは [CSV](/%s/seeds/orders.csv)。\n", base)
+	k := &domain.Knowledge{Type: domain.TypeMetrics, ID: id, Title: "売上",
+		Status: domain.StatusDraft, Body: body, CreatedBy: actor, UpdatedBy: actor}
+	if err := s.Create(ctx, k, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.PutAttachment(ctx, id, "chart.png", "image/png", "", []byte("png"), actor); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.PutAttachment(ctx, id, "orders.csv", "text/plain",
+		base+"/seeds/orders.csv", []byte("a,b\n"), actor); err != nil {
+		t.Fatal(err)
+	}
+
+	atts, err := s.ListAttachments(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(atts) != 2 {
+		t.Fatalf("attributed files = %+v, want the one under the namespace and the one the body links", atts)
+	}
+	// The one under the namespace needs no naming; the one elsewhere
+	// reports where it lives, which is what an export puts it back as.
+	byName := map[string]domain.Attachment{}
+	for _, a := range atts {
+		byName[a.Name] = a
+	}
+	if got := byName["chart.png"].OKFPath; got != "" {
+		t.Errorf("a file at the canonical path reports okf_path %q", got)
+	}
+	if got, want := byName["orders.csv"].OKFPath, base+"/seeds/orders.csv"; got != want {
+		t.Errorf("okf_path = %q, want %q", got, want)
+	}
+	// It is stored where the body says, not where the entry is.
+	var n int
+	if err := s.pool.QueryRow(ctx,
+		`SELECT count(*) FROM object WHERE path = $1 AND id IS NULL`, base+"/seeds/orders.csv").Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Errorf("the linked file is not at the path the body names")
+	}
+
+	// A file is not an entry. Nothing that lists or searches entries may
+	// return one — the failure this guards against is silent.
+	hits, err := s.SearchLexical(ctx, "chart", Filter{Prefixes: []string{base}}, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, h := range hits {
+		if h.ID != id {
+			t.Errorf("search returned a non-entry: %q", h.ID)
+		}
+	}
+	dirs, entries, _, err := s.Browse(ctx, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.ID != id {
+			t.Errorf("browse listed a non-entry: %q", e.ID)
+		}
+	}
+	for _, d := range dirs {
+		if d.Name == "seeds" && d.Count != 0 {
+			t.Errorf("a directory of files counts as %d entries", d.Count)
+		}
+	}
+
+	// Detaching takes the object with it, and the entry stops naming it.
+	if err := s.DeleteAttachment(ctx, id, "orders.csv", actor); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.pool.QueryRow(ctx,
+		`SELECT count(*) FROM object WHERE path = $1`, base+"/seeds/orders.csv").Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Errorf("the file object outlived the detach")
+	}
+}


### PR DESCRIPTION
#267 item 2, second half — and, because the two cannot be cleanly separated, the storage half of §3.3.

An attachment row was a mapping from `(entry, filename)` to a blob: the file existed only as something an entry *had*. A bundle does not work that way. A bundle is a directory tree, a diagram in it is a file at a path, and what makes it the metric's diagram is that the metric's document shows it.

## Why §3.3's derivation had to come along

I tried to land this as "the rows move, attribution stays as it is". It cannot be done without inventing an `owner_id` column that the very next PR deletes: the `links` column holds concept links only (`resolveTarget` returns "" for anything that is not a `.md`), so there is nothing in the schema that could answer "which entry shows this file?" once `attachment.knowledge_id` is gone.

So the derivation lands here, and it is permanent:

- **`<id>/` namespace** — a file directly under the entry's own namespace belongs to it. A question about the path alone.
- **`files`** — the non-concept paths the entry's body points at, derived on every write beside `links`, for the reason 0024 gives: the body is the record, and a list a writer could edit separately would be a second one to keep true.

Both halves are one predicate, `attributedTo`, that every read here goes through. `domain.FilesFromBody` is `LinksFromBody`'s counterpart over the same prose, keeping what it drops.

## What does not change

Nothing on the wire. A file is still fetched, attached and detached by `(entry, filename)`; `okf_path` still reports a file that lives somewhere other than the canonical `<id>/<name>`, read off the path now instead of stored beside it.

Two behaviours now follow from the derivation rather than from a column, and both are what 0046 asks for:

- **Moving an entry carries the files under its namespace** (§3.3), and only the files — a concept under there has an id, an address and a history of its own, which is [the rule settled in #276](https://github.com/na0fu3y/ochakai/issues/276#issuecomment-5106474349).
- **Attaching a file at a path the entry's body never mentions stores it at `<id>/<name>`** instead of orphaning it somewhere nothing points at.

## The delicate part

A file row lives in the table entries are read from, so a scan that forgets to exclude it starts returning files as entries — and fails silently, which is the worst way to fail. Every such scan now says `id IS NOT NULL`:

- `Filter.buildWhere`, which every filtered read (search, list, all three feeds) goes through — one place, not nine;
- `browse`, which lists a directory's concepts;
- `export`, which walks every live entry;
- the two embedding backlogs.

A file has no id because an id is a concept's address, and the path with `.md` removed is not one for a `.png`. NULL rather than `''` so the unique index on `id` keeps meaning what it means.

The lexical haystack follows the files (0020: a filename is a name the entry can be found by): a file row gets an empty one, an entry's gains the names of the files attributed to it, and writing a file refreshes the haystack of whoever it belongs to.

## Migration

One transaction: three columns and `files`, `id` made nullable, every `attachment` row inserted at its path, and `files` seeded from the attachment table itself — exact, rather than a re-parse, since that table records precisely which entry each file belonged to. A file whose `okf_path` collides moves to `<id>/<name>` rather than being dropped (§3.13: losing one of two files is the worse answer).

`attachment` and `attachment_embedding` keep their rows. The read paths move in this release and the tables go in a later one, the way 0024 kept `knowledge_revision.snapshot` until the history had been read out of it.

## Tests

- `TestIntegrationFilesAreObjectsAttributedByPathOrBody` — an entry with one file under its namespace and one linked from elsewhere: both are attributed, the linked one is stored where the body says and reports that as its `okf_path`, the canonical one reports none. Then the silent failure, asserted directly: neither search nor browse returns a file where entries go, and a directory of files counts zero entries. Then detach removes the object.
- `TestFilesFromBody` — the two halves partition what a body points at: nothing is both a concept link and a file.
- The existing move and search-haystack integration tests cover the derivation's effect on a move; they pass unchanged, which is the point.

`scripts/check --db` is clean.
