### PR TITLE
Read and write every object at its bundle path (0046 §3.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,30 @@ last entry.
 
 ### Added
 
+- **The bundle address reads and writes every object in it** (design doc
+  [0046](docs/design/0046-bundle-address-space.md) §3.5).
+  `GET|PUT|DELETE /api/v1/bundle/{path}` now serves a concept at
+  `<id>.md`, a file at its own path, and the two generated files as
+  before.
+
+  A concept answers and is written exactly as it is on
+  `/api/v1/knowledge/{id}` — the same View, the same document under
+  `Accept: text/markdown`, the same `ETag`, the same `If-Match` and
+  `If-None-Match: *`, the same `Ochakai-Unchanged`. One object, two
+  addresses, one answer: an address is not a second surface.
+
+  What the bytes are decides what they become. A markdown document whose
+  frontmatter carries a `type` is a concept; anything else is a file —
+  **including a markdown document with no `type`**, which SPEC §11 makes
+  not-a-concept and which a bundle that carried one now gets back
+  instead of losing (§3.2). A file needs no owner: whether an entry
+  shows it is a question its body answers (§3.3), so a file written
+  under an entry's namespace arrives attributed and one nothing points
+  at is simply a file.
+
+  `index.md` and `log.md` stay 409 on write, and a file's history lands
+  in the same ledger the concepts use — created and deleted, by whom.
+
 - **`ochakai log [path]`** prints the update history as OKF's `log.md`
   (SPEC §9): date-grouped, newest first, for a path or the whole bundle
   (design doc [0046](docs/design/0046-bundle-address-space.md) §3.8).

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -326,10 +326,21 @@ paths:
   /api/v1/bundle/{path}:
     get:
       operationId: getBundleFile
-      summary: Read one of the files OKF reserves
+      summary: Read one object of the bundle
       description: >
-        The two filenames SPEC §3.1 reserves, generated from the bundle
-        rather than stored in it (design doc 0046 §§3.7-3.8).
+        One object at its bundle path (design doc 0046 §3.5): a concept
+        at `<id>.md`, a file at its own path, or one of the two names OKF
+        reserves per directory — which are generated from the bundle
+        rather than stored in it (§§3.7-3.8).
+
+        A concept answers exactly as `GET /api/v1/knowledge/{id}` does,
+        the same View or the same document under `Accept: text/markdown`,
+        with the same ETag. One object, two addresses, one answer: an
+        address is not a second surface.
+
+        A file answers with its bytes, its content hash as the ETag, and
+        the headers that decide what a browser may do with them (see
+        `GET /api/v1/attachments/{path}`).
 
         `index.md` is one level of the tree — the subdirectories directly
         under the path, each with the count of entries beneath, plus the
@@ -348,18 +359,16 @@ paths:
         names. Two representations of one thing, at one address — the
         JSON is what a web UI's tree needs, not a second surface.
 
-        PUT and DELETE against these two names are 409: a generated file
-        is not one anybody writes. Paths other than the two reserved
-        names are 404 on read and 501 on write for now — the rest of the
-        bundle joins this address in a later change (0046 §3.5).
+        PUT and DELETE against the two reserved names are 409: a
+        generated file is not one anybody writes.
       parameters:
         - name: path
           in: path
           required: true
           description: >
-            The reserved file's bundle path — "index.md" or "log.md" at
-            the root, "metrics/index.md" below it. Slashes are real path
-            separators.
+            The object's bundle path — "metrics/revenue.md",
+            "metrics/revenue/chart.png", or a reserved "index.md" /
+            "metrics/log.md". Slashes are real path separators.
           schema: { type: string }
         - name: limit
           in: query
@@ -367,10 +376,18 @@ paths:
           schema: { type: integer }
       responses:
         "200":
-          description: The generated file, or its structured form.
+          description: >
+            The object: a concept's document or View, a file's bytes, or
+            a generated file and its structured form.
           headers:
             Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
+            ETag: { $ref: "#/components/headers/ETag" }
+            Content-Disposition:
+              description: Files only — inline for an image, a PDF or plain text; attachment otherwise (design doc 0046 §3.2).
+              schema: { type: string }
           content:
+            "*/*":
+              schema: { type: string, format: binary, description: A file's bytes, under the media type sniffed when it was stored. }
             text/markdown:
               schema: { type: string }
               example: |
@@ -435,10 +452,7 @@ paths:
         "400": { $ref: "#/components/responses/Error" }
         "403": { $ref: "#/components/responses/Forbidden" }
         "404":
-          description: >
-            No object at this path. Today that is every path but the two
-            reserved names: the concepts and files join this address in a
-            later change (design doc 0046 §3.5).
+          description: No object at this path.
           headers:
             Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
           content:
@@ -448,17 +462,56 @@ paths:
                 properties:
                   error: { type: string }
               example:
-                error: 'no object at "metrics/revenue.md": the bundle surface serves index.md and log.md'
+                error: knowledge not found
     put:
       operationId: putBundleFile
-      summary: Refused — generated at the reserved names, not built yet elsewhere
+      summary: Write one object of the bundle
       description: >
-        Two refusals, and the path decides which. index.md and log.md are
-        derived from the bundle (design doc 0046 §§3.7-3.8), so a write
-        there is a conflict with what the address is: 409. Every other
-        path is the write face 0046 §3.5 describes, which lands in a
-        later change: 501. The same goes for DELETE.
+        Stores the request body at the path (design doc 0046 §3.5). What
+        it becomes is decided by the bytes, not by a parameter:
+
+        A markdown path whose document carries a `type` is a concept, and
+        the write is exactly `PUT /api/v1/knowledge/{id}` — the same
+        preconditions (`If-Match`, `If-None-Match: *`), the same
+        `Ochakai-Unchanged`, the same answer. Anything else is a file,
+        including a markdown document with no `type`: SPEC §11 makes the
+        key what a concept has, and a bundle that carried a typeless
+        markdown file gets it back rather than losing it (§3.2).
+
+        index.md and log.md are 409: they are generated from the bundle,
+        so a write there is a conflict with what the address is.
       responses:
+        "200":
+          description: The object as stored — a View for a concept, file metadata otherwise.
+          headers:
+            ETag: { $ref: "#/components/headers/ETag" }
+            Ochakai-Unchanged:
+              description: Concepts only — the payload matched what was stored, so nothing was written.
+              schema: { type: string, enum: ["true"] }
+            Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - $ref: "#/components/schemas/View"
+                  - $ref: "#/components/schemas/Attachment"
+            text/markdown:
+              schema: { type: string }
+        "201":
+          description: A concept was created (If-None-Match "*", or the path was free).
+          headers:
+            ETag: { $ref: "#/components/headers/ETag" }
+            Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/View" }
+            text/markdown:
+              schema: { type: string }
+        "400": { $ref: "#/components/responses/Error" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "412": { $ref: "#/components/responses/Error" }
+        "413": { $ref: "#/components/responses/Error" }
+        "501": { $ref: "#/components/responses/Error" }
         "409":
           description: A generated file is not one anybody writes.
           headers:
@@ -471,35 +524,23 @@ paths:
                   error: { type: string }
               example:
                 error: index.md is generated from the bundle, not stored in it (design doc 0046 §§3.7-3.8)
-        "501":
-          description: The bundle write surface is not built yet.
-          headers:
-            Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error: { type: string }
-              example:
-                error: the bundle write surface lands in a later change (design doc 0046 §3.5)
     delete:
       operationId: deleteBundleFile
-      summary: Refused — generated at the reserved names, not built yet elsewhere
-      description: See PUT.
+      summary: Delete one object of the bundle
+      description: >
+        Removes the object at the path: a concept is soft-deleted, as
+        `DELETE /api/v1/knowledge/{id}` does, and a file is removed (its
+        bytes stay, named by the revisions that came before). index.md
+        and log.md are 409 for the same reason PUT gives.
       responses:
-        "409":
-          description: A generated file is not one anybody deletes.
+        "204":
+          description: Deleted.
           headers:
             Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error: { type: string }
-        "501":
-          description: The bundle write surface is not built yet.
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/Error" }
+        "409":
+          description: A generated file is not one anybody deletes.
           headers:
             Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
           content:

--- a/internal/domain/attachment.go
+++ b/internal/domain/attachment.go
@@ -134,3 +134,36 @@ func ValidateAttachment(name string, size int) error {
 	}
 	return nil
 }
+
+// ValidBundlePath reports whether p can address an object in the bundle:
+// path segments separated by "/", each one a valid filename, and neither
+// of the two names OKF reserves per directory (index.md, log.md — they
+// are generated from the bundle rather than stored in it, design doc
+// 0046 §§3.7-3.8).
+//
+// It is ValidID's rule one level down: an id is a path with ".md"
+// removed, so what makes a path addressable is what makes an id
+// addressable, minus the assumption that every object is a concept.
+func ValidBundlePath(p string) bool {
+	if p == "" || len(p) > 512 {
+		return false
+	}
+	segs := strings.Split(p, "/")
+	for _, s := range segs {
+		if !validSegment(s) {
+			return false
+		}
+	}
+	return !ReservedBundleName(segs[len(segs)-1])
+}
+
+// ReservedBundleName reports whether a filename is one OKF reserves per
+// directory: index.md and log.md, which ochakai generates from the
+// bundle rather than storing (design doc 0046 §§3.7-3.8).
+func ReservedBundleName(name string) bool {
+	switch strings.ToLower(name) {
+	case "index.md", "log.md":
+		return true
+	}
+	return false
+}

--- a/internal/okf/parse.go
+++ b/internal/okf/parse.go
@@ -528,3 +528,17 @@ func extraKeys(m map[string]any, known map[string]bool) domain.Extra {
 	}
 	return extra
 }
+
+// CarriesType reports whether a document's frontmatter names a type,
+// which is what makes it a concept (SPEC §11 requires the key). A
+// markdown file without one is not a malformed concept — it is a file
+// that happens to be markdown, and a bundle that carried one gets it
+// back (design doc 0046 §3.2).
+//
+// It parses rather than greps: "type:" inside a fenced block in the body
+// is prose, and the answer decides whether the bytes are stored as an
+// entry or as a file.
+func CarriesType(doc []byte) bool {
+	d, _, err := Parse(doc)
+	return err == nil && strings.TrimSpace(string(d.Type)) != ""
+}

--- a/internal/restapi/openapi_test.go
+++ b/internal/restapi/openapi_test.go
@@ -107,21 +107,35 @@ func forSpecRouting(p string) string {
 	return p
 }
 
-// carriesOpaqueBytes reports whether this is one of the two operations
-// whose body is raw attachment bytes: PUT (the file being stored) and GET
-// (the file coming back with its sniffed media type).
+// carriesOpaqueBytes reports whether this request stores raw bytes: a
+// PUT of a file, whose body is the file and whose Content-Type is
+// whatever the client sent, or nothing at all.
 //
-// Both are declared "*/*" in the spec, and the validator resolves media
-// types by exact match — it reads "*/*" as a literal type name, so an
-// image/png response, or a PUT that sends no Content-Type at all, is
-// reported as undeclared. Skipping them costs nothing that could have
-// drifted: `{type: string, format: binary}` under a wildcard asserts
-// nothing about the bytes, which is the whole point of an attachment.
-// DELETE on the same path keeps its 204 checked, and export — a tarball
-// under a named media type — validates normally.
+// The validator resolves media types by exact match — it reads "*/*" as
+// a literal type name — so a body under a wildcard is reported as
+// undeclared. Skipping costs nothing that could have drifted:
+// `{type: string, format: binary}` asserts nothing about the bytes,
+// which is the whole point of a file.
 func carriesOpaqueBytes(r *http.Request) bool {
-	return strings.HasPrefix(r.URL.Path, "/api/v1/attachments/") &&
-		(r.Method == http.MethodPut || r.Method == http.MethodGet)
+	return r.Method == http.MethodPut &&
+		(strings.HasPrefix(r.URL.Path, "/api/v1/attachments/") ||
+			strings.HasPrefix(r.URL.Path, "/api/v1/bundle/"))
+}
+
+// sniffedResponse reports whether a response's media type was decided by
+// sniffing the bytes rather than chosen by the handler — a file coming
+// back from the attachment or bundle address. Same exact-match problem,
+// same reasoning: the declared schema is a wildcard over bytes.
+//
+// Everything the handler does choose stays checked, which is what
+// matters here: a concept read through the bundle address answers
+// application/json or text/markdown and is validated like any other.
+func sniffedResponse(res *http.Response) bool {
+	switch mt, _, _ := strings.Cut(res.Header.Get("Content-Type"), ";"); strings.TrimSpace(mt) {
+	case "", "application/json", "text/markdown", "application/gzip":
+		return false
+	}
+	return true
 }
 
 // checkedServer is httptest.NewServer(Handler(svc)) with the spec in the
@@ -170,8 +184,10 @@ func checkedServer(t *testing.T, h http.Handler) *httptest.Server {
 		h.ServeHTTP(rec, r)
 		res := rec.Result()
 		res.Body = io.NopCloser(bytes.NewReader(rec.Body.Bytes()))
-		if ok, errs := v.ValidateHttpResponse(specReq(), res); !ok {
-			reportSpecErrors(t, "response", r, errs)
+		if !sniffedResponse(res) {
+			if ok, errs := v.ValidateHttpResponse(specReq(), res); !ok {
+				reportSpecErrors(t, "response", r, errs)
+			}
 		}
 
 		for k, vs := range rec.Header() {

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -136,13 +136,44 @@ func Handler(svc *service.Service) http.Handler {
 			}
 			writeMarkdown(w, doc)
 		default:
-			// Not yet an address for everything in the bundle: the
-			// objects and concepts join it in a later change (design
-			// doc 0046 §3.5), and until then this path serves the two
-			// files the format reserves.
-			writeJSON(w, http.StatusNotFound, map[string]string{
-				"error": fmt.Sprintf("no object at %q: the bundle surface serves index.md and log.md", path),
-			})
+			// Every other path is an object of the bundle: a concept at
+			// its own path, or a file (design doc 0046 §3.5). A concept
+			// is answered by the entry surface's own writer, so one
+			// address serves both kinds and neither has a shape of its
+			// own here.
+			if id, ok := strings.CutSuffix(path, ".md"); ok {
+				k, err := svc.Get(r.Context(), id)
+				if err == nil {
+					w.Header().Set("ETag", etagOf(k))
+					if wantsDocument(r) {
+						writeDocument(w, http.StatusOK, k)
+					} else {
+						writeView(w, http.StatusOK, k)
+					}
+					return
+				}
+				// A markdown path with no concept at it may still be a
+				// file: a document that carries no type is not a concept
+				// and is kept as a file (design doc 0046 §3.2).
+				if !errors.Is(err, store.ErrNotFound) {
+					writeError(w, err)
+					return
+				}
+			}
+			att, data, err := svc.GetFile(r.Context(), path)
+			if err != nil {
+				writeError(w, err)
+				return
+			}
+			w.Header().Set("ETag", `"`+att.SHA256+`"`)
+			w.Header().Set("Cache-Control", "private, no-cache")
+			if match := r.Header.Get("If-None-Match"); match != "" && strings.Contains(match, att.SHA256) {
+				w.WriteHeader(http.StatusNotModified)
+				return
+			}
+			w.Header().Set("Content-Type", mediaTypeHeader(att.MediaType))
+			serveDefensively(w, att.MediaType, att.Name)
+			_, _ = w.Write(data)
 		}
 	})
 
@@ -158,15 +189,52 @@ func Handler(svc *service.Service) http.Handler {
 	// named.
 	for _, m := range []string{"PUT", "DELETE"} {
 		mux.HandleFunc(m+" /api/v1/bundle/{path...}", func(w http.ResponseWriter, r *http.Request) {
-			if _, base := splitReserved(r.PathValue("path")); isReserved(base) {
+			path := r.PathValue("path")
+			if _, base := splitReserved(path); isReserved(base) {
 				writeJSON(w, http.StatusConflict, map[string]string{
 					"error": fmt.Sprintf("%s is generated from the bundle, not stored in it (design doc 0046 §§3.7-3.8)", base),
 				})
 				return
 			}
-			writeJSON(w, http.StatusNotImplemented, map[string]string{
-				"error": "the bundle write surface lands in a later change (design doc 0046 §3.5)",
-			})
+			actor := httpauth.Actor(r.Context())
+			// A markdown path is a concept's address, and a write there
+			// is a write to the entry — the same document, the same
+			// preconditions, the same answer. Anything else is a file.
+			//
+			// A .md that carries no type is not a concept (SPEC §11
+			// requires the key), and it is not an error either: it is a
+			// file that happens to be markdown, and a bundle that carried
+			// one gets it back (design doc 0046 §3.2).
+			id, isMarkdown := strings.CutSuffix(path, ".md")
+			if r.Method == http.MethodDelete {
+				err := store.ErrNotFound
+				if isMarkdown {
+					err = svc.Delete(r.Context(), id, actor)
+				}
+				if errors.Is(err, store.ErrNotFound) {
+					err = svc.DeleteFile(r.Context(), path, actor)
+				}
+				if err != nil {
+					writeError(w, err)
+					return
+				}
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+			body, ok := readBody(w, r, maxDocument, fmt.Sprintf("object exceeds %d bytes", maxDocument))
+			if !ok {
+				return
+			}
+			if isMarkdown && okf.CarriesType(body) {
+				putEntry(w, r, svc, id, body, actor)
+				return
+			}
+			att, err := svc.PutFile(r.Context(), path, body, actor)
+			if err != nil {
+				writeError(w, err)
+				return
+			}
+			writeJSON(w, http.StatusOK, att)
 		})
 	}
 
@@ -251,51 +319,18 @@ func Handler(svc *service.Service) http.Handler {
 	// means "only if the id is free", If-Match a version means "only if it
 	// still says this".
 	mux.HandleFunc("PUT /api/v1/knowledge/{id...}", func(w http.ResponseWriter, r *http.Request) {
-		k, ok := readDocument(w, r)
+		if mt := r.Header.Get("Content-Type"); strings.HasPrefix(mt, "application/json") {
+			writeJSON(w, http.StatusUnsupportedMediaType, map[string]string{
+				"error": "knowledge is written as an OKF document (Content-Type: text/markdown), " +
+					"not as JSON: the frontmatter is the metadata and the markdown is the body",
+			})
+			return
+		}
+		body, ok := readBody(w, r, maxDocument, fmt.Sprintf("document exceeds %d bytes", maxDocument))
 		if !ok {
 			return
 		}
-		// The path is the address; the document carries the metadata —
-		// type included, always (no fill-in from the stored entry, design
-		// doc 0017 §4.5).
-		k.ID = r.PathValue("id")
-		actor := httpauth.Actor(r.Context())
-
-		// If-Match is an optional optimistic-concurrency precondition: its
-		// value is the ETag from a prior read. Absent means last-write-wins
-		// (design doc 0030).
-		ifMatch := parseIfMatch(r)
-		var (
-			out              *domain.Knowledge
-			created, changed bool
-			err              error
-		)
-		if onlyIfAbsent(r) {
-			out, err = svc.Create(r.Context(), k, actor)
-			created, changed = true, true
-		} else {
-			out, created, changed, err = svc.Put(r.Context(), k, actor, ifMatch)
-		}
-		if err != nil {
-			writeError(w, err)
-			return
-		}
-		// A payload identical to the stored content wrote nothing (no
-		// revision, no version bump); the header lets clients report
-		// "unchanged" without an extra read.
-		if !changed {
-			w.Header().Set("Ochakai-Unchanged", "true")
-		}
-		w.Header().Set("ETag", etagOf(out))
-		status := http.StatusOK
-		if created {
-			status = http.StatusCreated
-		}
-		if wantsDocument(r) {
-			writeDocument(w, status, out)
-			return
-		}
-		writeView(w, status, out)
+		putEntry(w, r, svc, r.PathValue("id"), body, httpauth.Actor(r.Context()))
 	})
 
 	// POST /api/v1/verify/{id...} — record a verification against the
@@ -479,13 +514,7 @@ func Handler(svc *service.Service) http.Handler {
 		// Re-stamp from the row the bytes came from, in case the
 		// attachment was replaced between the two reads.
 		w.Header().Set("ETag", `"`+att.SHA256+`"`)
-		ct := att.MediaType
-		// Plain text without a charset invites browser guessing; the sniffer
-		// only passes UTF-8/UTF-16 text through, so declare it.
-		if ct == "text/plain" {
-			ct = "text/plain; charset=utf-8"
-		}
-		w.Header().Set("Content-Type", ct)
+		w.Header().Set("Content-Type", mediaTypeHeader(att.MediaType))
 		serveDefensively(w, att.MediaType, att.Name)
 		_, _ = w.Write(data)
 	})
@@ -781,39 +810,6 @@ const documentMediaType = "text/markdown; charset=utf-8"
 // number with room for the envelope rather than a new policy.
 const maxDocument = 5 << 20
 
-// readDocument parses the request body as an OKF document. Notes — values
-// the parser accepted but read differently than written — travel back in
-// a header rather than being swallowed: a reinterpretation is never
-// silent (design doc 0036 §3.4), and there is no room for them in a
-// response whose body is the entry.
-//
-// A JSON body is refused with the reason rather than a parse error: a
-// client sending one is a client written against the typed write surface
-// that 0043 §3.5 removed, and it needs to be told that, not told its
-// document has no frontmatter.
-func readDocument(w http.ResponseWriter, r *http.Request) (*domain.Knowledge, bool) {
-	if mt := r.Header.Get("Content-Type"); strings.HasPrefix(mt, "application/json") {
-		writeJSON(w, http.StatusUnsupportedMediaType, map[string]string{
-			"error": "knowledge is written as an OKF document (Content-Type: text/markdown), " +
-				"not as JSON: the frontmatter is the metadata and the markdown is the body",
-		})
-		return nil, false
-	}
-	data, ok := readBody(w, r, maxDocument, fmt.Sprintf("document exceeds %d bytes", maxDocument))
-	if !ok {
-		return nil, false
-	}
-	d, notes, err := okf.Parse(data)
-	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
-		return nil, false
-	}
-	for _, n := range notes {
-		w.Header().Add("Ochakai-Note", n)
-	}
-	return &d.Knowledge, true
-}
-
 // frontmatterFilter reads the "fm." query parameters — `?fm.question=…`,
 // `?fm.owner=finance` — into the filter that asks the frontmatter index
 // (design doc 0046 §3.11). The prefix is what keeps the surface
@@ -879,6 +875,63 @@ func wantsDocument(r *http.Request) bool {
 // conditional read, and a caller that means "only if absent" says "*".
 func onlyIfAbsent(r *http.Request) bool {
 	return strings.TrimSpace(r.Header.Get("If-None-Match")) == "*"
+}
+
+// putEntry writes one document as the entry at id and answers with the
+// read of it. Two addresses lead here — the entry surface and the bundle
+// path the concept lives at (design doc 0046 §3.5) — and a concept
+// written through either is written the same way, with the same
+// preconditions and the same answer. An address is not a second surface.
+func putEntry(w http.ResponseWriter, r *http.Request, svc *service.Service,
+	id string, body []byte, actor domain.Actor,
+) {
+	d, notes, err := okf.Parse(body)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	for _, n := range notes {
+		w.Header().Add("Ochakai-Note", n)
+	}
+	// The path is the address; the document carries the metadata — type
+	// included, always (no fill-in from the stored entry, design doc 0017
+	// §4.5).
+	k := &d.Knowledge
+	k.ID = id
+
+	// If-Match is an optional optimistic-concurrency precondition: its
+	// value is the ETag from a prior read. Absent means last-write-wins
+	// (design doc 0030).
+	var (
+		out              *domain.Knowledge
+		created, changed bool
+	)
+	if onlyIfAbsent(r) {
+		out, err = svc.Create(r.Context(), k, actor)
+		created, changed = true, true
+	} else {
+		out, created, changed, err = svc.Put(r.Context(), k, actor, parseIfMatch(r))
+	}
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	// A payload identical to the stored content wrote nothing (no
+	// revision, no version bump); the header lets clients report
+	// "unchanged" without an extra read.
+	if !changed {
+		w.Header().Set("Ochakai-Unchanged", "true")
+	}
+	w.Header().Set("ETag", etagOf(out))
+	status := http.StatusOK
+	if created {
+		status = http.StatusCreated
+	}
+	if wantsDocument(r) {
+		writeDocument(w, status, out)
+		return
+	}
+	writeView(w, status, out)
 }
 
 // writeView responds with a read of one entry: the canonical document,
@@ -1037,6 +1090,16 @@ func queryFloat(q url.Values, name string) (float64, error) {
 		return 0, service.Invalidf("invalid %s %q (want a number)", name, s)
 	}
 	return f, nil
+}
+
+// mediaTypeHeader is a stored media type as a Content-Type header. Plain
+// text without a charset invites browser guessing, and the sniffer only
+// passes UTF-8/UTF-16 text through, so it says which.
+func mediaTypeHeader(mediaType string) string {
+	if mediaType == "text/plain" {
+		return "text/plain; charset=utf-8"
+	}
+	return mediaType
 }
 
 // serveDefensively sets the headers that decide what a browser is

--- a/internal/restapi/restapi_integration_test.go
+++ b/internal/restapi/restapi_integration_test.go
@@ -1194,3 +1194,129 @@ func TestRESTIntegrationAnyFileIsAcceptedAndServedInert(t *testing.T) {
 		t.Errorf("the entry carries %d files, want 4 — nothing caps how many", len(view.Attachments))
 	}
 }
+
+// The bundle address serves and takes every object in it (design doc
+// 0046 §3.5): a concept at its own path, a file at its own path, and a
+// markdown document that carries no type — which is not a broken concept
+// but a file that happens to be markdown (SPEC §11 makes the key what a
+// concept has), and which a bundle that carried one gets back.
+func TestRESTIntegrationBundleAddressWritesEveryObject(t *testing.T) {
+	lockLiveAttachments(t)
+	srv, s := newIntegrationServer(t)
+	s.UseBlobStore(memBlobStore{})
+
+	typ := fmt.Sprintf("restbundle%d", time.Now().UnixNano())
+	id := typ + "/revenue"
+	bundle := srv.URL + "/api/v1/bundle/"
+	defer func() {
+		req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/knowledge/"+id, nil)
+		if resp, err := http.DefaultClient.Do(req); err == nil {
+			resp.Body.Close()
+		}
+	}()
+
+	put := func(t *testing.T, path string, body []byte) *http.Response {
+		t.Helper()
+		req, err := http.NewRequest(http.MethodPut, bundle+path, bytes.NewReader(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return resp
+	}
+
+	// A concept, written at the path it lives at. It is the entry
+	// surface's write: same status, same ETag, same View.
+	doc := fmt.Sprintf("---\ntype: %s\ntitle: 売上\n---\n\n![chart](revenue/chart.png)\n", typ)
+	resp := put(t, id+".md", []byte(doc))
+	var view domain.View
+	if err := json.NewDecoder(resp.Body).Decode(&view); err != nil {
+		t.Fatal(err)
+	}
+	etag := resp.Header.Get("ETag")
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated || view.Document != doc {
+		t.Fatalf("writing a concept at its path = %d, document %q", resp.StatusCode, view.Document)
+	}
+	if etag == "" {
+		t.Error("no ETag on a concept written through the bundle address")
+	}
+	// The same bytes again write nothing, exactly as on the entry surface.
+	resp = put(t, id+".md", []byte(doc))
+	resp.Body.Close()
+	if resp.Header.Get("Ochakai-Unchanged") != "true" {
+		t.Errorf("an identical write through the bundle address changed something")
+	}
+	// And it reads back at the same address.
+	var read domain.View
+	getJSON(t, bundle+id+".md", &read)
+	if read.Document != doc {
+		t.Errorf("reading the concept back gave %q", read.Document)
+	}
+
+	// A file, at a path of its own.
+	png := append([]byte("\x89PNG\r\n\x1a\n"), []byte("bundle chart")...)
+	resp = put(t, id+"/chart.png", png)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("writing a file = %d", resp.StatusCode)
+	}
+	resp, err := http.Get(bundle + id + "/chart.png")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if string(got) != string(png) {
+		t.Errorf("the file came back as %d bytes, want %d", len(got), len(png))
+	}
+	// It is attributed to the entry that shows it, without anybody
+	// having said so (design doc 0046 §3.3).
+	getJSON(t, srv.URL+"/api/v1/knowledge/"+id, &read)
+	if len(read.Attachments) != 1 || read.Attachments[0].Name != "chart.png" {
+		t.Errorf("the entry does not carry the file its body shows: %+v", read.Attachments)
+	}
+
+	// A markdown document with no type is a file, not a bad concept.
+	notes := []byte("# 会議メモ\n\ntype なし。\n")
+	resp = put(t, typ+"/notes.md", notes)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("writing a typeless markdown file = %d", resp.StatusCode)
+	}
+	resp, err = http.Get(bundle + typ + "/notes.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if string(got) != string(notes) {
+		t.Errorf("the typeless markdown file came back as %q", got)
+	}
+	// It is not an entry: nothing lists it, and the concept surface does
+	// not know it.
+	resp, err = http.Get(srv.URL + "/api/v1/knowledge/" + typ + "/notes")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("a typeless markdown file answers the entry surface: %d", resp.StatusCode)
+	}
+
+	// Delete reaches both kinds.
+	for _, path := range []string{typ + "/notes.md", id + "/chart.png"} {
+		req, _ := http.NewRequest(http.MethodDelete, bundle+path, nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusNoContent {
+			t.Errorf("deleting %s = %d", path, resp.StatusCode)
+		}
+	}
+}

--- a/internal/restapi/restapi_test.go
+++ b/internal/restapi/restapi_test.go
@@ -86,14 +86,16 @@ func TestBadRequestValidation(t *testing.T) {
 	}
 }
 
-// TestBundleAddressesRefuseByPath pins what /api/v1/bundle answers for
-// the paths it does not serve yet. Three different refusals, and which
-// one a caller gets is the whole point: a reserved name is a generated
-// file and never writable (409), any other path is the write face design
-// doc 0046 §3.5 describes and simply has not landed (501), and reading
-// one of those is a 404 for as long as that is true. One reason for all
-// three — "index.md and log.md are generated" — would answer a request
-// about metrics/revenue.md by talking about two files it never named.
+// TestBundleAddressesRefuseByPath pins the one refusal that is a
+// property of the address rather than of what is stored at it: the two
+// names OKF reserves per directory are generated from the bundle, so a
+// write to one is a conflict with what the address *is* (409, design doc
+// 0046 §§3.5, 3.7-3.8) — never a 404, and never the write path taking
+// the bytes and storing a file that would then be shadowed by the
+// generated document forever.
+//
+// Every other path is an object of the bundle and is read and written
+// like one; that is the integration test's, since it needs a store.
 //
 // Through checkedServer, so each status is one the contract declares:
 // the spec only covers what a test exercises, and until this one there
@@ -110,10 +112,6 @@ func TestBundleAddressesRefuseByPath(t *testing.T) {
 		{"put index.md", http.MethodPut, "index.md", http.StatusConflict, "generated from the bundle"},
 		{"put nested log.md", http.MethodPut, "metrics/log.md", http.StatusConflict, "log.md is generated"},
 		{"delete index.md", http.MethodDelete, "index.md", http.StatusConflict, "index.md is generated"},
-		{"put a concept", http.MethodPut, "metrics/revenue.md", http.StatusNotImplemented, "later change"},
-		{"delete a concept", http.MethodDelete, "metrics/revenue.md", http.StatusNotImplemented, "later change"},
-		{"put a file", http.MethodPut, "metrics/revenue/chart.png", http.StatusNotImplemented, "later change"},
-		{"get a concept", http.MethodGet, "metrics/revenue.md", http.StatusNotFound, "no object at"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/service/attachment.go
+++ b/internal/service/attachment.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"github.com/na0fu3y/ochakai/internal/domain"
 	"github.com/na0fu3y/ochakai/internal/embed"
@@ -145,4 +146,63 @@ func (s *Service) Detach(ctx context.Context, id, name string, actor domain.Acto
 		return err
 	}
 	return s.Store.DeleteAttachment(ctx, domain.Normalize(id), domain.Normalize(name), actor)
+}
+
+// PutFile writes a file at a bundle path (design doc 0046 §§3.2, 3.5).
+// It is Attach's counterpart for an object that belongs to no entry: a
+// producer's seed data in a shared directory, a diagram two entries
+// show, a markdown file carrying no type and so not a concept.
+//
+// Attribution is not asked for and not recorded. Whether an entry is
+// shown by this file is a question its body answers (§3.3), so a file
+// written under an entry's namespace, or one an entry already links,
+// arrives attributed and one nothing points at is simply a file.
+func (s *Service) PutFile(ctx context.Context, p string, data []byte, actor domain.Actor) (*domain.Attachment, error) {
+	if err := s.readOnly(); err != nil {
+		return nil, err
+	}
+	p = domain.Normalize(p)
+	if !s.Store.HasBlobStore() {
+		return nil, Unsupportedf("files are not supported without GCS: this instance stores markdown entries only; set OCHAKAI_GCS_BUCKET (design doc 0013)")
+	}
+	if !domain.ValidBundlePath(p) {
+		return nil, Invalidf("invalid bundle path %q (path segments separated by \"/\"; segments must not start with \".\", and index.md and log.md are generated rather than stored)", p)
+	}
+	if len(data) == 0 {
+		return nil, Invalidf("the file is empty")
+	}
+	if len(data) > domain.MaxAttachmentSize {
+		return nil, Invalidf("the file exceeds %d MiB", domain.MaxAttachmentSize>>20)
+	}
+	mediaType, err := domain.DetectAttachmentMediaType(data)
+	if err != nil {
+		return nil, Invalidf("%v", err)
+	}
+	att, err := s.Store.PutFile(ctx, p, mediaType, data, actor)
+	if err != nil {
+		return nil, err
+	}
+	// The vector is keyed by the entry the file is attributed to, which
+	// a file at a path nothing points at has none of. Reembed picks it up
+	// as soon as an entry names it (design doc 0020).
+	if owner, ok := strings.CutSuffix(p, "/"+att.Name); ok {
+		s.updateAttachmentEmbedding(ctx, owner, att, data)
+	}
+	return att, nil
+}
+
+// GetFile returns the file at a bundle path with its bytes.
+func (s *Service) GetFile(ctx context.Context, p string) (*domain.Attachment, []byte, error) {
+	if !s.Store.HasBlobStore() {
+		return nil, nil, Unsupportedf("files are not supported without GCS: set OCHAKAI_GCS_BUCKET (design doc 0013)")
+	}
+	return s.Store.GetFile(ctx, domain.Normalize(p))
+}
+
+// DeleteFile removes the file at a bundle path.
+func (s *Service) DeleteFile(ctx context.Context, p string, actor domain.Actor) error {
+	if err := s.readOnly(); err != nil {
+		return err
+	}
+	return s.Store.DeleteFile(ctx, domain.Normalize(p), actor)
 }

--- a/internal/service/readonly_test.go
+++ b/internal/service/readonly_test.go
@@ -30,6 +30,7 @@ func TestReadOnlyRefusesEveryWrite(t *testing.T) {
 		// (design doc 0046 §§3.7-3.8).
 		"IndexDocument": true, "LogDocument": true,
 		"Export": true, "Attachment": true, "AttachmentMeta": true,
+		"GetFile":         true,
 		"FillAttachments": true, "RefuseIfCurated": true,
 		"RefuseIfRevivingCurated": true, "Close": true,
 	}

--- a/internal/store/attachment.go
+++ b/internal/store/attachment.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"slices"
 	"strings"
 	"time"
@@ -346,4 +347,120 @@ func listAttachmentsTx(ctx context.Context, tx pgx.Tx, id string) ([]domain.Atta
 		return nil, err
 	}
 	return pgx.CollectRows(rows, scanFile(id))
+}
+
+// PutFile writes a file object at a bundle path, replacing whatever file
+// is there (design doc 0046 §§3.2, 3.5). It is the write behind the
+// bundle address: an object that belongs to no entry — a producer's seed
+// data, a diagram in a shared directory, a markdown file that carries no
+// type and so is not a concept.
+//
+// A concept at that path is not overwritten. The two kinds share one
+// address space, so the path is taken, and a caller who meant to edit
+// the entry there means PUT on the entry.
+func (s *Store) PutFile(ctx context.Context, p, mediaType string, data []byte, actor domain.Actor) (*domain.Attachment, error) {
+	if s.blobs == nil {
+		return nil, errNoBlobStore
+	}
+	sum := sha256.Sum256(data)
+	hash := hex.EncodeToString(sum[:])
+	at := NowStored()
+	// Outside the transaction, and content-addressed, so a failure after
+	// it leaves only an unreferenced object the next write reuses.
+	if err := s.blobs.Put(ctx, hash, mediaType, data); err != nil {
+		return nil, err
+	}
+	err := s.withTx(ctx, func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `INSERT INTO blob (sha256, media_type, size)
+			VALUES ($1, $2, $3) ON CONFLICT (sha256) DO NOTHING`, hash, mediaType, int64(len(data))); err != nil {
+			return err
+		}
+		tag, err := tx.Exec(ctx, `INSERT INTO object
+			(path, type, title, body, blob_hash, size, media_type,
+			 created_by_kind, created_by_name, updated_by_kind, updated_by_name,
+			 created_at, updated_at, content_changed_at)
+			VALUES ($1,'','','',$2,$3,$4,$5,$6,$5,$6,$7,$7,$7)
+			ON CONFLICT (path) DO UPDATE SET
+				blob_hash=EXCLUDED.blob_hash, size=EXCLUDED.size, media_type=EXCLUDED.media_type,
+				updated_by_kind=EXCLUDED.updated_by_kind, updated_by_name=EXCLUDED.updated_by_name,
+				updated_at=EXCLUDED.updated_at
+			WHERE object.id IS NULL`,
+			p, hash, int64(len(data)), mediaType, actor.Kind, actor.Name, at)
+		if err != nil {
+			return err
+		}
+		if tag.RowsAffected() == 0 {
+			return fmt.Errorf("%w: %s is a concept", ErrAlreadyExists, p)
+		}
+		return s.addFileRevision(ctx, tx, p, "create", actor)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &domain.Attachment{
+		Name: p[strings.LastIndex(p, "/")+1:], MediaType: mediaType,
+		Size: int64(len(data)), SHA256: hash, OKFPath: p,
+		CreatedBy: actor, CreatedAt: at,
+	}, nil
+}
+
+// GetFile returns the file object at a bundle path with its bytes.
+func (s *Store) GetFile(ctx context.Context, p string) (*domain.Attachment, []byte, error) {
+	att, err := s.GetFileMeta(ctx, p)
+	if err != nil {
+		return nil, nil, err
+	}
+	if s.blobs == nil {
+		return nil, nil, errNoBlobStore
+	}
+	data, err := s.blobs.Get(ctx, att.SHA256)
+	if err != nil {
+		return nil, nil, err
+	}
+	return att, data, nil
+}
+
+// GetFileMeta is GetFile without the bytes, for a conditional request.
+func (s *Store) GetFileMeta(ctx context.Context, p string) (*domain.Attachment, error) {
+	var a domain.Attachment
+	var at time.Time
+	err := s.pool.QueryRow(ctx, `SELECT media_type, size, blob_hash,
+		created_by_kind, created_by_name, created_at
+		FROM object WHERE path=$1 AND id IS NULL AND deleted_at IS NULL`, p).
+		Scan(&a.MediaType, &a.Size, &a.SHA256, &a.CreatedBy.Kind, &a.CreatedBy.Name, &at)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	a.Name, a.OKFPath, a.CreatedAt = p[strings.LastIndex(p, "/")+1:], p, at
+	return &a, nil
+}
+
+// DeleteFile removes the file object at a bundle path. The blob stays:
+// revisions still name its hash, and content-addressed rows are cheap.
+func (s *Store) DeleteFile(ctx context.Context, p string, actor domain.Actor) error {
+	return s.withTx(ctx, func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx, `DELETE FROM object WHERE path=$1 AND id IS NULL`, p)
+		if err != nil {
+			return err
+		}
+		if tag.RowsAffected() == 0 {
+			return ErrNotFound
+		}
+		return s.addFileRevision(ctx, tx, p, "delete", actor)
+	})
+}
+
+// addFileRevision records a file's own history, in the ledger the
+// concepts use (design doc 0046 §3.1). A file has no document, so the
+// revision carries the change and who made it and nothing else — which
+// is the whole of what happened.
+func (s *Store) addFileRevision(ctx context.Context, tx pgx.Tx, p, change string, actor domain.Actor) error {
+	_, err := tx.Exec(ctx, `INSERT INTO knowledge_revision
+		(path, id, rev, change, changed_by_kind, changed_by_name, changed_by_via, doc)
+		VALUES ($1, NULL, (SELECT COALESCE(MAX(rev), 0) + 1 FROM knowledge_revision WHERE path=$1), $2, $3, $4, $5, '')`,
+		p, change, actor.Kind, actor.Name, actor.Via)
+	return err
 }

