### PR TITLE
Receive what the bundle carries (0046 §3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,33 @@ last entry.
 
 ### Security
 
+- **A bundle carries what it carries** (design doc
+  [0046](docs/design/0046-bundle-address-space.md) §3.2). The write path
+  refuses no media type: the allowlist of png, jpeg, webp, pdf and plain
+  text is gone, and so is the cap of 20 files per entry. A file is still
+  sniffed rather than trusted, and still bounded at 5 MiB.
+
+  The allowlist was reasoned from a knowledge store that should hold only
+  what an agent can read (design doc
+  [0013](docs/design/0013-attachment-files-gcs-only.md)). What it missed
+  is that what ochakai holds is a *bundle*: refusing a producer's zip of
+  seed data, a `.parquet`, or an SVG diagram does not keep them out of
+  the knowledge base — it keeps them out of the copy ochakai hands back.
+  The cap was the same mistake in miniature; a limit on how many objects
+  a directory may hold is a limit on what a bundle may be.
+
+  What the allowlist protected against is protected against on delivery
+  instead, where it belongs, and has been since the entry below: an SVG
+  or an HTML file is served as a download under
+  `Content-Security-Policy: sandbox`, with no origin to run script in.
+  "Receive it, do not render it" is one rule with two halves, and both
+  halves are now true.
+
+  A file the embedding model does not take — an archive, a font — is
+  stored, served and exported like any other and found by its name. It is
+  no longer offered to the embedder, so a bundle full of them logs
+  nothing.
+
 - **A file is served the way its media type deserves** (design doc
   [0046](docs/design/0046-bundle-address-space.md) §3.2). An image, a PDF
   or plain text is served `inline` as before; anything else now goes out

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1779,11 +1779,13 @@ paths:
       operationId: putAttachment
       summary: Attach a file to a knowledge entry
       description: >
-        Stores the raw request body as an attachment, replacing any
-        attachment of the same name (kept as a revision). The media type
-        is sniffed from the bytes — png, jpeg, webp, pdf, and plain
-        text are accepted (never text/html or image/svg+xml: they can
-        carry scripts), at most 5 MiB and 20 attachments per entry.
+        Stores the raw request body as a file of the bundle, replacing
+        any file of the same name (kept as a revision). The media type is
+        sniffed from the bytes and nothing is refused for being what it
+        is: a bundle whose files come back missing is not the bundle that
+        was handed over (design doc 0046 §3.2). What a browser is allowed
+        to do with them is decided when they are served — see the GET
+        above. At most 5 MiB per file; no limit on how many.
         Reference the file from the entry's markdown body
         (`![baseline](<id last segment>/weekly.png)` or
         `[seeds](<id last segment>/seeds.txt)`) so it is findable and
@@ -2469,7 +2471,12 @@ components:
         agent context is never flooded with base64.
       properties:
         name: { type: string, description: Filename, unique within the entry. }
-        media_type: { type: string, enum: [image/png, image/jpeg, image/webp, application/pdf, text/plain] }
+        media_type:
+          type: string
+          description: >
+            Sniffed from the bytes, never taken from the client. Any type:
+            a bundle carries what it carries (design doc 0046 §3.2), and
+            what a browser may do with it is decided when it is served.
         size: { type: integer }
         sha256: { type: string, description: Content hash; attachments are content-addressed and immutable. }
         okf_path:

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -696,7 +696,7 @@ func cmdGet(ctx context.Context, args []string) error {
 func cmdAttach(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
 		"attach",
-		"Usage: ochakai attach [flags] <id> <file...>\n\nAttach files to a knowledge entry (png, jpeg, webp, pdf, plain\ntext — the type is sniffed from the bytes; max 5 MiB each, 20 per\nentry). An attachment of the same name is replaced (the change is kept\nas a revision). Reference the file from the entry's body so its\ncaption is searchable and it survives OKF export/import — the hint\nprinted after attaching shows the canonical relative link. Requires\nthe server to have GCS configured (OCHAKAI_GCS_BUCKET).",
+		"Usage: ochakai attach [flags] <id> <file...>\n\nAttach files to a knowledge entry (any file, up to 5 MiB each — the\nmedia type is sniffed from the bytes). A file of the same name is\nreplaced (the change is kept as a revision). Reference the file from the entry's body so its\ncaption is searchable and it survives OKF export/import — the hint\nprinted after attaching shows the canonical relative link. Requires\nthe server to have GCS configured (OCHAKAI_GCS_BUCKET).",
 		"  ochakai attach insights/reading-revenue weekly.png\n  ochakai attach tables/orders seeds.txt\n  ochakai attach tables/orders er-diagram.png --name schema.png\n")
 	name := fs.String("name", "", "attachment name (default: the file's basename; single file only)")
 	asJSON := fs.Bool("json", false, "print the attachment metadata as JSON")

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -62,10 +62,9 @@ Run "ochakai <command> -h" for flags and examples.
 ```
 Usage: ochakai attach [flags] <id> <file...>
 
-Attach files to a knowledge entry (png, jpeg, webp, pdf, plain
-text — the type is sniffed from the bytes; max 5 MiB each, 20 per
-entry). An attachment of the same name is replaced (the change is kept
-as a revision). Reference the file from the entry's body so its
+Attach files to a knowledge entry (any file, up to 5 MiB each — the
+media type is sniffed from the bytes). A file of the same name is
+replaced (the change is kept as a revision). Reference the file from the entry's body so its
 caption is searchable and it survives OKF export/import — the hint
 printed after attaching shows the canonical relative link. Requires
 the server to have GCS configured (OCHAKAI_GCS_BUCKET).

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -116,10 +116,14 @@ history with copies.
 markdown entries only. This is a whole-deployment setting, not a
 per-request one.
 
-**A file is refused.** The media type is decided by sniffing the bytes,
-never by what the client claims: png, jpeg, webp, pdf and plain text are
-accepted, and 5 MiB per file / 20 files per entry are the limits. HTML and
-SVG are refused on purpose — both can carry script into the web UI.
+**A file is refused.** Only for its size: 5 MiB per file is the limit,
+and there is no limit on how many. No media type is refused — a bundle
+whose files come back missing is not the bundle you handed over. What a
+file *is* is decided by sniffing the bytes, never by what the client
+claims, and what a browser may do with it is decided when it is served:
+an image, a PDF or plain text renders in place, and everything else is
+handed over as a download under a sandbox, so an SVG or an HTML file has
+no origin to run script in.
 
 **Attachment contents do not turn up in search.** Filenames match in every
 search, but contents join only when embeddings are on, and images and PDFs

--- a/internal/domain/attachment.go
+++ b/internal/domain/attachment.go
@@ -25,24 +25,25 @@ type Attachment struct {
 	CreatedAt time.Time `json:"created_at"`
 }
 
-// MaxAttachmentSize bounds one attachment (screenshots, diagrams, seed
-// files — not originals). MaxAttachmentsPerEntry bounds how many an entry
-// may carry.
-const (
-	MaxAttachmentSize      = 5 << 20
-	MaxAttachmentsPerEntry = 20
-)
+// MaxAttachmentSize bounds one file (screenshots, diagrams, seed files —
+// not originals).
+//
+// There is no bound on how many files an entry may carry. There was one,
+// of 20, from the days when a file was something an entry *had*: a cap
+// on a property of an entry. A file is an object in the bundle now
+// (design doc 0046 §§2.1, 3.3), and a cap on how many objects may sit in
+// a directory is a cap on what a bundle may contain — which is not
+// ochakai's to set, any more than it sets how many entries a directory
+// may hold. A bundle whose files come back missing is not a bundle that
+// round-trips (§3.2).
+const MaxAttachmentSize = 5 << 20
 
-// attachmentMediaTypes is the allowlist of what an attachment may be
-// (design doc 0013): exactly the intersection of what Claude accepts as
-// an upload and what gemini-embedding-2 takes as input — gif, in the
-// original image-only list (design doc 0008), is not embeddable and was
-// dropped. Never text/html or image/svg+xml: both can carry scripts, and
-// serving them from the API would hand every knowledge author an XSS
-// vector into web UIs. Note that sniffing decides — CSV/JSON/markup
-// without an HTML signature all pass as text/plain and are always served
-// as such, never as something executable.
-var attachmentMediaTypes = map[string]bool{
+// embeddableMediaTypes is what the file-embedding model takes as input
+// (gemini-embedding-2, design doc 0020). Anything else is stored and
+// served like everything else and is findable by its name alone — the
+// list decides what is worth a call to the embedder, not what a bundle
+// may hold.
+var embeddableMediaTypes = map[string]bool{
 	"image/png":       true,
 	"image/jpeg":      true,
 	"image/webp":      true,
@@ -50,20 +51,23 @@ var attachmentMediaTypes = map[string]bool{
 	"text/plain":      true,
 }
 
+// Embeddable reports whether a file of this media type can be handed to
+// the embedding model. A file that cannot is not a lesser file: it is
+// stored, served and exported the same, and found by its name.
+func Embeddable(mediaType string) bool {
+	mt, _, _ := strings.Cut(mediaType, ";")
+	return embeddableMediaTypes[strings.ToLower(strings.TrimSpace(mt))]
+}
+
 // InlineServable reports whether bytes of this media type may be handed
 // to a browser to render in place. Images (bar SVG), PDFs and plain text
 // may; everything else is served as a download instead (design doc 0046
 // §3.2).
 //
-// The rule is on the delivery side because that is where it belongs. A
-// write-time allowlist decides what a knowledge base may hold, and the
-// two questions are not the same one: 0046 §3.2 stops refusing media
-// types, on the grounds that a bundle whose files come back missing is
-// not a bundle that round-trips — "receive it, do not render it". Even
-// while the write side still refuses (design doc 0013), this is the
-// check that has to be true: a row written before that allowlist, or a
-// sniffer that reads one byte differently than a browser does, is a
-// script in the web UI's origin if the only guard is upstream.
+// This is the whole of the protection now. The write side accepts any
+// media type — a bundle whose files come back missing is not a bundle
+// that round-trips — so "receive it, do not render it" rests entirely on
+// this half. Nothing upstream will have refused the bytes on the way in.
 //
 // SVG is the case worth naming. It is an image by every convention and
 // an executable document by specification, so it is served the way an
@@ -87,13 +91,32 @@ func ValidAttachmentName(name string) bool {
 	return validSegment(name) && !strings.HasSuffix(strings.ToLower(name), ".md")
 }
 
-// DetectAttachmentMediaType sniffs data's media type and checks it against
-// the allowlist. The client's declared type is never trusted; bytes decide.
+// DetectAttachmentMediaType is the media type of these bytes, as
+// sniffed. The client's declared type is never trusted; bytes decide.
+//
+// Nothing is refused. It used to be: an allowlist of five types stood
+// here, on the reasoning that a knowledge store should hold only what an
+// agent could read (design doc 0013). What that reasoning missed is that
+// ochakai holds a *bundle*, and a bundle whose files come back missing
+// is not the bundle that was handed over (design doc 0046 §3.2). A
+// producer's zip of seed data, a `.parquet`, an SVG diagram — refusing
+// them does not keep them out of the knowledge base, it keeps them out
+// of the copy ochakai hands back.
+//
+// The error the allowlist prevented is prevented on delivery instead,
+// which is where it belongs: what a browser is allowed to do with bytes
+// is decided when they are served, by InlineServable and the headers
+// beside it. "Receive it, do not render it" is one rule with two halves,
+// and this is the half that receives.
+//
+// The signature still decides what the type *is*, so a file that only
+// claims to be an image is stored as what it sniffs as, never as what it
+// was called.
 func DetectAttachmentMediaType(data []byte) (string, error) {
 	mt, _, _ := strings.Cut(http.DetectContentType(data), ";")
 	mt = strings.TrimSpace(mt)
-	if !attachmentMediaTypes[mt] {
-		return "", fmt.Errorf("unsupported attachment content %q (allowed: png, jpeg, webp, pdf, plain text)", mt)
+	if mt == "" {
+		return "application/octet-stream", nil
 	}
 	return mt, nil
 }

--- a/internal/domain/attachment_test.go
+++ b/internal/domain/attachment_test.go
@@ -24,41 +24,43 @@ func TestValidAttachmentName(t *testing.T) {
 	}
 }
 
+// Bytes decide what a file is, and nothing is refused for being what it
+// is (design doc 0046 §3.2): a bundle whose files come back missing is
+// not the bundle that was handed over. What a browser may do with them
+// is decided on the way out, by InlineServable.
 func TestDetectAttachmentMediaType(t *testing.T) {
 	png := append([]byte("\x89PNG\r\n\x1a\n"), make([]byte, 16)...)
-	if mt, err := DetectAttachmentMediaType(png); err != nil || mt != "image/png" {
-		t.Errorf("png: got %q, %v", mt, err)
+	mustSniff(t, png, "image/png")
+	mustSniff(t, append([]byte("GIF89a"), make([]byte, 16)...), "image/gif")
+	mustSniff(t, []byte("%PDF-1.7 fake pdf body"), "application/pdf")
+	mustSniff(t, []byte("seed,urls\nhttps://example.com\n"), "text/plain")
+	// The two that carry script are stored as what they are, and never
+	// served inline — the delivery rule is what stands between them and
+	// the web UI's origin.
+	for _, tc := range []struct{ data, mediaType string }{
+		{`<!DOCTYPE html><script>alert(1)</script>`, "text/html"},
+		{`<?xml version="1.0"?><svg xmlns="http://www.w3.org/2000/svg"/>`, "text/xml"},
+	} {
+		mt := mustSniff(t, []byte(tc.data), tc.mediaType)
+		if InlineServable(mt) {
+			t.Errorf("%s is served inline", mt)
+		}
 	}
-	// gif fell out of the allowlist with the grandfather clause (Claude
-	// reads it, gemini-embedding-2 cannot embed it).
-	gif := append([]byte("GIF89a"), make([]byte, 16)...)
-	if _, err := DetectAttachmentMediaType(gif); err == nil {
-		t.Error("gif accepted")
+	// An archive, a font, anything at all: stored as what it sniffs as.
+	mustSniff(t, append([]byte("PK\x03\x04"), make([]byte, 16)...), "application/zip")
+	mustSniff(t, []byte{0x00, 0x01, 0x02, 0x03}, "application/octet-stream")
+}
+
+func mustSniff(t *testing.T, data []byte, want string) string {
+	t.Helper()
+	mt, err := DetectAttachmentMediaType(data)
+	if err != nil {
+		t.Errorf("sniffing %q: %v", want, err)
 	}
-	if mt, err := DetectAttachmentMediaType([]byte("%PDF-1.7 fake pdf body")); err != nil || mt != "application/pdf" {
-		t.Errorf("pdf: got %q, %v", mt, err)
+	if mt != want {
+		t.Errorf("sniffed %q, want %q", mt, want)
 	}
-	if mt, err := DetectAttachmentMediaType([]byte("seed,urls\nhttps://example.com\n")); err != nil || mt != "text/plain" {
-		t.Errorf("text: got %q, %v", mt, err)
-	}
-	// Markup with an HTML signature sniffs as text/html — refused
-	// (script-bearing; design doc 0013).
-	if _, err := DetectAttachmentMediaType([]byte(`<!DOCTYPE html><script>alert(1)</script>`)); err == nil {
-		t.Error("html accepted")
-	}
-	// An XML declaration sniffs as text/xml (SVG's usual shape) — refused.
-	if _, err := DetectAttachmentMediaType([]byte(`<?xml version="1.0"?><svg xmlns="http://www.w3.org/2000/svg"/>`)); err == nil {
-		t.Error("xml/svg accepted")
-	}
-	// SVG without the XML declaration has no HTML signature and passes as
-	// text/plain — stored and served inert, never as image/svg+xml.
-	if mt, err := DetectAttachmentMediaType([]byte(`<svg xmlns="http://www.w3.org/2000/svg"/>`)); err != nil || mt != "text/plain" {
-		t.Errorf("bare svg: got %q, %v (want inert text/plain)", mt, err)
-	}
-	// Binary that is no allowlisted format sniffs application/octet-stream.
-	if _, err := DetectAttachmentMediaType([]byte{0x00, 0x01, 0x02, 0x03}); err == nil {
-		t.Error("arbitrary binary accepted")
-	}
+	return mt
 }
 
 func TestValidateAttachment(t *testing.T) {

--- a/internal/restapi/restapi_integration_test.go
+++ b/internal/restapi/restapi_integration_test.go
@@ -386,8 +386,7 @@ func TestRESTIntegrationAttachments(t *testing.T) {
 	}
 	// A PNG renders in place, and says so with no sandbox on it; the
 	// sniffed type is never re-decided by the browser (design doc 0046
-	// §3.2, and serveDefensively for the half this entry cannot exercise —
-	// the write path still refuses the media types that would).
+	// §3.2).
 	if d := resp.Header.Get("Content-Disposition"); !strings.HasPrefix(d, "inline;") {
 		t.Errorf("Content-Disposition = %q, want inline for an image", d)
 	}
@@ -1101,5 +1100,97 @@ func TestRESTIntegrationDocumentSurvivesTheRoundTrip(t *testing.T) {
 	if resp.StatusCode != http.StatusOK || resp.Header.Get("Ochakai-Unchanged") != "true" {
 		t.Errorf("sending back what was read = %d, Ochakai-Unchanged = %q",
 			resp.StatusCode, resp.Header.Get("Ochakai-Unchanged"))
+	}
+}
+
+// A bundle carries what it carries (design doc 0046 §3.2): the write
+// path refuses no media type, and the delivery rule is what keeps the
+// dangerous ones from running. This is the pair #280 could only test one
+// half of, because nothing that takes the defended branch could be
+// stored yet.
+func TestRESTIntegrationAnyFileIsAcceptedAndServedInert(t *testing.T) {
+	lockLiveAttachments(t)
+	srv, s := newIntegrationServer(t)
+	s.UseBlobStore(memBlobStore{})
+
+	typ := fmt.Sprintf("restany%d", time.Now().UnixNano())
+	id := typ + "/diagram"
+	// Soft-delete at the end, like every other test that holds live
+	// files: the shared test database is scanned whole by the export and
+	// by the re-embed backlog, and those resolve bytes against their own
+	// blob fake. A defer rather than t.Cleanup — cleanups run after this
+	// function's defers, by which time the server is closed.
+	defer func() {
+		req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/knowledge/"+id, nil)
+		if resp, err := http.DefaultClient.Do(req); err == nil {
+			resp.Body.Close()
+		}
+	}()
+	resp := putDoc(t, srv.URL, id, docFrom(t, map[string]any{
+		"type": typ, "id": id, "title": "anything the bundle carried"}), true)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create status = %d", resp.StatusCode)
+	}
+
+	for _, tc := range []struct {
+		name, mediaType string
+		data            []byte
+		inline          bool
+	}{
+		// The two that carry script, and the two that were simply not on
+		// the old list. None of them is refused; the first two are handed
+		// over rather than rendered.
+		{"er.svg", "text/xml", []byte(`<?xml version="1.0"?><svg xmlns="http://www.w3.org/2000/svg"/>`), false},
+		{"report.html", "text/html", []byte(`<!DOCTYPE html><script>alert(1)</script>`), false},
+		{"seeds.zip", "application/zip", append([]byte("PK\x03\x04"), make([]byte, 16)...), false},
+		{"shot.gif", "image/gif", append([]byte("GIF89a"), make([]byte, 16)...), true},
+	} {
+		attURL := srv.URL + "/api/v1/attachments/" + id + "/" + tc.name
+		req, _ := http.NewRequest(http.MethodPut, attURL, bytes.NewReader(tc.data))
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("attaching %s = %d: %s", tc.name, resp.StatusCode, body)
+			continue
+		}
+
+		resp, err = http.Get(attURL)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if string(got) != string(tc.data) {
+			t.Errorf("%s came back as %d bytes, want %d", tc.name, len(got), len(tc.data))
+		}
+		if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, tc.mediaType) {
+			t.Errorf("%s is served as %q, want %q", tc.name, ct, tc.mediaType)
+		}
+		if resp.Header.Get("X-Content-Type-Options") != "nosniff" {
+			t.Errorf("%s: no nosniff", tc.name)
+		}
+		want, csp := "attachment;", "sandbox"
+		if tc.inline {
+			want, csp = "inline;", ""
+		}
+		if d := resp.Header.Get("Content-Disposition"); !strings.HasPrefix(d, want) {
+			t.Errorf("%s: Content-Disposition = %q, want %s…", tc.name, d, want)
+		}
+		if got := resp.Header.Get("Content-Security-Policy"); got != csp {
+			t.Errorf("%s: Content-Security-Policy = %q, want %q", tc.name, got, csp)
+		}
+	}
+
+	// And the entry carries all four: no cap on how many objects a
+	// directory of the bundle may hold.
+	var view domain.View
+	getJSON(t, srv.URL+"/api/v1/knowledge/"+id, &view)
+	if len(view.Attachments) != 4 {
+		t.Errorf("the entry carries %d files, want 4 — nothing caps how many", len(view.Attachments))
 	}
 }

--- a/internal/service/attachment.go
+++ b/internal/service/attachment.go
@@ -71,6 +71,13 @@ func (s *Service) updateAttachmentEmbedding(ctx context.Context, id string, att 
 		}
 		vec = vecs[0]
 	} else {
+		// A file the model does not take is not embedded and not
+		// complained about: since design doc 0046 §3.2 a bundle may carry
+		// anything, and most of what it carries — an archive, a parquet
+		// file, a font — was never embeddable. It stays findable by name.
+		if !domain.Embeddable(att.MediaType) {
+			return
+		}
 		fe, ok := s.Embedder.(embed.FileEmbedder)
 		if !ok {
 			return

--- a/internal/store/attachment.go
+++ b/internal/store/attachment.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
-	"fmt"
 	"slices"
 	"strings"
 	"time"
@@ -136,15 +135,6 @@ func (s *Store) PutAttachment(ctx context.Context, id, name, mediaType, okfPath 
 			return err
 		}
 		path := filePath(k, name, okfPath)
-		var count int
-		if err := tx.QueryRow(ctx, `SELECT count(*)
-			FROM object k JOIN object f ON `+attributedTo+`
-			WHERE k.id=$1 AND f.path<>$2`, id, path).Scan(&count); err != nil {
-			return err
-		}
-		if count >= domain.MaxAttachmentsPerEntry {
-			return fmt.Errorf("invalid attachment: entry already has %d attachments (max %d)", count, domain.MaxAttachmentsPerEntry)
-		}
 		// The blob row is metadata only now — the object row carries the
 		// media type and size a read answers with — but it stays the
 		// registry of which content exists, and a revision names bytes by

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -1630,7 +1630,7 @@ async function viewDetail(id) {
           <span class="provenance" id="att-chosen" style="margin:0"></span>
           <button class="btn small primary" id="att-upload">Attach</button>
         </div>
-        <p class="provenance write-only">png / jpeg / webp / pdf / plain text, max 5 MiB each, 20 per entry. Reference a file from the
+        <p class="provenance write-only">Any file, max 5 MiB each. Reference a file from the
         body (<code>![alt](${esc(lastSeg)}/name.png)</code> or <code>[name](${esc(lastSeg)}/name.txt)</code>) so it is findable and survives OKF export.</p>`;
     },
     linked: () => '<div class="empty">…</div>',


### PR DESCRIPTION
#267 item 3, the half that does not need the bundle write face: the write path refuses no media type, and the cap of 20 files per entry is gone.

## Why

The allowlist (png, jpeg, webp, pdf, plain text) was reasoned from a knowledge store that should hold only what an agent can read (0013). What it missed is that what ochakai holds is a **bundle**. Refusing a producer's zip of seed data, a `.parquet`, or an SVG diagram does not keep them out of the knowledge base — it keeps them out of the copy ochakai hands back, which is the one thing a bundle store must not do (0046 §3.2).

The cap was the same mistake in miniature. A limit on how many files an entry may carry made sense when a file was a *property* of an entry; now that a file is an object in the bundle (#288), it is a limit on how many objects a directory may hold, which is not ochakai's to set any more than it sets how many entries a directory may hold.

## Why this is safe

Because #280 landed first. What the allowlist protected against is protected on delivery, where it belongs: an SVG or an HTML file goes out as a download under `Content-Security-Policy: sandbox` with `nosniff`, and never inline. "Receive it, do not render it" is one rule with two halves; this is the half that receives, and both halves are now true.

The signature still decides what a file *is* — nothing is stored as what it was called.

## Also

A file the embedding model does not take (an archive, a font) is stored, served and exported like any other and found by its name, but is no longer handed to the embedder. Without that, a bundle full of archives would log a failed embedding call per file. `domain.Embeddable` is the old allowlist, in the one role it was actually right for.

## Tests

`TestRESTIntegrationAnyFileIsAcceptedAndServedInert` is the pair #280 could only test one half of, since nothing that takes the defended branch could be stored then. Four files — an SVG, an HTML file, a zip, a gif — are attached, come back byte-identical as the type they sniff as, and each is checked for the headers its type earns: `attachment` + `sandbox` for the first three, `inline` for the gif, `nosniff` on all four. Then the entry carries all four, because nothing caps how many.

`TestDetectAttachmentMediaType` now asserts what each shape sniffs as rather than which are refused, and asserts that the two script-bearing ones are never inline-servable — the invariant that replaced the refusal.

The OpenAPI enum of five media types went with the allowlist. The contract test caught that, not me.

`scripts/check --db` is clean. Docs, CLI help (regenerated), the web UI's hint and the troubleshooting entry all say what the rule is now.
