### PR TITLE
Make the MCP write face one tool (0046 §3.14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,26 @@ last entry.
 
 ### Added
 
+- **BREAKING** — the MCP write face is one tool. `create_knowledge` and
+  `update_knowledge` are `put_knowledge`: it creates when the id is free
+  and replaces when it is taken (design doc
+  [0046](docs/design/0046-bundle-address-space.md) §3.14).
+
+  The two tools asked the agent a question the document does not answer.
+  A write states what the entry should say, and whether the id was
+  already taken is not part of that statement — the same reasoning that
+  gave REST one `PUT` instead of a POST beside it. The guards are
+  unchanged and still apply to the half they belong to: reviving a
+  curated tombstone is refused on the create side, replacing an entry a
+  human ruled on is refused on the other, and both refusals still name
+  the way forward.
+
+  It is also where the tool budget actually is. The whole surface is
+  33.5 KB of JSON schema; this merge saves about 6 KB of it, which is
+  nearly twice what dropping `delete_knowledge`, `get_knowledge_usage`
+  and `get_attachment` would have bought — so those three stay
+  (issue #272), and the surface is eight tools.
+
 - **What enters the bundle leaves it** (design doc
   [0046](docs/design/0046-bundle-address-space.md) §3.2). `ochakai
   import` now keeps every file the bundle carried, at the path it

--- a/README.md
+++ b/README.md
@@ -380,8 +380,7 @@ And it stays small by refusing things:
 | `search_knowledge` | Cross-type search; verified entries rank higher |
 | `get_knowledge` | Fetch one entry as an OKF document, with its links and attachment metadata |
 | `get_attachment` | Fetch a file attached to an entry (dashboard screenshots, ER diagrams, seeds files) |
-| `create_knowledge` | Write learnings back (agents create drafts) |
-| `update_knowledge` | Update; every change is kept as a revision |
+| `put_knowledge` | Write learnings back — creates if the id is free, replaces if it is taken; every change is kept as a revision |
 | `delete_knowledge` | Soft-delete (history retained) |
 | `get_knowledge_usage` | Usage totals per entry — draft-promotion evidence, staleness signal |
 | `report_outcome` | Report worked/failed after acting on knowledge — failed reports flag verified entries for re-verification |

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -67,15 +67,15 @@ index — about 16 ms across 5000 entries.
 
 ### Can an agent overwrite or delete knowledge a human verified?
 
-Not over MCP. `create_knowledge`, `update_knowledge` and
-`delete_knowledge` all refuse an entry a human has ruled on — verified,
-rejected or deprecated — and the refusal says what to do instead:
+Not over MCP. `put_knowledge` and `delete_knowledge` both refuse an entry
+a human has ruled on — verified, rejected or deprecated — and the refusal
+says what to do instead:
 
 > cannot update metrics/revenue from this surface: it is verified, and
 > this surface has no If-Match precondition to replace curated knowledge
 > safely. If it is wrong, say so with report_outcome failed — that puts it
 > in the re-verification feed. If you have something better,
-> create_knowledge a new draft. A human changes curated entries from the
+> put_knowledge a new draft. A human changes curated entries from the
 > web UI or CLI.
 
 This is not authorization — a human on the same deployment can edit

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -120,7 +120,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"After acting on knowledge (running an attested computation, writing SQL from a metric definition), report " +
 			"whether it actually worked with report_outcome — failed reports are how stale " +
 			"verified knowledge gets caught. " +
-			"Write learnings back with create_knowledge; leave new entries as drafts for a human to " +
+			"Write learnings back with put_knowledge; leave new entries as drafts for a human to " +
 			"confirm — status is how ready an entry is (draft, stable, deprecated), and whether " +
 			"anyone checked it is recorded separately, by whoever checked it. Knowledge that was " +
 			"reviewed and not accepted is marked rejected by a human, with the reason; " +
@@ -259,15 +259,32 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 		return nil, knowledgeOut{Knowledge: v}, nil
 	}))
 
