### PR TITLE
Say which address to build on while 0046 §3.5's fold is in flight (#301)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,6 +220,33 @@ last entry.
 
 ### Changed
 
+- **The published contract says which address to build on.** While
+  [0046](docs/design/0046-bundle-address-space.md) §3.5's fold is in
+  flight, three addresses answer for the same object, and
+  `api/openapi.yaml` did not say which one survives it.
+  `/api/v1/bundle/{path}` does. The operations it replaces —
+  `GET|PUT|DELETE /api/v1/knowledge/{id}` and
+  `GET|PUT|DELETE /api/v1/attachments/{path}` — are now marked
+  `deprecated`, each naming the bundle call that answers the same
+  question. Nothing is removed and no behaviour changes: a removal
+  arrives in a minor release with a changelog entry, as
+  [the compatibility policy](docs/compatibility.md) says, not after a
+  deprecation window.
+
+  `/api/v1/knowledge` (the list), `/api/v1/backlinks/{id}` and
+  `/api/v1/export` are retired by the same section but carry no mark:
+  their successors are not built yet, so they are still the only way to
+  ask what they answer. The document says so rather than leaving a
+  reader to find out.
+
+  Two things that read as holes are closed with it. The `501` on
+  `PUT /api/v1/bundle/{path}` now says what it is — writing a file needs
+  GCS (design doc 0013), and a concept is unaffected — rather than
+  standing unexplained where a "not built yet" placeholder used to be.
+  And `/api/v1/export`'s recipe for writing your own importer no longer
+  sends the reader to a `POST /api/v1/knowledge` that does not exist:
+  it is one PUT per bundle member, at the path it arrived at.
+
 - **A file is an object in the bundle** (design doc
   [0046](docs/design/0046-bundle-address-space.md) §§3.3, 3.13). Migration
   0029 moves every `attachment` row into `object`, at the path the file

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -7,9 +7,23 @@ info:
     terms, dataset and table catalog entries, and references (mirrors of
     external material) in one knowledge base. The REST API is a superset
     of the MCP tools — the same operations plus bulk export, the
-    human-facing browse/revisions/backlinks reads, and attachment writes —
-    so users can build their own web UIs. ochakai executes no SQL and uses
-    no LLM.
+    human-facing backlinks read, and file writes — so users can build
+    their own web UIs. ochakai executes no SQL and uses no LLM.
+
+
+    **Which address to build on.** A concept and a file are both objects
+    of one bundle, and `/api/v1/bundle/{path}` is the address that says
+    so (design doc 0046 §3.5). Several older addresses still answer for
+    the same objects and are on their way out; where a replacement is
+    already serving, the operation below is marked `deprecated` and names
+    it. `/api/v1/knowledge` (the list), `/api/v1/backlinks/{id}` and
+    `/api/v1/export` are retired by the same section, but their
+    successors — a ranking face at `/api/v1/search` with `links_to=`, and
+    a subtree under `Accept: application/gzip` — are not built yet, so
+    they are the only way to ask those questions today and carry no such
+    mark. Every interface is unstable while the major version is 0
+    (docs/compatibility.md): a removal arrives in a minor release with a
+    changelog entry, not after a deprecation window.
   version: 0.15.0
   license:
     name: MIT
@@ -195,7 +209,7 @@ paths:
                   description: >
                     A hit names an entry and says what ranked it; it does
                     not hand the entry over. Read the ones worth reading
-                    with GET /api/v1/knowledge/{id}, or ask
+                    with GET /api/v1/bundle/{id}.md, or ask
                     GET /api/v1/context for the documents behind the top
                     hits in one call.
                     Attachment metadata rides along (filled in one batch),
@@ -480,6 +494,11 @@ paths:
 
         index.md and log.md are 409: they are generated from the bundle,
         so a write there is a conflict with what the address is.
+
+        Writing a file needs the server to have GCS configured
+        (OCHAKAI_GCS_BUCKET); without it an instance stores concepts and
+        nothing else, and a write that is not a concept is a 501 (design
+        doc 0013). A concept is unaffected.
       responses:
         "200":
           description: The object as stored — a View for a concept, file metadata otherwise.
@@ -868,7 +887,13 @@ paths:
     get:
       operationId: getKnowledge
       summary: Get one knowledge entry
+      deprecated: true
       description: >
+        Build on `GET /api/v1/bundle/{id}.md`, which answers exactly this
+        — the same View, the same document under `Accept: text/markdown`,
+        the same ETag — at the address a concept has in the bundle. This
+        one is retired by design doc 0046 §3.5.
+
         Answers a View by default: the entry's document as it was
         written, the projection to read it by, and what this instance
         observed about it (design docs 0043 §3.5, 0046 §2.2). Comments,
@@ -1054,13 +1079,17 @@ paths:
     put:
       operationId: putKnowledge
       summary: Write a knowledge entry from an OKF document
+      deprecated: true
       description: >
-        The one way to write knowledge. The body is an OKF document —
-        YAML frontmatter, then markdown — which is what an entry is
-        (design doc 0043 §3.5): the path is the address, the document is
-        what the entry says, and there is no typed JSON write surface
-        beside it to drift from the format. A JSON body is a 415 naming
-        the document form.
+        Build on `PUT /api/v1/bundle/{id}.md`, which writes exactly this
+        — the same document, the same preconditions, the same answer.
+        This one is retired by design doc 0046 §3.5.
+
+        The body is an OKF document — YAML frontmatter, then markdown —
+        which is what an entry is (design doc 0043 §3.5): the path is the
+        address, the document is what the entry says, and there is no
+        typed JSON write surface beside it to drift from the format. A
+        JSON body is a 415 naming the document form.
         It is create-or-replace, and a full replacement: what the document
         omits is cleared, so send the entry as it should end up. A PUT
         states what the entry should say; whether an entry already held
@@ -1283,7 +1312,13 @@ paths:
     delete:
       operationId: deleteKnowledge
       summary: Soft-delete a knowledge entry (history retained)
+      deprecated: true
       description: >
+        The soft delete is `DELETE /api/v1/bundle/{id}.md`; build on
+        that. `purge=true` has no bundle-address form yet — design doc
+        0046 §3.5 gives it one and it is not built — so a purge is still
+        asked for here. This one is retired by the same section.
+
         Soft-deletes by default: the entry disappears from reads, its
         history stays, and creating the same id revives it. With
         `purge=true` the entry is hard-deleted instead — entry,
@@ -1819,7 +1854,14 @@ paths:
     put:
       operationId: putAttachment
       summary: Attach a file to a knowledge entry
+      deprecated: true
       description: >
+        Build on `PUT /api/v1/bundle/{path}`, which stores the same bytes
+        at the path they live at — so there is nothing for `okf_path` to
+        preserve and no entry to attribute the file to at write time
+        (whether an entry shows a file is a question its body answers).
+        This one is retired by design doc 0046 §§3.3, 3.5.
+
         Stores the raw request body as a file of the bundle, replacing
         any file of the same name (kept as a revision). The media type is
         sniffed from the bytes and nothing is refused for being what it
@@ -1879,7 +1921,12 @@ paths:
     get:
       operationId: getAttachment
       summary: Fetch attachment bytes
+      deprecated: true
       description: >
