### PR TITLE
Let a file report the path it lives at (0046 §3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,25 @@ last entry.
 
 ### Added
 
+- **BREAKING** — a file reports the path it lives at. `okf_path` is gone
+  from the wire and from the attach call; `Attachment` carries `path`
+  instead (design doc
+  [0046](docs/design/0046-bundle-address-space.md) §3.3).
+
+  `okf_path` meant "this file is not where ochakai would have put it" —
+  a second identity for one object, and one that could disagree with the
+  row it described. Since files became objects at paths, where a file
+  lives is simply its address: a file written through
+  `/api/v1/attachments/{id}/{name}` is at `<id>/<name>`, and one written
+  at its own bundle path is there. `name` stays beside `path` as the last
+  segment, the way a concept keeps its id beside its path.
+
+  The `?okf_path=` parameter on attach is gone with it. A file that
+  belongs elsewhere in the bundle is written at the path it belongs at
+  (`PUT /api/v1/bundle/{path}`), which is what `ochakai import` now does
+  — where a file lives is an address, not an annotation on a write to
+  something else.
+
 - **BREAKING** — the MCP write face is one tool. `create_knowledge` and
   `update_knowledge` are `put_knowledge`: it creates when the id is free
   and replaces when it is taken (design doc

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1835,15 +1835,6 @@ paths:
         the request fails with 501.
       parameters:
         - $ref: "#/components/parameters/OnBehalfOf"
-        - name: okf_path
-          in: query
-          required: false
-          description: >
-            Bundle path a foreign OKF import carried this file at
-            (clean, bundle-relative). Export writes the file back there
-            so the original body links keep working. Omit for
-            attachments born in ochakai.
-          schema: { type: string }
       requestBody:
         required: true
         content:
@@ -2520,12 +2511,15 @@ components:
             what a browser may do with it is decided when it is served.
         size: { type: integer }
         sha256: { type: string, description: Content hash; attachments are content-addressed and immutable. }
-        okf_path:
+        path:
           type: string
           description: >
-            Bundle path a foreign OKF import carried this file at; export
-            writes it back there so body links keep working. Absent for
-            attachments born in ochakai (exported to "<id>/<name>").
+            Where the file lives in the bundle — its address, and what an
+            export writes it back as. A file written through this address
+            is at `<id>/<name>`; one written at its own bundle path is
+            there, which is how a foreign layout round-trips (design doc
+            0046 §3.3). `name` is the last segment, beside it the way a
+            concept keeps its id beside its path.
         created_by: { $ref: "#/components/schemas/Actor", readOnly: true }
         created_at: { type: string, format: date-time, readOnly: true }
     Usage:

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -728,7 +728,7 @@ func cmdAttach(ctx context.Context, args []string) error {
 		if attName == "" {
 			attName = filepath.Base(file)
 		}
-		att, err := c.Attach(ctx, id, attName, "", data)
+		att, err := c.Attach(ctx, id, attName, data)
 		if err != nil {
 			return fmt.Errorf("%s: %w", file, err)
 		}
@@ -1246,17 +1246,14 @@ func cmdImport(ctx context.Context, args []string) error {
 			fmt.Fprintln(os.Stderr, "skip:", skipped[len(skipped)-1])
 			continue
 		}
-		// A file already at the canonical layout needs no okf_path — the
-		// preserved-location rule is for foreign layouts only.
-		okfPath := a.Path
-		if okfPath == a.ID+"/"+a.Name {
-			okfPath = ""
-		}
-		if _, err := c.Attach(ctx, a.ID, a.Name, okfPath, a.Data); err != nil {
-			return fmt.Errorf("attach %s/%s: %w", a.ID, a.Name, err)
+		// At the path the bundle carried it at, which is the whole of
+		// what preserving a foreign location means now (design doc 0046
+		// §3.3): the entry claims it because its body points there.
+		if err := c.PutBundleFile(ctx, a.Path, a.Data); err != nil {
+			return fmt.Errorf("write %s: %w", a.Path, err)
 		}
 		attached++
-		fmt.Printf("attached %s/%s\n", a.ID, a.Name)
+		fmt.Printf("attached %s (%s)\n", a.Path, a.ID)
 	}
 	// The files that belong to no entry, at the paths they arrived at.
 	// A bundle carries more than its concepts, and what enters it leaves

--- a/internal/apiclient/apiclient.go
+++ b/internal/apiclient/apiclient.go
@@ -453,15 +453,10 @@ func (c *Client) Move(ctx context.Context, id, newID string) (*domain.View, erro
 
 // Attach uploads data as an attachment of the entry (PUT
 // /api/v1/attachments/{id}/{name}), replacing any attachment of
-// the same name. okfPath preserves a foreign bundle location for
-// round-trips; "" for attachments born here. The server sniffs the media
-// type from the bytes.
-func (c *Client) Attach(ctx context.Context, id, name, okfPath string, data []byte) (*domain.Attachment, error) {
-	var q url.Values
-	if okfPath != "" {
-		q = url.Values{"okf_path": {okfPath}}
-	}
-	resp, err := c.doRaw(ctx, http.MethodPut, attachmentPath(id, name), q,
+// the same name. The file lands at <id>/<name>; one that lives elsewhere
+// in the bundle is written with PutBundleFile, at the path it lives at.
+func (c *Client) Attach(ctx context.Context, id, name string, data []byte) (*domain.Attachment, error) {
+	resp, err := c.doRaw(ctx, http.MethodPut, attachmentPath(id, name), nil,
 		"application/octet-stream", nil, bytes.NewReader(data))
 	if err != nil {
 		return nil, err

--- a/internal/apiclient/apiclient_test.go
+++ b/internal/apiclient/apiclient_test.go
@@ -361,14 +361,16 @@ func TestContextBuildsQueryAndDecodesPack(t *testing.T) {
 	}
 }
 
-func TestAttachSendsBytesAndOKFPath(t *testing.T) {
+// A file goes to the address it lives at, with nothing beside it saying
+// where it really lives (design doc 0046 §3.3).
+func TestAttachSendsBytesToTheAddress(t *testing.T) {
 	body := []byte("attachment bytes")
 	c := newTestPair(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPut || r.URL.Path != "/api/v1/attachments/insights/sales/reading/weekly.png" {
 			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
-		if r.URL.Query().Get("okf_path") != "images/weekly.png" {
-			t.Errorf("okf_path = %q", r.URL.Query().Get("okf_path"))
+		if r.URL.RawQuery != "" {
+			t.Errorf("the write carries a parameter: %q", r.URL.RawQuery)
 		}
 		got, _ := io.ReadAll(r.Body)
 		if string(got) != string(body) {
@@ -376,7 +378,7 @@ func TestAttachSendsBytesAndOKFPath(t *testing.T) {
 		}
 		_ = json.NewEncoder(w).Encode(domain.Attachment{Name: "weekly.png", MediaType: "image/png", Size: int64(len(body))})
 	})
-	att, err := c.Attach(context.Background(), "insights/sales/reading", "weekly.png", "images/weekly.png", body)
+	att, err := c.Attach(context.Background(), "insights/sales/reading", "weekly.png", body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/domain/attachment.go
+++ b/internal/domain/attachment.go
@@ -17,10 +17,15 @@ type Attachment struct {
 	MediaType string `json:"media_type"`
 	Size      int64  `json:"size"`
 	SHA256    string `json:"sha256"`
-	// OKFPath is the bundle path a foreign import carried this file at;
-	// export writes it back there so body links keep working. Empty for
-	// attachments born in ochakai (exported to "<type>/<id>/<name>").
-	OKFPath   string    `json:"okf_path,omitempty"`
+	// Path is where the file lives in the bundle — its address, and the
+	// whole of what "where it came from" used to mean. A file imported
+	// from a foreign layout is at the path it arrived at, and one born
+	// here is at "<id>/<name>"; okf_path reported the difference between
+	// those two cases, which the path itself states (design doc 0046
+	// §3.3). Name is the last segment, kept beside it the way a concept
+	// keeps its id beside its path: derived, and what every surface
+	// calls the file.
+	Path      string    `json:"path"`
 	CreatedBy Actor     `json:"created_by"`
 	CreatedAt time.Time `json:"created_at"`
 }

--- a/internal/okf/attachment.go
+++ b/internal/okf/attachment.go
@@ -27,15 +27,17 @@ import (
 //     for an entry in the bundle, attaches to that entry. Data files next
 //     to a concept document — a seeds.txt, an expected-results CSV —
 //     round-trip without requiring a body link.
-//   - A foreign file goes back where it came from: okf_path (recorded on
-//     import) wins over the canonical layout, so body links that use the
-//     original location keep working byte-for-byte.
+//   - A foreign file goes back where it came from, because that is where
+//     it is: a file's path is its address (design doc 0046 §3.3), so
+//     body links that use the original location keep working
+//     byte-for-byte without a second field recording the difference.
 
-// AttachmentPath returns the bundle path for one attachment: its
-// preserved foreign location if it has one, else the canonical layout.
+// AttachmentPath returns the bundle path for one attachment. It is the
+// attachment's own path, and falls back to the canonical layout for a
+// caller that composed one in memory without a path.
 func AttachmentPath(id string, att *domain.Attachment) string {
-	if att.OKFPath != "" {
-		return att.OKFPath
+	if att.Path != "" {
+		return att.Path
 	}
 	return id + "/" + att.Name
 }

--- a/internal/okf/attachment_test.go
+++ b/internal/okf/attachment_test.go
@@ -181,7 +181,7 @@ func TestAttachmentPath(t *testing.T) {
 	if p := AttachmentPath("insights/sales/revenue-reading", native); p != "insights/sales/revenue-reading/weekly.png" {
 		t.Errorf("canonical path = %q", p)
 	}
-	foreign := &domain.Attachment{Name: "er.png", OKFPath: "diagrams/er.png"}
+	foreign := &domain.Attachment{Name: "er.png", Path: "diagrams/er.png"}
 	if p := AttachmentPath("tables/orders", foreign); p != "diagrams/er.png" {
 		t.Errorf("foreign path = %q", p)
 	}

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -16,7 +16,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"path"
 	"sort"
 	"strconv"
 	"strings"
@@ -467,15 +466,11 @@ func Handler(svc *service.Service) http.Handler {
 		if !ok {
 			return
 		}
-		// okf_path preserves the bundle location a foreign import carried
-		// this file at, so re-export keeps the original body links working.
-		okfPath := r.URL.Query().Get("okf_path")
-		if okfPath != "" && (okfPath != path.Clean(okfPath) || okfPath == "." ||
-			strings.HasPrefix(okfPath, "/") || strings.HasPrefix(okfPath, "..")) {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid okf_path (want a clean bundle-relative path)"})
-			return
-		}
-		att, err := svc.Attach(r.Context(), id, name, okfPath, data, httpauth.Actor(r.Context()))
+		// This address writes at <id>/<name>, always. A file that lives
+		// somewhere else in the bundle is written at the path it lives
+		// at — PUT /api/v1/bundle/{path} — rather than here with a
+		// parameter saying where it really is (design doc 0046 §3.3).
+		att, err := svc.Attach(r.Context(), id, name, data, httpauth.Actor(r.Context()))
 		if err != nil {
 			writeError(w, err)
 			return

--- a/internal/service/attachment.go
+++ b/internal/service/attachment.go
@@ -16,14 +16,18 @@ import (
 // interpretation.
 
 // Attach stores data as an attachment of the entry, replacing any
-// attachment of the same name. The media type is sniffed from the bytes,
-// never taken from the caller. okfPath preserves a foreign bundle
-// location for round-trips; "" for attachments born here.
-func (s *Service) Attach(ctx context.Context, id, name, okfPath string, data []byte, actor domain.Actor) (*domain.Attachment, error) {
+// file of the same name. The media type is sniffed from the bytes, never
+// taken from the caller.
+//
+// The file lands at <id>/<name>. One that belongs somewhere else in the
+// bundle is written at the path it belongs at (PutFile): where a file
+// lives is its address, not an annotation on a write to another one
+// (design doc 0046 §3.3).
+func (s *Service) Attach(ctx context.Context, id, name string, data []byte, actor domain.Actor) (*domain.Attachment, error) {
 	if err := s.readOnly(); err != nil {
 		return nil, err
 	}
-	id, name, okfPath = domain.Normalize(id), domain.Normalize(name), domain.Normalize(okfPath)
+	id, name = domain.Normalize(id), domain.Normalize(name)
 	if !s.Store.HasBlobStore() {
 		return nil, Unsupportedf("attachments are not supported without GCS: this instance stores markdown entries only; set OCHAKAI_GCS_BUCKET (design doc 0013)")
 	}
@@ -36,7 +40,7 @@ func (s *Service) Attach(ctx context.Context, id, name, okfPath string, data []b
 	if err != nil {
 		return nil, Invalidf("%v", err)
 	}
-	att, err := s.Store.PutAttachment(ctx, id, name, mediaType, okfPath, data, actor)
+	att, err := s.Store.PutAttachment(ctx, id, name, mediaType, "", data, actor)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/attachment_integration_test.go
+++ b/internal/service/attachment_integration_test.go
@@ -151,7 +151,7 @@ func TestAttachmentSearchIntegration(t *testing.T) {
 		defer func() { _ = s.SoftDelete(ctx, decoy, actor) }()
 	}
 
-	if _, err := svc.Attach(ctx, id, "expected.txt", "", []byte(content), actor); err != nil {
+	if _, err := svc.Attach(ctx, id, "expected.txt", []byte(content), actor); err != nil {
 		t.Fatalf("Attach: %v", err)
 	}
 
@@ -175,7 +175,7 @@ func TestAttachmentSearchIntegration(t *testing.T) {
 	// Non-text attachments are not embeddable yet (design doc 0020 §3):
 	// attach must succeed without leaving an embedding row.
 	png := append([]byte("\x89PNG\r\n\x1a\n"), []byte("fake image bytes")...)
-	if _, err := svc.Attach(ctx, id, "chart.png", "", png, actor); err != nil {
+	if _, err := svc.Attach(ctx, id, "chart.png", png, actor); err != nil {
 		t.Fatalf("Attach png: %v", err)
 	}
 	att, data, err := svc.Attachment(ctx, id, "chart.png")
@@ -204,7 +204,7 @@ func TestAttachmentSearchIntegration(t *testing.T) {
 		stubEmbedder: emb,
 		files:        map[string][]float32{"chart.png": {0, 0, 1, 0}},
 	}, Log: slog.New(slog.DiscardHandler)}
-	if _, err := fsvc.Attach(ctx, id, "chart.png", "", png, actor); err != nil {
+	if _, err := fsvc.Attach(ctx, id, "chart.png", png, actor); err != nil {
 		t.Fatalf("re-attach png with file embedder: %v", err)
 	}
 	vhits, err = s.SearchVectorAttachments(ctx, []float32{0, 0, 1, 0}, "stub", store.Filter{}, 50)
@@ -259,7 +259,7 @@ func TestReembedCoversAttachmentsIntegration(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = svc.Delete(ctx, id, actor) })
 	for _, name := range []string{"a.txt", "b.txt"} {
-		if _, err := svc.Attach(ctx, id, name, "", []byte("some text for "+name), actor); err != nil {
+		if _, err := svc.Attach(ctx, id, name, []byte("some text for "+name), actor); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/store/attachment.go
+++ b/internal/store/attachment.go
@@ -50,43 +50,32 @@ const attributedTo = `f.id IS NULL AND f.deleted_at IS NULL
 const fileCols = `f.path, f.media_type, f.size, f.blob_hash,
 	f.created_by_kind, f.created_by_name, f.created_at`
 
-// asAttachment renders one file object the way the surfaces name it.
-// ownerID decides whether the path is the canonical <id>/<name>, in
-// which case there is no okf_path to report: okf_path means "this file
-// is not where ochakai would have put it" (design doc 0013), and after
-// 0046 §3.3 that is a fact about the path rather than a stored column.
-func asAttachment(ownerID, path, mediaType string, size int64, hash string,
+// asAttachment renders one file object the way the surfaces name it: at
+// its path, with the last segment as the name every surface calls it by.
+func asAttachment(path, mediaType string, size int64, hash string,
 	by domain.Actor, at time.Time,
 ) domain.Attachment {
-	name := path[strings.LastIndex(path, "/")+1:]
-	okfPath := path
-	if path == ownerID+"/"+name {
-		okfPath = ""
-	}
 	return domain.Attachment{
-		Name: name, MediaType: mediaType, Size: size, SHA256: hash,
-		OKFPath: okfPath, CreatedBy: by, CreatedAt: at,
+		Name: path[strings.LastIndex(path, "/")+1:], MediaType: mediaType,
+		Size: size, SHA256: hash, Path: path, CreatedBy: by, CreatedAt: at,
 	}
 }
 
-// scanFile pairs fileCols with asAttachment, for the reads that know
-// whose file it is.
-func scanFile(ownerID string) func(pgx.CollectableRow) (domain.Attachment, error) {
-	return func(row pgx.CollectableRow) (domain.Attachment, error) {
-		var path, mediaType, hash string
-		var size int64
-		var by domain.Actor
-		var at time.Time
-		if err := row.Scan(&path, &mediaType, &size, &hash, &by.Kind, &by.Name, &at); err != nil {
-			return domain.Attachment{}, err
-		}
-		return asAttachment(ownerID, path, mediaType, size, hash, by, at), nil
+// scanFile pairs fileCols with asAttachment.
+func scanFile(row pgx.CollectableRow) (domain.Attachment, error) {
+	var path, mediaType, hash string
+	var size int64
+	var by domain.Actor
+	var at time.Time
+	if err := row.Scan(&path, &mediaType, &size, &hash, &by.Kind, &by.Name, &at); err != nil {
+		return domain.Attachment{}, err
 	}
+	return asAttachment(path, mediaType, size, hash, by, at), nil
 }
 
 // filePath is where a file with this name, written against this entry,
-// lives: the path it arrived at when the entry's own body points there,
-// and the canonical <id>/<name> otherwise.
+// lives: the path it names when the entry's own body points there, and
+// the canonical <id>/<name> otherwise.
 //
 // The body is what decides, because the body is what attributes the file
 // (design doc 0046 §3.3). A caller naming a path the entry says nothing
@@ -94,13 +83,13 @@ func scanFile(ownerID string) func(pgx.CollectableRow) (domain.Attachment, error
 // moment it lands, and one no export would put back where it was asked
 // for. Under the entry's own namespace it needs no mention: the path
 // says whose it is.
-func filePath(k *domain.Knowledge, name, okfPath string) string {
+func filePath(k *domain.Knowledge, name, at string) string {
 	canonical := k.ID + "/" + name
-	if okfPath == "" || okfPath == canonical {
+	if at == "" || at == canonical {
 		return canonical
 	}
-	if slices.Contains(domain.FilesFromBody(k.ID, k.Body), okfPath) {
-		return okfPath
+	if slices.Contains(domain.FilesFromBody(k.ID, k.Body), at) {
+		return at
 	}
 	return canonical
 }
@@ -110,14 +99,14 @@ func filePath(k *domain.Knowledge, name, okfPath string) string {
 // (domain.DetectAttachmentMediaType). Attach and detach count as changes
 // to the entry: updated_at is bumped and a revision (with the attachment
 // list in the snapshot) is recorded.
-func (s *Store) PutAttachment(ctx context.Context, id, name, mediaType, okfPath string, data []byte, actor domain.Actor) (*domain.Attachment, error) {
+func (s *Store) PutAttachment(ctx context.Context, id, name, mediaType, at string, data []byte, actor domain.Actor) (*domain.Attachment, error) {
 	sum := sha256.Sum256(data)
 	att := &domain.Attachment{
 		Name:      name,
 		MediaType: mediaType,
 		Size:      int64(len(data)),
 		SHA256:    hex.EncodeToString(sum[:]),
-		OKFPath:   okfPath,
+		Path:      at,
 		CreatedBy: actor,
 		CreatedAt: time.Now().UTC(),
 	}
@@ -135,7 +124,7 @@ func (s *Store) PutAttachment(ctx context.Context, id, name, mediaType, okfPath 
 		if err != nil {
 			return err
 		}
-		path := filePath(k, name, okfPath)
+		path := filePath(k, name, at)
 		// The blob row is metadata only now — the object row carries the
 		// media type and size a read answers with — but it stays the
 		// registry of which content exists, and a revision names bytes by
@@ -203,7 +192,7 @@ func (s *Store) ListAttachments(ctx context.Context, id string) ([]domain.Attach
 	if err != nil {
 		return nil, err
 	}
-	return pgx.CollectRows(rows, scanFile(id))
+	return pgx.CollectRows(rows, scanFile)
 }
 
 // ListAttachmentsBatch returns file metadata for a set of entries in one
@@ -229,7 +218,7 @@ func (s *Store) ListAttachmentsBatch(ctx context.Context, ids []string) (map[str
 		if err := rows.Scan(&owner, &path, &mediaType, &size, &hash, &by.Kind, &by.Name, &at); err != nil {
 			return nil, err
 		}
-		out[owner] = append(out[owner], asAttachment(owner, path, mediaType, size, hash, by, at))
+		out[owner] = append(out[owner], asAttachment(path, mediaType, size, hash, by, at))
 	}
 	return out, rows.Err()
 }
@@ -250,7 +239,7 @@ func (s *Store) GetAttachmentMeta(ctx context.Context, id, name string) (*domain
 	if err != nil {
 		return nil, err
 	}
-	att, err := pgx.CollectExactlyOneRow(rows, scanFile(id))
+	att, err := pgx.CollectExactlyOneRow(rows, scanFile)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, ErrNotFound
 	}
@@ -274,7 +263,7 @@ func (s *Store) DeleteAttachment(ctx context.Context, id, name string, actor dom
 		if err != nil {
 			return err
 		}
-		path := filePath(k, att.Name, att.OKFPath)
+		path := filePath(k, att.Name, att.Path)
 		tag, err := tx.Exec(ctx, `DELETE FROM object WHERE path=$1 AND id IS NULL`, path)
 		if err != nil {
 			return err
@@ -346,7 +335,7 @@ func listAttachmentsTx(ctx context.Context, tx pgx.Tx, id string) ([]domain.Atta
 	if err != nil {
 		return nil, err
 	}
-	return pgx.CollectRows(rows, scanFile(id))
+	return pgx.CollectRows(rows, scanFile)
 }
 
 // PutFile writes a file object at a bundle path, replacing whatever file
@@ -399,7 +388,7 @@ func (s *Store) PutFile(ctx context.Context, p, mediaType string, data []byte, a
 	}
 	return &domain.Attachment{
 		Name: p[strings.LastIndex(p, "/")+1:], MediaType: mediaType,
-		Size: int64(len(data)), SHA256: hash, OKFPath: p,
+		Size: int64(len(data)), SHA256: hash, Path: p,
 		CreatedBy: actor, CreatedAt: at,
 	}, nil
 }
@@ -434,7 +423,7 @@ func (s *Store) GetFileMeta(ctx context.Context, p string) (*domain.Attachment, 
 	if err != nil {
 		return nil, err
 	}
-	a.Name, a.OKFPath, a.CreatedAt = p[strings.LastIndex(p, "/")+1:], p, at
+	a.Name, a.Path, a.CreatedAt = p[strings.LastIndex(p, "/")+1:], p, at
 	return &a, nil
 }
 

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -121,7 +121,7 @@ func (e *ExportSnapshot) AttachmentMeta(ctx context.Context) ([]ExportAttachment
 		if err := row.Scan(&a.ID, &path, &mediaType, &size, &hash, &by.Kind, &by.Name, &at); err != nil {
 			return a, err
 		}
-		a.Att = asAttachment(a.ID, path, mediaType, size, hash, by, at)
+		a.Att = asAttachment(path, mediaType, size, hash, by, at)
 		return a, nil
 	})
 	if err != nil {

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"reflect"
 	"slices"
 	"sort"
 	"strings"
@@ -2960,17 +2961,17 @@ func TestIntegrationFilesAreObjectsAttributedByPathOrBody(t *testing.T) {
 	if len(atts) != 2 {
 		t.Fatalf("attributed files = %+v, want the one under the namespace and the one the body links", atts)
 	}
-	// The one under the namespace needs no naming; the one elsewhere
-	// reports where it lives, which is what an export puts it back as.
+	// Each reports where it lives, which is what an export puts it back
+	// as — the one under the namespace and the one elsewhere alike.
 	byName := map[string]domain.Attachment{}
 	for _, a := range atts {
 		byName[a.Name] = a
 	}
-	if got := byName["chart.png"].OKFPath; got != "" {
-		t.Errorf("a file at the canonical path reports okf_path %q", got)
+	if got, want := byName["chart.png"].Path, id+"/chart.png"; got != want {
+		t.Errorf("path = %q, want %q", got, want)
 	}
-	if got, want := byName["orders.csv"].OKFPath, base+"/seeds/orders.csv"; got != want {
-		t.Errorf("okf_path = %q, want %q", got, want)
+	if got, want := byName["orders.csv"].Path, base+"/seeds/orders.csv"; got != want {
+		t.Errorf("path = %q, want %q", got, want)
 	}
 	// It is stored where the body says, not where the entry is.
 	var n int
@@ -3018,5 +3019,71 @@ func TestIntegrationFilesAreObjectsAttributedByPathOrBody(t *testing.T) {
 	}
 	if n != 0 {
 		t.Errorf("the file object outlived the detach")
+	}
+}
+
+// A file's path is the whole of where it lives (design doc 0046 §3.3).
+// It used to take two fields: a name, and an okf_path that said "not
+// where ochakai would have put it" — a second identity for the same
+// object, and one that could disagree with the row it described.
+func TestIntegrationAFileReportsItsPath(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	s.UseBlobStore(newFakeBlobStore())
+	actor := domain.Actor{Kind: domain.ActorHuman, Name: "t"}
+	base := fmt.Sprintf("it-path-%d", time.Now().UnixNano())
+	id := base + "/revenue"
+	defer func() {
+		_, _ = s.pool.Exec(ctx, `DELETE FROM object WHERE path LIKE $1 || '%'`, base)
+		_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_revision WHERE path LIKE $1 || '%'`, base)
+	}()
+
+	body := fmt.Sprintf("![chart](revenue/chart.png)\n\n[CSV](/%s/seeds/orders.csv)\n", base)
+	k := &domain.Knowledge{Type: domain.TypeMetrics, ID: id, Title: "it path",
+		Status: domain.StatusDraft, Body: body, CreatedBy: actor, UpdatedBy: actor}
+	if err := s.Create(ctx, k, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.PutAttachment(ctx, id, "chart.png", "image/png", "", []byte("png"), actor); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.PutFile(ctx, base+"/seeds/orders.csv", "text/plain", []byte("a,b\n"), actor); err != nil {
+		t.Fatal(err)
+	}
+
+	atts, err := s.ListAttachments(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]string{}
+	for _, a := range atts {
+		got[a.Name] = a.Path
+	}
+	// Both report where they are. The one under the entry's namespace is
+	// not a special case with an empty field — it has an address like
+	// everything else, and it is the address an export writes it back at.
+	want := map[string]string{
+		"chart.png":  id + "/chart.png",
+		"orders.csv": base + "/seeds/orders.csv",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("paths = %v, want %v", got, want)
+	}
+	for _, a := range atts {
+		if okf.AttachmentPath(id, &a) != a.Path {
+			t.Errorf("the export path of %s disagrees with its own: %q vs %q",
+				a.Name, okf.AttachmentPath(id, &a), a.Path)
+		}
 	}
 }

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -1550,7 +1550,7 @@ async function viewDetail(id) {
   const resolveFile = ref => {
     const p = normalize(ref.startsWith('/') ? ref : (docDir ? docDir + '/' : '') + ref);
     const canonical = a => entry.id + '/' + a.name;
-    let hit = atts.find(a => p === (a.okf_path || canonical(a)) || p === canonical(a));
+    let hit = atts.find(a => p === a.path || p === canonical(a));
     // Forgiving fallback: names are unique within the entry, so a filename
     // match resolves references written against a layout we don't know.
     hit = hit || atts.find(a => a.name === ref.split('/').pop());


### PR DESCRIPTION
#267 item 6, the part that does not touch the addresses #304 is documenting — so the two do not collide.

`okf_path` meant *"this file is not where ochakai would have put it"*: a second identity for one object, derived from the first, and one that could disagree with the row it described. Since files became objects at paths (#288), where a file lives is simply its address.

## What changes

`domain.Attachment` carries `path` and no longer carries `okf_path`. A file written through `/api/v1/attachments/{id}/{name}` is at `<id>/<name>`; one written at its own bundle path is there. Nothing has to say which case it is, because the path says it.

`name` stays beside `path` as the last segment — kept the way a concept keeps its id beside its path: derived, and what every surface calls the file. That is the precedent 0046 already set, not a second identity sneaking back.

The `?okf_path=` query parameter on attach goes with it. A file that belongs elsewhere in the bundle is written at the path it belongs at (`PUT /api/v1/bundle/{path}`), which is what `ochakai import` now does — one PUT per bundle member, at the path the bundle carried it at. Where a file lives is an address, not an annotation on a write to something else, and the entry claims it because its body points there rather than because the write said so.

## Tests

`TestIntegrationAFileReportsItsPath` writes both cases — one file under the entry's namespace, one at a path elsewhere that the body links — and asserts each reports where it is. The one under the namespace is no longer a special case with an empty field; it has an address like everything else. The test also asserts `okf.AttachmentPath` agrees with the file's own `path`, which is the disagreement the two fields made possible.

`TestAttachSendsBytesToTheAddress` (renamed from `…AndOKFPath`) now asserts the write carries **no** query string at all.

The store, service, apiclient and CLI signatures lose the parameter; the OpenAPI schema and the web UI's link resolver follow.

`scripts/check --db` is clean.
