### PR TITLE
Count the surface, so growing it has to be said out loud

### DIFF
--- a/.claude/skills/design-doc/SKILL.md
+++ b/.claude/skills/design-doc/SKILL.md
@@ -118,6 +118,14 @@ step 6 says what the record decided. Spend the attention there.
 
 ## Surface consistency
 
+Start from no. [docs/surface.md](../../../docs/surface.md) counts every
+REST operation, MCP tool and CLI command, and a change that widens one
+answers its three questions in the PR: who actually got stuck, whether an
+existing surface already covers it, and what can be folded away in
+exchange. `cmd/ochakai/surface_test.go` fails until the document matches
+what the build offers — the failure prints the section as it should read,
+so the bookkeeping is free and the judgment is the part to spend on.
+
 If the change adds or changes a feature, [0015](../../../docs/design/0015-surface-consistency.md)
 requires the PR to state, per surface, where it lands — **including the
 deliberate omissions**:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,6 +17,11 @@ context, including the store integration test and the fuzz targets).
       integration test, which is what puts it under the OpenAPI contract check
 - [ ] The change lands on every surface it belongs on — REST / MCP / CLI /
       Web UI — and what it stays off is deliberate (design doc 0015)
+- [ ] Widens a surface — a REST operation, an MCP tool, a CLI command?
+      `docs/surface.md` is updated (`cmd/ochakai/surface_test.go` says so) and
+      the three questions are answered under *What and why*: who actually got
+      stuck, why an existing surface does not already cover it, and what is
+      folded away in exchange. The default answer is no
 
 ## Design docs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,27 @@ chains get a replacement instead). The bookkeeping half of it is checked:
 an index that disagrees with a record's `Status:` header about whether it
 is current, or a supersession recorded at only one end.
 
