### PR TITLE
Keep what the bundle carried (0046 §3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,24 @@ last entry.
 
 ### Added
 
+- **What enters the bundle leaves it** (design doc
+  [0046](docs/design/0046-bundle-address-space.md) §3.2). `ochakai
+  import` now keeps every file the bundle carried, at the path it
+  arrived at — a file no entry references, a markdown document with no
+  `type`, an archive, an SVG. They are written through the bundle
+  address, so nothing is attributed to an entry that did not ask for it:
+  whether an entry shows a file is a question its body answers (§3.3).
+
+  A bundle used to come back smaller than it went in. Anything that was
+  not a concept and not an attachment was reported and dropped, which is
+  the one thing a store of bundles must not do — and the report made it
+  look deliberate. The skip list is now down to what cannot be stored at
+  all: an empty file, one past 5 MiB, or a path ochakai cannot address.
+
+  The summary line and `--dry-run` count them (`… 0 attachments, 3
+  files, 0 skipped`), and `--strict` is unaffected: a file that is kept
+  is not a reinterpretation of anything.
+
 - **The bundle address reads and writes every object in it** (design doc
   [0046](docs/design/0046-bundle-address-space.md) §3.5).
   `GET|PUT|DELETE /api/v1/bundle/{path}` now serves a concept at

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -1128,7 +1128,7 @@ func cmdExport(ctx context.Context, args []string) error {
 func cmdImport(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
 		"import",
-		"Usage: ochakai import [flags] <dir | file.tar.gz | ->\n\nImport an OKF bundle (a directory of markdown + YAML frontmatter, or\na tar.gz of one; \"-\" reads the tar.gz from stdin). The inverse of\n`ochakai export`: each path names its entry (the path minus .md is\nthe id), the frontmatter type key names the type (required — files\nwithout one are skipped and reported), reserved index.md / log.md\nfiles are skipped, keys the format does not define are kept as\nwritten, and existing entries are replaced (kept as revisions; entries identical\nto what is stored are left untouched and reported as unchanged;\nentries the server rejects as invalid — e.g. one whose type is not a\nsingle line — are skipped and reported).\nFiles referenced by an entry's body markdown links become its\nattachments, wherever they sit in the bundle (their location is\npreserved for re-export); unreferenced data files inside an entry's\ndirectory (<id>/<name>) attach to that entry. The packed shape is\nthe structure: an archive wrapped in a single directory imports\nunder that directory — the bundle keeps its own namespace. Works\nwith any OKF bundle, not just ochakai's own.\nA file that cannot be read is skipped; a value read differently than\nit was written is a note and the entry still imports. Both are\nreported and neither fails the command, because a consumer takes the\ndocument rather than rejecting it. --strict is the opposite posture,\nfor a sync nobody watches: a bundle that is not read exactly as\nwritten fails, and the counts land in the summary line either way.",
+		"Usage: ochakai import [flags] <dir | file.tar.gz | ->\n\nImport an OKF bundle (a directory of markdown + YAML frontmatter, or\na tar.gz of one; \"-\" reads the tar.gz from stdin). The inverse of\n`ochakai export`: each path names its entry (the path minus .md is\nthe id), the frontmatter type key names the type (required — a\nmarkdown file without one is not a concept, and is kept as a file),\nreserved index.md / log.md files are skipped, keys the format does\nnot define are kept as written, and existing entries are replaced (kept as revisions; entries identical\nto what is stored are left untouched and reported as unchanged;\nentries the server rejects as invalid — e.g. one whose type is not a\nsingle line — are skipped and reported).\nFiles referenced by an entry's body markdown links become its\nattachments, wherever they sit in the bundle (their location is\npreserved for re-export); unreferenced data files inside an entry's\ndirectory (<id>/<name>) attach to that entry. Everything else the\nbundle carried is written at the path it arrived at — what enters\nleaves, so nothing is dropped for belonging to no entry. The packed shape is\nthe structure: an archive wrapped in a single directory imports\nunder that directory — the bundle keeps its own namespace. Works\nwith any OKF bundle, not just ochakai's own.\nA file that cannot be stored at all — empty, oversized, or at a path\nochakai cannot address — is skipped; a value read differently than\nit was written is a note and the entry still imports. Both are\nreported and neither fails the command, because a consumer takes the\ndocument rather than rejecting it. --strict is the opposite posture,\nfor a sync nobody watches: a bundle that is not read exactly as\nwritten fails, and the counts land in the summary line either way.",
 		"  ochakai import ./knowledge\n  ochakai import ga4-bundle.tar.gz --dry-run\n  ochakai import ./knowledge --dry-run --strict   # gate a CI sync on a clean parse\n  ochakai export - | OCHAKAI_URL=https://other ochakai import -\n")
 	dryRun := fs.Bool("dry-run", false, "parse and list what would be written, write nothing")
 	strict := fs.Bool("strict", false, "refuse a bundle that is not read exactly as written: any note or skip fails the command instead of being reported. Parse-time ones are found before anything is written, so a strict import either lands whole or writes nothing")
@@ -1140,7 +1140,7 @@ func cmdImport(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	entries, atts, skipped, notes := okf.FromBundle(files)
+	entries, atts, loose, skipped, notes := okf.FromBundle(files)
 	for _, s := range skipped {
 		fmt.Fprintln(os.Stderr, "skip:", s)
 	}
@@ -1166,8 +1166,11 @@ func cmdImport(ctx context.Context, args []string) error {
 		for _, a := range atts {
 			fmt.Printf("would attach %s/%s (from %s)\n", a.ID, a.Name, a.Path)
 		}
-		fmt.Printf("dry run: %d entries, %d attachments, %d skipped, %d notes\n",
-			len(entries), len(atts), len(skipped), noted)
+		for _, f := range loose {
+			fmt.Printf("would write %s\n", f.Path)
+		}
+		fmt.Printf("dry run: %d entries, %d attachments, %d files, %d skipped, %d notes\n",
+			len(entries), len(atts), len(loose), len(skipped), noted)
 		return nil
 	}
 	c, err := newClient(ctx, *url)
@@ -1255,8 +1258,27 @@ func cmdImport(ctx context.Context, args []string) error {
 		attached++
 		fmt.Printf("attached %s/%s\n", a.ID, a.Name)
 	}
-	fmt.Printf("imported %d entries (%d created, %d updated, %d unchanged, %d attachments, %d skipped, %d notes)\n",
-		created+updated+unchanged, created, updated, unchanged, attached, len(skipped), noted)
+	// The files that belong to no entry, at the paths they arrived at.
+	// A bundle carries more than its concepts, and what enters it leaves
+	// it (design doc 0046 §3.2): a producer's seed data in a shared
+	// directory, a diagram nothing links yet, a markdown file with no
+	// type. Whether an entry ever claims one is a question that entry's
+	// body answers (§3.3), so nothing is attributed here.
+	var written int
+	for _, f := range loose {
+		if err := c.PutBundleFile(ctx, f.Path, f.Data); err != nil {
+			if !isInvalid(err) {
+				return fmt.Errorf("write %s: %w", f.Path, err)
+			}
+			skipped = append(skipped, f.Path+": rejected by the server: "+err.Error())
+			fmt.Fprintln(os.Stderr, "skip:", skipped[len(skipped)-1])
+			continue
+		}
+		written++
+		fmt.Printf("wrote %s\n", f.Path)
+	}
+	fmt.Printf("imported %d entries (%d created, %d updated, %d unchanged, %d attachments, %d files, %d skipped, %d notes)\n",
+		created+updated+unchanged, created, updated, unchanged, attached, written, len(skipped), noted)
 	// The parse-time gate above cannot see what the server read differently
 	// or refused, so --strict asks again with the writes already done. The
 	// summary is printed first: the exit code says the sync is not clean,

--- a/cmd/ochakai/client_test.go
+++ b/cmd/ochakai/client_test.go
@@ -273,7 +273,7 @@ func TestImportReportsUnchanged(t *testing.T) {
 	for _, want := range []string{
 		"unchanged ochakai://metrics/same\n",
 		"updated ochakai://metrics/diff\n",
-		"imported 2 entries (0 created, 1 updated, 1 unchanged, 0 attachments, 0 skipped, 0 notes)\n",
+		"imported 2 entries (0 created, 1 updated, 1 unchanged, 0 attachments, 0 files, 0 skipped, 0 notes)\n",
 	} {
 		if !strings.Contains(string(out), want) {
 			t.Errorf("output misses %q:\n%s", want, out)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -307,21 +307,24 @@ Usage: ochakai import [flags] <dir | file.tar.gz | ->
 Import an OKF bundle (a directory of markdown + YAML frontmatter, or
 a tar.gz of one; "-" reads the tar.gz from stdin). The inverse of
 `ochakai export`: each path names its entry (the path minus .md is
-the id), the frontmatter type key names the type (required — files
-without one are skipped and reported), reserved index.md / log.md
-files are skipped, keys the format does not define are kept as
-written, and existing entries are replaced (kept as revisions; entries identical
+the id), the frontmatter type key names the type (required — a
+markdown file without one is not a concept, and is kept as a file),
+reserved index.md / log.md files are skipped, keys the format does
+not define are kept as written, and existing entries are replaced (kept as revisions; entries identical
 to what is stored are left untouched and reported as unchanged;
 entries the server rejects as invalid — e.g. one whose type is not a
 single line — are skipped and reported).
 Files referenced by an entry's body markdown links become its
 attachments, wherever they sit in the bundle (their location is
 preserved for re-export); unreferenced data files inside an entry's
-directory (<id>/<name>) attach to that entry. The packed shape is
+directory (<id>/<name>) attach to that entry. Everything else the
+bundle carried is written at the path it arrived at — what enters
+leaves, so nothing is dropped for belonging to no entry. The packed shape is
 the structure: an archive wrapped in a single directory imports
 under that directory — the bundle keeps its own namespace. Works
 with any OKF bundle, not just ochakai's own.
-A file that cannot be read is skipped; a value read differently than
+A file that cannot be stored at all — empty, oversized, or at a path
+ochakai cannot address — is skipped; a value read differently than
 it was written is a note and the entry still imports. Both are
 reported and neither fails the command, because a consumer takes the
 document rather than rejecting it. --strict is the opposite posture,

--- a/internal/apiclient/apiclient.go
+++ b/internal/apiclient/apiclient.go
@@ -665,3 +665,19 @@ func (c *Client) doJSON(ctx context.Context, method, path string, query url.Valu
 	}
 	return json.NewDecoder(resp.Body).Decode(out)
 }
+
+// PutBundleFile writes one object of the bundle at its path
+// (PUT /api/v1/bundle/{path}, design doc 0046 §3.5). It is how an import
+// keeps what a bundle carried besides its concepts: a file no entry
+// references, or a markdown file with no type, which the server stores
+// as a file rather than reading as a concept.
+func (c *Client) PutBundleFile(ctx context.Context, path string, data []byte) error {
+	resp, err := c.doRaw(ctx, http.MethodPut, "/api/v1/bundle/"+path, nil,
+		"application/octet-stream", nil, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return nil
+}

--- a/internal/okf/attachment_test.go
+++ b/internal/okf/attachment_test.go
@@ -28,7 +28,7 @@ func TestFromBundleAttachments(t *testing.T) {
 		"terms/broken.md": []byte("---\ntype: Glossary Term\ntitle: x\n---\n\n" +
 			"![missing](nowhere/gone.png)\n"), // broken links are tolerated, never an error
 	}
-	entries, atts, skipped, _ := FromBundle(files)
+	entries, atts, loose, skipped, _ := FromBundle(files)
 	if len(entries) != 3 {
 		t.Fatalf("entries = %d, want 3", len(entries))
 	}
@@ -43,10 +43,15 @@ func TestFromBundleAttachments(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("attachments = %v, want %v", got, want)
 	}
-	// The unreferenced image stays in the skip report; the referenced ones
-	// must not appear there.
-	if len(skipped) != 1 || !strings.Contains(skipped[0], "unreferenced.png") {
-		t.Errorf("skipped = %v, want only unreferenced.png", skipped)
+	// The unreferenced image belongs to no entry, and is kept anyway: it
+	// is the bundle's file, at the path it arrived at (design doc 0046
+	// §3.2). Nothing is skipped — a bundle that came in whole goes back
+	// out whole.
+	if len(loose) != 1 || loose[0].Path != "unreferenced.png" {
+		t.Errorf("loose files = %v, want only unreferenced.png", loose)
+	}
+	if len(skipped) != 0 {
+		t.Errorf("skipped = %v, want nothing", skipped)
 	}
 }
 
@@ -57,15 +62,16 @@ func TestFromBundleRootConceptAttachment(t *testing.T) {
 		"overview.md":   []byte("---\ntype: Insight\ntitle: overview\n---\n\n![chart](img/chart.png)\n"),
 		"img/chart.png": pngBytes(),
 	}
-	_, atts, _, _ := FromBundle(files)
+	_, atts, _, _, _ := FromBundle(files)
 	if len(atts) != 1 || atts[0].Path != "img/chart.png" || atts[0].ID != "overview" {
 		t.Fatalf("atts = %+v", atts)
 	}
 }
 
 // Markdown links must not attach concept documents, oversized files, or
-// files that resolve nowhere; orphans outside any entry's namespace stay
-// in the skip report.
+// files that resolve nowhere. A file nobody claims is kept as the
+// bundle's own (design doc 0046 §3.2); only what cannot be stored at all
+// is reported.
 func TestFromBundleAttachmentAllowlist(t *testing.T) {
 	files := map[string][]byte{
 		"terms/a.md": []byte("---\ntype: Glossary Term\ntitle: a\n---\n\n" +
@@ -74,13 +80,19 @@ func TestFromBundleAttachmentAllowlist(t *testing.T) {
 		"data.csv":   []byte("a,b,c"),
 		"big.png":    append(pngBytes(), make([]byte, domain.MaxAttachmentSize)...),
 	}
-	_, atts, skipped, _ := FromBundle(files)
+	_, atts, loose, skipped, _ := FromBundle(files)
 	if len(atts) != 0 {
 		t.Errorf("nothing should attach, got %+v", atts)
 	}
-	// data.csv and big.png stay reported; terms/b.md imported as an entry.
-	if len(skipped) != 2 {
-		t.Errorf("skipped = %v", skipped)
+	// terms/b.md is imported as an entry. data.csv resolves nowhere from
+	// a.md's directory, so it is nobody's file and is kept as the
+	// bundle's. big.png is past the size limit, which is the one thing
+	// that cannot be kept — and is therefore the only thing reported.
+	if len(loose) != 1 || loose[0].Path != "data.csv" {
+		t.Errorf("loose = %+v, want only data.csv", loose)
+	}
+	if len(skipped) != 1 || !strings.Contains(skipped[0], "big.png") {
+		t.Errorf("skipped = %v, want only big.png", skipped)
 	}
 }
 
@@ -94,7 +106,7 @@ func TestFromBundleFileAttachments(t *testing.T) {
 		"data/seeds.txt":         []byte("https://example.com/schema\nhttps://example.com/docs\n"),
 		"tables/orders/spec.pdf": []byte("%PDF-1.7 fake pdf body"),
 	}
-	_, atts, skipped, _ := FromBundle(files)
+	_, atts, _, skipped, _ := FromBundle(files)
 	got := map[string]string{}
 	for _, a := range atts {
 		got[a.ID+"/"+a.Name] = a.Path
@@ -123,7 +135,7 @@ func TestFromBundleNamespaceAttribution(t *testing.T) {
 		"tables/orders/seeds.txt": []byte("seed data, referenced by no body\n"),
 		"orphan/seeds.txt":        []byte("no entry named orphan\n"),
 	}
-	entries, atts, skipped, _ := FromBundle(files)
+	entries, atts, loose, skipped, _ := FromBundle(files)
 	if len(entries) != 1 {
 		t.Fatalf("entries = %d, want 1", len(entries))
 	}
@@ -138,8 +150,13 @@ func TestFromBundleNamespaceAttribution(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("attachments = %v, want %v", got, want)
 	}
-	if len(skipped) != 1 || !strings.Contains(skipped[0], "orphan/seeds.txt") {
-		t.Errorf("skipped = %v, want only orphan/seeds.txt", skipped)
+	// A file under no entry's namespace is attributed to nobody and kept
+	// anyway, at the path it arrived at (design doc 0046 §3.2).
+	if len(loose) != 1 || loose[0].Path != "orphan/seeds.txt" {
+		t.Errorf("loose = %+v, want only orphan/seeds.txt", loose)
+	}
+	if len(skipped) != 0 {
+		t.Errorf("skipped = %v, want nothing", skipped)
 	}
 }
 
@@ -150,7 +167,7 @@ func TestFromBundleNamespaceHierarchicalID(t *testing.T) {
 		"queries/sales/monthly.md":           []byte("---\ntype: Attested Computation\ntitle: monthly\n---\n"),
 		"queries/sales/monthly/expected.txt": []byte("month,revenue\n2026-01,100\n"),
 	}
-	_, atts, skipped, _ := FromBundle(files)
+	_, atts, _, skipped, _ := FromBundle(files)
 	if len(atts) != 1 || atts[0].ID != "queries/sales/monthly" || atts[0].Name != "expected.txt" {
 		t.Fatalf("atts = %+v", atts)
 	}

--- a/internal/okf/bundle.go
+++ b/internal/okf/bundle.go
@@ -26,15 +26,22 @@ import (
 // producer's layout works (design doc 0008); the original path is
 // preserved for re-export. Unreferenced non-markdown files sitting in an
 // entry's canonical namespace ("<id>/<name>") attach to that entry
-// (design doc 0013). Anything else that cannot become an entry or an
-// attachment — orphaned non-markdown files, unparsable documents, invalid
-// ids — is reported in skipped as "path: reason" lines rather than
+// (design doc 0013).
+//
+// Everything else the bundle carried comes back in loose, at the path it
+// arrived at: a file no entry references, and a markdown document with
+// no type — which SPEC §11 makes not-a-concept, and which is therefore a
+// markdown file rather than a broken entry. What enters the bundle
+// leaves it (design doc 0046 §3.2), so the skip report is down to the
+// paths that cannot be stored at all: a segment that starts with a dot,
+// a name OKF reserves for a generated file, an empty file, one past the
+// size limit. Those are reported as "path: reason" lines rather than
 // failing the whole bundle.
 //
 // There is no archive unwrapping: `tar czf ga4.tgz ga4/` imports under
 // "ga4/" — the packed shape is the structure, and a wrapper directory is
 // how a bundle keeps its own namespace (design doc 0017 §4.3).
-func FromBundle(files map[string][]byte) (entries []Doc, atts []BundleAttachment, skipped, notes []string) {
+func FromBundle(files map[string][]byte) (entries []Doc, atts []BundleAttachment, loose []BundleFile, skipped, notes []string) {
 	paths := make([]string, 0, len(files))
 	for p := range files {
 		paths = append(paths, p)
@@ -56,7 +63,13 @@ func FromBundle(files map[string][]byte) (entries []Doc, atts []BundleAttachment
 		}
 		d, docNotes, err := fromBundleFile(clean, files[p])
 		if err != nil {
-			skipped = append(skipped, p+": "+err.Error())
+			// A markdown file that is not a concept is still a file the
+			// bundle carried (design doc 0046 §3.2). SPEC §11 makes the
+			// type key what a concept has, so a document without one is
+			// not a broken concept — and one that does not parse as
+			// frontmatter at all is a markdown file, which is a thing a
+			// producer's bundle is full of.
+			nonMarkdown = append(nonMarkdown, p)
 			continue
 		}
 		for _, n := range docNotes {
@@ -71,13 +84,49 @@ func FromBundle(files map[string][]byte) (entries []Doc, atts []BundleAttachment
 	}
 	atts, used := resolveAttachments(files, concepts)
 	for _, p := range nonMarkdown {
-		if !used[cleanPath(p)] {
-			skipped = append(skipped, p+": not a markdown concept (referenced by no entry body, and not in an entry's directory)")
+		clean := cleanPath(p)
+		if used[clean] {
+			continue
 		}
+		// Nobody's file is still the bundle's file. What enters leaves
+		// (design doc 0046 §3.2): the only thing that cannot be kept is
+		// a path ochakai cannot address — a segment starting with a dot,
+		// a name OKF reserves for a generated file, an empty file, or
+		// one past the size limit.
+		if err := loadable(clean, files[p]); err != nil {
+			skipped = append(skipped, p+": "+err.Error())
+			continue
+		}
+		loose = append(loose, BundleFile{Path: clean, Data: files[p]})
 	}
 
 	sort.Slice(entries, func(i, j int) bool { return entries[i].ID < entries[j].ID })
-	return entries, atts, skipped, notes
+	sort.Slice(loose, func(i, j int) bool { return loose[i].Path < loose[j].Path })
+	return entries, atts, loose, skipped, notes
+}
+
+// BundleFile is one object of the bundle that belongs to no entry: a
+// producer's seed data in a shared directory, a diagram nothing links
+// yet, a markdown file that carries no type. It is written at the path
+// it arrived at (design doc 0046 §§3.2, 3.5), and whether an entry ever
+// claims it is a question that entry's body answers (§3.3).
+type BundleFile struct {
+	Path string
+	Data []byte
+}
+
+// loadable reports why a bundle path cannot be stored, or nil.
+func loadable(clean string, data []byte) error {
+	if !domain.ValidBundlePath(clean) {
+		return fmt.Errorf("not an addressable bundle path")
+	}
+	if len(data) == 0 {
+		return fmt.Errorf("empty file")
+	}
+	if len(data) > domain.MaxAttachmentSize {
+		return fmt.Errorf("exceeds %d MiB", domain.MaxAttachmentSize>>20)
+	}
+	return nil
 }
 
 // cleanPath canonicalizes one bundle path: relative prefix stripped,

--- a/internal/okf/bundle_test.go
+++ b/internal/okf/bundle_test.go
@@ -113,7 +113,7 @@ func TestBundleRoundTrip(t *testing.T) {
 			Body:        "本文。", UpdatedAt: now},
 	}
 	files := bundle(t, want)
-	got, _, skipped, _ := FromBundle(files)
+	got, _, _, skipped, _ := FromBundle(files)
 	if len(skipped) != 0 {
 		t.Fatalf("skipped %v", skipped)
 	}
@@ -145,7 +145,7 @@ func TestBundleTitleOptional(t *testing.T) {
 	files := map[string][]byte{
 		"insights/サンプル.md": []byte("---\ntype: Insight\n---\n\n本文。\n"),
 	}
-	entries, _, skipped, _ := FromBundle(files)
+	entries, _, _, skipped, _ := FromBundle(files)
 	if len(skipped) != 0 {
 		t.Fatalf("skipped %v", skipped)
 	}
@@ -172,7 +172,7 @@ func TestFromBundleNFCPaths(t *testing.T) {
 			"![chart](" + nfd + "/chart.png)\n"),
 		"insights/" + nfd + "/chart.png": pngBytes(),
 	}
-	entries, atts, skipped, _ := FromBundle(files)
+	entries, atts, _, skipped, _ := FromBundle(files)
 	if len(skipped) != 0 {
 		t.Fatalf("skipped %v", skipped)
 	}
@@ -187,8 +187,9 @@ func TestFromBundleNFCPaths(t *testing.T) {
 // A foreign OKF bundle — free layout, spelled frontmatter types,
 // non-markdown extras — imports with structure preserved: the path is the
 // id verbatim, the frontmatter alone names the type (design doc 0016),
-// the reserved index.md / log.md files are skipped silently, and
-// non-markdown files and typeless documents are skipped with a report.
+// the reserved index.md / log.md files are skipped silently, and a
+// non-markdown file or a typeless document — neither of which is a
+// concept — is kept as a file of the bundle (design doc 0046 §3.2).
 func TestFromBundleForeign(t *testing.T) {
 	files := map[string][]byte{
 		"index.md":         []byte("# my bundle\n"),
@@ -200,9 +201,19 @@ func TestFromBundleForeign(t *testing.T) {
 		"notes/2026/q3.md": []byte("---\ntitle: Q3 notes\n---\n"), // no frontmatter type at all
 		"viz.html":         []byte("<html></html>"),
 	}
-	entries, _, skipped, _ := FromBundle(files)
-	if len(skipped) != 2 || !strings.Contains(skipped[0], "notes/2026/q3.md") || !strings.Contains(skipped[1], "viz.html") {
-		t.Errorf("skipped = %v, want the typeless document and viz.html", skipped)
+	entries, _, loose, skipped, _ := FromBundle(files)
+	// A document with no type is not a concept (SPEC §11) and not a
+	// mistake either: it is a markdown file, and it goes back where it
+	// came from. So does the HTML nobody references.
+	var kept []string
+	for _, f := range loose {
+		kept = append(kept, f.Path)
+	}
+	if !reflect.DeepEqual(kept, []string{"notes/2026/q3.md", "viz.html"}) {
+		t.Errorf("kept = %v, want the typeless document and viz.html", kept)
+	}
+	if len(skipped) != 0 {
+		t.Errorf("skipped = %v, want nothing", skipped)
 	}
 	byURI := map[string]domain.Knowledge{}
 	for _, e := range entries {
@@ -256,9 +267,12 @@ func TestFromBundleFixture(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	entries, _, skipped, _ := FromBundle(files)
-	if len(skipped) != 1 || !strings.Contains(skipped[0], "viz.html") {
-		t.Errorf("skipped = %v, want only viz.html", skipped)
+	entries, _, loose, skipped, _ := FromBundle(files)
+	if len(loose) != 1 || loose[0].Path != "viz.html" {
+		t.Errorf("loose = %+v, want only viz.html", loose)
+	}
+	if len(skipped) != 0 {
+		t.Errorf("skipped = %v, want nothing", skipped)
 	}
 	if len(entries) != 3 {
 		t.Fatalf("entries = %d, want 3", len(entries))
@@ -309,7 +323,7 @@ func TestFromBundleWrappedArchive(t *testing.T) {
 		"._ga4":                []byte("apple double"),
 		"ga4/.DS_Store":        []byte("finder noise"),
 	}
-	entries, _, skipped, _ := FromBundle(wrapped)
+	entries, _, _, skipped, _ := FromBundle(wrapped)
 	if len(skipped) != 0 {
 		t.Errorf("skipped = %v, want none (hidden files skip silently)", skipped)
 	}
@@ -320,5 +334,66 @@ func TestFromBundleWrappedArchive(t *testing.T) {
 	// changes the namespace, never the type.
 	if entries[0].Type != domain.TypeTables || len(entries[0].Attrs) != 0 {
 		t.Errorf("type = %q attrs = %v", entries[0].Type, entries[0].Attrs)
+	}
+}
+
+// What enters the bundle leaves it (design doc 0046 §3.2). The reading
+// that FromBundle used to take — anything that is not a concept and not
+// an attachment is reported and dropped — meant a producer's bundle came
+// back smaller than it went in, which is the one thing a bundle store
+// must not do. The only paths still reported are the ones that cannot be
+// stored at all.
+func TestFromBundleKeepsWhatItCannotAttribute(t *testing.T) {
+	files := map[string][]byte{
+		// The concepts, and a file each of them claims.
+		"metrics/revenue.md":        []byte("---\ntype: Metric\ntitle: 売上\n---\n\n![chart](revenue/chart.png)\n"),
+		"metrics/revenue/chart.png": pngBytes(),
+
+		// Nobody's, all of it kept.
+		"seeds/orders.csv":  []byte("a,b\n1,2\n"),
+		"notes/meeting.md":  []byte("# 議事録\n\ntype なし。\n"),      // not a concept (SPEC §11)
+		"vendor/report.zip": append([]byte("PK\x03\x04"), 0, 0), // never was on any allowlist
+		"diagrams/er.svg":   []byte(`<svg xmlns="http://www.w3.org/2000/svg"/>`),
+
+		// Generated, and hidden: skipped in silence, as before.
+		"index.md":          []byte("# bundle\n"),
+		"metrics/log.md":    []byte("# log\n"),
+		".git/config":       []byte("[core]\n"),
+		"._AppleDouble":     []byte("junk"),
+		"metrics/.DS_Store": []byte("junk"),
+
+		// The one thing that cannot be kept: nothing to store.
+		"empty.txt": {},
+	}
+	entries, atts, loose, skipped, _ := FromBundle(files)
+	if len(entries) != 1 || len(atts) != 1 {
+		t.Fatalf("entries = %d, attachments = %d, want 1 and 1", len(entries), len(atts))
+	}
+	var kept []string
+	for _, f := range loose {
+		kept = append(kept, f.Path)
+	}
+	want := []string{"diagrams/er.svg", "notes/meeting.md", "seeds/orders.csv", "vendor/report.zip"}
+	if !reflect.DeepEqual(kept, want) {
+		t.Errorf("kept = %v, want %v", kept, want)
+	}
+	if len(skipped) != 1 || !strings.Contains(skipped[0], "empty.txt") {
+		t.Errorf("skipped = %v, want only empty.txt", skipped)
+	}
+	// Every path the bundle carried is accounted for exactly once.
+	seen := map[string]int{}
+	for _, e := range entries {
+		seen[e.ID+".md"]++
+	}
+	for _, a := range atts {
+		seen[a.Path]++
+	}
+	for _, f := range loose {
+		seen[f.Path]++
+	}
+	for p, n := range seen {
+		if n != 1 {
+			t.Errorf("%s was taken %d times", p, n)
+		}
 	}
 }


### PR DESCRIPTION
The rest of #267 item 3, now that #290 gave an object with no owner somewhere to go.

An import used to hand back a smaller bundle than it took. Anything that was not a concept and not an attachment — a file no entry references, a markdown document with no `type`, an archive, an SVG — was reported and dropped, and the report made the loss look deliberate.

## What changes

`FromBundle` returns those files instead of skipping them, and `ochakai import` writes them through `PUT /api/v1/bundle/{path}`, at the paths they arrived at.

Nothing is attributed to an entry that did not ask for it. Whether an entry shows a file is a question its body answers (§3.3, #288), so a file under an entry's namespace arrives attributed and the rest is simply the bundle's.

**A markdown document with no `type` is the case worth naming.** SPEC §11 makes the type key what a concept has, so a document without one is not a broken concept to report — it is a markdown file, and it goes back where it came from.

## What is still skipped

Only what cannot be stored at all: an empty file, one past 5 MiB, or a path ochakai cannot address (a segment starting with a dot, a name OKF reserves for a generated file). Hidden paths and the generated files stay silent, as before.

## Tests

The tests that asserted the old dropping now assert the keeping — that is the clearest statement of what changed, so they were edited rather than replaced:

- `TestFromBundleAttachments`: `unreferenced.png` was "skipped, want only unreferenced.png"; it is now kept and nothing is skipped.
- `TestFromBundleAttachmentAllowlist`: `data.csv` resolves nowhere from its referrer's directory, so it is nobody's file and is kept; `big.png` is past the limit, and is now the *only* thing reported.
- `TestFromBundleNamespaceAttribution`, `TestFromBundleForeign`, `TestFromBundleFixture`: same shape.

New: `TestFromBundleKeepsWhatItCannotAttribute` walks a bundle with all of it at once — concepts, a claimed file, four unclaimed ones (csv, typeless markdown, zip, svg), the generated and hidden paths, and one empty file. It asserts what is kept, that the empty file is the only report, and that **every path the bundle carried is accounted for exactly once** across entries, attachments and files. That last check is the property this PR is really about.

`scripts/check --db` is clean; CLI help regenerated.
