### PR TITLE
Give a file one address (0046 §§3.3, 3.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,22 @@ last entry.
 
 ### Added
 
+- **BREAKING** — `GET|PUT|DELETE /api/v1/attachments/{id}/{name}` is
+  retired. A file is read, written and deleted at the path it lives at:
+  `/api/v1/bundle/{path}` (design doc
+  [0046](docs/design/0046-bundle-address-space.md) §§3.3, 3.5). MCP's
+  `get_attachment` takes a `path` for the same reason.
+
+  The old address was named after a concept that no longer exists. A
+  file used to be something an entry *had*, and the address said so by
+  putting the entry's id in front of a filename. Whether an entry shows
+  a file is now a question its body answers, so the address that
+  asserted it had nothing left to say — and an imported file that lives
+  elsewhere in the bundle had no honest spelling there at all.
+
+  Every file an entry shows carries its `path`, so a client that reads
+  an entry has the address of each of its files without composing one.
+
 - **Something to tell you the review queue is not empty** (design doc
   [0049](docs/design/0049-queue-counts.md)). `GET /api/v1/queues` and
   `ochakai queues` count the three feeds a curator empties — drafts

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -407,9 +407,12 @@ paths:
         with the same ETag. One object, two addresses, one answer: an
         address is not a second surface.
 
-        A file answers with its bytes, its content hash as the ETag, and
-        the headers that decide what a browser may do with them (see
-        `GET /api/v1/attachments/{path}`).
+        A file answers with its bytes, its content hash as the ETag, a
+        `304` when `If-None-Match` matches it, and the headers that
+        decide what a browser may do with them: an image, a PDF or plain
+        text renders in place, everything else is a download under
+        `Content-Security-Policy: sandbox`, and `nosniff` is always set
+        (design doc 0046 §3.2).
 
         `index.md` is one level of the tree — the subdirectories directly
         under the path, each with the count of entries beneath, plus the
@@ -518,6 +521,10 @@ paths:
                         description: Net revenue from completed orders, excluding tax and shipping.
                         status: stable
                         updated_at: "2026-07-14T02:33:41.019778Z"
+        "304":
+          description: Not modified — a file whose If-None-Match matched its content hash.
+          headers:
+            Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
         "400": { $ref: "#/components/responses/Error" }
         "403": { $ref: "#/components/responses/Forbidden" }
         "404":
@@ -1989,147 +1996,6 @@ paths:
                         updated_at: "2026-07-10T01:52:16.774301Z"
         "400": { $ref: "#/components/responses/Error" }
         "403": { $ref: "#/components/responses/Forbidden" }
-  /api/v1/attachments/{path}:
-    parameters:
-      - name: path
-        in: path
-        required: true
-        description: >
-          "{id}/{name}" — the entry's id (its bundle path) followed by
-          the attachment filename. The final segment is always the
-          filename; everything before it is the id
-          (PUT /api/v1/attachments/insights/revenue-reading/weekly.png).
-        schema: { type: string }
-    put:
-      operationId: putAttachment
-      summary: Attach a file to a knowledge entry
-      deprecated: true
-      description: >
-        Build on `PUT /api/v1/bundle/{path}`, which stores the same bytes
-        at the path they live at — so there is nothing for `okf_path` to
-        preserve and no entry to attribute the file to at write time
-        (whether an entry shows a file is a question its body answers).
-        This one is retired by design doc 0046 §§3.3, 3.5.
-
-        Stores the raw request body as a file of the bundle, replacing
-        any file of the same name (kept as a revision). The media type is
-        sniffed from the bytes and nothing is refused for being what it
-        is: a bundle whose files come back missing is not the bundle that
-        was handed over (design doc 0046 §3.2). What a browser is allowed
-        to do with them is decided when they are served — see the GET
-        above. At most 5 MiB per file; no limit on how many.
-        Reference the file from the entry's markdown body
-        (`![baseline](<id last segment>/weekly.png)` or
-        `[seeds](<id last segment>/seeds.txt)`) so it is findable and
-        survives OKF export/import (design docs 0008, 0013). Requires the
-        server to have GCS configured (OCHAKAI_GCS_BUCKET); without it
-        the request fails with 501.
-      parameters:
-        - $ref: "#/components/parameters/OnBehalfOf"
-      requestBody:
-        required: true
-        content:
-          "*/*":
-            schema: { type: string, format: binary }
-      responses:
-        "200":
-          description: Attachment metadata (bytes are fetched with GET).
-          headers:
-            Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
-          content:
-            application/json:
-              schema: { $ref: "#/components/schemas/Attachment" }
-              examples:
-                stored:
-                  summary: PUT /api/v1/attachments/metrics/revenue/revenue-2026h1.png
-                  description: >
-                    The media type was sniffed from the bytes, not taken from
-                    the request. sha256 is the content address and the ETag a
-                    later GET answers If-None-Match with.
-                  value:
-                    name: revenue-2026h1.png
-                    media_type: image/png
-                    size: 48213
-                    sha256: 9f2c1d0a7b3e5648c1d9f0a2b7e4c8d63f5a1b2c9e0d7a4f6b3c8e1d5a0f7b29
-                    created_by: { kind: human, name: tanaka@example.co.jp }
-                    created_at: "2026-06-02T04:20:11.663210Z"
-        "400": { $ref: "#/components/responses/Error" }
-        "403": { $ref: "#/components/responses/Forbidden" }
-        "404": { $ref: "#/components/responses/Error" }
-        "413": { $ref: "#/components/responses/Error" }
-        "501": { $ref: "#/components/responses/Error" }
-    get:
-      operationId: getAttachment
-      summary: Fetch attachment bytes
-      deprecated: true
-      description: >
-        Build on `GET /api/v1/bundle/{path}`, which answers the same
-        bytes, the same ETag and the same delivery headers. This one is
-        retired by design doc 0046 §3.5.
-
-        Returns the file bytes with the stored (sniffed) media type; the
-        ETag is the content's SHA-256, and a matching If-None-Match gets
-        a 304 answered from metadata alone (no blob read, so repeat
-        renders in a UI cost nothing). Cache-Control is private,
-        no-cache: names are mutable (replace-by-name), so clients
-        revalidate every time. Fetching the bytes records a usage event
-        against the owning entry; a 304 revalidation does not.
-
-        The bytes were uploaded by somebody, so what a browser may do
-        with them is decided here (design doc 0046 §3.2). An image, a
-        PDF or plain text is served `inline`; anything else — an SVG and
-        an HTML file above all, which are documents that carry script —
-        is served as an `attachment` under
-        `Content-Security-Policy: sandbox`, so it has no origin to run
-        in. `X-Content-Type-Options: nosniff` is set either way, because
-        the media type was decided by sniffing the bytes and a browser
-        must not decide it again.
-      responses:
-        "200":
-          description: The attachment bytes.
-          headers:
-            Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
-            Content-Disposition:
-              description: >
-                `inline` for an image, a PDF or plain text; `attachment`
-                for everything else (design doc 0046 §3.2).
-              schema: { type: string }
-            Content-Security-Policy:
-              description: >
-                `sandbox`, on the responses that are not served inline —
-                bytes that could carry script get no origin to run in.
-              schema: { type: string }
-            X-Content-Type-Options:
-              description: "`nosniff`, always."
-              schema: { type: string }
-          content:
-            "*/*":
-              schema: { type: string, format: binary }
-        "304":
-          description: Not modified (If-None-Match matched the content hash).
-          headers:
-            Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
-        "403": { $ref: "#/components/responses/Forbidden" }
-        "404": { $ref: "#/components/responses/Error" }
-    delete:
-      operationId: deleteAttachment
-      summary: Detach a file from a knowledge entry
-      deprecated: true
-      description: >
-        Build on `DELETE /api/v1/bundle/{path}`, which removes the same
-        file. This one is retired by design doc 0046 §3.5.
-
-        Removes the attachment (kept as a revision; the content-addressed
-        bytes remain referenced by history).
-      parameters:
-        - $ref: "#/components/parameters/OnBehalfOf"
-      responses:
-        "204":
-          description: Detached.
-          headers:
-            Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
-        "403": { $ref: "#/components/responses/Forbidden" }
-        "404": { $ref: "#/components/responses/Error" }
   /api/v1/queues:
     get:
       operationId: getQueues

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -788,7 +788,7 @@ func cmdGet(ctx context.Context, args []string) error {
 			return err
 		}
 		for _, att := range k.Attachments {
-			data, _, err := c.Attachment(ctx, id, att.Name)
+			data, _, err := c.Attachment(ctx, att.Path)
 			if err != nil {
 				return fmt.Errorf("attachment %s: %w", att.Name, err)
 			}
@@ -891,10 +891,23 @@ func cmdDetach(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	if err := c.Detach(ctx, id, rest[0]); err != nil {
+	// The file is at <id>/<name> unless the entry's body puts it
+	// elsewhere; read the entry and detach whichever one carries the
+	// name, so the command means the same thing for both (design doc
+	// 0046 §3.3).
+	path := id + "/" + rest[0]
+	if k, err := c.Get(ctx, id); err == nil {
+		for _, a := range k.Attachments {
+			if a.Name == rest[0] && a.Path != "" {
+				path = a.Path
+				break
+			}
+		}
+	}
+	if err := c.Detach(ctx, path); err != nil {
 		return err
 	}
-	fmt.Printf("detached %s/%s\n", id, rest[0])
+	fmt.Printf("detached %s\n", path)
 	return nil
 }
 

--- a/internal/apiclient/apiclient.go
+++ b/internal/apiclient/apiclient.go
@@ -482,12 +482,12 @@ func (c *Client) Move(ctx context.Context, id, newID string) (*domain.View, erro
 	return &moved, nil
 }
 
-// Attach uploads data as an attachment of the entry (PUT
-// /api/v1/attachments/{id}/{name}), replacing any attachment of
-// the same name. The file lands at <id>/<name>; one that lives elsewhere
-// in the bundle is written with PutBundleFile, at the path it lives at.
+// Attach writes data as a file of the entry, at the canonical
+// <id>/<name> (PUT /api/v1/bundle/{path}). A file that lives elsewhere
+// in the bundle is written with PutBundleFile, at the path it lives at —
+// there is one address for a file, and it is where the file is.
 func (c *Client) Attach(ctx context.Context, id, name string, data []byte) (*domain.Attachment, error) {
-	resp, err := c.doRaw(ctx, http.MethodPut, attachmentPath(id, name), nil,
+	resp, err := c.doRaw(ctx, http.MethodPut, bundlePath(id+"/"+name), nil,
 		"application/octet-stream", nil, bytes.NewReader(data))
 	if err != nil {
 		return nil, err
@@ -500,11 +500,11 @@ func (c *Client) Attach(ctx context.Context, id, name string, data []byte) (*dom
 	return &att, nil
 }
 
-// Attachment fetches one attachment's bytes and media type (GET
-// /api/v1/attachments/{id}/{name}). Full metadata travels with
-// the entry (Get → Knowledge.Attachments).
-func (c *Client) Attachment(ctx context.Context, id, name string) (data []byte, mediaType string, err error) {
-	resp, err := c.get(ctx, attachmentPath(id, name), nil)
+// Attachment fetches one file's bytes and media type by its bundle path
+// (GET /api/v1/bundle/{path}). Metadata travels with the entry that
+// shows it (Get → Knowledge.Attachments), each carrying its path.
+func (c *Client) Attachment(ctx context.Context, path string) (data []byte, mediaType string, err error) {
+	resp, err := c.get(ctx, bundlePath(path), nil)
 	if err != nil {
 		return nil, "", err
 	}
@@ -516,13 +516,13 @@ func (c *Client) Attachment(ctx context.Context, id, name string) (data []byte, 
 	return data, resp.Header.Get("Content-Type"), nil
 }
 
-// Detach removes an attachment (DELETE /api/v1/attachments/{id}/{name}).
-func (c *Client) Detach(ctx context.Context, id, name string) error {
-	return c.doJSON(ctx, http.MethodDelete, attachmentPath(id, name), nil, nil, nil)
+// Detach removes the file at a bundle path (DELETE /api/v1/bundle/{path}).
+func (c *Client) Detach(ctx context.Context, path string) error {
+	return c.doJSON(ctx, http.MethodDelete, bundlePath(path), nil, nil, nil)
 }
 
-func attachmentPath(id, name string) string {
-	return escapedPath("/api/v1/attachments/", id) + "/" + url.PathEscape(name)
+func bundlePath(p string) string {
+	return escapedPath("/api/v1/bundle/", p)
 }
 
 // Usage fetches usage totals for one entry (GET /api/v1/usage/{id}):
@@ -714,7 +714,7 @@ func (c *Client) doJSON(ctx context.Context, method, path string, query url.Valu
 // references, or a markdown file with no type, which the server stores
 // as a file rather than reading as a concept.
 func (c *Client) PutBundleFile(ctx context.Context, path string, data []byte) error {
-	resp, err := c.doRaw(ctx, http.MethodPut, "/api/v1/bundle/"+path, nil,
+	resp, err := c.doRaw(ctx, http.MethodPut, bundlePath(path), nil,
 		"application/octet-stream", nil, bytes.NewReader(data))
 	if err != nil {
 		return err

--- a/internal/apiclient/apiclient_test.go
+++ b/internal/apiclient/apiclient_test.go
@@ -398,7 +398,7 @@ func TestContextBuildsQueryAndDecodesPack(t *testing.T) {
 func TestAttachSendsBytesToTheAddress(t *testing.T) {
 	body := []byte("attachment bytes")
 	c := newTestPair(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPut || r.URL.Path != "/api/v1/attachments/insights/sales/reading/weekly.png" {
+		if r.Method != http.MethodPut || r.URL.Path != "/api/v1/bundle/insights/sales/reading/weekly.png" {
 			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
 		if r.URL.RawQuery != "" {
@@ -421,13 +421,13 @@ func TestAttachSendsBytesToTheAddress(t *testing.T) {
 
 func TestAttachmentFetchesBytesAndMediaType(t *testing.T) {
 	c := newTestPair(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v1/attachments/insights/reading/weekly.png" {
+		if r.URL.Path != "/api/v1/bundle/insights/reading/weekly.png" {
 			t.Errorf("path = %s", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "image/png")
 		_, _ = w.Write([]byte("png bytes"))
 	})
-	data, mediaType, err := c.Attachment(context.Background(), "insights/reading", "weekly.png")
+	data, mediaType, err := c.Attachment(context.Background(), "insights/reading/weekly.png")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -440,12 +440,12 @@ func TestDetachHitsAttachmentPath(t *testing.T) {
 	called := false
 	c := newTestPair(t, func(w http.ResponseWriter, r *http.Request) {
 		called = true
-		if r.Method != http.MethodDelete || r.URL.Path != "/api/v1/attachments/insights/reading/weekly.png" {
+		if r.Method != http.MethodDelete || r.URL.Path != "/api/v1/bundle/insights/reading/weekly.png" {
 			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
 		w.WriteHeader(http.StatusNoContent)
 	})
-	if err := c.Detach(context.Background(), "insights/reading", "weekly.png"); err != nil {
+	if err := c.Detach(context.Background(), "insights/reading/weekly.png"); err != nil {
 		t.Fatal(err)
 	}
 	if !called {

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -361,15 +361,15 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "get_attachment",
 		Annotations: readOnly,
-		Description: "Fetch one file attached to a knowledge entry (get_knowledge lists attachment " +
-			"metadata under \"attachments\": images, PDFs, plain-text data files). Returns the " +
-			"file as content plus its metadata. Attachments are context-heavy — fetch them " +
+		Description: "Fetch one file of the bundle by its path (get_knowledge lists the files an " +
+			"entry shows under \"attachments\", each with its path: images, PDFs, plain-text data " +
+			"files, anything a producer put there). Returns the file as content plus its metadata. Attachments are context-heavy — fetch them " +
 			"deliberately, when the entry's body references one you need to see (a dashboard's " +
 			"normal shape, an ER diagram, a seeds file). ochakai never interprets attachments; " +
 			"if you learn something from one, write it back into the entry's body with " +
 			"put_knowledge so the knowledge becomes searchable text.",
 	}, tool(svc, func(ctx context.Context, _ domain.Actor, in attachmentIn) (*mcp.CallToolResult, attachmentOut, error) {
-		att, data, err := svc.Attachment(ctx, in.ID, in.Name)
+		att, data, err := svc.GetFile(ctx, in.Path)
 		if err != nil {
 			return nil, attachmentOut{}, err
 		}
@@ -384,7 +384,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			content = &mcp.TextContent{Text: string(data)}
 		default:
 			content = &mcp.EmbeddedResource{Resource: &mcp.ResourceContents{
-				URI:      fmt.Sprintf("ochakai://%s/attachments/%s", in.ID, att.Name),
+				URI:      "ochakai://" + att.Path,
 				MIMEType: att.MediaType,
 				Blob:     data,
 			}}
@@ -565,8 +565,7 @@ type knowledgeOut struct {
 }
 
 type attachmentIn struct {
-	ID   string `json:"id" jsonschema:"the entry's id (its path, e.g. metrics/revenue)"`
-	Name string `json:"name" jsonschema:"attachment filename, from the entry's attachments metadata"`
+	Path string `json:"path" jsonschema:"the file's bundle path, from the path field of an entry's attachments metadata (e.g. metrics/revenue/chart.png)"`
 }
 
 type attachmentOut struct {

--- a/internal/restapi/openapi_test.go
+++ b/internal/restapi/openapi_test.go
@@ -81,7 +81,7 @@ var idAddressed = []string{
 	"/api/v1/usage/",
 	"/api/v1/bundle/",
 	"/api/v1/backlinks/",
-	"/api/v1/attachments/",
+	"/api/v1/bundle/",
 }
 
 // forSpecRouting collapses a multi-segment id down to one segment so the
@@ -117,9 +117,7 @@ func forSpecRouting(p string) string {
 // `{type: string, format: binary}` asserts nothing about the bytes,
 // which is the whole point of a file.
 func carriesOpaqueBytes(r *http.Request) bool {
-	return r.Method == http.MethodPut &&
-		(strings.HasPrefix(r.URL.Path, "/api/v1/attachments/") ||
-			strings.HasPrefix(r.URL.Path, "/api/v1/bundle/"))
+	return r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/api/v1/bundle/")
 }
 
 // sniffedResponse reports whether a response's media type was decided by

--- a/internal/restapi/readonly_test.go
+++ b/internal/restapi/readonly_test.go
@@ -39,8 +39,8 @@ func TestReadOnlyRefusesWritesWith403(t *testing.T) {
 		{http.MethodPost, "/api/v1/usage/m", `{"outcome":"worked"}`, "application/json"},
 		{http.MethodPost, "/api/v1/move", `{"from":"m","to":"n"}`, "application/json"},
 		{http.MethodPost, "/api/v1/reembed", "", ""},
-		{http.MethodPut, "/api/v1/attachments/m/f.txt", "x", "application/json"},
-		{http.MethodDelete, "/api/v1/attachments/m/f.txt", "", ""},
+		{http.MethodPut, "/api/v1/bundle/m/f.txt", "x", "application/json"},
+		{http.MethodDelete, "/api/v1/bundle/m/f.txt", "", ""},
 	} {
 		req, err := http.NewRequest(w.method, srv.URL+w.path, strings.NewReader(w.body))
 		if err != nil {

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -474,92 +474,13 @@ func Handler(svc *service.Service) http.Handler {
 		}
 		writeJSON(w, http.StatusOK, map[string]any{"entries": rows})
 	})
-	// Attachments (design docs 0008, 0013): files attached to an entry
-	// (images, PDFs, plain text), bytes fetched on demand — entry reads
-	// carry metadata only. The path is
-	// /attachments/{id segments...}/{name}; the final segment is always
-	// the filename (attachment names are single segments), so the
-	// wildcard split is unambiguous. Lives outside /knowledge/ for the
-	// same reason /usage does: a suffix after a hierarchical {id...}
-	// would be unroutable.
-	attachmentRef := func(w http.ResponseWriter, r *http.Request) (string, string, bool) {
-		id, name, ok := splitAttachmentPath(r.PathValue("path"))
-		if !ok {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid attachment path (want /api/v1/attachments/{id}/{name})"})
-			return "", "", false
-		}
-		return id, name, true
-	}
-
-	mux.HandleFunc("PUT /api/v1/attachments/{path...}", func(w http.ResponseWriter, r *http.Request) {
-		id, name, ok := attachmentRef(w, r)
-		if !ok {
-			return
-		}
-		data, ok := readBody(w, r, domain.MaxAttachmentSize,
-			fmt.Sprintf("attachment exceeds %d MiB", domain.MaxAttachmentSize>>20))
-		if !ok {
-			return
-		}
-		// This address writes at <id>/<name>, always. A file that lives
-		// somewhere else in the bundle is written at the path it lives
-		// at — PUT /api/v1/bundle/{path} — rather than here with a
-		// parameter saying where it really is (design doc 0046 §3.3).
-		att, err := svc.Attach(r.Context(), id, name, data, httpauth.Actor(r.Context()))
-		if err != nil {
-			writeError(w, err)
-			return
-		}
-		writeJSON(w, http.StatusOK, att)
-	})
-
-	mux.HandleFunc("GET /api/v1/attachments/{path...}", func(w http.ResponseWriter, r *http.Request) {
-		id, name, ok := attachmentRef(w, r)
-		if !ok {
-			return
-		}
-		// Conditional GET before touching the blob store: bytes are
-		// content-addressed, so the hash is a perfect ETag, and the web
-		// UI re-renders the same images on every search — a 304 answered
-		// from metadata alone keeps GCS reads and egress off the bill.
-		// no-cache means "revalidate every time", which is required
-		// because the name→content mapping is mutable (replace-by-name).
-		meta, err := svc.AttachmentMeta(r.Context(), id, name)
-		if err != nil {
-			writeError(w, err)
-			return
-		}
-		etag := `"` + meta.SHA256 + `"`
-		w.Header().Set("ETag", etag)
-		w.Header().Set("Cache-Control", "private, no-cache")
-		if r.Header.Get("If-None-Match") == etag {
-			w.WriteHeader(http.StatusNotModified)
-			return
-		}
-		att, data, err := svc.Attachment(r.Context(), id, name)
-		if err != nil {
-			writeError(w, err)
-			return
-		}
-		// Re-stamp from the row the bytes came from, in case the
-		// attachment was replaced between the two reads.
-		w.Header().Set("ETag", `"`+att.SHA256+`"`)
-		w.Header().Set("Content-Type", mediaTypeHeader(att.MediaType))
-		serveDefensively(w, att.MediaType, att.Name)
-		_, _ = w.Write(data)
-	})
-
-	mux.HandleFunc("DELETE /api/v1/attachments/{path...}", func(w http.ResponseWriter, r *http.Request) {
-		id, name, ok := attachmentRef(w, r)
-		if !ok {
-			return
-		}
-		if err := svc.Detach(r.Context(), id, name, httpauth.Actor(r.Context())); err != nil {
-			writeError(w, err)
-			return
-		}
-		w.WriteHeader(http.StatusNoContent)
-	})
+	// A file has one address, and it is the path it lives at:
+	// /api/v1/bundle/{path} reads, writes and deletes it (design doc 0046
+	// §§3.3, 3.5). /api/v1/attachments/{id}/{name} is gone with the
+	// concept it was named after — a file was something an entry *had*,
+	// and the address said so by putting the entry's id in front of a
+	// filename. Whether an entry shows a file is now a question its body
+	// answers, so the address that asserted it had nothing left to say.
 
 	// DELETE soft-deletes; ?purge=true hard-deletes an entry that is
 	// already soft-deleted, freeing its id (a tombstone still owns the

--- a/internal/restapi/restapi_integration_test.go
+++ b/internal/restapi/restapi_integration_test.go
@@ -348,7 +348,7 @@ func TestRESTIntegrationAttachments(t *testing.T) {
 	}
 
 	png := append([]byte("\x89PNG\r\n\x1a\n"), []byte("hit thumbnail bytes")...)
-	attURL := srv.URL + "/api/v1/attachments/" + typ + "/reading/weekly.png"
+	attURL := srv.URL + "/api/v1/bundle/" + typ + "/reading/weekly.png"
 	req, _ := http.NewRequest(http.MethodPut, attURL, bytes.NewReader(png))
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -1235,7 +1235,7 @@ func TestRESTIntegrationAnyFileIsAcceptedAndServedInert(t *testing.T) {
 		{"seeds.zip", "application/zip", append([]byte("PK\x03\x04"), make([]byte, 16)...), false},
 		{"shot.gif", "image/gif", append([]byte("GIF89a"), make([]byte, 16)...), true},
 	} {
-		attURL := srv.URL + "/api/v1/attachments/" + id + "/" + tc.name
+		attURL := srv.URL + "/api/v1/bundle/" + id + "/" + tc.name
 		req, _ := http.NewRequest(http.MethodPut, attURL, bytes.NewReader(tc.data))
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {

--- a/internal/restapi/restapi_test.go
+++ b/internal/restapi/restapi_test.go
@@ -150,7 +150,7 @@ func TestAttachWithoutBlobStore(t *testing.T) {
 	png := append([]byte("\x89PNG\r\n\x1a\n"), make([]byte, 16)...)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPut,
-		"/api/v1/attachments/insights/revenue/weekly.png", bytes.NewReader(png)))
+		"/api/v1/bundle/insights/revenue/weekly.png", bytes.NewReader(png)))
 	if rec.Code != http.StatusNotImplemented {
 		t.Fatalf("PUT attachment without GCS = %d, want 501 (body: %s)", rec.Code, rec.Body)
 	}
@@ -169,8 +169,8 @@ func TestOversizedBodies(t *testing.T) {
 		size              int
 		wantSubstr        string
 	}{
-		{"attachment", http.MethodPut, "/api/v1/attachments/insights/revenue/weekly.png",
-			domain.MaxAttachmentSize + 1, "attachment exceeds"},
+		{"attachment", http.MethodPut, "/api/v1/bundle/insights/revenue/weekly.png",
+			domain.MaxAttachmentSize + 1, "object exceeds"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/service/attachment.go
+++ b/internal/service/attachment.go
@@ -15,39 +15,6 @@ import (
 // into the body is the client agent's job, like every other
 // interpretation.
 
-// Attach stores data as an attachment of the entry, replacing any
-// file of the same name. The media type is sniffed from the bytes, never
-// taken from the caller.
-//
-// The file lands at <id>/<name>. One that belongs somewhere else in the
-// bundle is written at the path it belongs at (PutFile): where a file
-// lives is its address, not an annotation on a write to another one
-// (design doc 0046 §3.3).
-func (s *Service) Attach(ctx context.Context, id, name string, data []byte, actor domain.Actor) (*domain.Attachment, error) {
-	if err := s.readOnly(); err != nil {
-		return nil, err
-	}
-	id, name = domain.Normalize(id), domain.Normalize(name)
-	if !s.Store.HasBlobStore() {
-		return nil, Unsupportedf("attachments are not supported without GCS: this instance stores markdown entries only; set OCHAKAI_GCS_BUCKET (design doc 0013)")
-	}
-	// Both are judgments about the client's bytes, so classify them as
-	// input errors (REST: 400).
-	if err := domain.ValidateAttachment(name, len(data)); err != nil {
-		return nil, Invalidf("%v", err)
-	}
-	mediaType, err := domain.DetectAttachmentMediaType(data)
-	if err != nil {
-		return nil, Invalidf("%v", err)
-	}
-	att, err := s.Store.PutAttachment(ctx, id, name, mediaType, "", data, actor)
-	if err != nil {
-		return nil, err
-	}
-	s.updateAttachmentEmbedding(ctx, id, att, data)
-	return att, nil
-}
-
 // updateAttachmentEmbedding refreshes an attachment's document vector
 // (design doc 0020). Embedding a file is encoding, not interpretation,
 // so the no-interpretation principle above holds. Text embeds via the
@@ -102,26 +69,6 @@ func (s *Service) updateAttachmentEmbedding(ctx context.Context, id string, att 
 	}
 }
 
-// Attachment returns one attachment with its bytes and records a fetch
-// against the owning entry — reading the image is using the knowledge.
-func (s *Service) Attachment(ctx context.Context, id, name string) (*domain.Attachment, []byte, error) {
-	id, name = domain.Normalize(id), domain.Normalize(name)
-	att, data, err := s.Store.GetAttachment(ctx, id, name)
-	if err != nil {
-		return nil, nil, err
-	}
-	s.recordUsage(ctx, domain.EventFetched, []string{id})
-	return att, data, nil
-}
-
-// AttachmentMeta returns one attachment's metadata without its bytes —
-// enough for a conditional GET (ETag = content hash) to answer 304
-// without a blob-store read, and without recording a fetch: a cache
-// revalidation is not a use of the knowledge.
-func (s *Service) AttachmentMeta(ctx context.Context, id, name string) (*domain.Attachment, error) {
-	return s.Store.GetAttachmentMeta(ctx, domain.Normalize(id), domain.Normalize(name))
-}
-
 // FillAttachments fills attachment metadata on entries in one batch
 // query. The REST list surfaces (search hits, backlinks) carry it so a
 // UI can render image previews without a fetch per entry; MCP search
@@ -142,14 +89,6 @@ func (s *Service) FillAttachments(ctx context.Context, ks []*domain.Knowledge) e
 		k.Attachments = atts[k.ID]
 	}
 	return nil
-}
-
-// Detach removes an attachment (the change is kept as a revision).
-func (s *Service) Detach(ctx context.Context, id, name string, actor domain.Actor) error {
-	if err := s.readOnly(); err != nil {
-		return err
-	}
-	return s.Store.DeleteAttachment(ctx, domain.Normalize(id), domain.Normalize(name), actor)
 }
 
 // PutFile writes a file at a bundle path (design doc 0046 §§3.2, 3.5).

--- a/internal/service/attachment_integration_test.go
+++ b/internal/service/attachment_integration_test.go
@@ -151,7 +151,7 @@ func TestAttachmentSearchIntegration(t *testing.T) {
 		defer func() { _ = s.SoftDelete(ctx, decoy, actor) }()
 	}
 
-	if _, err := svc.Attach(ctx, id, "expected.txt", []byte(content), actor); err != nil {
+	if _, err := svc.PutFile(ctx, id+"/expected.txt", []byte(content), actor); err != nil {
 		t.Fatalf("Attach: %v", err)
 	}
 
@@ -175,10 +175,10 @@ func TestAttachmentSearchIntegration(t *testing.T) {
 	// Non-text attachments are not embeddable yet (design doc 0020 §3):
 	// attach must succeed without leaving an embedding row.
 	png := append([]byte("\x89PNG\r\n\x1a\n"), []byte("fake image bytes")...)
-	if _, err := svc.Attach(ctx, id, "chart.png", png, actor); err != nil {
+	if _, err := svc.PutFile(ctx, id+"/chart.png", png, actor); err != nil {
 		t.Fatalf("Attach png: %v", err)
 	}
-	att, data, err := svc.Attachment(ctx, id, "chart.png")
+	att, data, err := svc.GetFile(ctx, id+"/chart.png")
 	if err != nil || att.MediaType != "image/png" {
 		t.Fatalf("Attachment(chart.png) = %+v, %v", att, err)
 	}
@@ -204,7 +204,7 @@ func TestAttachmentSearchIntegration(t *testing.T) {
 		stubEmbedder: emb,
 		files:        map[string][]float32{"chart.png": {0, 0, 1, 0}},
 	}, Log: slog.New(slog.DiscardHandler)}
-	if _, err := fsvc.Attach(ctx, id, "chart.png", png, actor); err != nil {
+	if _, err := fsvc.PutFile(ctx, id+"/chart.png", png, actor); err != nil {
 		t.Fatalf("re-attach png with file embedder: %v", err)
 	}
 	vhits, err = s.SearchVectorAttachments(ctx, []float32{0, 0, 1, 0}, "stub", store.Filter{}, 50)
@@ -259,7 +259,7 @@ func TestReembedCoversAttachmentsIntegration(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = svc.Delete(ctx, id, actor) })
 	for _, name := range []string{"a.txt", "b.txt"} {
-		if _, err := svc.Attach(ctx, id, name, []byte("some text for "+name), actor); err != nil {
+		if _, err := svc.PutFile(ctx, id+"/"+name, []byte("some text for "+name), actor); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -1065,7 +1065,7 @@ async function runSearch(append = false) {
 function cardThumbs(h) {
   const imgs = (h.attachments || []).filter(a => (a.media_type || '').startsWith('image/')).slice(0, 4);
   if (!imgs.length) return '';
-  const src = a => BASE + '/api/v1/attachments/' + idPath(h.id) + '/' + encodeURIComponent(a.name);
+  const src = a => BASE + '/api/v1/bundle/' + idPath(a.path);
   return `<div class="thumbs">${imgs.map(a =>
     `<img src="${src(a)}" alt="${esc(a.name)}" title="${esc(a.name)}" loading="lazy">`).join('')}</div>`;
 }
@@ -1558,8 +1558,13 @@ async function viewDetail(id) {
   // (the id's parent), or bundle-root when they start with "/".
   const lastSeg = entry.id.split('/').pop();
   const docDir = entry.id.includes('/') ? entry.id.slice(0, entry.id.lastIndexOf('/')) : '';
-  const attPath = name => '/api/v1/attachments/' + idPath(entry.id) + '/' + encodeURIComponent(name);
-  const attURL = name => BASE + attPath(name);
+  // A file is addressed by the path it lives at (design doc 0046 §3.3).
+  // Writing one from here puts it at the entry's canonical <id>/<name>;
+  // reading one follows the path the entry reported, which is where an
+  // imported file actually is.
+  const attPath = path => '/api/v1/bundle/' + idPath(path);
+  const attURL = path => BASE + attPath(path);
+  const canonicalPath = name => entry.id + '/' + name;
   const normalize = p => {
     const out = [];
     for (const seg of p.split('/')) {
@@ -1575,7 +1580,7 @@ async function viewDetail(id) {
     // Forgiving fallback: names are unique within the entry, so a filename
     // match resolves references written against a layout we don't know.
     hit = hit || atts.find(a => a.name === ref.split('/').pop());
-    return hit ? attURL(hit.name) : null;
+    return hit ? attURL(hit.path || canonicalPath(hit.name)) : null;
   };
   // Links to other entries, resolved the way the server derives them from
   // this same body (design doc 0024): SPEC §6's two forms, bundle-absolute
@@ -1629,8 +1634,8 @@ async function viewDetail(id) {
       const cards = atts.map(a => {
         const isImage = (a.media_type || '').startsWith('image/');
         const thumb = isImage
-          ? `<a class="thumb" href="${attURL(a.name)}" target="_blank" rel="noopener"><img src="${attURL(a.name)}" alt="${esc(a.name)}" loading="lazy"></a>`
-          : `<a class="thumb thumb-file" href="${attURL(a.name)}" target="_blank" rel="noopener">${a.media_type === 'application/pdf' ? 'PDF' : 'TXT'}</a>`;
+          ? `<a class="thumb" href="${attURL(a.path)}" target="_blank" rel="noopener"><img src="${attURL(a.path)}" alt="${esc(a.name)}" loading="lazy"></a>`
+          : `<a class="thumb thumb-file" href="${attURL(a.path)}" target="_blank" rel="noopener">${a.media_type === 'application/pdf' ? 'PDF' : 'TXT'}</a>`;
         const ref = isImage ? `![${esc(a.name)}](${esc(lastSeg)}/${esc(a.name)})` : `[${esc(a.name)}](${esc(lastSeg)}/${esc(a.name)})`;
         return `
         <div class="card att-card">
@@ -1639,7 +1644,7 @@ async function viewDetail(id) {
             <span class="mono">${esc(a.name)}</span>
             <span class="meta">${esc(a.media_type || '')} · ${fmtSize(a.size)}${a.created_by && a.created_by.name ? ' · ' + esc(actorStr(a.created_by)) : ''}${a.created_at ? ' · ' + esc(fmtDate(a.created_at)) : ''}</span>
             <span class="meta">body reference: <code>${ref}</code></span>
-            <button class="btn small danger write-only" data-detach="${esc(a.name)}">Detach</button>
+            <button class="btn small danger write-only" data-detach="${esc(a.path)}" data-name="${esc(a.name)}">Detach</button>
           </div>
         </div>`;
       }).join('');
@@ -1670,17 +1675,17 @@ async function viewDetail(id) {
       if (!files.length) { toast('Choose files first.'); return; }
       try {
         for (const f of files) {
-          await api(attPath(f.name), { method: 'PUT', raw: f });
+          await api(attPath(canonicalPath(f.name)), { method: 'PUT', raw: f });
         }
         toast(files.length > 1 ? `Attached ${files.length} files.` : 'Attached.');
         viewDetail(entry.id);
       } catch (e) { toast('Attach failed: ' + e.message); }
     });
     body.querySelectorAll('[data-detach]').forEach(b => b.addEventListener('click', async () => {
-      const name = b.dataset.detach;
-      if (!confirm(`Detach ${name}? The change is kept as a revision.`)) return;
+      const path = b.dataset.detach;
+      if (!confirm(`Detach ${b.dataset.name}? The change is kept as a revision.`)) return;
       try {
-        await api(attPath(name), { method: 'DELETE' });
+        await api(attPath(path), { method: 'DELETE' });
         toast('Detached.');
         viewDetail(entry.id);
       } catch (e) { toast('Detach failed: ' + e.message); }


### PR DESCRIPTION
#267 item 6, and the removal #304 anticipated: "if the removals land before the next tag, no release ever carries a `deprecated` mark."

`GET|PUT|DELETE /api/v1/attachments/{id}/{name}` is retired. A file is read, written and deleted at the path it lives at — `/api/v1/bundle/{path}`, which has served files since #290.

## Why the address had to go, not just be deprecated

It was named after a concept that no longer exists. A file used to be something an entry *had*, and the address said so by putting the entry's id in front of a filename. Whether an entry shows a file is a question its body answers now (#288), so the address that asserted it had nothing left to say.

Worse, it could not spell the truth. A file an import keeps where it found it — `seeds/orders.csv`, shown by `metrics/revenue.md` — has no `<id>/<name>` form. Under the old address it was reachable only through a filename lookup that quietly hoped the name was unique.

## What follows

- **MCP `get_attachment` takes a `path`.** Its embedded-resource URI becomes `ochakai://<path>` instead of a composed `<id>/attachments/<name>` that named no real address.
- **The web UI addresses files by path** — including the thumbnails on a hit card, which composed `<id>/<name>` and so could not show an imported file at all. That was a live bug, not just a rename.
- **`service.Attach`, `Detach`, `Attachment` and `AttachmentMeta` are gone**: no callers were left once the handlers were. `PutFile` / `GetFile` / `DeleteFile` are what the bundle address uses, and they were already there.
- `apiclient`'s `Attach` / `Attachment` / `Detach` keep their names and speak the bundle address; `Attach` still means "at the entry's canonical `<id>/<name>`", which is what the CLI command means.
- `ochakai detach <id> <name>` reads the entry first and deletes whichever file carries that name, so it works for an imported file too.

## The contract

The `/api/v1/attachments/{path}` block is out of `api/openapi.yaml`. The bundle read gained the `304` it always answered for a file, which the contract test caught the moment the attachment tests moved over — that response was declared on the old address only.

`scripts/check --db` is clean.