+## Surface, and the default answer
+
+What ochakai costs the person using it is its **surface** — the endpoints
+they can call, the tool schemas that spend their agent's context, the
+commands they have to learn — not the code behind it.
+[docs/surface.md](docs/surface.md) counts all three in one place, and
+`cmd/ochakai/surface_test.go` fails when the count and the build
+disagree, so an addition shows up as a heading moving from `(19)` to
+`(20)` instead of disappearing into a spec diff.
+
+**The default answer to a new feature is no.** Before writing code that
+widens a surface, answer that document's three questions in the PR
+description: who actually got stuck, whether an existing surface already
+covers it (if it does, don't add), and what can be folded away in
+exchange. Per-surface defaults are
+[0015 §3.1](docs/design/0015-surface-consistency.md) — REST is the only
+contract, CLI is the completeness surface, MCP's default is *no* because
+tool schemas are paid for out of the agent's context window, and the web
+UI is a curation surface rather than a BI tool. Proposing the smaller
+thing, or nothing, is the useful answer more often than not.
+
 ## Checks and conventions
 
 Run the checks CI runs:
@@ -51,7 +72,8 @@ fuzzing.
   in sync.
 - New features must land consistently across surfaces per
   [docs/design/0015](docs/design/0015-surface-consistency.md)
-  (REST / MCP / CLI / Web UI — including deliberate omissions).
+  (REST / MCP / CLI / Web UI — including deliberate omissions), and
+  [docs/surface.md](docs/surface.md) has to stay true to what shipped.
 - Write commit messages and code comments in English.
 - Cutting a release is a reviewed PR, then a tag, then verification —
   use the `release` skill rather than working from memory. A pushed tag

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,21 @@ Unrelated to any of this, `examples/claude-code/` is a *product* example
 — hooks that pull team knowledge out of a running ochakai and write back
 to it. It is not part of this repository's own setup.
 
+## Proposing a feature
+
+The default answer is no, and [docs/surface.md](docs/surface.md) is where
+that is made concrete. It counts every REST operation, MCP tool and CLI
+command in one place — what somebody using ochakai actually pays for —
+and `cmd/ochakai/surface_test.go` fails when the count and the build
+disagree, so an addition arrives as a heading moving from `(19)` to
+`(20)` rather than as a few lines buried in a spec.
+
+A PR that widens a surface answers three questions in its description:
+who actually got stuck and on what, whether an existing surface already
+covers it (if it does, don't add), and what can be folded away in
+exchange. The test holds the arithmetic; those answers are the part
+review spends time on.
+
 ## Design docs
 
 Architecture decisions live in [docs/design](docs/design) as numbered
@@ -176,6 +191,8 @@ Two decisions worth knowing before proposing features:
 ## Pull requests
 
 - Keep PRs small and focused; include tests for behavior changes.
+- A PR that widens a surface updates [docs/surface.md](docs/surface.md)
+  and answers its three questions in the description.
 - The public wire surface is [api/openapi.yaml](api/openapi.yaml) — keep
   it, `internal/restapi`, `internal/mcpserver`, and `internal/apiclient`
   in sync (wire compatibility is pinned by tests). The REST half is

--- a/cmd/ochakai/surface_test.go
+++ b/cmd/ochakai/surface_test.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http/httptest"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	yaml "go.yaml.in/yaml/v3"
+
+	"github.com/na0fu3y/ochakai/internal/mcpserver"
+	"github.com/na0fu3y/ochakai/internal/service"
+)
+
+// What ochakai costs the person using it is its surface — the endpoints
+// they can call, the tool schemas that eat their agent's context, the
+// commands they have to learn — not the lines behind it. Nothing counted
+// that surface, so it could grow one reasonable-looking addition at a
+// time and no diff ever said so.
+//
+// [docs/surface.md] is where it is counted. This test reads the three
+// enumerable surfaces back out of the code and fails when the document
+// and the build disagree, so growing the surface means editing a document
+// whose whole subject is how big the surface is (design doc 0035: check
+// the invariant from outside rather than trust the convention).
+//
+// The check holds the arithmetic, not the judgment. Whether an addition
+// earned its place is the reviewer's, and docs/surface.md says what to
+// ask.
+const surfaceDoc = "../../docs/surface.md"
+
+// A heading opens a counted surface: "## REST (19)". The number is
+// redundant with the list under it, deliberately — it is the line a
+// reader notices moving.
+var surfaceHeadingRe = regexp.MustCompile(`^## ([A-Z]+) \((\d+)\)$`)
+
+// An item is a whole line of backticked name, so prose that happens to
+// mention `get_context` is not mistaken for an entry.
+var surfaceItemRe = regexp.MustCompile("^- `([^`]+)`$")
+
+// surfaceSection is one counted surface as docs/surface.md declares it.
+type surfaceSection struct {
+	declared int      // the count in the heading
+	items    []string // the list under it, in document order
+}
+
+func surfaceSections(t *testing.T) map[string]surfaceSection {
+	t.Helper()
+	content, err := os.ReadFile(surfaceDoc)
+	if err != nil {
+		t.Fatalf("read %s: %v", surfaceDoc, err)
+	}
+	sections := map[string]surfaceSection{}
+	name := ""
+	for _, line := range strings.Split(string(content), "\n") {
+		if m := surfaceHeadingRe.FindStringSubmatch(line); m != nil {
+			if _, dup := sections[m[1]]; dup {
+				t.Fatalf("%s: two %s sections", surfaceDoc, m[1])
+			}
+			count, err := strconv.Atoi(m[2])
+			if err != nil {
+				t.Fatalf("%s: heading %q: %v", surfaceDoc, line, err)
+			}
+			name = m[1]
+			sections[name] = surfaceSection{declared: count}
+			continue
+		}
+		if strings.HasPrefix(line, "## ") {
+			name = "" // an uncounted section: prose, not a surface
+			continue
+		}
+		if m := surfaceItemRe.FindStringSubmatch(line); m != nil && name != "" {
+			s := sections[name]
+			s.items = append(s.items, m[1])
+			sections[name] = s
+		}
+	}
+	return sections
+}
+
+// compareSurface reports the document against what the build actually
+// offers. want is sorted, so the failure can print the section as it
+// should read rather than leaving the author to diff two lists by eye.
+func compareSurface(t *testing.T, name string, want []string) {
+	t.Helper()
+	section, ok := surfaceSections(t)[name]
+	if !ok {
+		t.Fatalf("%s has no %q section; every surface ochakai offers is counted there", surfaceDoc, name)
+	}
+	sort.Strings(want)
+	if section.declared != len(want) || !equalStrings(section.items, want) {
+		block := &strings.Builder{}
+		fmt.Fprintf(block, "## %s (%d)\n\n", name, len(want))
+		for _, item := range want {
+			fmt.Fprintf(block, "- `%s`\n", item)
+		}
+		t.Errorf(`%s's %s section does not match the build.
+
+It lists %d (heading says %d); the build offers %d. The surface is what
+somebody using ochakai pays for, so it is counted in one place and the
+count moves in the diff. If this addition is meant, update the section
+and say in the PR which of docs/surface.md's three questions it answers.
+
+The section should read:
+
+%s`, surfaceDoc, name, len(section.items), section.declared, len(want), block)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// REST is the only contract; the other three surfaces are its clients
+// (design doc 0015 §2), so its operations are read from the contract
+// itself rather than from the router.
+func TestSurfaceDocCountsRESTOperations(t *testing.T) {
+	content, err := os.ReadFile("../../api/openapi.yaml")
+	if err != nil {
+		t.Fatalf("read openapi.yaml: %v", err)
+	}
+	var spec struct {
+		Paths map[string]map[string]yaml.Node `yaml:"paths"`
+	}
+	if err := yaml.Unmarshal(content, &spec); err != nil {
+		t.Fatalf("parse openapi.yaml: %v", err)
+	}
+	methods := map[string]bool{"get": true, "put": true, "post": true, "delete": true, "patch": true}
+	var ops []string
+	for path, item := range spec.Paths {
+		for method := range item {
+			if methods[method] {
+				ops = append(ops, strings.ToUpper(method)+" "+path)
+			}
+		}
+	}
+	if len(ops) == 0 {
+		t.Fatal("no operations found in openapi.yaml: this check now guards nothing")
+	}
+	compareSurface(t, "REST", ops)
+}
+
+// Tool schemas are spent out of the agent's context window, which is why
+// the tool count is a budget and not a mirror of REST (design doc 0015
+// §3.1). Read from a running server: what an agent sees is what it
+// offers, not what the source appears to register.
+func TestSurfaceDocCountsMCPTools(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	srv := httptest.NewServer(mcpserver.Handler(&service.Service{}, "test"))
+	defer srv.Close()
+
+	cs, err := mcp.NewClient(&mcp.Implementation{Name: "surface-test", Version: "1"}, nil).
+		Connect(ctx, &mcp.StreamableClientTransport{Endpoint: srv.URL}, nil)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = cs.Close() }()
+
+	res, err := cs.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	tools := make([]string, 0, len(res.Tools))
+	for _, tool := range res.Tools {
+		tools = append(tools, tool.Name)
+	}
+	if len(tools) == 0 {
+		t.Fatal("the server offered no tools: this check now guards nothing")
+	}
+	compareSurface(t, "MCP", tools)
+}
+
+// The CLI is the completeness surface (design doc 0015 §3.1), so it is
+// the one expected to grow with REST — counted for the same reason, and
+// because every command is something a reader has to learn. `serve`,
+// `serve-ui`, `version` and `help` are how the binary is run rather than
+// things it knows, and are not counted.
+func TestSurfaceDocCountsCLICommands(t *testing.T) {
+	commands := make([]string, 0, len(clientCommands))
+	for name := range clientCommands {
+		commands = append(commands, "ochakai "+name)
+	}
+	if len(commands) == 0 {
+		t.Fatal("no client commands: this check now guards nothing")
+	}
+	compareSurface(t, "CLI", commands)
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,6 +60,11 @@ types, and every environment variable.
 
 - [CONTRIBUTING.md](../CONTRIBUTING.md) — local setup, the exact checks CI
   runs, and how design docs work.
+- [The surface](surface.md) — every REST operation, MCP tool and CLI
+  command counted in one place, with the three questions a change that
+  adds one has to answer. The default answer is no. A test reads the
+  three lists back out of the build, so the count cannot drift and a
+  feature cannot arrive without the diff saying so.
 - [docs/design](design) — the numbered, immutable decision records, and
   the [index](design/README.md) that says which ones still describe the
   current state. Mostly Japanese; authoritative where they and the English

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -1,0 +1,125 @@
+# ochakai の表面
+
+ochakai を使う人が払うのは実装の行数ではなく**表面**である — 呼べる
+エンドポイント、エージェントのコンテキストを消費するツールスキーマ、
+覚えなければならないコマンド。この文書はその全部を一箇所で数える。
+
+数えるだけで、止めはしない。止めるのは人で、この文書がするのは
+**表面が増えたことを diff に出す**ことである。エンドポイントを一本足す
+変更は [api/openapi.yaml](../api/openapi.yaml) の数十行の差分に埋もれる
+が、ここでは `## REST (19)` が `(20)` に変わる一行として出る。
+`cmd/ochakai/surface_test.go` が下の三つの節を実物と突き合わせ、
+食い違えば CI が落ちる([0035](design/0035-verifiability.md):
+規約を信じるのではなく、外から不変条件を読む)。
+
+## 足す前に答える三つの問い
+
+**既定の答えは no である。** 表面を増やす PR は、説明でこの三つに答える。
+
+1. **誰が、何をしていて詰まったか。** 実際に起きた一件を書く。「あると
+   便利」「対称性のため」「他のツールにはある」は理由ではない。
+   [ROADMAP](../ROADMAP.md) が断ってきたものは、どれも使われた結果では
+   なく想像から始まった機能である。
+2. **既存の面で回避できるか。** 回避できるなら足さない。サーバ側の一括
+   import を断った理由がこれで、既存のエンドポイントのループで足りる
+   ものに二つ目の経路を作ると、買えるのは capability ではなく
+   convenience だけだった([0015 §3.2](design/0015-surface-consistency.md))。
+3. **何が畳めるか。** 一つ足すとき、既存のどれが要らなくなるかを探す。
+   何も畳めないなら、表面が単調に増えてよい理由を書く — 書けるなら
+   足してよい。書けないと気づくことが、この問いの目的である。
+
+面ごとの既定は [0015 §3.1](design/0015-surface-consistency.md) が決めて
+いる。**REST** は唯一の契約で、すべては `/api/v1` に載るか、どこにも
+載らない。**CLI** は完全性の面なので既定は yes。**MCP の既定は no** —
+ツールスキーマはエージェントのコンテキストから支払われるので、ツール数
+は予算である。**Web UI** は人の curation に要るときだけで、BI ツールで
+はない。
+
+## この文書は番号を取らない
+
+設計ドキュメントの番号は取らない。[0048 §3](design/0048-decision-records-for-wire-contracts.md)
+が「以後、プロセスについての決定は書かない」と定めており、これはその
+規則の下で動く運用であって、規則の変更ではない。増やしたくないものを
+数える仕組みが、自分の数え先を増やすのでは筋が通らない。
+
+## REST (19)
+
+- `DELETE /api/v1/bundle/{path}`
+- `DELETE /api/v1/knowledge/{id}`
+- `DELETE /api/v1/reject/{id}`
+- `GET /api/v1/backlinks/{id}`
+- `GET /api/v1/bundle/{path}`
+- `GET /api/v1/context`
+- `GET /api/v1/export`
+- `GET /api/v1/knowledge`
+- `GET /api/v1/knowledge/{id}`
+- `GET /api/v1/queues`
+- `GET /api/v1/stats`
+- `GET /api/v1/usage/{id}`
+- `POST /api/v1/move`
+- `POST /api/v1/reembed`
+- `POST /api/v1/reject/{id}`
+- `POST /api/v1/usage/{id}`
+- `POST /api/v1/verify/{id}`
+- `PUT /api/v1/bundle/{path}`
+- `PUT /api/v1/knowledge/{id}`
+
+## MCP (8)
+
+- `delete_knowledge`
+- `get_attachment`
+- `get_context`
+- `get_knowledge`
+- `get_knowledge_usage`
+- `put_knowledge`
+- `report_outcome`
+- `search_knowledge`
+
+## CLI (28)
+
+- `ochakai attach`
+- `ochakai backlinks`
+- `ochakai browse`
+- `ochakai completion`
+- `ochakai context`
+- `ochakai create`
+- `ochakai delete`
+- `ochakai detach`
+- `ochakai export`
+- `ochakai get`
+- `ochakai import`
+- `ochakai log`
+- `ochakai mcp-stdio`
+- `ochakai move`
+- `ochakai purge`
+- `ochakai queues`
+- `ochakai reembed`
+- `ochakai reject`
+- `ochakai report`
+- `ochakai revisions`
+- `ochakai search`
+- `ochakai stats`
+- `ochakai ui`
+- `ochakai update`
+- `ochakai usage`
+- `ochakai use`
+- `ochakai verify`
+- `ochakai whoami`
+
+## 数えていないもの
+
+- **Web UI。** 自分のアドレス空間を持たず、`/api/v1` の client として
+  動く([0006](design/0006-web-ui-serving.md))ので、増えるとすれば REST
+  の節に出る。ページ自身の予算は「ビルドステップなし・フレームワーク
+  なし・CDN なし」の一枚という形の制約で、数ではない。
+- **`serve` / `serve-ui` / `version` / `help`。** バイナリの動かし方で
+  あって、ochakai が知っていることではない。
+- **実装の行数、内部パッケージ、依存。** 外から見えないものは、増えても
+  使う人は払わない。困るのは維持者だけで、それは別の問題である。
+
+## この仕組みが持てないもの
+
+テストが読めるのは数だけで、**足したものがその場所に値したかは読め
+ない**。三つの問いに答えたふりをして節を書き換えるのは何秒もかからず、
+CI は通る。この仕組みが買っているのは、それを**気づかないままやれなく
+する**ことだけである。判断はレビューに残り、理由は PR に残る。


### PR DESCRIPTION
## What and why

What ochakai costs the person using it is its **surface** — the endpoints they can call, the tool schemas that spend their agent's context, the commands they have to learn — not the code behind it. Nothing counted that surface, so it could grow one reasonable-looking addition at a time and no diff ever said so. An endpoint arrives as forty lines inside a spec that is already two thousand; an MCP tool arrives as one more `AddTool`.

[`docs/surface.md`](https://github.com/na0fu3y/ochakai/blob/claude/prevent-feature-bloat-oacutg/docs/surface.md) counts the three enumerable surfaces in one place — 19 REST operations, 8 MCP tools, 28 CLI commands — and `cmd/ochakai/surface_test.go` reads all three back out of the build: REST from `api/openapi.yaml`, MCP from a running server's `ListTools`, CLI from `clientCommands`. A mismatch fails CI and prints the section as it should read, so the bookkeeping is free. What the diff then shows is a heading moving from `(19)` to `(20)`.

The document also writes down the default that was already implicit in the ROADMAP's refusals and in 0015 §3 — **the answer is no** — as three questions a widening PR answers in its description:

1. **Who actually got stuck, and on what.** One thing that happened. "Would be handy", "for symmetry", "the other tool has it" are not reasons.
2. **Can an existing surface already cover it?** If it can, don't add — that is the reasoning that closed the server-side bulk import (0015 §3.2).
3. **What can be folded away in exchange?** If nothing, write down why the surface may grow monotonically. Noticing you cannot write it is the point of the question.

`CLAUDE.md`, `CONTRIBUTING.md`, `docs/README.md`, the PR template and the `design-doc` skill all point at it.

**No design-doc number.** [0048 §3](https://github.com/na0fu3y/ochakai/blob/main/docs/design/0048-decision-records-for-wire-contracts.md) settled that process decisions are not written as records, and a mechanism for not growing things should not start by growing the thing it is trying to hold down.

**What this cannot do**, stated in the document itself: the test reads the arithmetic and nothing else. Rewriting a section while pretending to have answered the three questions takes seconds and CI stays green. What it buys is that nobody can do it *without noticing* — the judgment stays with the reviewer, and the reason stays in the PR.

## Checks

- [x] `scripts/check` is clean — add `--db` when the change touches the store
- [x] Behavior changes come with tests

`scripts/check core` and `scripts/check lint` both clean (0 issues). Verified in both directions: removing one entry from the CLI section fails with the corrected section printed, restoring it passes.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and `internal/apiclient` say the same thing — unchanged; nothing on the wire moves
- [x] The change lands on every surface it belongs on — **not applicable**: REST, MCP, CLI and the web UI are all untouched. This changes how the repository is written, not what ochakai offers
- [x] Widens a surface? **No** — the counts are recorded at what already shipped

## Design docs

- [x] Alters an accepted decision? It does not — 0048 §3 rules out a numbered record for a process decision, and `docs/surface.md` says so in its own text
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQaAjNJrdycMabqNDuo6qc)_