### PR TITLE
Say what the surface is for: the seven conditions (#316 follow-up)

### DIFF
--- a/.claude/skills/design-doc/SKILL.md
+++ b/.claude/skills/design-doc/SKILL.md
@@ -118,11 +118,13 @@ step 6 says what the record decided. Spend the attention there.
 
 ## Surface consistency
 
-Start from no. [docs/surface.md](../../../docs/surface.md) counts every
-REST operation, MCP tool and CLI command, and a change that widens one
-answers its three questions in the PR: who actually got stuck, whether an
-existing surface already covers it, and what can be folded away in
-exchange. `cmd/ochakai/surface_test.go` fails until the document matches
+Start from no. [docs/surface.md](../../../docs/surface.md) opens with the
+seven conditions ochakai exists to satisfy — a change that serves none of
+them is a no before anything else — and counts every REST operation, MCP
+tool, CLI command and environment variable. A change that widens one
+names the condition it serves and answers the three questions in the PR:
+who actually got stuck, whether an existing surface already covers it,
+and what can be folded away in exchange. `cmd/ochakai/surface_test.go` fails until the document matches
 what the build offers — the failure prints the section as it should read,
 so the bookkeeping is free and the judgment is the part to spend on.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,11 +17,13 @@ context, including the store integration test and the fuzz targets).
       integration test, which is what puts it under the OpenAPI contract check
 - [ ] The change lands on every surface it belongs on — REST / MCP / CLI /
       Web UI — and what it stays off is deliberate (design doc 0015)
-- [ ] Widens a surface — a REST operation, an MCP tool, a CLI command?
-      `docs/surface.md` is updated (`cmd/ochakai/surface_test.go` says so) and
-      the three questions are answered under *What and why*: who actually got
-      stuck, why an existing surface does not already cover it, and what is
-      folded away in exchange. The default answer is no
+- [ ] Widens a surface — a REST operation, an MCP tool, a CLI command, an
+      environment variable? `docs/surface.md` is updated
+      (`cmd/ochakai/surface_test.go` says so), the description names which of
+      its seven conditions the addition serves, and the three questions are
+      answered under *What and why*: who actually got stuck, why an existing
+      surface does not already cover it, and what is folded away in exchange.
+      The default answer is no
 
 ## Design docs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,11 +35,21 @@ is current, or a supersession recorded at only one end.
 
 What ochakai costs the person using it is its **surface** — the endpoints
 they can call, the tool schemas that spend their agent's context, the
-commands they have to learn — not the code behind it.
-[docs/surface.md](docs/surface.md) counts all three in one place, and
-`cmd/ochakai/surface_test.go` fails when the count and the build
-disagree, so an addition shows up as a heading moving from `(19)` to
-`(20)` instead of disappearing into a spec diff.
+commands they have to learn, the variables they have to set — not the
+code behind it. [docs/surface.md](docs/surface.md) counts all four in one
+place, and `cmd/ochakai/surface_test.go` fails when the count and the
+build disagree, so an addition shows up as a heading moving from `(19)`
+to `(20)` instead of disappearing into a spec diff.
+
+That document opens with the **seven conditions** ochakai exists to
+satisfy — the knowledge stays the user's, Google Cloud with no secrets,
+OKF v0.2, no forward-deployed engineer, usable from Claude Code, a small
+embeddable REST API, a measurable improvement loop. Read them before
+proposing anything a user would touch. **A proposal that serves none of
+the seven is one to decline**, and saying so is the more useful answer;
+naming which one it serves is where a proposal that survives begins.
+Serving a condition is necessary and not sufficient — every condition has
+infinitely many mechanisms that would serve it.
 
 **The default answer to a new feature is no.** Before writing code that
 widens a surface, answer that document's three questions in the PR

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,14 +107,21 @@ to it. It is not part of this repository's own setup.
 ## Proposing a feature
 
 The default answer is no, and [docs/surface.md](docs/surface.md) is where
-that is made concrete. It counts every REST operation, MCP tool and CLI
-command in one place — what somebody using ochakai actually pays for —
-and `cmd/ochakai/surface_test.go` fails when the count and the build
-disagree, so an addition arrives as a heading moving from `(19)` to
-`(20)` rather than as a few lines buried in a spec.
+that is made concrete. It counts every REST operation, MCP tool, CLI
+command and environment variable in one place — what somebody using
+ochakai actually pays for — and `cmd/ochakai/surface_test.go` fails when
+the count and the build disagree, so an addition arrives as a heading
+moving from `(19)` to `(20)` rather than as a few lines buried in a spec.
 
-A PR that widens a surface answers three questions in its description:
-who actually got stuck and on what, whether an existing surface already
+The same document opens with the seven conditions ochakai exists to
+satisfy. **A proposal that serves none of them is a no before the
+questions start**, and that is the cheapest place to find out. If it does
+serve one, saying which is where the description begins — serving a
+condition is necessary, not sufficient, since every condition has
+infinitely many mechanisms that would serve it.
+
+From there a PR that widens a surface answers three questions: who
+actually got stuck and on what, whether an existing surface already
 covers it (if it does, don't add), and what can be folded away in
 exchange. The test holds the arithmetic; those answers are the part
 review spends time on.
@@ -191,8 +198,10 @@ Two decisions worth knowing before proposing features:
 ## Pull requests
 
 - Keep PRs small and focused; include tests for behavior changes.
-- A PR that widens a surface updates [docs/surface.md](docs/surface.md)
-  and answers its three questions in the description.
+- A PR that widens a surface — a REST operation, an MCP tool, a CLI
+  command, an environment variable — names which of
+  [docs/surface.md](docs/surface.md)'s seven conditions it serves, updates
+  the count there, and answers the three questions in the description.
 - The public wire surface is [api/openapi.yaml](api/openapi.yaml) — keep
   it, `internal/restapi`, `internal/mcpserver`, and `internal/apiclient`
   in sync (wire compatibility is pinned by tests). The REST half is

--- a/README.md
+++ b/README.md
@@ -621,7 +621,10 @@ gh attestation verify oci://ghcr.io/na0fu3y/ochakai:<tag> -R na0fu3y/ochakai
 
 [docs/architecture.md](docs/architecture.md) is the English overview: how
 the pieces fit, what the data model is, and why there is no authorization
-layer.
+layer. [docs/surface.md](docs/surface.md) is the shorter question — what
+ochakai is for and how big it is allowed to get: seven conditions, and
+every endpoint, tool, command and variable that serves one of them,
+counted.
 
 Underneath it, the decisions themselves live in
 [docs/design](docs/design) as numbered, immutable decision records — the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,6 +13,12 @@ The project is maintained by one person and stays small by refusing things, so
 the last section is the load-bearing one: knowing what ochakai will not do is
 more useful than a list of what it might.
 
+What those refusals are measured against is written down in
+[docs/surface.md](docs/surface.md): seven conditions ochakai exists to satisfy,
+and every surface that serves them, counted. A request that serves none of the
+seven is one this project will decline — it is fairer to say so up front than
+to leave it open.
+
 Priorities are open to input. Say what you need in
 [Discussions](https://github.com/na0fu3y/ochakai/discussions), or open an issue
 if the proposal is concrete.

--- a/cmd/ochakai/surface_test.go
+++ b/cmd/ochakai/surface_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
@@ -201,4 +203,48 @@ func TestSurfaceDocCountsCLICommands(t *testing.T) {
 		t.Fatal("no client commands: this check now guards nothing")
 	}
 	compareSurface(t, "CLI", commands)
+}
+
+// Configuration is surface for the same reason a command is: somebody
+// deploying reads it, and can set it wrong. A project whose fourth
+// condition is "no forward-deployed engineer" pays for every knob in
+// exactly that currency, so the variables are counted beside the calls.
+//
+// They are read from the shipped source rather than from a list here: a
+// variable exists the moment something asks the environment for it, and
+// a second list would be one more thing to keep true. Test files are
+// skipped — a variable only a test sets is not something a user
+// configures.
+func TestSurfaceDocCountsEnvironmentVariables(t *testing.T) {
+	varRe := regexp.MustCompile(`"(OCHAKAI_[A-Z_]+)"`)
+	seen := map[string]bool{}
+	for _, root := range []string{"../../internal", "../../cmd"} {
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			content, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			for _, m := range varRe.FindAllStringSubmatch(string(content), -1) {
+				seen[m[1]] = true
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", root, err)
+		}
+	}
+	if len(seen) == 0 {
+		t.Fatal("no OCHAKAI_* variables found: this check now guards nothing")
+	}
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	compareSurface(t, "ENV", names)
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,11 +60,12 @@ types, and every environment variable.
 
 - [CONTRIBUTING.md](../CONTRIBUTING.md) — local setup, the exact checks CI
   runs, and how design docs work.
-- [The surface](surface.md) — every REST operation, MCP tool and CLI
-  command counted in one place, with the three questions a change that
-  adds one has to answer. The default answer is no. A test reads the
-  three lists back out of the build, so the count cannot drift and a
-  feature cannot arrive without the diff saying so.
+- [The surface](surface.md) — the seven conditions ochakai exists to
+  satisfy, and every REST operation, MCP tool, CLI command and environment
+  variable counted in one place, with the three questions a change that
+  adds one has to answer. The default answer is no. A test reads the four
+  lists back out of the build, so the count cannot drift and a feature
+  cannot arrive without the diff saying so.
 - [docs/design](design) — the numbered, immutable decision records, and
   the [index](design/README.md) that says which ones still describe the
   current state. Mostly Japanese; authoritative where they and the English

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -2,15 +2,42 @@
 
 ochakai を使う人が払うのは実装の行数ではなく**表面**である — 呼べる
 エンドポイント、エージェントのコンテキストを消費するツールスキーマ、
-覚えなければならないコマンド。この文書はその全部を一箇所で数える。
+覚えなければならないコマンド、設定を間違えられる環境変数。この文書は
+その全部を一箇所で数え、**何のための表面か**を先に決めている。
 
 数えるだけで、止めはしない。止めるのは人で、この文書がするのは
 **表面が増えたことを diff に出す**ことである。エンドポイントを一本足す
 変更は [api/openapi.yaml](../api/openapi.yaml) の数十行の差分に埋もれる
 が、ここでは `## REST (19)` が `(20)` に変わる一行として出る。
-`cmd/ochakai/surface_test.go` が下の三つの節を実物と突き合わせ、
+`cmd/ochakai/surface_test.go` が下の四つの節を実物と突き合わせ、
 食い違えば CI が落ちる([0035](design/0035-verifiability.md):
 規約を信じるのではなく、外から不変条件を読む)。
+
+## 七つの条件
+
+数える前に、**何のための表面かを決めておく**。ochakai が満たそうと
+しているのは次の七つで、これで全部である。
+
+| id | 条件 |
+|---|---|
+| C1 | 資産は利用者のもの — 丸ごと出て、丸ごと戻り、求められれば消える([0009](design/0009-provenance-portability.md)・[0031](design/0031-purge.md)・[0046](design/0046-bundle-address-space.md)) |
+| C2 | Google Cloud、secret なし — Cloud Run IAM と Cloud SQL IAM で、トークンもパスワードも置かない([0002](design/0002-authn-authz.md)・[0003](design/0003-gcp-only.md)) |
+| C3 | 形式は Open Knowledge Format v0.2 — 保存もワイヤも往復も OKF で、その横に第二の形式を発明しない([0036](design/0036-okf-schema-first.md)・[0046](design/0046-bundle-address-space.md)) |
+| C4 | No FDE — デプロイは自分でできて、必要な操作には自分で打てるコマンドがある([0004](design/0004-cli.md)・[0007](design/0007-api-only-cli.md)) |
+| C5 | Claude Code から使える — MCP over HTTP と、それを話せないクライアントのための stdio 橋([0015](design/0015-surface-consistency.md)・[0039](design/0039-mcp-stdio-bridge.md)) |
+| C6 | 利用者が自分の Web サービスに埋められる小さな REST API — OpenAPI 一枚で、クライアントライブラリを要らなくする([0001](design/0001-architecture.md)・[0015](design/0015-surface-consistency.md)) |
+| C7 | 人間の改善ループが測れる — 検証・結果報告・キューの長さ・答えの無かった問いを、推測ではなく数で持つ([0025](design/0025-closing-the-loop.md)・[0029](design/0029-usage-recording-off-the-read-path.md)・[0049](design/0049-queue-counts.md)・[0051](design/0051-instance-metrics-and-search-misses.md)) |
+
+**どれにも当たらない提案は、三つの問いに進むまでもなく no である。**
+逆は成り立たない — 条件に当たることは必要条件であって十分条件では
+ない。「C7 に当たる」は足す理由にならず(C7 に当たる機構は無限にある)、
+落ちなかったものが次の三つの問いに進む。
+
+七つは互いに独立ではない(C4 は C2 の secret-zero に支えられ、C5 と C6
+は同じナレッジを別の口から出す)。それでよい — これは分類ではなく、
+**「足さない」と言うための共通の物差し**である。八つめを足すのは製品を
+別のものにする決定であり、表面を一つ足すのとは桁が違う。ここに行を
+足す PR は、そう扱われる。
 
 ## 足す前に答える三つの問い
 
@@ -105,6 +132,30 @@ ochakai を使う人が払うのは実装の行数ではなく**表面**であ�
 - `ochakai use`
 - `ochakai verify`
 - `ochakai whoami`
+
+## ENV (16)
+
+環境変数も表面である — デプロイする人が読み、間違えられる。No FDE(C4)
+を掲げる以上、**設定の数は「自分で立ち上げられるか」に直接効く**。
+非テストの Go ソースから読み戻すので、`os.Getenv` を一つ足せばここも
+動く。
+
+- `OCHAKAI_DATABASE_URL`
+- `OCHAKAI_DB_IAM_AUTH`
+- `OCHAKAI_DELEGATING_CALLERS`
+- `OCHAKAI_EMBEDDINGS`
+- `OCHAKAI_EMBEDDING_DIM`
+- `OCHAKAI_GCS_BUCKET`
+- `OCHAKAI_IAP_AUDIENCE`
+- `OCHAKAI_INSECURE_DEV`
+- `OCHAKAI_PRODUCER`
+- `OCHAKAI_PUBLIC_READ_ONLY`
+- `OCHAKAI_READ_ONLY`
+- `OCHAKAI_RECORD_MISSES`
+- `OCHAKAI_URL`
+- `OCHAKAI_VERTEX_LOCATION`
+- `OCHAKAI_VERTEX_MODEL`
+- `OCHAKAI_VERTEX_PROJECT`
 
 ## 数えていないもの
 


### PR DESCRIPTION
## What and why

Rebased onto `main` after #316 landed. That PR built the counting mechanism this
branch was independently building — `docs/surface.md` plus
`cmd/ochakai/surface_test.go` — so the duplicate is gone. What is left is the
half #316 does not have.

**The seven conditions.** `docs/surface.md` asks three questions before a
surface grows, and all three are procedural: who got stuck, is it already
covered, what folds away. They assume an answer to a prior question — *what is
this product for?* — that is nowhere written down. Without it, "the default
answer is no" rests on the maintainer's judgment on the day, and an addition
argued well enough passes. So the document now opens with the seven conditions
ochakai exists to satisfy:

| id | 条件 |
|---|---|
| C1 | 資産は利用者のもの(0009, 0031, 0046) |
| C2 | Google Cloud、secret なし(0002, 0003) |
| C3 | 形式は OKF v0.2(0036, 0046) |
| C4 | No FDE(0004, 0007) |
| C5 | Claude Code から使える(0015, 0039) |
| C6 | 埋め込める小さな REST API(0001, 0015) |
| C7 | 改善ループが測れる(0025, 0029, 0049, 0051) |

A proposal that serves none of them is a no *before* the three questions start —
the cheapest place to find out. One that does serve one says which, and that is
where its description begins. Necessary, not sufficient: every condition has
infinitely many mechanisms that would serve it, so naming C7 is not an argument.

**Environment variables become the fourth counted surface (16).** A variable is
read by whoever deploys and can be set wrong, which is exactly what a command
costs. A project whose fourth condition is *no forward-deployed engineer* pays
for every knob in that currency, and the section was missing while REST, MCP and
CLI were counted. They are read out of the shipped source rather than listed a
second time, so a new `os.Getenv` moves the count the way a new `AddTool` does.
`TestSurfaceDocCountsEnvironmentVariables` reuses `compareSurface`, so the
failure prints the section as it should read, same as the other three.

`CLAUDE.md`, `CONTRIBUTING.md`, `ROADMAP.md`, `README.md`, `docs/README.md`, the
PR template and the `design-doc` skill point at the conditions beside the counts.

No design record is taken: 0048 §3 says process decisions get none, and
`docs/surface.md` already explains why the document that counts surfaces should
not add one.

### The three questions, for the ENV section itself

1. **Who got stuck.** The count that a reader of this repo would reach for first
   — "how much do I have to configure?" — had no answer, while the three
   surfaces they touch less often did. #308 added `OCHAKAI_EMBEDDINGS` and #311
   added `OCHAKAI_PRODUCER` in the same week and neither moved a number.
2. **Does an existing surface cover it.** No. `README.md`'s Configuration table
   documents the variables but is prose nothing reads back, and it is not a
   count.
3. **What folds away.** Nothing here, and this is the honest answer: the section
   is 55 lines of document and one test function. What it makes visible is
   `VERTEX_PROJECT` / `VERTEX_LOCATION` / `VERTEX_MODEL` / `EMBEDDING_DIM` /
   `EMBEDDINGS` — five knobs for one feature that 0053 just made the default,
   against C4.

## Checks

- [x] `scripts/check` is clean — add `--db` when the change touches the store
      (`scripts/check core` clean; no store code touched)
- [x] Behavior changes come with tests — no behavior change; the ENV check was
      confirmed to fail on a wrong count before being restored

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — untouched
- [x] The change lands on every surface it belongs on — it lands on none: the
      running server does not know its own outline
- [x] Widens a surface? It widens no surface; it counts one that was already
      there. The heading `## ENV (16)` states today's build

## Design docs

- [x] Alters an accepted decision? No — no numbered doc, per 0048 §3
- [x] Commit messages and code comments are in English