+        Build on `GET /api/v1/bundle/{path}`, which answers the same
+        bytes, the same ETag and the same delivery headers. This one is
+        retired by design doc 0046 §3.5.
+
         Returns the file bytes with the stored (sniffed) media type; the
         ETag is the content's SHA-256, and a matching If-None-Match gets
         a 304 answered from metadata alone (no blob read, so repeat
@@ -1927,7 +1974,11 @@ paths:
     delete:
       operationId: deleteAttachment
       summary: Detach a file from a knowledge entry
+      deprecated: true
       description: >
+        Build on `DELETE /api/v1/bundle/{path}`, which removes the same
+        file. This one is retired by design doc 0046 §3.5.
+
         Removes the attachment (kept as a revision; the content-addressed
         bytes remain referenced by history).
       parameters:
@@ -1964,10 +2015,9 @@ paths:
         endpoints already here, so a server-side version would add a
         second path to the same outcome without adding a capability.
         To write your own importer against any OKF bundle: walk the
-        tar.gz, POST each `<id>.md` to /api/v1/knowledge (PUT to
-        /api/v1/knowledge/{id} if it exists), and PUT each non-markdown
-        file to /api/v1/attachments/{id}/{name}, attributing it to the
-        entry whose directory it sits in or whose body links to it.
+        tar.gz and PUT every member to /api/v1/bundle/{path} at the path
+        it arrived at. One address takes both kinds — the bytes decide
+        which — so there is nothing to attribute and nothing to route.
         `index.md` files are generated on export and are not entries.
         Frontmatter keys the server owns — `generated`, `verified`,
         `created_by`, `rejected_by`, `rejected_at`, and the pre-v0.2
@@ -1975,8 +2025,10 @@ paths:
         ignored on write; provenance comes from the caller's identity
         (design docs 0009, 0036 §3.2). The one exception is that the
         presence of a `verified` key decides how OKF's `stable` status
-        maps onto ochakai's (design doc 0036 §3.4). `ochakai import` is
-        exactly this loop.
+        maps onto ochakai's (design doc 0036 §3.4). `ochakai import`
+        walks the same loop, still routing a concept and an attachment
+        through the older addresses it was written against — the same
+        outcome by a longer route, until they go.
       parameters:
         - name: attachments
           in: query
@@ -2481,8 +2533,8 @@ components:
           items: { $ref: "#/components/schemas/Attachment" }
           description: >
             Attachment metadata (no bytes — fetch them via
-            /api/v1/attachments/{id}/{name}). Managed through the
-            attachment endpoints. Absent when the entry has none.
+            /api/v1/bundle/{path}, which is also where they are written).
+            Absent when the entry has none.
         created_at: { type: string, format: date-time, readOnly: true }
         updated_at: { type: string, format: date-time, readOnly: true }
         trust:

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -16,7 +16,14 @@ Everything a client can touch:
 
 - **REST** — paths, request and response shapes, status codes. `0.13.0`
   moved the knowledge out of `/context`'s `hits`; `0.14.0` moved seven
-  keys out of `attrs` into envelope fields.
+  keys out of `attrs` into envelope fields. Right now several addresses
+  answer for the same object while
+  [0046](design/0046-bundle-address-space.md) §3.5's fold is in flight:
+  **build on `/api/v1/bundle/{path}`**, which is the one that survives
+  it. The addresses it replaces are marked `deprecated` in
+  [api/openapi.yaml](../api/openapi.yaml) and name their successor;
+  where no successor is serving yet, the operation says so and carries
+  no such mark.
 - **MCP** — tool names, arguments, and which tools exist at all.
   `compile_sql` existed until `0.13.0` and does not now.
 - **The CLI** — commands, flags, and the shape of what they print.

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -177,16 +177,14 @@ func Handler(svc *service.Service) http.Handler {
 		}
 	})
 
-	// PUT and DELETE /api/v1/bundle/{path...} — two refusals, and which
-	// one the caller gets depends on the path.
+	// PUT and DELETE /api/v1/bundle/{path...} — the write face of the one
+	// address space (design doc 0046 §3.5).
 	//