--- a/internal/store/migrations/0030_file_revisions.sql
+++ b/internal/store/migrations/0030_file_revisions.sql
@@ -1,0 +1,11 @@
+-- A file's history goes in the ledger the concepts use (design doc 0046
+-- §3.1): creating and deleting a file is a change to the bundle, and a
+-- second place to record it would be a second history to read.
+--
+-- The ledger is keyed by path (0028) and carries the concept id beside
+-- it, for the reads that still ask by id. A file has no concept id — an
+-- id is a concept's address, and the path with ".md" removed is not one
+-- for a .png — so the column stops being NOT NULL. NULL rather than '':
+-- the same reason object.id took, and it keeps "which revisions are this
+-- concept's" an equality rather than a special case.
+ALTER TABLE knowledge_revision ALTER COLUMN id DROP NOT NULL;


### PR DESCRIPTION
#267 item 5's write face, moved ahead of the rest of item 3 because the import needs somewhere to put an object that belongs to no entry.

`GET|PUT|DELETE /api/v1/bundle/{path}` now reaches a concept at `<id>.md` and a file at its own path, beside the two generated files that were already there.

## One object, two addresses, one answer

A concept read or written through the bundle address answers exactly as it does on `/api/v1/knowledge/{id}`: the same View, the same document under `Accept: text/markdown`, the same `ETag`, the same `If-Match` / `If-None-Match: *`, the same `Ochakai-Unchanged`.