+	// put_knowledge is the one write face (design doc 0046 §3.14). It was
+	// create_knowledge and update_knowledge, which asked the agent a
+	// question the document does not answer: a write states what the
+	// entry should say, and whether an id was already taken is not part
+	// of that statement (0043 §3.5). Two tools also cost more of the
+	// agent's context than the three this surface was going to drop put
+	// together — the merge is where the saving actually was.
 	mcp.AddTool(s, &mcp.Tool{
-		Name:        "create_knowledge",
+		Name:        "put_knowledge",
 		Annotations: nonDestructive,
-		Description: "Create a knowledge entry. Write back what you learned: metric caveats, confirmed answers, " +
-			"glossary terms. Write status: draft unless you are recording something already agreed — a " +
-			"document that names no status reads as stable (OKF SPEC §5.4). Your identity is recorded as " +
-			"created_by, and the entry stays unverified until a person confirms it. " +
-			"Before creating, search with rejected=true to avoid " +
-			"re-proposing knowledge that was already rejected (the ruling records why). " +
+		Description: "Write a knowledge entry: create it if the id is free, replace it if it is taken. " +
+			"Write back what you learned: metric caveats, confirmed answers, glossary terms. " +
+			"Write status: draft unless you are recording something already agreed — a document that " +
+			"names no status reads as stable (OKF SPEC §5.4). Your identity is recorded as created_by, " +
+			"and the entry stays unverified until a person confirms it. " +
+			"The document you send is the whole entry: a key you leave out is cleared, so on a replace, " +
+			"get_knowledge first, change what you mean to change, and send the rest back as it came. " +
+			"Every change is kept as a revision; a write identical to the stored content writes nothing. " +
+			"Before writing something new, search with rejected=true to avoid re-proposing knowledge " +
+			"that was already rejected (the ruling records why). " +
+			"Entries a human has ruled on — verified, rejected, or deprecated — cannot be replaced from " +
+			"this surface: if a verified entry is wrong, report_outcome failed; otherwise put_knowledge " +
+			"a better draft at a different id and let a human promote it. " +
+			"status is the lifecycle only — draft, stable, deprecated (OKF SPEC §5.4). Whether anyone " +
+			"has confirmed the entry is not yours to set: it comes from the verification ledger, and " +
+			"this surface does not verify or reject. Put the reason for deprecating in status_note. " +
 			"For BigQuery Table/BigQuery Dataset/Reference entries, set resource to the asset's canonical URI and favor " +
 			"the conventional body sections: # Schema, # Common query patterns. " +
 			"An \"Attested Computation\" entry records a sanctioned computation others must run instead of " +
@@ -291,46 +308,22 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 		if err != nil {
 			return nil, knowledgeOut{}, err
 		}
-		k, err := svc.CreateKeepingCurated(ctx, write, actor)
-		if err != nil {
-			return nil, knowledgeOut{}, err
+		// Whether the id is taken decides which guard applies, not which
+		// tool the agent should have called. Creating on a soft-deleted
+		// id revives it, which is the one way past the curation guards,
+		// so the create path has its own check; replacing a live entry
+		// is refused for a curated one and otherwise carries the version
+		// read by the guard as its precondition, since this surface has
+		// no If-Match channel of its own.
+		version, err := svc.RefuseIfCurated(ctx, in.ID, "replace")
+		if errors.Is(err, store.ErrNotFound) {
+			k, err := svc.CreateKeepingCurated(ctx, write, actor)
+			if err != nil {
+				return nil, knowledgeOut{}, err
+			}
+			out, err := view(k, notes)
+			return nil, out, err
 		}
-		v, err := okf.ViewOf(k)
-		if err != nil {
-			return nil, knowledgeOut{}, err
-		}
-		return nil, knowledgeOut{Knowledge: v, Notes: notes}, nil
-	}))
-
-	mcp.AddTool(s, &mcp.Tool{
-		Name:        "update_knowledge",
-		Annotations: nonDestructive,
-		Description: "Update a knowledge entry by replacing its document. The document you send is the " +
-			"whole entry: a key you leave out is cleared, so get_knowledge first, change what you mean " +
-			"to change, and send the rest back as it came. " +
-			"Links are not a key: they come from the markdown links in the body, so keep the ones you want to keep. " +
-			"Every change is kept as a revision; an update identical to the stored content writes nothing. " +
-			"Entries a human has ruled on — verified, rejected, or deprecated — cannot be updated from " +
-			"this surface: if a verified entry is wrong, report_outcome failed; otherwise create_knowledge " +
-			"a better draft and let a human promote it. " +
-			"status is the lifecycle only — draft, stable, deprecated (OKF SPEC §5.4); a document that " +
-			"names none reads as stable, so write status: draft for a draft. Whether anyone has confirmed " +
-			"the entry is not yours to set: it comes from the verification ledger, and this surface does " +
-			"not verify or reject. Put the reason for deprecating in status_note.",
-	}, tool(svc, func(ctx context.Context, actor domain.Actor, in writeIn) (*mcp.CallToolResult, knowledgeOut, error) {
-		// MCP has no conditional-update channel, so it cannot opt into the
-		// If-Match precondition (nil) and writes are last-write-wins. That
-		// is tolerable for drafts and not for curated knowledge, so
-		// verified entries are refused here rather than clobbered.
-		version, err := svc.RefuseIfCurated(ctx, in.ID, "update")
-		if err != nil {
-			return nil, knowledgeOut{}, err
-		}
-		// The version read by the guard becomes the precondition, so an
-		// entry curated in the window between the two is a conflict rather
-		// than a clobber — the surface has no If-Match channel of its own,
-		// but the check can supply one.
-		write, notes, err := in.toKnowledge()
 		if err != nil {
 			return nil, knowledgeOut{}, err
 		}
@@ -338,18 +331,15 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 		if err != nil {
 			return nil, knowledgeOut{}, err
 		}
-		v, err := okf.ViewOf(k)
-		if err != nil {
-			return nil, knowledgeOut{}, err
-		}
-		return nil, knowledgeOut{Knowledge: v, Notes: notes}, nil
+		out, err := view(k, notes)
+		return nil, out, err
 	}))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "delete_knowledge",
 		Annotations: destructive,
 		Description: "Soft-delete a knowledge entry. History is retained as revisions; " +