-	// The reserved names are generated from the bundle rather than stored
-	// in it, so a write is a conflict with what the address is: 409, as
-	// design doc 0046 §3.5 says. Every other path is the write face that
-	// same section describes, and it lands in a later change: 501, which
-	// is what "not built yet" means. Answering the reserved-file reason
-	// there would explain a refusal in terms of two files the caller never
-	// named.
+	// The reserved names are the one refusal the address itself makes:
+	// they are generated from the bundle rather than stored in it, so a
+	// write there is a conflict with what the address is (409). Every
+	// other path is an object, and what it becomes is decided by the
+	// bytes rather than by the caller — see below.
 	for _, m := range []string{"PUT", "DELETE"} {
 		mux.HandleFunc(m+" /api/v1/bundle/{path...}", func(w http.ResponseWriter, r *http.Request) {
 			path := r.PathValue("path")


### PR DESCRIPTION
Closes #301.

## What and why

**Half of #301 is already fixed, and the half that is left is the one worth answering.**

The text it quotes — "Paths other than the two reserved names are 404 on read and 501 on write for now" — is gone: #290 and #296 landed §3.5's read and write faces, and `/api/v1/bundle/{path}` now serves every object. So the "501 placeholder" as such no longer exists. What survives is the second sentence of the title: three addresses answer for the same object, and the published contract does not say which one a reader should build on.

Nothing has been released in that state — every §3.5 change is still under `[Unreleased]` — so the issue's option (2), one release for the whole fold, is still available and costs nothing extra. This PR does option (3) anyway, because (2) is a decision about when to tag and (3) is what makes the contract truthful in the meantime. The two do not conflict: if the removals land before the next tag, no release ever carries a `deprecated` mark, and nothing here has to be undone.

**What it marks.** `GET|PUT|DELETE /api/v1/knowledge/{id}` and `GET|PUT|DELETE /api/v1/attachments/{path}` get `deprecated: true`, each naming the bundle call that answers the same question. These are the six operations whose successor is *serving today*, which is the whole test — the one caveat is `?purge=true`, which 0046 §3.5 gives a bundle form and which is not built, so `deleteKnowledge` says that rather than pretending it is covered.

**What it does not mark.** `/api/v1/knowledge` (the list), `/api/v1/backlinks/{id}` and `/api/v1/export` are retired by the same section, but `/api/v1/search`, `links_to=` and the gzip subtree do not exist yet. "Deprecated" means *use the other one*, and there is no other one — so they carry no mark and `info.description` says why. A mark that points nowhere is the same hole in a different place.

Two adjacent holes close with it:

- The `501` on `PUT /api/v1/bundle/{path}` stood unexplained where the transitional text used to justify it. It is real — writing a file needs GCS (0013) and a concept is unaffected — and now says so, instead of reading like the placeholder that is gone.
- `/api/v1/export`'s recipe for writing your own importer sent readers to `POST /api/v1/knowledge`, which has never existed, and to `/api/v1/attachments/{id}/{name}` with hand-rolled attribution. It is one PUT per bundle member now. The line claiming `ochakai import` is "exactly this loop" is corrected too — import still routes through the older addresses.

`docs/compatibility.md` carries the one-line answer for someone deciding what to integrate against, next to the policy that says a removal arrives in a minor release rather than after a deprecation window.

The handler comment above the bundle write face still said the face "lands in a later change: 501, which is what 'not built yet' means" — directly above the code that lands it.

## Checks

- [x] `scripts/check` is clean — `core` and lint pass; `--db` needs a Docker daemon this environment has none of, and `govulncheck` cannot reach `vuln.go.dev` through the proxy. No store code changed.
- [x] Behavior changes come with tests — there are no behavior changes. `TestOpenAPISpecIsValid` covers the edited document, and every integration test keeps running through `checkedServer` against it.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and `internal/apiclient` say the same thing — the only code change is a comment; the spec edits describe what those three already do.
- [x] The change lands on every surface it belongs on — it is the published REST contract, which is one surface. MCP, CLI and the Web UI expose no address to choose between.

## Design docs

- [x] Not applicable. 0046 §3.5 already recorded that these addresses are retired; this publishes that decision in the contract rather than making a new one, which 0048 §2.2 puts in the PR description ("既存エンドポイントへのドキュメント追加").
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ve9Epchjdpr7W2HPAt6eN3)_