That is not two handlers that happen to agree. The entry `PUT` body was pulled out into `putEntry` and both addresses call it — an address is not a second surface, and the way to keep that true is to have one implementation rather than a test that compares two.

## What the bytes are decides what they become

A markdown document whose frontmatter carries a `type` is a concept. Anything else is a file — **including a markdown document with no `type`**. SPEC §11 makes the type key what a concept has, so a document without one is not a broken concept: it is a file that happens to be markdown, and a bundle that carried one now gets it back instead of losing it (§3.2). That is the piece the import was waiting for.

A file written here needs no owner. Whether an entry shows it is a question its body answers (§3.3, landed in #288), so a file written under an entry's namespace arrives attributed, and one nothing points at is simply a file. The integration test checks that: `chart.png` is written at a bare path and turns up in the entry's `attachments` because the entry's body shows it, with nobody having said so.

A file's history lands in the ledger the concepts use — created and deleted, by whom — which is what §3.1 meant by a revision being an event about an object. Migration 0030 lets that ledger hold a row with no concept id, for the same reason the object table does.

`index.md` and `log.md` stay 409 on write. That refusal is a property of the address, not of what is stored at it, so it stays in the unit test that needs no store; everything else moved to the integration test.

## The contract test grew a rule, not an exception

`carriesOpaqueBytes` skipped the attachment endpoint because the validator matches media types exactly and reads `*/*` as a literal type name. Rather than extend that list, the skip is now stated as what it is: **a response whose media type was decided by sniffing is not validated against the spec**, since the schema under the wildcard asserts nothing about bytes. Everything the handler *chooses* stays checked — a concept read through the bundle address is `application/json` or `text/markdown` and is validated like any other, which is precisely the part that could drift.

## Tests

`TestRESTIntegrationBundleAddressWritesEveryObject` walks all three kinds through one address: a concept (201, byte-identical document back, `Ochakai-Unchanged` on the repeat, same read at the same address), a file (bytes back byte-identical, attributed to the entry whose body shows it), and a typeless markdown file (stored, read back verbatim, and **404 on the entry surface** — it is not an entry). Then DELETE reaches both kinds.

`scripts/check --db` is clean.