-			"create_knowledge on the same id revives it. Entries a human has ruled on — verified, " +
+			"put_knowledge on the same id revives it. Entries a human has ruled on — verified, " +
 			"rejected, or deprecated — cannot be deleted from this surface; deleting a rejected " +
 			"entry and recreating it would erase the record of why it was turned down.",
 	}, tool(svc, func(ctx context.Context, actor domain.Actor, in getIn) (*mcp.CallToolResult, deleteOut, error) {
@@ -374,7 +364,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"deliberately, when the entry's body references one you need to see (a dashboard's " +
 			"normal shape, an ER diagram, a seeds file). ochakai never interprets attachments; " +
 			"if you learn something from one, write it back into the entry's body with " +
-			"update_knowledge so the knowledge becomes searchable text.",
+			"put_knowledge so the knowledge becomes searchable text.",
 	}, tool(svc, func(ctx context.Context, _ domain.Actor, in attachmentIn) (*mcp.CallToolResult, attachmentOut, error) {
 		att, data, err := svc.Attachment(ctx, in.ID, in.Name)
 		if err != nil {
@@ -453,7 +443,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 // deployment. The service refuses these operations anyway (that is the
 // guarantee); removing them here is what stops an agent from wasting a
 // turn discovering it.
-var writeTools = []string{"create_knowledge", "update_knowledge", "delete_knowledge", "report_outcome"}
+var writeTools = []string{"put_knowledge", "delete_knowledge", "report_outcome"}
 
 // Tool annotations let clients apply auto-approval policies without reading
 // prose. readOnlyHint here describes the knowledge domain: search/get
@@ -545,7 +535,7 @@ const defaultContextBudget = 12000
 func contextHint(truncated int) string {
 	hint := "After acting on this knowledge, call report_outcome (worked/failed) on the entries you " +
 		"used — failed reports are how stale verified knowledge gets caught. If this session " +
-		"produced reusable knowledge, write it back with create_knowledge as a draft; search " +
+		"produced reusable knowledge, write it back with put_knowledge as a draft; search " +
 		"statuses=[\"rejected\"] first so you do not re-propose something already turned down."
 	if truncated > 0 {
 		hint += fmt.Sprintf(" %d entries did not fit the budget and are listed under \"outline\" — "+
@@ -601,6 +591,16 @@ type deleteOut struct {
 // It is also the shape an LLM handles best: frontmatter and markdown is
 // what the entries it reads look like, so editing one means returning it
 // changed rather than translating it into a schema and back.
+// view renders one entry as a tool's answer, with any notes the parse
+// produced. Every write path ends the same way, so it is written once.
+func view(k *domain.Knowledge, notes []string) (knowledgeOut, error) {
+	v, err := okf.ViewOf(k)
+	if err != nil {
+		return knowledgeOut{}, err
+	}
+	return knowledgeOut{Knowledge: v, Notes: notes}, nil
+}
+
 type writeIn struct {
 	ID       string `json:"id" jsonschema:"where the entry lives: its full path, segments separated by / (e.g. metrics/revenue, 用語/売上); place together what should be read together; the last segment must not be \"index\" or \"log\""`
 	Document string `json:"document" jsonschema:"the entry as an OKF document: YAML frontmatter, then markdown. Frontmatter: type (required, one line — recommended: Metric, Attested Computation, Skill, Playbook, Insight, Policy, Glossary Term, BigQuery Dataset, BigQuery Table, API Endpoint, Reference; any custom type works), title (optional — the id's last segment is the name without one), description, tags, resource (the underlying asset's URI), status (draft, stable or deprecated; defaults to draft — whether anyone confirmed the entry is recorded separately and is not yours to set), status_note, stale_after (YYYY-MM-DD), sources (list of {resource, id, title, author, usage_count, last_modified} — the material this derives from), usage_window ({from, to}), and for an Attested Computation runtime (required), parameters (list of {name, type, required}), computation, executor ({resource, receipt}), attester ({resource}). Producer-defined keys go at the top level beside these and are kept as written. Link to other entries with a markdown link to their path in the body — [revenue](/metrics/revenue.md) — and those links become the entry's links. Keys the server owns (generated, verified, created_by, rejected_by, rejected_at) are ignored if present, so a document read back from ochakai can be edited and returned as-is"`

--- a/internal/mcpserver/mcpserver_integration_test.go
+++ b/internal/mcpserver/mcpserver_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -86,14 +87,14 @@ func TestIntegrationDelegatedActorFollowsEachCall(t *testing.T) {
 	sw.set("human:bob@example.co.jp")
 	id := fmt.Sprintf("mcpit%d/delegation", time.Now().UnixNano())
 	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
-		Name:      "create_knowledge",
+		Name:      "put_knowledge",
 		Arguments: map[string]any{"id": id, "document": "---\ntype: glossary\n---\n\nwritten on behalf of bob\n"},
 	})
 	if err != nil {
-		t.Fatalf("create_knowledge: %v", err)
+		t.Fatalf("put_knowledge: %v", err)
 	}
 	if res.IsError {
-		t.Fatalf("create_knowledge failed: %+v", res.Content)
+		t.Fatalf("put_knowledge failed: %+v", res.Content)
 	}
 
 	k, err := svc.Get(context.Background(), id)
@@ -135,5 +136,108 @@ func TestIntegrationDelegatedActorFollowsEachCall(t *testing.T) {
 	}
 	if kind != string(domain.ActorHuman) || name != "carol@example.co.jp" {
 		t.Errorf("outcome recorded %s:%s, want human:carol@example.co.jp (actor pinned to the session initializer?)", kind, name)
+	}
+}
+
+// put_knowledge creates on a free id and replaces on a taken one, and
+// the guards that used to belong to two tools still apply to the right
+// half: reviving a curated tombstone is refused on the create side, and
+// replacing a curated entry on the other (design docs 0015 §3.1, 0046
+// §3.14).
+func TestIntegrationPutKnowledgeCreatesThenReplaces(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := t.Context()
+	s, err := store.New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{InsecureDev: true}
+	svc := &service.Service{Store: s, Config: cfg, Log: slog.New(slog.NewTextHandler(os.Stderr, nil))}
+	srv := httptest.NewServer(httpauth.Middleware(cfg, Handler(svc, "test")))
+	defer srv.Close()
+	transport := &mcp.StreamableClientTransport{Endpoint: srv.URL}
+	cs, err := mcp.NewClient(&mcp.Implementation{Name: "host", Version: "0"}, nil).Connect(ctx, transport, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cs.Close()
+
+	id := fmt.Sprintf("mcpput%d/revenue", time.Now().UnixNano())
+	defer func() {
+		_ = svc.Delete(context.Background(), id, domain.Actor{Kind: domain.ActorHuman, Name: "t"})
+	}()
+
+	put := func(t *testing.T, doc string) *mcp.CallToolResult {
+		t.Helper()
+		res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+			Name:      "put_knowledge",
+			Arguments: map[string]any{"id": id, "document": doc},
+		})
+		if err != nil {
+			t.Fatalf("put_knowledge: %v", err)
+		}
+		if res.IsError {
+			t.Fatalf("put_knowledge failed: %+v", res.Content)
+		}
+		return res
+	}
+
+	// A title of this test's own: the test database is shared with the
+	// packages running beside it, and a live entry called 売上 would
+	// crowd their search assertions while this one runs.
+	title := "mcp put " + id
+	put(t, "---\ntype: Metric\ntitle: "+title+"\nstatus: draft\n---\n\n受注合計。\n")
+	k, err := svc.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("the entry was not created: %v", err)
+	}
+	if k.Title != title {
+		t.Errorf("title = %q", k.Title)
+	}
+
+	// The same id again is a replace, not a conflict: a write says what
+	// the entry should say, and the id being taken is not the agent's
+	// question to answer.
+	put(t, "---\ntype: Metric\ntitle: "+title+"(改)\nstatus: draft\n---\n\n受注合計。返品を除く。\n")
+	k, err = svc.Get(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if k.Title != title+"(改)" {
+		t.Errorf("the second write did not replace: title = %q", k.Title)
+	}
+
+	// A human ruling still stops the replace half, with the advice the
+	// two tools used to carry between them.
+	if _, err := svc.Verify(ctx, id, domain.Actor{Kind: domain.ActorHuman, Name: "na0"}); err != nil {
+		t.Fatal(err)
+	}
+	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "put_knowledge",
+		Arguments: map[string]any{"id": id, "document": "---\ntype: Metric\ntitle: 上書き\n---\n\nx\n"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Fatal("put_knowledge replaced a verified entry")
+	}
+	var said string
+	for _, c := range res.Content {
+		if tc, ok := c.(*mcp.TextContent); ok {
+			said += tc.Text
+		}
+	}
+	for _, want := range []string{"report_outcome failed", "verified"} {
+		if !strings.Contains(said, want) {
+			t.Errorf("the refusal does not mention %q: %s", want, said)
+		}
 	}
 }

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -243,8 +243,7 @@ func TestToolAnnotations(t *testing.T) {
 		"get_knowledge":       {readOnly: true},
 		"get_attachment":      {readOnly: true},
 		"get_knowledge_usage": {readOnly: true},
-		"create_knowledge":    {destructive: &no},
-		"update_knowledge":    {destructive: &no},
+		"put_knowledge":       {destructive: &no},
 		"delete_knowledge":    {destructive: &yes},
 	}
 	seen := map[string]bool{}
@@ -366,7 +365,7 @@ func TestContextSchemaBoundsResponse(t *testing.T) {
 // so this string is the only copy it will ever see.
 func TestContextHint(t *testing.T) {
 	plain := contextHint(0)
-	for _, want := range []string{"report_outcome", "create_knowledge", "rejected"} {
+	for _, want := range []string{"report_outcome", "put_knowledge", "rejected"} {
 		if !strings.Contains(plain, want) {
 			t.Errorf("hint does not mention %q: %s", want, plain)
 		}
@@ -393,12 +392,13 @@ func TestCuratedGuardIsAdvertised(t *testing.T) {
 		t.Fatalf("ListTools: %v", err)
 	}
 	want := map[string][]string{
-		"update_knowledge": {"verified, rejected, or deprecated", "report_outcome failed", "create_knowledge"},
+
 		"delete_knowledge": {"verified, rejected, or deprecated", "erase the record of why"},
 		// Reviving a curated tombstone is the third way to overwrite a
 		// ruling, and an agent that only learns of it from an error has
 		// already written the draft (design doc 0015 §3.1).
-		"create_knowledge": {"deleted can be reused", "verified, rejected, deprecated", "different id"},
+		"put_knowledge": {"deleted can be reused", "verified, rejected, deprecated", "different id",
+			"verified, rejected, or deprecated", "report_outcome failed"},
 	}
 	for _, tool := range res.Tools {
 		substrs, ok := want[tool.Name]
@@ -571,7 +571,7 @@ func TestToolSchemasCarryTheTypeVocabulary(t *testing.T) {
 	}
 	// Only the tools that take a type: the read filters and the writes.
 	want := map[string]bool{"search_knowledge": true, "get_context": true,
-		"create_knowledge": true, "update_knowledge": true}
+		"put_knowledge": true}
 	seen := 0
 	for _, tool := range res.Tools {
 		if !want[tool.Name] {
@@ -596,5 +596,43 @@ func TestToolSchemasCarryTheTypeVocabulary(t *testing.T) {
 	}
 	if seen != len(want) {
 		t.Errorf("checked %d type-taking tools, want %d", seen, len(want))
+	}
+}
+
+// One write face, and the branch inside it is about the id rather than
+// about which tool the agent should have called (design doc 0046 §3.14).
+// The two tools it replaces asked a question the document does not
+// answer: a write states what the entry should say, and whether the id
+// was already taken is not part of that statement (0043 §3.5).
+func TestOneWriteFace(t *testing.T) {
+	cs := connect(t)
+	res, err := cs.ListTools(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := map[string]bool{}
+	for _, tool := range res.Tools {
+		names[tool.Name] = true
+	}
+	for _, gone := range []string{"create_knowledge", "update_knowledge"} {
+		if names[gone] {
+			t.Errorf("%s is back; the write face is put_knowledge", gone)
+		}
+	}
+	// The eight the surface carries (design doc 0046 §3.14, issue #272).
+	// The three at the end were once slated to go, and the measurement
+	// went the other way: they are the cheapest tools here, and the
+	// saving was in the merge above.
+	want := []string{
+		"search_knowledge", "get_context", "get_knowledge", "put_knowledge", "report_outcome",
+		"delete_knowledge", "get_knowledge_usage", "get_attachment",
+	}
+	for _, w := range want {
+		if !names[w] {
+			t.Errorf("tool %s is missing", w)
+		}
+	}
+	if len(names) != len(want) {
+		t.Errorf("tools = %d, want %d: %v", len(names), len(want), names)
 	}
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -151,18 +151,18 @@ func (s *Service) explainOccupiedID(ctx context.Context, id string, err error) e
 	switch ruling {
 	case domain.RulingRejected:
 		instead = "The rejection is the record of a decision and carries the reason; read it " +
-			"(get_knowledge) before proposing this again. If you disagree, create_knowledge a new " +
+			"(get_knowledge) before proposing this again. If you disagree, put_knowledge a new " +
 			"entry at a different id and let a human judge it."
 	case domain.RulingVerified:
 		instead = "If it is wrong, say so with report_outcome failed — that puts it in the " +
-			"re-verification feed. If you have something better, create_knowledge it at a " +
+			"re-verification feed. If you have something better, put_knowledge it at a " +
 			"different id and let a human judge it."
 	case domain.RulingDeprecated:
 		instead = "Deprecated means it was correct and is no longer recommended. If it is worth " +
-			"reviving, create_knowledge a draft at a different id that says why."
+			"reviving, put_knowledge a draft at a different id that says why."
 	default:
 		return fmt.Errorf("%w: %s is a live %s entry. Nobody has ruled on it: "+
-			"update_knowledge replaces it in place", err, id, k.Status)
+			"put_knowledge replaces it in place", err, id, k.Status)
 	}
 	return fmt.Errorf("%w: %s is a live %s entry. %s", err, id, ruling, instead)
 }
@@ -331,14 +331,14 @@ func (s *Service) RefuseIfCurated(ctx context.Context, id, op string) (*string, 
 	switch ruling {
 	case domain.RulingVerified:
 		instead = "If it is wrong, say so with report_outcome failed — that puts it in the " +
-			"re-verification feed. If you have something better, create_knowledge a new draft."
+			"re-verification feed. If you have something better, put_knowledge a new draft."
 	case domain.RulingRejected:
 		instead = "The rejection is the record of a decision and carries the reason; read it " +
-			"before proposing this again. If you disagree, create_knowledge a new entry at a " +
+			"before proposing this again. If you disagree, put_knowledge a new entry at a " +
 			"different id and let a human judge it."
 	case domain.RulingDeprecated:
 		instead = "Deprecated means it was correct and is no longer recommended. If it is worth " +
-			"reviving, create_knowledge a draft that says why."
+			"reviving, put_knowledge a draft that says why."
 	default:
 		return &k.ContentHash, nil
 	}
@@ -379,13 +379,13 @@ func (s *Service) RefuseIfRevivingCurated(ctx context.Context, id string) error 
 	case domain.RulingRejected:
 		instead = "The rejection is the record of a decision and carries the reason; read it " +
 			"(search_knowledge with rejected=true) before proposing this again. If you disagree, " +
-			"create_knowledge a new entry at a different id and let a human judge it."
+			"put_knowledge a new entry at a different id and let a human judge it."
 	case domain.RulingVerified:
 		instead = "It was verified knowledge when it was deleted. Propose the replacement at a " +
 			"different id and let a human judge it against the history this id still holds."
 	case domain.RulingDeprecated:
 		instead = "Deprecated means it was correct and is no longer recommended. If it is worth " +
-			"reviving, create_knowledge a draft at a different id that says why."
+			"reviving, put_knowledge a draft at a different id that says why."
 	default:
 		return nil
 	}

--- a/internal/service/service_integration_test.go
+++ b/internal/service/service_integration_test.go
@@ -349,7 +349,7 @@ func TestRefuseIfCuratedIntegration(t *testing.T) {
 	advice := map[domain.Ruling]string{
 		domain.RulingVerified:   "report_outcome failed",
 		domain.RulingRejected:   "the reason",
-		domain.RulingDeprecated: "create_knowledge",
+		domain.RulingDeprecated: "put_knowledge",
 	}
 	for _, tc := range rulings {
 		t.Run(string(tc.ruling)+" is refused", func(t *testing.T) {
@@ -514,7 +514,7 @@ func TestRefuseIfCuratedIntegration(t *testing.T) {
 			domain.RulingRejected:   "the reason",
 			domain.RulingVerified:   "report_outcome failed",
 			domain.RulingDeprecated: "no longer recommended",
-			"":                      "update_knowledge",
+			"":                      "put_knowledge",
 		}
 		cases := append([]struct {
 			ruling domain.Ruling


### PR DESCRIPTION
#267 item 6's MCP half. `create_knowledge` and `update_knowledge` become **`put_knowledge`**: it creates when the id is free and replaces when it is taken.

## Why one

The two tools asked the agent a question the document does not answer. A write states what the entry should say; whether the id was already taken is not part of that statement. That is the same reasoning that gave REST one `PUT` rather than a POST beside it (0043 §3.5), and it is the part of 0046 §3.14 with a reason behind it beyond arithmetic.

## The guards did not move

The branch inside `put_knowledge` is about the id, not about which tool the agent should have called:

- **free id** → the create path, whose own check refuses reviving a tombstone a human curated (`RefuseIfRevivingCurated`, 0015 §3.1);
- **taken id** → the replace path, which refuses an entry a human ruled on and otherwise carries the version the guard just read as its precondition. This surface still has no `If-Match` channel of its own, so the check supplies one.

Both refusals still name the way forward, and every message that used to say "create_knowledge a new draft" now says `put_knowledge` — on all three surfaces that print one (`service.explainOccupiedID`, `RefuseIfCurated`, the tool descriptions), plus the FAQ and the README table.

## And where the budget actually was

The measurement from #272: the whole surface is 33.5 KB of JSON schema. This merge saves about 6 KB — nearly twice what dropping `delete_knowledge`, `get_knowledge_usage` and `get_attachment` would have bought. So those three stay, and the surface is **eight tools**.

## Tests

- `TestOneWriteFace` pins the eight, and that the two old names do not come back.
- `TestIntegrationPutKnowledgeCreatesThenReplaces` runs the branch: a create on a free id, a replace on the same id (not a conflict — the id being taken is not the agent's question), then a verification, then a refused replace whose message still names `report_outcome failed`.
- The existing annotation, curated-guard and type-vocabulary tests follow the rename rather than being deleted, so what they were guarding is still guarded.

`scripts/check --db` is clean.

**Note for the release**: this is a breaking MCP change, in the same release as the rest of 0046's implementation.
