### PR TITLE
Give a concept one address, and the ranking its own (0046 §3.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,40 @@ last entry.
 
 ### Added
 
+- **BREAKING** — `GET|PUT|DELETE /api/v1/knowledge/{id}` is retired, and
+  `GET /api/v1/knowledge` is now `GET /api/v1/search` (design doc
+  [0046](docs/design/0046-bundle-address-space.md) §3.5). A concept is
+  read, written and deleted at the path it lives at, its id plus `.md`:
+
+  ```
+  GET    /api/v1/knowledge/metrics/revenue      →  GET    /api/v1/bundle/metrics/revenue.md
+  PUT    /api/v1/knowledge/metrics/revenue      →  PUT    /api/v1/bundle/metrics/revenue.md
+  DELETE /api/v1/knowledge/metrics/revenue      →  DELETE /api/v1/bundle/metrics/revenue.md
+  DELETE /api/v1/knowledge/metrics/revenue?purge=true
+                                                →  DELETE /api/v1/bundle/metrics/revenue.md?purge=true
+  GET    /api/v1/knowledge?q=revenue            →  GET    /api/v1/search?q=revenue
+  ```
+
+  Nothing was added and nothing can no longer be asked: the retired
+  address was a *second spelling* of what the bundle address already
+  answered, one suffix away, and a client had to know which of two names
+  ochakai preferred for the same object. The View, the document under
+  `Accept: text/markdown`, the ETag, `If-Match`, `If-None-Match: *`,
+  `Ochakai-Unchanged` and the 415 for a JSON body are all unchanged —
+  they are the same code, reached at the address the object has.
+
+  The list face is renamed rather than moved, because it does not return
+  an object of the bundle at all: it returns a *ranking*, which is
+  ochakai's own. Under the old name it read as the collection that
+  `/api/v1/knowledge/{id}` indexed into, and it was neither that
+  collection nor addressable as one.
+
+  The CLI, the MCP tools and the web UI are unchanged — they speak this
+  for you. A direct REST caller edits the URL. The REST surface goes from
+  19 operations to 16 (docs/surface.md); `/api/v1/backlinks/{id}` and
+  `/api/v1/export`, which §3.5 also folds, keep working until their
+  successors exist.
+
 - **Which agent, at which build, wrote this** (design doc
   [0052](docs/design/0052-producer-beside-the-actor.md)). An actor now
   carries a fourth field, `producer` — OKF SPEC §7's

--- a/README.md
+++ b/README.md
@@ -67,16 +67,17 @@ toolchain-free, take a
 or talk to the API directly, since that is all the CLI does:
 
 ```sh
-curl -X PUT http://localhost:8080/api/v1/knowledge/metrics/revenue \
+curl -X PUT http://localhost:8080/api/v1/bundle/metrics/revenue.md \
   -H 'content-type: text/markdown' \
   --data-binary $'---\ntype: Metric\n---\n\nCompleted orders only, net of refunds.\n'
 ```
 
 Knowledge is written as an OKF document — the frontmatter is the
-metadata, the markdown is the body, and the path is the address. It is
-the same text `ochakai get` prints and an export writes, so reading an
-entry, editing it and sending it back is one loop with no translation in
-it.
+metadata, the markdown is the body, and the path is the address: a
+concept lives in the bundle at its id plus `.md`, which is the same place
+an export writes it and the same place `ochakai get` reads it from. So
+reading an entry, editing it and sending it back is one loop with no
+translation in it.
 
 ## Quick start
 
@@ -92,7 +93,7 @@ works too:
 ```sh
 export OCHAKAI_URL=http://localhost:8080
 go run ./cmd/ochakai import examples/demo
-curl 'http://localhost:8080/api/v1/knowledge?q=revenue'
+curl 'http://localhost:8080/api/v1/search?q=revenue'
 ```
 
 [examples/demo](examples/demo) is a knowledge base rather than a sample

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -532,6 +532,23 @@ paths:
             Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
         "400": { $ref: "#/components/responses/Error" }
         "403": { $ref: "#/components/responses/Forbidden" }
+        "501":
+          description: >
+            A file was asked for on an instance that holds no files
+            (no OCHAKAI_GCS_BUCKET, design doc 0013). Only for a path
+            that is not a concept's: at `<id>.md` the answer is the
+            concept's own 404, because what was asked about is the
+            concept and not the deployment.
+          headers:
+            Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error: { type: string }
+              example:
+                error: "files are not supported without GCS: set OCHAKAI_GCS_BUCKET (design doc 0013)"
         "404":
           description: No object at this path.
           headers:
@@ -543,7 +560,7 @@ paths:
                 properties:
                   error: { type: string }
               example:
-                error: knowledge not found
+                error: no object at this path
     put:
       operationId: putBundleFile
       summary: Write one object of the bundle

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -11,17 +11,23 @@ info:
     their own web UIs. ochakai executes no SQL and uses no LLM.
 
 
-    **Which address to build on.** A concept and a file are both objects
-    of one bundle, and `/api/v1/bundle/{path}` is the address that says
-    so (design doc 0046 §3.5). Several older addresses still answer for
-    the same objects and are on their way out; where a replacement is
-    already serving, the operation below is marked `deprecated` and names
-    it. `/api/v1/knowledge` (the list), `/api/v1/backlinks/{id}` and
-    `/api/v1/export` are retired by the same section, but their
-    successors — a ranking face at `/api/v1/search` with `links_to=`, and
-    a subtree under `Accept: application/gzip` — are not built yet, so
-    they are the only way to ask those questions today and carry no such
-    mark. Every interface is unstable while the major version is 0
+    **One address for an object.** A concept and a file are both objects
+    of one bundle, and `/api/v1/bundle/{path}` is where they live — a
+    concept at `<id>.md` (design doc 0046 §3.5). The second spelling,
+    `/api/v1/knowledge/{id}`, is gone: it read, wrote and deleted exactly
+    what the bundle address does, one suffix away.
+
+    What is not an object of the bundle does not live there. A ranking is
+    ochakai's own rather than something the bundle holds, so the list
+    face is `/api/v1/search` — the old spelling `/api/v1/knowledge` made
+    it look like the collection its own detail address indexed into, and
+    it is neither. Two addresses named by §3.5 are still their old
+    selves: `/api/v1/backlinks/{id}` (a `links_to=` filter on search) and
+    `/api/v1/export` (a subtree under `Accept: application/gzip`). Their
+    successors are not built, so they carry no deprecation mark and are
+    the only way to ask those questions today.
+
+    Every interface is unstable while the major version is 0
     (docs/compatibility.md): a removal arrives in a minor release with a
     changelog entry, not after a deprecation window.
   version: 0.15.0
@@ -38,7 +44,7 @@ servers:
 # every call; it is declared below (components/parameters/OnBehalfOf)
 # on the operations that record provenance.
 paths:
-  /api/v1/knowledge:
+  /api/v1/search:
     get:
       operationId: searchKnowledge
       summary: Search knowledge (lexical, plus hybrid vector search when configured)
@@ -252,7 +258,7 @@ paths:
                       on the last page, and on every search.
               examples:
                 search:
-                  summary: GET /api/v1/knowledge?q=monthly+revenue&limit=3
+                  summary: GET /api/v1/search?q=monthly+revenue&limit=3
                   description: >
                     A hit names an entry and says what ranked it; it does
                     not hand the entry over. Read the ones worth reading
@@ -319,7 +325,7 @@ paths:
                         updated_at: "2026-07-21T06:14:55.402881Z"
                         score: 0.43
                 usageFeed:
-                  summary: GET /api/v1/knowledge?sort=usage&status=draft
+                  summary: GET /api/v1/search?sort=usage&status=draft
                   description: >
                     The draft review feed. A listing ranks by demand rather
                     than by text, so every hit carries score 0 and the usage
@@ -402,10 +408,9 @@ paths:
         reserves per directory — which are generated from the bundle
         rather than stored in it (§§3.7-3.8).
 
-        A concept answers exactly as `GET /api/v1/knowledge/{id}` does,
-        the same View or the same document under `Accept: text/markdown`,
-        with the same ETag. One object, two addresses, one answer: an
-        address is not a second surface.
+        A concept answers with a View, or with the document itself
+        under `Accept: text/markdown`, and carries the ETag to echo back
+        in `If-Match` on a later write.
 
         A file answers with its bytes, its content hash as the ETag, a
         `304` when `If-None-Match` matches it, and the headers that
@@ -546,10 +551,15 @@ paths:
         Stores the request body at the path (design doc 0046 §3.5). What
         it becomes is decided by the bytes, not by a parameter:
 
-        A markdown path whose document carries a `type` is a concept, and
-        the write is exactly `PUT /api/v1/knowledge/{id}` — the same
-        preconditions (`If-Match`, `If-None-Match: *`), the same
-        `Ochakai-Unchanged`, the same answer. Anything else is a file,
+        A markdown path whose document carries a `type` is a concept.
+        The write is create-or-replace and states what the concept should
+        say; existence is expressed by the preconditions instead
+        (`If-None-Match: *` for "only if the path is free", `If-Match` for
+        "only if it still says this" — design doc 0030), and a body that
+        matched what was stored answers `Ochakai-Unchanged`. A JSON body
+        is a 415 naming the document form: the frontmatter is the
+        metadata and the markdown is the body, and there is no typed
+        write surface beside the format. Anything else is a file,
         including a markdown document with no `type`: SPEC §11 makes the
         key what a concept has, and a bundle that carried a typeless
         markdown file gets it back rather than losing it (§3.2).
@@ -592,6 +602,7 @@ paths:
         "403": { $ref: "#/components/responses/Forbidden" }
         "412": { $ref: "#/components/responses/Error" }
         "413": { $ref: "#/components/responses/Error" }
+        "415": { $ref: "#/components/responses/Error" }
         "501": { $ref: "#/components/responses/Error" }
         "409":
           description: A generated file is not one anybody writes.
@@ -609,15 +620,36 @@ paths:
       operationId: deleteBundleFile
       summary: Delete one object of the bundle
       description: >
-        Removes the object at the path: a concept is soft-deleted, as
-        `DELETE /api/v1/knowledge/{id}` does, and a file is removed (its
-        bytes stay, named by the revisions that came before). index.md
-        and log.md are 409 for the same reason PUT gives.
+        Removes the object at the path: a concept is soft-deleted — it
+        disappears from reads, its history stays, and writing the same
+        path revives it — and a file is removed (its bytes stay, named by
+        the revisions that came before). index.md and log.md are 409 for
+        the same reason PUT gives.
+
+        With `purge=true` a concept that is *already* soft-deleted is
+        hard-deleted instead: concept, revisions, usage and file metadata
+        erased, the path freed for a move. Two calls, deliberately: the
+        first is reversible, the second is not. Purging a live concept is
+        a 409; delete it first. Content-addressed bytes are left in the
+        blob store and nothing reclaims them afterwards. The purge itself
+        is recorded — who destroyed which id, and how much history went
+        with it — in the one table a purge does not touch (design doc
+        0031). A file has no tombstone, so the parameter is a concept's.
+      parameters:
+        - name: purge
+          in: query
+          description: >
+            Hard-delete an already soft-deleted concept. `true` or
+            `false`; anything else is a 400 rather than a soft delete,
+            because a 204 for a value meant as a purge would report a
+            path freed that is not.
+          schema: { type: boolean, default: false }
       responses:
         "204":
           description: Deleted.
           headers:
             Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
+        "400": { $ref: "#/components/responses/Error" }
         "403": { $ref: "#/components/responses/Forbidden" }
         "404": { $ref: "#/components/responses/Error" }
         "409":
@@ -715,7 +747,7 @@ paths:
           in: query
           description: >
             Only entries addressed under this path, repeatable and OR-ed —
-            the same subtree filter GET /api/v1/knowledge takes (design doc
+            the same subtree filter GET /api/v1/search takes (design doc
             0041). It scopes the search that picks the hits, not the link
             expansion: an entry inside the scope that cites a glossary term
             outside it still arrives with the term, which is the reason
@@ -942,487 +974,6 @@ paths:
                     truncated: 1
         "400": { $ref: "#/components/responses/Error" }
         "403": { $ref: "#/components/responses/Forbidden" }
-  /api/v1/knowledge/{id}:
-    parameters:
-      - name: id
-        in: path
-        required: true
-        description: >
-          The entry's id — its bundle path. Slashes are real path
-          separators (GET /api/v1/knowledge/queries/sales/monthly-revenue).
-        schema: { type: string }
-    get:
-      operationId: getKnowledge
-      summary: Get one knowledge entry
-      deprecated: true
-      description: >
-        Build on `GET /api/v1/bundle/{id}.md`, which answers exactly this
-        — the same View, the same document under `Accept: text/markdown`,
-        the same ETag — at the address a concept has in the bundle. This
-        one is retired by design doc 0046 §3.5.
-
-        Answers a View by default: the entry's document as it was
-        written, the projection to read it by, and what this instance
-        observed about it (design docs 0043 §3.5, 0046 §2.2). Comments,
-        key order and quoting style are the writer's, and stay theirs.
-
-        With "Accept: text/markdown" it answers a document instead — the
-        export form, keys the server owns included, which is what a
-        reader of a bundle sees. Either text can be edited and sent
-        straight back to PUT; the export form has server-owned keys to
-        ignore and the View's document does not.
-      responses:
-        "200":
-          description: The entry.
-          headers:
-            ETag: { $ref: "#/components/headers/ETag" }
-            Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
-          content:
-            text/markdown:
-              schema: { type: string }
-            application/json:
-              schema: { $ref: "#/components/schemas/View" }
-              examples:
-                metric:
-                  summary: GET /api/v1/knowledge/metrics/revenue
-                  description: >
-                    A verified entry. `document` is the whole of what the
-                    entry says — the citations under sources with the
-                    window their usage_count was counted over, the
-                    declared expiry, the producer keys inline where their
-                    writer put them, the body. `summary` is the index over
-                    it that listing surfaces sort by, and `observed` is
-                    what this instance recorded happening to it. The ETag
-                    header carries summary.content_hash, quoted, for a
-                    later If-Match.
-                  value:
-                    id: metrics/revenue
-                    document: |
-                      ---
-                      type: Metric
-                      resource: bigquery://example-analytics.shop.orders
-                      title: Revenue
-                      description: Net revenue from completed orders, excluding tax and shipping.
-                      tags:
-                          - finance
-                          - core
-                      sources:
-                          - resource: https://wiki.example.co.jp/finance/revenue-recognition
-                            id: revenue-policy
-                            title: Revenue recognition policy (FY2026)
-                            author: human:finance@example.co.jp
-                            usage_count: 24
-                            last_modified: "2026-05-30"
-                          - resource: bigquery://example-analytics.shop.orders
-                            id: orders-schema
-                            title: shop.orders table schema
-                            last_modified: "2026-06-18"
-                            usage_window:
-                                from: "2026-01-01"
-                                to: "2026-06-30"
-                      usage_window:
-                          from: "2026-06-01"
-                          to: "2026-06-30"
-                      status: stable
-                      stale_after: "2026-12-31"
-                      unit: JPY
-                      grain: order
-                      ---
-
-                      Revenue is the sum of `net_amount` over every
-                      [completed order](/glossary/completed-order.md) in
-                      [shop.orders](/tables/shop-orders.md). Tax and shipping
-                      are excluded.
-
-                      A refund is subtracted in the month it settles, not the
-                      month of the order it reverses[^revenue-policy].
-
-                      ![Revenue, 2026 H1](revenue/revenue-2026h1.png)
-
-                      [^revenue-policy]: Revenue recognition policy (FY2026).
-                    summary:
-                      id: metrics/revenue
-                      type: Metric
-                      title: Revenue
-                      description: Net revenue from completed orders, excluding tax and shipping.
-                      resource: bigquery://example-analytics.shop.orders
-                      tags: [finance, core]
-                      status: stable
-                      stale_after: "2026-12-31"
-                      trust: human-reviewed
-                      verified_at: "2026-07-14T02:33:41.019778Z"
-                      rejected: false
-                      links:
-                        - { target: glossary/completed-order, text: completed order }
-                        - { target: tables/shop-orders, text: shop.orders }
-                      content_hash: 8a3b71c0e5d24f96b1c8027ae4f35d6098b2c7e14d0a6f38b5c9e207d1a4f6b3
-                      created_at: "2026-06-02T04:11:38.201044Z"
-                      updated_at: "2026-07-14T02:33:41.019778Z"
-                    observed:
-                      created_by: { kind: human, name: tanaka@example.co.jp }
-                      generated:
-                        by: { kind: human, name: tanaka@example.co.jp }
-                        at: "2026-07-14T02:33:41.019778Z"
-                      verified:
-                        - by: { kind: human, name: sato@example.co.jp }
-                          at: "2026-07-14T02:33:41.019778Z"
-                    attachments:
-                      - name: revenue-2026h1.png
-                        media_type: image/png
-                        size: 48213
-                        sha256: 9f2c1d0a7b3e5648c1d9f0a2b7e4c8d63f5a1b2c9e0d7a4f6b3c8e1d5a0f7b29
-                        created_by: { kind: human, name: tanaka@example.co.jp }
-                        created_at: "2026-06-02T04:20:11.663210Z"
-                delegated:
-                  summary: An entry written through an application acting for a person
-                  description: >
-                    The end user forwarded with X-Ochakai-On-Behalf-Of is the
-                    actor; the application that forwarded them is kept as via
-                    (design doc 0027), never dropped. It is an observation,
-                    so it is in `observed` and not in the document — a
-                    bundle carries knowledge, not who this instance saw
-                    write it (design doc 0009).
-                  value:
-                    id: insights/revenue-seasonality
-                    document: |
-                      ---
-                      type: Insight
-                      title: Reading revenue month over month
-                      description: Why a December spike and a January drop are normal.
-                      tags:
-                          - finance
-                      status: draft
-                      stale_after: "2027-01-31"
-                      ---
-
-                      [Revenue](/metrics/revenue.md) is seasonal: December runs
-                      well above the trailing median and January falls back
-                      below it.
-                    summary:
-                      id: insights/revenue-seasonality
-                      type: Insight
-                      title: Reading revenue month over month
-                      description: Why a December spike and a January drop are normal.
-                      tags: [finance]
-                      status: draft
-                      stale_after: "2027-01-31"
-                      trust: unverified
-                      rejected: false
-                      links:
-                        - { target: metrics/revenue, text: Revenue }
-                      content_hash: 15c8e3097b6d2a41f0c85b3ed729a4f6108c5d3b7e2a094f6c1b8d503a7e2f94
-                      created_at: "2026-07-21T06:14:55.402881Z"
-                      updated_at: "2026-07-21T06:14:55.402881Z"
-                    observed:
-                      created_by:
-                        kind: human
-                        name: tanaka@example.co.jp
-                        via: process:insightflow@example.iam.gserviceaccount.com
-                      generated:
-                        by:
-                          kind: human
-                          name: tanaka@example.co.jp
-                          via: process:insightflow@example.iam.gserviceaccount.com
-                        at: "2026-07-21T06:14:55.402881Z"
-        "403": { $ref: "#/components/responses/Forbidden" }
-        "404":
-          description: Error.
-          headers:
-            Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error: { type: string }
-              examples:
-                notFound:
-                  summary: No live entry at that id
-                  description: >
-                    A soft-deleted entry reads as missing here; its history is
-                    still in the log.md of the directory it was in.
-                  value:
-                    error: knowledge not found
-    put:
-      operationId: putKnowledge
-      summary: Write a knowledge entry from an OKF document
-      deprecated: true
-      description: >
-        Build on `PUT /api/v1/bundle/{id}.md`, which writes exactly this
-        — the same document, the same preconditions, the same answer.
-        This one is retired by design doc 0046 §3.5.
-
-        The body is an OKF document — YAML frontmatter, then markdown —
-        which is what an entry is (design doc 0043 §3.5): the path is the
-        address, the document is what the entry says, and there is no
-        typed JSON write surface beside it to drift from the format. A
-        JSON body is a 415 naming the document form.
-        It is create-or-replace, and a full replacement: what the document
-        omits is cleared, so send the entry as it should end up. A PUT
-        states what the entry should say; whether an entry already held
-        the id is not something the writer of a document is saying
-        anything about, which is why there is no separate create. The
-        preconditions are where existence is expressed — If-None-Match "*"
-        writes only if the id is free (an occupied one is a 409), and
-        If-Match a version writes only if the entry still says that.
-        A 201 means the entry was created, a 200 that it was replaced.
-        Keys the server owns (generated, verified, created_by,
-        rejected_by, rejected_at) never reach a ledger, so a document
-        read back from ochakai can be edited and sent as it came. They
-        are not discarded either: unless they say exactly what this
-        instance already observed about the entry, they are kept under a
-        `received` key as the document's own claim (design doc 0046
-        §2.2) and reported as an Ochakai-Note. Nothing derives trust
-        from a claim — the trust tier and ?trust= answer from this
-        instance's ledger, as before. Values read differently than they
-        were written come back as Ochakai-Note headers rather than being
-        applied in silence.
-      parameters:
-        - $ref: "#/components/parameters/IfMatch"
-        - name: If-None-Match
-          in: header
-          required: false
-          description: >
-            "*" writes only if the id is free; an occupied id is a 409.
-            Any other value is ignored — ochakai has no conditional read,
-            and a caller that means "only if absent" says "*".
-          schema: { type: string, enum: ["*"] }
-        - $ref: "#/components/parameters/OnBehalfOf"
-        - $ref: "#/components/parameters/Producer"
-      requestBody:
-        required: true
-        content:
-          text/markdown:
-            schema:
-              type: string
-              description: >
-                An OKF document: YAML frontmatter, `---`, then markdown.
-                The frontmatter keys ochakai reads are `type` (required,
-                one line — see the Type schema for the recommended
-                vocabulary), `title` (the id's last segment is the name
-                without one), `description`, `tags`, `resource` (the
-                underlying asset's URI), `status` (see the Status schema;
-                `draft` by default — whether anybody confirmed the entry
-                is a separate ruling and not the writer's to declare),
-                `status_note`, `stale_after` (YYYY-MM-DD), `sources` (a
-                list of `{resource, id, title, author, usage_count,
-                last_modified, usage_window}` — the material this entry
-                derives from, SPEC §5.1), `usage_window` (`{from, to}`),
-                and for an Attested Computation `runtime` (required
-                there), `parameters` (a list of `{name, type,
-                required}`), `computation`, `executor` (`{resource,
-                receipt}`) and `attester` (`{resource}`) — SPEC §10.2,
-                which ochakai records and never runs.
-
-                Producer-defined keys (SPEC §4.1) go at the top level
-                beside these, and inside a `sources` entry, a parameter,
-                the executor or the attester; all of them are kept
-                exactly as written (design doc 0043 §3.6). Link to
-                another entry with a markdown link to its path in the
-                body — [revenue](/metrics/revenue.md) — and the link
-                becomes an edge, and a backlink the other way.
-            example: |
-              ---
-              type: Metric
-              title: Revenue
-              description: Net revenue, refunds excluded.
-              tags:
-                  - finance
-              sources:
-                  - resource: https://wiki.example/finance/revenue-recognition
-                    id: rev-rec
-              status: stable
-              stale_after: "2027-06-30"
-              ---
-
-              Net of refunds, per [revenue recognition](/policies/revenue-recognition.md).
-      responses:
-        "201":
-          description: The id was free, so the entry was created.
-          headers:
-            ETag: { $ref: "#/components/headers/ETag" }
-            Ochakai-Note: { $ref: "#/components/headers/Note" }
-            Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
-          content:
-            application/json:
-              schema: { $ref: "#/components/schemas/View" }
-            text/markdown:
-              schema: { type: string }
-        # If-None-Match "*" was sent and the id is taken. Without that
-        # precondition the write would have replaced the entry.
-        "409": { $ref: "#/components/responses/Error" }
-        "200":
-          description: Replaced, or unchanged (see the Ochakai-Unchanged header).
-          headers:
-            ETag: { $ref: "#/components/headers/ETag" }
-            Ochakai-Unchanged:
-              description: >
-                Set to "true" when the payload matched the stored content
-                exactly, so nothing was written — no revision, no
-                updated_at bump. Absent on a real update.
-              schema: { type: string, enum: ["true"] }
-            Ochakai-Note: { $ref: "#/components/headers/Note" }
-            Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
-          content:
-            text/markdown:
-              schema: { type: string }
-            application/json:
-              schema: { $ref: "#/components/schemas/View" }
-              examples:
-                updated:
-                  summary: The replacement above, as stored
-                  description: >
-                    observed.generated.by is now the caller who made this
-                    edit, while observed.created_by still names whoever
-                    wrote the entry. The verifications ledger is untouched
-                    — a PUT edits the document and rules on nothing;
-                    POST /api/v1/verify/{id} is what confirms an entry.
-                    `document` comes back as it was written — the bytes
-                    that were stored (design doc 0046 §2.2), with no
-                    server-owned keys to strip before the next edit.
-                  value:
-                    id: metrics/revenue
-                    document: |
-                      ---
-                      type: Metric
-                      resource: bigquery://example-analytics.shop.orders
-                      title: Revenue
-                      description: Net revenue from completed orders, excluding tax, shipping, and gift wrapping.
-                      tags:
-                          - finance
-                          - core
-                      sources:
-                          - resource: https://wiki.example.co.jp/finance/revenue-recognition
-                            id: revenue-policy
-                            title: Revenue recognition policy (FY2027)
-                            author: human:finance@example.co.jp
-                            usage_count: 31
-                            last_modified: "2026-07-20"
-                      usage_window:
-                          from: "2026-07-01"
-                          to: "2026-07-31"
-                      status: stable
-                      stale_after: "2027-12-31"
-                      unit: JPY
-                      grain: order
-                      ---
-
-                      Revenue is the sum of `net_amount` over every
-                      [completed order](/glossary/completed-order.md) in
-                      [shop.orders](/tables/shop-orders.md). Tax, shipping, and
-                      gift wrapping are excluded.
-
-                      A refund is subtracted in the month it settles, not the
-                      month of the order it reverses[^revenue-policy].
-
-                      [^revenue-policy]: Revenue recognition policy (FY2027).
-                    summary:
-                      id: metrics/revenue
-                      type: Metric
-                      title: Revenue
-                      description: Net revenue from completed orders, excluding tax, shipping, and gift wrapping.
-                      resource: bigquery://example-analytics.shop.orders
-                      tags: [finance, core]
-                      status: stable
-                      stale_after: "2027-12-31"
-                      trust: human-reviewed
-                      verified_at: "2026-07-14T02:33:41.019778Z"
-                      rejected: false
-                      links:
-                        - { target: glossary/completed-order, text: completed order }
-                        - { target: tables/shop-orders, text: shop.orders }
-                      content_hash: e2740b18a95c6d3f0b47e18c25da936f4b0c8e71d5a29f63b0c847e1da395f26
-                      created_at: "2026-06-02T04:11:38.201044Z"
-                      updated_at: "2026-07-27T00:18:52.640117Z"
-                    observed:
-                      created_by: { kind: human, name: tanaka@example.co.jp }
-                      generated:
-                        by: { kind: human, name: sato@example.co.jp }
-                        at: "2026-07-27T00:18:52.640117Z"
-                      verified:
-                        - by: { kind: human, name: sato@example.co.jp }
-                          at: "2026-07-14T02:33:41.019778Z"
-        "400":
-          description: >
-            The document could not be parsed, or says something invalid.
-            A version is opaque, so an If-Match value has no format to be
-            malformed in: one that matches nothing is a 412.
-          headers:
-            Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error: { type: string }
-              examples:
-                invalidStaleAfter:
-                  summary: A stale_after that is not an absolute date
-                  value:
-                    error: invalid stale_after "30d" (an absolute date, YYYY-MM-DD, e.g. 2026-12-31)
-        "403": { $ref: "#/components/responses/Forbidden" }
-        "404": { $ref: "#/components/responses/Error" }
-        "412":
-          description: >
-            The If-Match precondition failed: the entry changed since it
-            was read. Nothing was written — re-read the entry, redo the
-            edit, and retry with the new version.
-          headers:
-            Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error: { type: string }
-              examples:
-                staleVersion:
-                  summary: Someone else wrote the entry since it was read
-                  description: >
-                    GET the entry again, reapply the edit to what is there
-                    now, and retry with the ETag from that read.
-                  value:
-                    error: knowledge changed since it was read
-    delete:
-      operationId: deleteKnowledge
-      summary: Soft-delete a knowledge entry (history retained)
-      deprecated: true
-      description: >
-        The soft delete is `DELETE /api/v1/bundle/{id}.md`; build on
-        that. `purge=true` has no bundle-address form yet — design doc
-        0046 §3.5 gives it one and it is not built — so a purge is still
-        asked for here. This one is retired by the same section.
-
-        Soft-deletes by default: the entry disappears from reads, its
-        history stays, and creating the same id revives it. With
-        `purge=true` the entry is hard-deleted instead — entry,
-        revisions, usage, and attachment metadata erased, the id freed
-        for a move. Two calls, deliberately: the first is reversible, the
-        second is not. Purging a live entry is a 409; delete it first.
-        Content-addressed attachment bytes are left in the blob store, as
-        detaching leaves them; nothing reclaims them afterwards. The purge
-        itself is recorded — who destroyed which id, and how much history
-        went with it — in the one table a purge does not touch.
-      parameters:
-        - name: purge
-          in: query
-          description: >
-            Hard-delete an already soft-deleted entry. `true` or `false`;
-            anything else is a 400 rather than a soft delete, because a
-            204 for a value meant as a purge would report an id freed
-            that is not.
-          schema: { type: boolean, default: false }
-        - $ref: "#/components/parameters/OnBehalfOf"
-        - $ref: "#/components/parameters/Producer"
-      responses:
-        "204":
-          description: Deleted.
-          headers:
-            Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
-        "400": { $ref: "#/components/responses/Error" }
-        "403": { $ref: "#/components/responses/Forbidden" }
-        "404": { $ref: "#/components/responses/Error" }
-        "409": { $ref: "#/components/responses/Error" }
   /api/v1/move:
     post:
       operationId: moveKnowledge
@@ -2008,7 +1559,7 @@ paths:
       operationId: getQueues
       summary: How much work each review queue is holding
       description: >
-        The three listing feeds of GET /api/v1/knowledge, counted rather
+        The three listing feeds of GET /api/v1/search, counted rather
         than listed (design doc 0049): drafts waiting to be published or
         turned down (sort=usage with status=draft), entries whose failure
         reports are still unanswered (sort=failed), and entries past the
@@ -2812,7 +2363,7 @@ components:
           type: integer
           description: >
             Drafts waiting to be published or turned down — GET
-            /api/v1/knowledge?sort=usage&status=draft. Verifying does not
+            /api/v1/search?sort=usage&status=draft. Verifying does not
             empty this one: confirming and publishing are different acts,
             so a draft leaves when it is edited to another status or
             rejected (design doc 0043 §3.2).

--- a/cmd/ochakai/client_test.go
+++ b/cmd/ochakai/client_test.go
@@ -238,7 +238,7 @@ func TestImportReportsUnchanged(t *testing.T) {
 	}
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("PUT /api/v1/knowledge/{id...}", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("PUT /api/v1/bundle/{path...}", func(w http.ResponseWriter, r *http.Request) {
 		// The payload is a document now (design doc 0043 §3.5), and the
 		// import loop makes one call per entry rather than create-then-
 		// update: whether the id was free is not something a bundle says.
@@ -253,7 +253,8 @@ func TestImportReportsUnchanged(t *testing.T) {
 			return
 		}
 		k := d.Knowledge
-		k.ID = r.PathValue("id")
+		// A concept lives at its id plus `.md` (design doc 0046 §3.5).
+		k.ID = strings.TrimSuffix(r.PathValue("path"), ".md")
 		if k.ID == "metrics/same" {
 			w.Header().Set("Ochakai-Unchanged", "true")
 		}
@@ -310,7 +311,7 @@ func TestImportStrictRefusesBeforeWriting(t *testing.T) {
 
 	puts := 0
 	mux := http.NewServeMux()
-	mux.HandleFunc("PUT /api/v1/knowledge/{id...}", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("PUT /api/v1/bundle/{path...}", func(w http.ResponseWriter, r *http.Request) {
 		puts++
 		body, _ := io.ReadAll(r.Body)
 		d, _, err := okf.Parse(body)
@@ -320,7 +321,8 @@ func TestImportStrictRefusesBeforeWriting(t *testing.T) {
 			return
 		}
 		k := d.Knowledge
-		k.ID = r.PathValue("id")
+		// A concept lives at its id plus `.md` (design doc 0046 §3.5).
+		k.ID = strings.TrimSuffix(r.PathValue("path"), ".md")
 		w.WriteHeader(http.StatusCreated)
 		_ = json.NewEncoder(w).Encode(k)
 	})
@@ -357,7 +359,7 @@ func TestImportStrictRefusesBeforeWriting(t *testing.T) {
 func TestUpdateIfMatchSendsHeaderAndExplainsConflict(t *testing.T) {
 	var gotIfMatch string
 	mux := http.NewServeMux()
-	mux.HandleFunc("PUT /api/v1/knowledge/{id...}", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("PUT /api/v1/bundle/{path...}", func(w http.ResponseWriter, r *http.Request) {
 		gotIfMatch = r.Header.Get("If-Match")
 		w.WriteHeader(http.StatusPreconditionFailed)
 		_ = json.NewEncoder(w).Encode(map[string]string{"error": "knowledge changed since it was read"})
@@ -509,7 +511,7 @@ func TestImportReportsAKeptClaim(t *testing.T) {
 	run := func(t *testing.T, keep bool) string {
 		t.Helper()
 		mux := http.NewServeMux()
-		mux.HandleFunc("PUT /api/v1/knowledge/{id...}", func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("PUT /api/v1/bundle/{path...}", func(w http.ResponseWriter, r *http.Request) {
 			body, _ := io.ReadAll(r.Body)
 			if !keep {
 				body = []byte(strings.Split(string(body), "received:")[0] + "---\n\nbody\n")

--- a/cmd/ochakai/serveui_test.go
+++ b/cmd/ochakai/serveui_test.go
@@ -74,7 +74,7 @@ func TestServeUIProxySignsAsService(t *testing.T) {
 	local := httptest.NewServer(h)
 	defer local.Close()
 
-	req, _ := http.NewRequest(http.MethodGet, local.URL+"/api/v1/knowledge?q=x", nil)
+	req, _ := http.NewRequest(http.MethodGet, local.URL+"/api/v1/search?q=x", nil)
 	req.Header.Set("Authorization", "Bearer browser-supplied")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -157,7 +157,7 @@ func TestServeUIProxyStripsBrowserDelegation(t *testing.T) {
 	local := httptest.NewServer(h)
 	defer local.Close()
 
-	req, _ := http.NewRequest(http.MethodGet, local.URL+"/api/v1/knowledge?q=x", nil)
+	req, _ := http.NewRequest(http.MethodGet, local.URL+"/api/v1/search?q=x", nil)
 	req.Header.Set(httpauth.OnBehalfOfHeader, "human:attacker@example.co.jp")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -186,7 +186,7 @@ func TestServeUIProxyNamesTheIAPUser(t *testing.T) {
 	local := httptest.NewServer(h)
 	defer local.Close()
 
-	req, _ := http.NewRequest(http.MethodGet, local.URL+"/api/v1/knowledge?q=x", nil)
+	req, _ := http.NewRequest(http.MethodGet, local.URL+"/api/v1/search?q=x", nil)
 	req.Header.Set(httpauth.OnBehalfOfHeader, "human:attacker@example.co.jp")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -215,7 +215,7 @@ func TestServeUIProxyRefusesUnsignedRequestsWhenIAPConfigured(t *testing.T) {
 	local := httptest.NewServer(h)
 	defer local.Close()
 
-	resp, err := http.Get(local.URL + "/api/v1/knowledge?q=x")
+	resp, err := http.Get(local.URL + "/api/v1/search?q=x")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/ochakai/ui_test.go
+++ b/cmd/ochakai/ui_test.go
@@ -49,7 +49,7 @@ func TestUIHandlerProxiesWithToken(t *testing.T) {
 	local := httptest.NewServer(h)
 	defer local.Close()
 
-	req, _ := http.NewRequest(http.MethodGet, local.URL+"/api/v1/knowledge?q=x", nil)
+	req, _ := http.NewRequest(http.MethodGet, local.URL+"/api/v1/search?q=x", nil)
 	req.Header.Set("Authorization", "Bearer browser-supplied")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -81,7 +81,7 @@ func TestUIHandlerNilTokensSendsNoCredentials(t *testing.T) {
 	local := httptest.NewServer(h)
 	defer local.Close()
 
-	req, _ := http.NewRequest(http.MethodGet, local.URL+"/api/v1/knowledge", nil)
+	req, _ := http.NewRequest(http.MethodGet, local.URL+"/api/v1/search", nil)
 	req.Header.Set("Authorization", "Bearer browser-supplied")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -141,7 +141,7 @@ func TestUIHandlerRejectsForeignOrigin(t *testing.T) {
 		"null":                      http.StatusForbidden, // opaque origin (sandboxed iframe, data: page)
 	} {
 		reached = false
-		req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8098/api/v1/knowledge", nil)
+		req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8098/api/v1/search", nil)
 		if origin != "" {
 			req.Header.Set("Origin", origin)
 		}
@@ -176,7 +176,7 @@ func TestUIHandlerStripsDelegationHeader(t *testing.T) {
 	local := httptest.NewServer(h)
 	defer local.Close()
 
-	req, _ := http.NewRequest(http.MethodGet, local.URL+"/api/v1/knowledge?q=x", nil)
+	req, _ := http.NewRequest(http.MethodGet, local.URL+"/api/v1/search?q=x", nil)
 	req.Header.Set(httpauth.OnBehalfOfHeader, "human:someone-else@example.co.jp")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -209,7 +209,7 @@ func TestUIHandlerStripsServerlessAuthorization(t *testing.T) {
 	local := httptest.NewServer(h)
 	defer local.Close()
 
-	req, _ := http.NewRequest(http.MethodGet, local.URL+"/api/v1/knowledge?q=x", nil)
+	req, _ := http.NewRequest(http.MethodGet, local.URL+"/api/v1/search?q=x", nil)
 	req.Header.Set("X-Serverless-Authorization", "Bearer browser-supplied")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -424,7 +424,7 @@ claude mcp add --transport http ochakai http://localhost:8787/mcp
 Smoke test over REST (through the proxy, also tokenless):
 
 ```sh
-curl "http://localhost:8787/api/v1/knowledge?q=revenue"
+curl "http://localhost:8787/api/v1/search?q=revenue"
 ```
 
 ## 5b. Optional: the team web UI behind IAP (separate service, by design)
@@ -692,8 +692,8 @@ The demo is the one deployment where a plain `curl` is supposed to work, so
 it is also the one you can verify without a proxy:
 
 ```sh
-curl -s -o /dev/null -w '%{http_code}\n' "$OCHAKAI_URL/api/v1/knowledge?q=revenue"  # 200, no token
-curl -s -o /dev/null -w '%{http_code}\n' -X DELETE "$OCHAKAI_URL/api/v1/knowledge/queries/monthly-revenue"  # 403
+curl -s -o /dev/null -w '%{http_code}\n' "$OCHAKAI_URL/api/v1/search?q=revenue"  # 200, no token
+curl -s -o /dev/null -w '%{http_code}\n' -X DELETE "$OCHAKAI_URL/api/v1/bundle/queries/monthly-revenue.md"  # 403
 ```
 
 200 without a token proves the public grant and `OCHAKAI_PUBLIC_READ_ONLY`
@@ -902,7 +902,7 @@ doesn't work as written.
   than the organization.
 - **`run.app` returns Google's HTML 404 ("That's an error") even though
   the service is Ready**: before suspecting infrastructure, test a real
-  application endpoint (e.g. `/api/v1/knowledge?q=x`) and check request
+  application endpoint (e.g. `/api/v1/search?q=x`) and check request
   logs. Two Google Frontend behaviors conspire to make a healthy service
   look dead:
   1. `/healthz` is intercepted by Google Frontends on `run.app` and 404s

--- a/docs/guides/golden-query-canary.md
+++ b/docs/guides/golden-query-canary.md
@@ -38,7 +38,7 @@ Fetch the ones you are about to run with `ochakai get <id>`, which prints
 the document — question, `runtime` and `# Computation` fence included.
 
 Straight REST is
-`GET /api/v1/knowledge?type=Attested%20Computation&trust=human-reviewed&sort=verified_at&limit=100`;
+`GET /api/v1/search?type=Attested%20Computation&trust=human-reviewed&sort=verified_at&limit=100`;
 over MCP, `search_knowledge` with `sort: "verified_at"` returns the same
 feed. `sort=verified_at` orders by verification time, oldest first, with
 unverified entries last. "Verified queries not re-checked in 90 days" is
@@ -88,7 +88,7 @@ canonicalize a run against. ochakai takes no part in this step.
   and failed totals show up under `/usage`, so verified entries that have
   accumulated failures can be picked up for re-verification first. **The
   `sort=failed` re-verification feed** (`ochakai search --sort failed
-  --trust human-reviewed`, REST: `GET /api/v1/knowledge?sort=failed`, MCP:
+  --trust human-reviewed`, REST: `GET /api/v1/search?sort=failed`, MCP:
   `search_knowledge` with `sort: "failed"`) lists them in order of how
   often they were reported wrong. It is the evidence-based entrance,
   complementing the time-based `sort=verified_at` (design doc 0025).
@@ -114,10 +114,10 @@ jobs:
         run: |
           TOKEN=$(gcloud auth print-identity-token --audiences="$OCHAKAI_URL")
           curl -s -H "Authorization: Bearer $TOKEN" \
-            "$OCHAKAI_URL/api/v1/knowledge?type=Attested%20Computation&trust=human-reviewed&sort=verified_at&limit=50" \
+            "$OCHAKAI_URL/api/v1/search?type=Attested%20Computation&trust=human-reviewed&sort=verified_at&limit=50" \
           | jq -r '.hits[].id' | while read -r id; do
               doc=$(curl -s -H "Authorization: Bearer $TOKEN" \
-                -H 'Accept: text/markdown' "$OCHAKAI_URL/api/v1/knowledge/$id")
+                -H 'Accept: text/markdown' "$OCHAKAI_URL/api/v1/bundle/$id.md")
               sql=$(printf '%s' "$doc" | sed -n '/^```sql$/,/^```$/p' | sed '1d;$d')
               if ! bq query --nouse_legacy_sql --dry_run "$sql" >/dev/null 2>&1; then
                 echo "::error::computation $id no longer compiles against the warehouse"

--- a/docs/guides/operating.md
+++ b/docs/guides/operating.md
@@ -119,7 +119,7 @@ It is `/health` and not `/healthz` because Google Frontends intercept
 `/healthz` on `run.app` URLs and return their own 404.
 
 A stricter check, if you want one, is any read that touches the store:
-`GET /api/v1/knowledge?sort=verified_at&limit=1` succeeds only when the
+`GET /api/v1/search?sort=verified_at&limit=1` succeeds only when the
 database answers. `ochakai whoami` does the same thing from a shell and
 also prints which identity the server sees.
 

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -69,18 +69,16 @@ ochakai を使う人が払うのは実装の行数ではなく**表面**であ�
 規則の下で動く運用であって、規則の変更ではない。増やしたくないものを
 数える仕組みが、自分の数え先を増やすのでは筋が通らない。
 
-## REST (19)
+## REST (16)
 
 - `DELETE /api/v1/bundle/{path}`
-- `DELETE /api/v1/knowledge/{id}`
 - `DELETE /api/v1/reject/{id}`
 - `GET /api/v1/backlinks/{id}`
 - `GET /api/v1/bundle/{path}`
 - `GET /api/v1/context`
 - `GET /api/v1/export`
-- `GET /api/v1/knowledge`
-- `GET /api/v1/knowledge/{id}`
 - `GET /api/v1/queues`
+- `GET /api/v1/search`
 - `GET /api/v1/stats`
 - `GET /api/v1/usage/{id}`
 - `POST /api/v1/move`
@@ -89,7 +87,17 @@ ochakai を使う人が払うのは実装の行数ではなく**表面**であ�
 - `POST /api/v1/usage/{id}`
 - `POST /api/v1/verify/{id}`
 - `PUT /api/v1/bundle/{path}`
-- `PUT /api/v1/knowledge/{id}`
+
+19 から 16 へ。[0046 §3.5](design/0046-bundle-address-space.md) の
+畳み込みの一部で、**足したものは無く、消えたのは重複である** —
+`/api/v1/knowledge/{id}` の 3 操作は、`/api/v1/bundle/{path}` が同じ
+オブジェクトに与えていた第二の綴りだった。一覧は `/api/v1/search` に
+改名してある(順位はバンドルの中に無いので、住所もバンドルの外にある)。
+
+§3.5 が畳むと決めた面のうち **2 つがまだ残っている**:
+`/api/v1/backlinks/{id}`(検索の `links_to=` に吸収される)と
+`/api/v1/export`(`Accept: application/gzip` の部分木に吸収される)。
+どちらも後継が無いので今は消せない。畳み終えると 14 になる。
 
 ## MCP (8)
 

--- a/internal/apiclient/apiclient.go
+++ b/internal/apiclient/apiclient.go
@@ -121,7 +121,7 @@ func (e *APIError) Error() string {
 	return http.StatusText(e.StatusCode)
 }
 
-// SearchParams are the query parameters of GET /api/v1/knowledge.
+// SearchParams are the query parameters of GET /api/v1/search.
 type SearchParams struct {
 	Query    string
 	Types    []string
@@ -211,7 +211,7 @@ func (c *Client) Search(ctx context.Context, p SearchParams) (*SearchResult, err
 		q.Set("cursor", p.Cursor)
 	}
 	var out SearchResult
-	err := c.doJSON(ctx, http.MethodGet, "/api/v1/knowledge", q, nil, &out)
+	err := c.doJSON(ctx, http.MethodGet, "/api/v1/search", q, nil, &out)
 	return &out, err
 }
 
@@ -380,7 +380,7 @@ func (c *Client) Get(ctx context.Context, id string) (*domain.View, error) {
 }
 
 // Put writes doc — an OKF document — to the entry at id, creating it
-// when the id is free (PUT /api/v1/knowledge/{id}). One call, because a
+// when the id is free (PUT /api/v1/bundle/{path}). One call, because a
 // document says what the entry should say and nothing about whether it
 // already existed (design doc 0043 §3.5).
 //
@@ -620,9 +620,11 @@ func (c *Client) Reembed(ctx context.Context, cursor string, limit int) (*Reembe
 	return &out, nil
 }
 
-// entryPath escapes each ID segment separately: the id is a path
-// ("metric/revenue") and its slashes must stay real path separators.
-func entryPath(id string) string { return escapedPath("/api/v1/knowledge/", id) }
+// entryPath is where a concept lives in the bundle: its id plus `.md`,
+// which is its only address (design doc 0046 §3.5). Each ID segment is
+// escaped separately — the id is a path ("metrics/revenue") and its
+// slashes must stay real path separators.
+func entryPath(id string) string { return escapedPath("/api/v1/bundle/", id) + ".md" }
 
 func escapedPath(base, id string) string {
 	var b strings.Builder

--- a/internal/apiclient/apiclient_test.go
+++ b/internal/apiclient/apiclient_test.go
@@ -32,7 +32,7 @@ func newTestPair(t *testing.T, h http.HandlerFunc) *Client {
 func TestSearchBuildsQueryAndDecodesHits(t *testing.T) {
 	var got url.Values
 	c := newTestPair(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/knowledge" {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/search" {
 			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
 		got = r.URL.Query()
@@ -272,7 +272,7 @@ func TestPutSendsADocumentAndDelete204(t *testing.T) {
 				Summary: domain.Summary{Type: domain.TypeMetrics, ID: "metrics/revenue",
 					Title: "売上", Status: domain.StatusDraft}})
 		case http.MethodDelete:
-			if r.URL.Path != "/api/v1/knowledge/metrics/revenue" {
+			if r.URL.Path != "/api/v1/bundle/metrics/revenue.md" {
 				t.Errorf("path = %s", r.URL.Path)
 			}
 			w.WriteHeader(http.StatusNoContent)
@@ -484,7 +484,7 @@ func TestPutSendsIfMatchAndMapsConflict(t *testing.T) {
 	const stale = "0000000000000000000000000000000000000000000000000000000000000000"
 	var got []string
 	c := newTestPair(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPut || r.URL.Path != "/api/v1/knowledge/metrics/revenue" {
+		if r.Method != http.MethodPut || r.URL.Path != "/api/v1/bundle/metrics/revenue.md" {
 			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
 		v, sent := r.Header["If-Match"]

--- a/internal/httpauth/httpauth_test.go
+++ b/internal/httpauth/httpauth_test.go
@@ -70,7 +70,7 @@ func TestCloudRunIAMPrefersServerlessHeader(t *testing.T) {
 		got = Actor(r.Context())
 	}))
 
-	r := httptest.NewRequest(http.MethodGet, "/api/v1/knowledge", nil)
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/search", nil)
 	r.Header.Set("Authorization", "Bearer "+fakeIDToken(`{"email":"forged@example.com"}`))
 	r.Header.Set("X-Serverless-Authorization", "Bearer "+fakeIDToken(`{"email":"real@example.com"}`))
 	w := httptest.NewRecorder()
@@ -88,7 +88,7 @@ func TestCloudRunIAMRejectsMissingToken(t *testing.T) {
 	cfg := &config.Config{}
 	h := Middleware(cfg, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
 	w := httptest.NewRecorder()
-	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/knowledge", nil))
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/search", nil))
 	if w.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want 401", w.Code)
 	}
@@ -101,7 +101,7 @@ func TestInsecureDevActsAsAnonymous(t *testing.T) {
 		got = Actor(r.Context())
 	}))
 	w := httptest.NewRecorder()
-	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/knowledge", nil))
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/search", nil))
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d", w.Code)
 	}
@@ -247,7 +247,7 @@ func TestMiddlewareRejectsInTheAPIErrorEnvelope(t *testing.T) {
 		t.Error("a rejected request must not reach the handler")
 	}))
 
-	r := httptest.NewRequest(http.MethodGet, "/api/v1/knowledge", nil)
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/search", nil)
 	r.Header.Set("X-Serverless-Authorization", "Bearer "+fakeIDToken(`{"email":"stranger@example.iam.gserviceaccount.com"}`))
 	r.Header.Set(OnBehalfOfHeader, "human:tanaka@example.co.jp")
 	w := httptest.NewRecorder()

--- a/internal/httpauth/publicreadonly_test.go
+++ b/internal/httpauth/publicreadonly_test.go
@@ -73,7 +73,7 @@ func TestPublicReadOnlyRefusesNobody(t *testing.T) {
 		}))
 
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/knowledge?q=revenue", nil))
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/search?q=revenue", nil))
 	if rec.Code != http.StatusOK {
 		t.Errorf("anonymous read = %d, want 200", rec.Code)
 	}

--- a/internal/restapi/openapi_test.go
+++ b/internal/restapi/openapi_test.go
@@ -76,12 +76,11 @@ func TestOpenAPISpecIsValid(t *testing.T) {
 // idAddressed are the endpoints whose trailing path parameter is an entry
 // id — or, for attachments, an id followed by a filename.
 var idAddressed = []string{
-	"/api/v1/knowledge/",
+	"/api/v1/bundle/",
 	"/api/v1/verify/",
+	"/api/v1/reject/",
 	"/api/v1/usage/",
-	"/api/v1/bundle/",
 	"/api/v1/backlinks/",
-	"/api/v1/bundle/",
 }
 
 // forSpecRouting collapses a multi-segment id down to one segment so the
@@ -206,7 +205,7 @@ func checkedServer(t *testing.T, h http.Handler) *httptest.Server {
 func TestCheckedServerOutlivesTheTestBody(t *testing.T) {
 	srv := readOnlyServer(t)
 	t.Cleanup(func() {
-		req, err := http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/knowledge/gone", nil)
+		req, err := http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/bundle/gone.md", nil)
 		if err != nil {
 			t.Error(err)
 			return

--- a/internal/restapi/readonly_test.go
+++ b/internal/restapi/readonly_test.go
@@ -31,8 +31,8 @@ func TestReadOnlyRefusesWritesWith403(t *testing.T) {
 	srv := readOnlyServer(t)
 	const doc = "---\ntype: Metric\ntitle: m\n---\n"
 	for _, w := range []struct{ method, path, body, mediaType string }{
-		{http.MethodPut, "/api/v1/knowledge/m", doc, "text/markdown"},
-		{http.MethodDelete, "/api/v1/knowledge/m", "", ""},
+		{http.MethodPut, "/api/v1/bundle/m.md", doc, "text/markdown"},
+		{http.MethodDelete, "/api/v1/bundle/m.md", "", ""},
 		{http.MethodPost, "/api/v1/verify/m", "", ""},
 		{http.MethodPost, "/api/v1/reject/m", `{"note":"no"}`, "application/json"},
 		{http.MethodDelete, "/api/v1/reject/m", "", ""},
@@ -71,7 +71,7 @@ func TestReadOnlyRefusesWritesWith403(t *testing.T) {
 // (design doc 0040 §2.3).
 func TestReadOnlyAnnouncesItselfOnEveryResponse(t *testing.T) {
 	srv := readOnlyServer(t)
-	req, err := http.NewRequest(http.MethodPut, srv.URL+"/api/v1/knowledge/m",
+	req, err := http.NewRequest(http.MethodPut, srv.URL+"/api/v1/bundle/m.md",
 		strings.NewReader("---\ntype: Metric\ntitle: m\n---\n"))
 	if err != nil {
 		t.Fatal(err)
@@ -83,7 +83,7 @@ func TestReadOnlyAnnouncesItselfOnEveryResponse(t *testing.T) {
 	}
 	resp.Body.Close()
 	if got := resp.Header.Get("Ochakai-Read-Only"); got != "true" {
-		t.Errorf("PUT /api/v1/knowledge/m: Ochakai-Read-Only = %q, want \"true\"", got)
+		t.Errorf("PUT /api/v1/bundle/m:.md Ochakai-Read-Only = %q, want \"true\"", got)
 	}
 
 	// A route that does not exist carries it too: the header describes the

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -159,7 +159,8 @@ func Handler(svc *service.Service) http.Handler {
 			// is answered by the entry surface's own writer, so one
 			// address serves both kinds and neither has a shape of its
 			// own here.
-			if id, ok := strings.CutSuffix(path, ".md"); ok {
+			id, isMarkdown := strings.CutSuffix(path, ".md")
+			if isMarkdown {
 				k, err := svc.Get(r.Context(), id)
 				if err == nil {
 					w.Header().Set("ETag", etagOf(k))
@@ -180,7 +181,7 @@ func Handler(svc *service.Service) http.Handler {
 			}
 			att, data, err := svc.GetFile(r.Context(), path)
 			if err != nil {
-				writeError(w, err)
+				writeError(w, missingObject(err, isMarkdown))
 				return
 			}
 			w.Header().Set("ETag", `"`+att.SHA256+`"`)
@@ -254,7 +255,7 @@ func Handler(svc *service.Service) http.Handler {
 					err = svc.Delete(r.Context(), id, actor)
 				}
 				if errors.Is(err, store.ErrNotFound) && !purge {
-					err = svc.DeleteFile(r.Context(), path, actor)
+					err = missingObject(svc.DeleteFile(r.Context(), path, actor), isMarkdown)
 				}
 				if err != nil {
 					writeError(w, err)
@@ -960,6 +961,29 @@ func writeError(w http.ResponseWriter, err error) {
 		status = http.StatusNotImplemented
 	}
 	writeJSON(w, status, map[string]string{"error": err.Error()})
+}
+
+// missingObject reports what a read or delete that fell through to the
+// file half should say about a markdown path.
+//
+// A `.md` path is a concept's address first (design doc 0046 §3.5); the
+// file lookup behind it is §3.2's accommodation for a markdown document
+// that carries no type. When this instance holds no files at all — no
+// GCS (design doc 0013) — that accommodation is simply unavailable, and
+// answering 501 would reply to a question about a concept with news
+// about the deployment. There is no object at the path: 404.
+//
+// It matters because the bundle path is now a concept's only address:
+// without this, every 404 for a soft-deleted or never-written concept
+// became a 501 on an instance without GCS, which is most of them.
+// A path that is not markdown keeps the 501 — there, "this instance
+// cannot hold files" is exactly the answer to what was asked.
+func missingObject(err error, markdown bool) error {
+	var unsupported *service.UnsupportedError
+	if markdown && errors.As(err, &unsupported) {
+		return store.ErrNotFound
+	}
+	return err
 }
 
 // etagOf renders the entry's version as an ETag: the hash of its

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -1,11 +1,16 @@
 // Package restapi serves /api/v1 so users can build their own web UIs
-// (the bundled one lives in internal/webui). It is a superset of the MCP tools:
-// the same knowledge/search/usage operations plus the bulk export
+// (the bundled one lives in internal/webui). It is a superset of the MCP
+// tools: the same read, write and usage operations plus the bulk export
 // endpoint that makes no sense as an agent tool call, and human-facing
 // endpoints (the reserved bundle files, backlinks) that stay off MCP by
 // design (agents get search/get_context instead; design doc 0015 records
 // the per-surface policy). The CLI covers this whole surface; the spec is
 // committed at api/openapi.yaml.
+//
+// One object has one address: /api/v1/bundle/{path}, a concept at
+// <id>.md (design doc 0046 §3.5). What is not an object of the bundle is
+// addressed outside it — a ranking at /api/v1/search, a judgment at
+// /api/v1/verify or /api/v1/reject, a measurement at /api/v1/usage.
 package restapi
 
 import (
@@ -36,7 +41,18 @@ const exportBatch = 100
 func Handler(svc *service.Service) http.Handler {
 	mux := http.NewServeMux()
 
-	// GET /api/v1/knowledge?q=...&type=...&status=...&tag=...&source=...&prefix=...&limit=...
+	// GET /api/v1/search?q=...&type=...&status=...&tag=...&source=...&prefix=...&limit=...
+	//
+	// Named for what it returns rather than for what it returns them
+	// from. Every other read in this file answers with an object of the
+	// bundle at the address it lives at; this one answers with a
+	// *ranking*, which is ochakai's own and is nowhere in the bundle
+	// (design doc 0046 §3.5, the same posture as 0033). Under the old
+	// spelling /api/v1/knowledge it looked like the collection that
+	// /api/v1/knowledge/{id} indexed into, and that reading was wrong in
+	// both directions: the ranking is not the collection, and the
+	// collection is addressed as the bundle.
+	//
 	// With sort=verified_at, lists by verification age (oldest first)
 	// instead of searching — the feed for canary runs.
 	// source narrows to the entries citing one resource — the reverse of
@@ -47,7 +63,7 @@ func Handler(svc *service.Service) http.Handler {
 	// cursor walks a listing past the limit — a listing has a total order
 	// to resume from, a search has a ranking window and refuses it
 	// (design doc 0050).
-	mux.HandleFunc("GET /api/v1/knowledge", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("GET /api/v1/search", func(w http.ResponseWriter, r *http.Request) {
 		q := r.URL.Query()
 		limit, err := queryInt(q, "limit")
 		if err != nil {
@@ -180,7 +196,18 @@ func Handler(svc *service.Service) http.Handler {
 	})
 
 	// PUT and DELETE /api/v1/bundle/{path...} — the write face of the one
-	// address space (design doc 0046 §3.5).
+	// address space (design doc 0046 §3.5), and now the only one: the
+	// second spelling of a concept's address, /api/v1/knowledge/{id}, is
+	// gone. It read, wrote and deleted exactly what this face does, one
+	// suffix away, which meant a client had to know which of two names
+	// ochakai preferred for the same object and an id was a bundle path
+	// with the `.md` filed off.
+	//
+	// A PUT is create-or-replace, and states what the object should say.
+	// Whether something already held the address is not part of that
+	// statement, so there is no POST beside it: existence is expressed by
+	// the preconditions (0030), If-None-Match "*" for "only if free" and
+	// If-Match for "only if it still says this".
 	//
 	// The reserved names are the one refusal the address itself makes:
 	// they are generated from the bundle rather than stored in it, so a
@@ -207,11 +234,26 @@ func Handler(svc *service.Service) http.Handler {
 			// one gets it back (design doc 0046 §3.2).
 			id, isMarkdown := strings.CutSuffix(path, ".md")
 			if r.Method == http.MethodDelete {
-				err := store.ErrNotFound
-				if isMarkdown {
+				// ?purge=true hard-deletes a concept that is already
+				// soft-deleted, freeing its id (a tombstone still owns
+				// the primary key, so a move onto it fails). Two calls,
+				// deliberately: the first is reversible, the second is
+				// not. Not on MCP — destroying history is a human
+				// decision (design docs 0015, 0031). A file has no
+				// tombstone to purge, so the parameter is a concept's.
+				purge, err := queryBool(r.URL.Query(), "purge", false)
+				if err != nil {
+					writeError(w, err)
+					return
+				}
+				err = store.ErrNotFound
+				switch {
+				case isMarkdown && purge:
+					err = svc.Purge(r.Context(), id, actor)
+				case isMarkdown:
 					err = svc.Delete(r.Context(), id, actor)
 				}
-				if errors.Is(err, store.ErrNotFound) {
+				if errors.Is(err, store.ErrNotFound) && !purge {
 					err = svc.DeleteFile(r.Context(), path, actor)
 				}
 				if err != nil {
@@ -219,6 +261,21 @@ func Handler(svc *service.Service) http.Handler {
 					return
 				}
 				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+			// At a concept's address the body is an OKF document, which
+			// is what a concept is (design doc 0043 §3.5). JSON there is
+			// the one wrong guess worth naming: there is no typed write
+			// surface beside the format, and stored as bytes it would
+			// carry no `type` and be kept as a *file* called `x.md` —
+			// the silent wrong outcome. Only at a `.md` path: JSON at
+			// any other path is a caller storing a JSON file, which is
+			// an object of the bundle like any other.
+			if mt := r.Header.Get("Content-Type"); isMarkdown && strings.HasPrefix(mt, "application/json") {
+				writeJSON(w, http.StatusUnsupportedMediaType, map[string]string{
+					"error": "a concept is written as an OKF document (Content-Type: text/markdown), " +
+						"not as JSON: the frontmatter is the metadata and the markdown is the body",
+				})
 				return
 			}
 			body, ok := readBody(w, r, maxDocument, fmt.Sprintf("object exceeds %d bytes", maxDocument))
@@ -288,7 +345,7 @@ func Handler(svc *service.Service) http.Handler {
 	})
 
 	// GET /api/v1/queues?prefix=... — the three review queues as counts
-	// (design doc 0049). The feeds under /api/v1/knowledge answer "what
+	// (design doc 0049). The feeds under /api/v1/search answer "what
 	// is waiting"; this answers "is anything", which is the question a
 	// scheduled job can ask cheaply and a human can be told the answer
 	// to. prefix scopes it to a subtree, as it scopes the feeds.
@@ -299,52 +356,6 @@ func Handler(svc *service.Service) http.Handler {
 			return
 		}
 		writeJSON(w, http.StatusOK, map[string]any{"queues": counts})
-	})
-
-	// {id...} because the id is the entry's full bundle path (design doc
-	// 0016) — the wildcard captures every segment.
-	mux.HandleFunc("GET /api/v1/knowledge/{id...}", func(w http.ResponseWriter, r *http.Request) {
-		k, err := svc.Get(r.Context(), r.PathValue("id"))
-		if err != nil {
-			writeError(w, err)
-			return
-		}
-		// The ETag is the entry's version: a client can echo it in If-Match
-		// on a later PUT to update only if nothing changed meanwhile.
-		w.Header().Set("ETag", etagOf(k))
-		if wantsDocument(r) {
-			writeDocument(w, http.StatusOK, k)
-			return
-		}
-		writeView(w, http.StatusOK, k)
-	})
-
-	// PUT /api/v1/knowledge/{id...} — the one way to write knowledge. The
-	// body is an OKF document, which is what an entry is (design doc 0043
-	// §3.5): the path is the address, the frontmatter and body are what it
-	// says, and there is no typed JSON write surface beside it to drift
-	// from the format.
-	//
-	// It is create-or-replace. A PUT states what the entry should say, and
-	// whether an entry already held the id is not something the writer of
-	// a document is saying anything about — so a separate POST would only
-	// make the caller answer a question it does not have to ask. The
-	// preconditions are where existence is expressed: If-None-Match "*"
-	// means "only if the id is free", If-Match a version means "only if it
-	// still says this".
-	mux.HandleFunc("PUT /api/v1/knowledge/{id...}", func(w http.ResponseWriter, r *http.Request) {
-		if mt := r.Header.Get("Content-Type"); strings.HasPrefix(mt, "application/json") {
-			writeJSON(w, http.StatusUnsupportedMediaType, map[string]string{
-				"error": "knowledge is written as an OKF document (Content-Type: text/markdown), " +
-					"not as JSON: the frontmatter is the metadata and the markdown is the body",
-			})
-			return
-		}
-		body, ok := readBody(w, r, maxDocument, fmt.Sprintf("document exceeds %d bytes", maxDocument))
-		if !ok {
-			return
-		}
-		putEntry(w, r, svc, r.PathValue("id"), body, httpauth.Actor(r.Context()))
 	})
 
 	// POST /api/v1/verify/{id...} — record a verification against the
@@ -481,29 +492,6 @@ func Handler(svc *service.Service) http.Handler {
 	// and the address said so by putting the entry's id in front of a
 	// filename. Whether an entry shows a file is now a question its body
 	// answers, so the address that asserted it had nothing left to say.
-
-	// DELETE soft-deletes; ?purge=true hard-deletes an entry that is
-	// already soft-deleted, freeing its id (a tombstone still owns the
-	// primary key, so a move onto it fails). Two calls, deliberately: the
-	// first is reversible, the second is not. Not on MCP — destroying
-	// history is a human decision (design doc 0015).
-	mux.HandleFunc("DELETE /api/v1/knowledge/{id...}", func(w http.ResponseWriter, r *http.Request) {
-		purge, err := queryBool(r.URL.Query(), "purge", false)
-		if err != nil {
-			writeError(w, err)
-			return
-		}
-		if purge {
-			err = svc.Purge(r.Context(), r.PathValue("id"), httpauth.Actor(r.Context()))
-		} else {
-			err = svc.Delete(r.Context(), r.PathValue("id"), httpauth.Actor(r.Context()))
-		}
-		if err != nil {
-			writeError(w, err)
-			return
-		}
-		w.WriteHeader(http.StatusNoContent)
-	})
 
 	// POST /api/v1/move {"from": ..., "to": ...} — rename an entry: the
 	// id is the address (design doc 0017), so the move carries revisions,

--- a/internal/restapi/restapi_integration_test.go
+++ b/internal/restapi/restapi_integration_test.go
@@ -96,7 +96,7 @@ func removeEntries(t *testing.T, srv *httptest.Server, ids ...string) {
 	t.Cleanup(func() {
 		for _, id := range ids {
 			for _, q := range []string{"", "?purge=true"} {
-				req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/knowledge/"+id+q, nil)
+				req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/bundle/"+id+".md"+q, nil)
 				resp, err := http.DefaultClient.Do(req)
 				if err != nil {
 					t.Errorf("cleaning up %s%s: %v", id, q, err)
@@ -137,7 +137,7 @@ func TestRESTIntegration(t *testing.T) {
 	// to read it by, and what this instance observed (design doc 0043
 	// §3.5).
 	var got domain.View
-	getJSON(t, srv.URL+"/api/v1/knowledge/"+typ+"/sales/orders", &got)
+	getJSON(t, srv.URL+"/api/v1/bundle/"+typ+"/sales/orders.md", &got)
 	// The document named no status, so it reads as OKF's default rather
 	// than as a draft — and nobody has confirmed it, which is what the
 	// trust tier says (design doc 0046 §§3.9-3.10).
@@ -311,7 +311,7 @@ func TestRESTIntegration(t *testing.T) {
 	}
 
 	// Delete, then the entry is gone.
-	req, _ = http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/knowledge/"+typ+"/sales/orders", nil)
+	req, _ = http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/bundle/"+typ+"/sales/orders.md", nil)
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -320,7 +320,7 @@ func TestRESTIntegration(t *testing.T) {
 	if resp.StatusCode != http.StatusNoContent {
 		t.Errorf("delete status = %d", resp.StatusCode)
 	}
-	resp, err = http.Get(srv.URL + "/api/v1/knowledge/" + typ + "/sales/orders")
+	resp, err = http.Get(srv.URL + "/api/v1/bundle/" + typ + "/sales/orders.md")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -363,7 +363,7 @@ func TestRESTIntegrationAttachments(t *testing.T) {
 	var hits struct {
 		Hits []domain.SearchHit `json:"hits"`
 	}
-	getJSON(t, srv.URL+"/api/v1/knowledge?sort=verified_at&type="+typ, &hits)
+	getJSON(t, srv.URL+"/api/v1/search?sort=verified_at&type="+typ, &hits)
 	if len(hits.Hits) != 1 || len(hits.Hits[0].Attachments) != 1 ||
 		hits.Hits[0].Attachments[0].Name != "weekly.png" ||
 		hits.Hits[0].Attachments[0].MediaType != "image/png" {
@@ -446,7 +446,7 @@ func TestRESTIntegrationAttachments(t *testing.T) {
 	// the shared test database: other packages' tests scan all live
 	// attachments (the export snapshot) and resolve bytes from their own
 	// blob stores, while this test's bytes live only in this process.
-	req, _ = http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/knowledge/"+typ+"/reading", nil)
+	req, _ = http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/bundle/"+typ+"/reading.md", nil)
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -500,7 +500,7 @@ func docFrom(t *testing.T, entry map[string]any) []byte {
 // is what the tests that used to POST mean.
 func putDoc(t *testing.T, base, id string, doc []byte, onlyIfAbsent bool) *http.Response {
 	t.Helper()
-	req, err := http.NewRequest(http.MethodPut, base+"/api/v1/knowledge/"+id, bytes.NewReader(doc))
+	req, err := http.NewRequest(http.MethodPut, base+"/api/v1/bundle/"+id+".md", bytes.NewReader(doc))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -642,7 +642,7 @@ func TestRESTIntegrationVerify(t *testing.T) {
 	}
 
 	// Leave nothing live behind: the test database is shared (CONTRIBUTING).
-	req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/knowledge/"+id, nil)
+	req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/bundle/"+id+".md", nil)
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -852,7 +852,7 @@ func TestRESTIntegrationPrefixScopesSearchNotLinks(t *testing.T) {
 
 	search := func(query string) []string {
 		t.Helper()
-		resp, err := http.Get(srv.URL + "/api/v1/knowledge?" + query)
+		resp, err := http.Get(srv.URL + "/api/v1/search?" + query)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -895,7 +895,7 @@ func TestRESTIntegrationPrefixScopesSearchNotLinks(t *testing.T) {
 	}
 
 	// A scope that cannot lead an id is a 400, not a silent everything.
-	resp, err := http.Get(srv.URL + "/api/v1/knowledge?q=" + root + "&prefix=" + url.QueryEscape("a//b"))
+	resp, err := http.Get(srv.URL + "/api/v1/search?q=" + root + "&prefix=" + url.QueryEscape("a//b"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -980,7 +980,7 @@ func TestRESTIntegrationDocumentWrites(t *testing.T) {
 	// A document ochakai wrote can be edited and sent back as it came:
 	// the keys the server owns are ignored rather than refused, which is
 	// what makes get → edit → put a loop a human can run.
-	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/v1/knowledge/"+id, nil)
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/v1/bundle/"+id+".md", nil)
 	req.Header.Set("Accept", "text/markdown")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -1012,7 +1012,7 @@ func TestRESTIntegrationDocumentWrites(t *testing.T) {
 	}
 
 	// A stale version is refused and writes nothing.
-	req, _ = http.NewRequest(http.MethodPut, srv.URL+"/api/v1/knowledge/"+id, strings.NewReader(doc))
+	req, _ = http.NewRequest(http.MethodPut, srv.URL+"/api/v1/bundle/"+id+".md", strings.NewReader(doc))
 	req.Header.Set("Content-Type", "text/markdown")
 	req.Header.Set("If-Match", `"`+created.Summary.ContentHash+`"`)
 	resp, err = http.DefaultClient.Do(req)
@@ -1060,7 +1060,7 @@ func TestRESTIntegrationDocumentSurvivesTheRoundTrip(t *testing.T) {
 	}
 
 	var read domain.View
-	getJSON(t, srv.URL+"/api/v1/knowledge/"+id, &read)
+	getJSON(t, srv.URL+"/api/v1/bundle/"+id+".md", &read)
 	if read.Document != written {
 		t.Errorf("the read rewrote the document:\n got %q\nwant %q", read.Document, written)
 	}
@@ -1079,7 +1079,7 @@ func TestRESTIntegrationDocumentSurvivesTheRoundTrip(t *testing.T) {
 
 	// The markdown representation is the same bytes with this instance's
 	// observations appended — the export form, not a second document.
-	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/v1/knowledge/"+id, nil)
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/v1/bundle/"+id+".md", nil)
 	req.Header.Set("Accept", "text/markdown")
 	mdResp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -1168,7 +1168,7 @@ func TestRESTIntegrationForeignTrustFamilyIsKeptAsAClaim(t *testing.T) {
 
 	// The export form carries both — the claim and this instance's own
 	// observation — and sending it back is still not a change.
-	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/v1/knowledge/"+id, nil)
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/v1/bundle/"+id+".md", nil)
 	req.Header.Set("Accept", "text/markdown")
 	mdResp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -1210,7 +1210,7 @@ func TestRESTIntegrationAnyFileIsAcceptedAndServedInert(t *testing.T) {
 	// blob fake. A defer rather than t.Cleanup — cleanups run after this
 	// function's defers, by which time the server is closed.
 	defer func() {
-		req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/knowledge/"+id, nil)
+		req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/bundle/"+id+".md", nil)
 		if resp, err := http.DefaultClient.Do(req); err == nil {
 			resp.Body.Close()
 		}
@@ -1278,7 +1278,7 @@ func TestRESTIntegrationAnyFileIsAcceptedAndServedInert(t *testing.T) {
 	// And the entry carries all four: no cap on how many objects a
 	// directory of the bundle may hold.
 	var view domain.View
-	getJSON(t, srv.URL+"/api/v1/knowledge/"+id, &view)
+	getJSON(t, srv.URL+"/api/v1/bundle/"+id+".md", &view)
 	if len(view.Attachments) != 4 {
 		t.Errorf("the entry carries %d files, want 4 — nothing caps how many", len(view.Attachments))
 	}
@@ -1298,7 +1298,7 @@ func TestRESTIntegrationBundleAddressWritesEveryObject(t *testing.T) {
 	id := typ + "/revenue"
 	bundle := srv.URL + "/api/v1/bundle/"
 	defer func() {
-		req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/knowledge/"+id, nil)
+		req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/bundle/"+id+".md", nil)
 		if resp, err := http.DefaultClient.Do(req); err == nil {
 			resp.Body.Close()
 		}
@@ -1364,7 +1364,7 @@ func TestRESTIntegrationBundleAddressWritesEveryObject(t *testing.T) {
 	}
 	// It is attributed to the entry that shows it, without anybody
 	// having said so (design doc 0046 §3.3).
-	getJSON(t, srv.URL+"/api/v1/knowledge/"+id, &read)
+	getJSON(t, srv.URL+"/api/v1/bundle/"+id+".md", &read)
 	if len(read.Attachments) != 1 || read.Attachments[0].Name != "chart.png" {
 		t.Errorf("the entry does not carry the file its body shows: %+v", read.Attachments)
 	}
@@ -1387,7 +1387,7 @@ func TestRESTIntegrationBundleAddressWritesEveryObject(t *testing.T) {
 	}
 	// It is not an entry: nothing lists it, and the concept surface does
 	// not know it.
-	resp, err = http.Get(srv.URL + "/api/v1/knowledge/" + typ + "/notes")
+	resp, err = http.Get(srv.URL + "/api/v1/bundle/" + typ + "/notes.md")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1444,7 +1444,7 @@ func TestRESTIntegrationStats(t *testing.T) {
 	var hits struct {
 		Hits []domain.SearchHit `json:"hits"`
 	}
-	getJSON(t, srv.URL+"/api/v1/knowledge?q="+nonsense, &hits)
+	getJSON(t, srv.URL+"/api/v1/search?q="+nonsense, &hits)
 	if len(hits.Hits) != 0 {
 		t.Fatalf("the nonsense query matched %d entries", len(hits.Hits))
 	}
@@ -1521,7 +1521,7 @@ func TestRESTIntegrationListingsPage(t *testing.T) {
 
 	page := func(query string) (hits []string, cursor string) {
 		t.Helper()
-		resp, err := http.Get(srv.URL + "/api/v1/knowledge?" + query)
+		resp, err := http.Get(srv.URL + "/api/v1/search?" + query)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1571,7 +1571,7 @@ func TestRESTIntegrationListingsPage(t *testing.T) {
 
 	// A ranking has no next page, and saying so is a client error rather
 	// than a cursor quietly ignored.
-	resp, err := http.Get(srv.URL + "/api/v1/knowledge?q=" + root + "&cursor=" + url.QueryEscape(cursorOf(t, page, feed)))
+	resp, err := http.Get(srv.URL + "/api/v1/search?q=" + root + "&cursor=" + url.QueryEscape(cursorOf(t, page, feed)))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/restapi/restapi_integration_test.go
+++ b/internal/restapi/restapi_integration_test.go
@@ -1317,8 +1317,8 @@ func TestRESTIntegrationBundleAddressWritesEveryObject(t *testing.T) {
 		return resp
 	}
 
-	// A concept, written at the path it lives at. It is the entry
-	// surface's write: same status, same ETag, same View.
+	// A concept, written at the path it lives at — which is now the only
+	// place it can be written (design doc 0046 §3.5).
 	doc := fmt.Sprintf("---\ntype: %s\ntitle: 売上\n---\n\n![chart](revenue/chart.png)\n", typ)
 	resp := put(t, id+".md", []byte(doc))
 	var view domain.View
@@ -1333,7 +1333,7 @@ func TestRESTIntegrationBundleAddressWritesEveryObject(t *testing.T) {
 	if etag == "" {
 		t.Error("no ETag on a concept written through the bundle address")
 	}
-	// The same bytes again write nothing, exactly as on the entry surface.
+	// The same bytes again write nothing.
 	resp = put(t, id+".md", []byte(doc))
 	resp.Body.Close()
 	if resp.Header.Get("Ochakai-Unchanged") != "true" {
@@ -1385,15 +1385,18 @@ func TestRESTIntegrationBundleAddressWritesEveryObject(t *testing.T) {
 	if string(got) != string(notes) {
 		t.Errorf("the typeless markdown file came back as %q", got)
 	}
-	// It is not an entry: nothing lists it, and the concept surface does
-	// not know it.
-	resp, err = http.Get(srv.URL + "/api/v1/bundle/" + typ + "/notes.md")
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp.Body.Close()
-	if resp.StatusCode != http.StatusNotFound {
-		t.Errorf("a typeless markdown file answers the entry surface: %d", resp.StatusCode)
+	// It is not a concept, and the way to see that is what lists it —
+	// nothing does. There is no second surface left to ask: the concept
+	// address /api/v1/knowledge/{id} is gone (design doc 0046 §3.5), so
+	// "the concept surface 404s for it" is no longer a question anybody
+	// can put. index.md lists the concepts at a level, and this file is
+	// not among them.
+	var listing service.BrowseResult
+	getJSON(t, srv.URL+"/api/v1/bundle/"+typ+"/index.md", &listing)
+	for _, e := range listing.Entries {
+		if e.ID == typ+"/notes" || e.ID == typ+"/notes.md" {
+			t.Errorf("a typeless markdown file is listed as a concept: %+v", e)
+		}
 	}
 
 	// Delete reaches both kinds.

--- a/internal/restapi/restapi_test.go
+++ b/internal/restapi/restapi_test.go
@@ -322,3 +322,27 @@ func TestBooleanQueryParamsRejectUnreadableValues(t *testing.T) {
 		})
 	}
 }
+
+// A concept's address is a bundle path now, and the read behind it falls
+// through to the file half when no concept is there. On an instance
+// without GCS that half cannot answer at all, and it says so with a 501
+// — which turned every 404 for a soft-deleted or never-written concept
+// into "this deployment does not do files". The path decides which
+// answer is the honest one.
+func TestMissingObjectAnswersAboutTheObjectNotTheDeployment(t *testing.T) {
+	noFiles := service.Unsupportedf("files are not supported without GCS")
+	if got := missingObject(noFiles, true); !errors.Is(got, store.ErrNotFound) {
+		t.Errorf("a markdown path with nothing at it = %v, want a 404: the question was "+
+			"about a concept, and the deployment's file support is not an answer to it", got)
+	}
+	if got := missingObject(noFiles, false); !errors.Is(got, noFiles) {
+		t.Errorf("a file path on an instance that holds no files = %v, want the 501 kept: "+
+			"there, what the deployment cannot do is exactly what was asked", got)
+	}
+	// Anything else travels unchanged, in both shapes.
+	for _, markdown := range []bool{true, false} {
+		if got := missingObject(store.ErrNotFound, markdown); !errors.Is(got, store.ErrNotFound) {
+			t.Errorf("markdown=%v: a plain 404 became %v", markdown, got)
+		}
+	}
+}

--- a/internal/restapi/restapi_test.go
+++ b/internal/restapi/restapi_test.go
@@ -51,13 +51,13 @@ func TestBadRequestValidation(t *testing.T) {
 	cases := []struct {
 		name, url, wantSubstr string
 	}{
-		{"invalid sort", "/api/v1/knowledge?sort=created_at", "invalid sort"},
-		{"neither q nor sort", "/api/v1/knowledge", "needs a query"},
-		{"whitespace query", "/api/v1/knowledge?q=%20%09", "needs a query"},
-		{"sort with query", "/api/v1/knowledge?sort=verified_at&q=revenue", "cannot be combined"},
-		{"usage sort with query", "/api/v1/knowledge?sort=usage&q=revenue", "cannot be combined"},
-		{"failed sort with query", "/api/v1/knowledge?sort=failed&q=revenue", "cannot be combined"},
-		{"bad search limit", "/api/v1/knowledge?limit=abc", "invalid limit"},
+		{"invalid sort", "/api/v1/search?sort=created_at", "invalid sort"},
+		{"neither q nor sort", "/api/v1/search", "needs a query"},
+		{"whitespace query", "/api/v1/search?q=%20%09", "needs a query"},
+		{"sort with query", "/api/v1/search?sort=verified_at&q=revenue", "cannot be combined"},
+		{"usage sort with query", "/api/v1/search?sort=usage&q=revenue", "cannot be combined"},
+		{"failed sort with query", "/api/v1/search?sort=failed&q=revenue", "cannot be combined"},
+		{"bad search limit", "/api/v1/search?limit=abc", "invalid limit"},
 		{"bad log limit", "/api/v1/bundle/metrics/log.md?limit=abc", "invalid limit"},
 		{"bad backlinks limit", "/api/v1/backlinks/metrics/revenue?limit=1.5", "invalid limit"},
 		{"bad context limit", "/api/v1/context?q=x&limit=1.5", "invalid limit"},
@@ -67,13 +67,13 @@ func TestBadRequestValidation(t *testing.T) {
 		// doc 0047). The five with a column behind them, and every key
 		// OKF does not define, are refused on both surfaces that take a
 		// filter, searching or listing, before any store access.
-		{"fm.status", "/api/v1/knowledge?q=x&fm.status=stable", "use status="},
-		{"fm.tags while listing", "/api/v1/knowledge?sort=usage&fm.tags=core", "use tag="},
-		{"fm.sources", "/api/v1/knowledge?q=x&fm.sources=bq://t", "use source=URI"},
-		{"fm.stale_after", "/api/v1/knowledge?q=x&fm.stale_after=2026-12-31", "use sort=stale_after"},
+		{"fm.status", "/api/v1/search?q=x&fm.status=stable", "use status="},
+		{"fm.tags while listing", "/api/v1/search?sort=usage&fm.tags=core", "use tag="},
+		{"fm.sources", "/api/v1/search?q=x&fm.sources=bq://t", "use source=URI"},
+		{"fm.stale_after", "/api/v1/search?q=x&fm.stale_after=2026-12-31", "use sort=stale_after"},
 		{"fm.type on a context pack", "/api/v1/context?q=x&fm.type=Metric", "use type="},
-		{"producer key", "/api/v1/knowledge?q=x&fm.owner=finance", "OKF does not define"},
-		{"producer key while listing", "/api/v1/knowledge?sort=usage&fm.owner=finance", "OKF does not define"},
+		{"producer key", "/api/v1/search?q=x&fm.owner=finance", "OKF does not define"},
+		{"producer key while listing", "/api/v1/search?sort=usage&fm.owner=finance", "OKF does not define"},
 		{"producer key on a context pack", "/api/v1/context?q=x&fm.owner=finance", "OKF does not define"},
 	}
 	for _, c := range cases {
@@ -226,7 +226,7 @@ func TestETagRoundTrip(t *testing.T) {
 		t.Fatalf("etagOf = %s", etag)
 	}
 
-	req := httptest.NewRequest(http.MethodPut, "/api/v1/knowledge/metrics/x", nil)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/bundle/metrics/x.md", nil)
 	req.Header.Set("If-Match", etag)
 	got := parseIfMatch(req)
 	if got == nil || *got != hash {
@@ -262,7 +262,7 @@ func TestETagRoundTrip(t *testing.T) {
 func TestOversizedDocumentIsTooLarge(t *testing.T) {
 	h := Handler(&service.Service{})
 	body := "---\ntype: Metric\n---\n\n" + strings.Repeat("a", 6<<20)
-	req := httptest.NewRequest(http.MethodPut, "/api/v1/knowledge/metrics/x", strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/bundle/metrics/x.md", strings.NewReader(body))
 	req.Header.Set("Content-Type", "text/markdown")
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
@@ -281,7 +281,7 @@ func TestOversizedDocumentIsTooLarge(t *testing.T) {
 // frontmatter.
 func TestJSONWriteSaysToSendADocument(t *testing.T) {
 	h := Handler(&service.Service{})
-	req := httptest.NewRequest(http.MethodPut, "/api/v1/knowledge/metrics/x",
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/bundle/metrics/x.md",
 		strings.NewReader(`{"type":"Metric","id":"metrics/x"}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -304,9 +304,9 @@ func TestBooleanQueryParamsRejectUnreadableValues(t *testing.T) {
 	cases := []struct {
 		name, method, url, wantSubstr string
 	}{
-		{"purge=1", http.MethodDelete, "/api/v1/knowledge/metrics/revenue?purge=1", "invalid purge"},
-		{"purge=True", http.MethodDelete, "/api/v1/knowledge/metrics/revenue?purge=True", "invalid purge"},
-		{"purge=yes", http.MethodDelete, "/api/v1/knowledge/metrics/revenue?purge=yes", "invalid purge"},
+		{"purge=1", http.MethodDelete, "/api/v1/bundle/metrics/revenue.md?purge=1", "invalid purge"},
+		{"purge=True", http.MethodDelete, "/api/v1/bundle/metrics/revenue.md?purge=True", "invalid purge"},
+		{"purge=yes", http.MethodDelete, "/api/v1/bundle/metrics/revenue.md?purge=yes", "invalid purge"},
 		{"attachments=0", http.MethodGet, "/api/v1/export?attachments=0", "invalid attachments"},
 	}
 	for _, c := range cases {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -967,7 +967,7 @@ func jsonSize(v any) int {
 	return len(b)
 }
 
-// SearchOrList answers the query surface REST (GET /api/v1/knowledge) and
+// SearchOrList answers the query surface REST (GET /api/v1/search) and
 // MCP (search_knowledge) both expose, so the two cannot drift: one place
 // decides whether a request searches or lists, validates the mode, and
 // runs it. A sort mode names one of the listing feeds (see list); with no

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -585,6 +585,9 @@ function idPath(id) {
   return String(id).split('/').map(encodeURIComponent).join('/');
 }
 const entryHash = e => '#/k/' + idPath(e.id);
+// API path for a concept: it lives in the bundle at its id plus `.md`,
+// which is the only address it has (design doc 0046 §3.5).
+const conceptURL = id => '/api/v1/bundle/' + idPath(id) + '.md';
 // Display name: the title when set, else the id's last segment — with
 // title optional, the filename usually is the name (design doc 0022).
 const displayTitle = e => e.title || String(e.id).split('/').pop();
@@ -1014,7 +1017,7 @@ async function runSearch(append = false) {
     runSearch();
   });
   try {
-    const page = await api('/api/v1/knowledge?' + p);
+    const page = await api('/api/v1/search?' + p);
     if (my !== runSearch._seq || out !== $('#results')) return; // stale response
     // The cursor is the server's word for "there is more"; its absence
     // ends the listing, and no count comes with either (0050 §2.3).
@@ -1456,7 +1459,7 @@ async function viewDetail(id) {
     // A read is {id, document, summary, observed, attachments} (design
     // doc 0043 §3.5). The summary is flattened onto entry so the header
     // reads one object; the document is the entry itself.
-    const v = await api('/api/v1/knowledge/' + idPath(id));
+    const v = await api(conceptURL(id));
     entry = Object.assign({ id: v.id, attachments: v.attachments || [] }, v.summary);
     observed = v.observed || {};
     document_ = v.document || '';
@@ -1820,7 +1823,7 @@ async function viewDetail(id) {
     closeMenu();
     if (!confirm(`Soft-delete ${entry.id}? Revision history is retained.`)) return;
     try {
-      await api('/api/v1/knowledge/' + idPath(entry.id), { method: 'DELETE' });
+      await api(conceptURL(entry.id), { method: 'DELETE' });
       toast('Deleted.');
       refreshTree();
       location.hash = '#/';
@@ -1863,8 +1866,8 @@ async function applyStatus(id, status) {
   // what makes this safe: the page never holds the whole entry, only the
   // projection, so anything assembled from what it holds would be missing
   // the rest of the document.
-  const v = await api('/api/v1/knowledge/' + idPath(id));
-  await api('/api/v1/knowledge/' + idPath(id), {
+  const v = await api(conceptURL(id));
+  await api(conceptURL(id), {
     method: 'PUT', doc: withStatus(v.document || '', status),
   });
   return true;
@@ -2023,7 +2026,7 @@ async function runReview(append = false) {
   if (!out) return;
   const my = runReview._seq = (runReview._seq || 0) + 1;
   const limit = 100;
-  let url = '/api/v1/knowledge?sort=usage&status=draft&limit=' + limit;
+  let url = '/api/v1/search?sort=usage&status=draft&limit=' + limit;
   if (append && review.cursor) url += '&cursor=' + encodeURIComponent(review.cursor);
   else { review.loaded = []; review.cursor = ''; }
   try {
@@ -2146,7 +2149,7 @@ async function viewEditor(id, prefix = '') {
   let entryID = prefix;
   if (editing) {
     try {
-      const v = await api('/api/v1/knowledge/' + idPath(id));
+      const v = await api(conceptURL(id));
       doc = v.document || '';
       entryID = v.id;
     } catch (e) {
@@ -2229,7 +2232,7 @@ async function viewEditor(id, prefix = '') {
       return;
     }
     try {
-      const saved = await api('/api/v1/knowledge/' + idPath(entryId), {
+      const saved = await api(conceptURL(entryId), {
         method: 'PUT', doc: document_, onlyIfAbsent: !editing,
       });
       dirty = false;

--- a/internal/webui/webui_test.go
+++ b/internal/webui/webui_test.go
@@ -70,7 +70,7 @@ func TestAStatusChangeEditsTheDocumentRatherThanRebuildingIt(t *testing.T) {
 		t.Fatal("the status change no longer goes through a document edit")
 	}
 	body := section(t, page, "async function applyStatus(", "\n}")
-	if !strings.Contains(body, "api('/api/v1/knowledge/' + idPath(id))") {
+	if !strings.Contains(body, "api(conceptURL(id))") {
 		t.Error("applyStatus does not read the document first, so it cannot be editing one")
 	}
 	if !strings.Contains(body, "withStatus(") {


### PR DESCRIPTION
## What and why

A concept was reachable two ways, and both were ochakai's own:

| gone | stays |
|---|---|
| `GET /api/v1/knowledge/{id}` | `GET /api/v1/bundle/{id}.md` |
| `PUT /api/v1/knowledge/{id}` | `PUT /api/v1/bundle/{id}.md` |
| `DELETE /api/v1/knowledge/{id}` | `DELETE /api/v1/bundle/{id}.md` |
| `GET /api/v1/knowledge?q=…` | `GET /api/v1/search?q=…` (renamed) |

The retired address read the same object, wrote it **through the same
code**, returned the same View, the same document under `Accept:
text/markdown`, the same ETag, honored the same preconditions and answered
the same `Ochakai-Unchanged`. What it cost was that a client had to know
which of two names ochakai preferred for one object, and that an id was a
bundle path with the `.md` filed off. 0046 §3.5 decided this fold when it
made the bundle the address space; #309 gave files their one address, this
gives concepts theirs.

**`?purge=true` moved with it.** It was the one capability the bundle
address did not have — the spec said so in as many words ("`purge=true`
has no bundle-address form yet … and it is not built"), so removing the
old address without building it would have lost 0031. It is now on
`DELETE /api/v1/bundle/{path}`; a file has no tombstone, so purging one is
a 404.

**The 415 for a JSON body moved, narrowed.** At a `.md` path a JSON body
is worth naming: stored as bytes it would carry no `type` and be kept as a
*file* called `x.md`, which is the silent wrong outcome. At any other path
a JSON body is a caller storing a JSON file — an object of the bundle like
any other — so the guard is `.md`-only. Rejecting it everywhere would have
made a whole media type unstorable, and `readonly_test.go`'s
`PUT /api/v1/bundle/m/f.txt` with `application/json` caught exactly that
while I had it wrong.

**The list face is renamed, not moved.** It does not return an object of
the bundle: it returns a *ranking*, which is ochakai's own and is nowhere
in the bundle — the posture 0033 took for context hits. Under the old name
it read as the collection that `/api/v1/knowledge/{id}` indexed into, and
it is neither that collection nor addressable as one.

### Which of the seven conditions

C3 (OKF v0.2) and C6 (a small REST API). Nothing is added: **the surface
goes 19 → 16**, and the three questions do not apply to a fold. What is
folded away is named in the commit.

### What is still standing

Two of §3.5's folds, because their successors do not exist yet:
`/api/v1/backlinks/{id}` wants a `links_to=` filter on search, and
`/api/v1/export` wants a subtree under `Accept: application/gzip`.
`docs/surface.md` says this where the count is, so 16 does not read as the
finished number — the fold ends at 14.

## Checks

- [x] `scripts/check core` is clean; `gofmt`, `go vet`, `go test -race`,
      build all pass
- [ ] **`scripts/check --db` could not run here — no Docker in this
      environment.** The store-gated integration tests are the ones this
      change touches most (`restapi_integration_test.go`, ~20 request
      URLs), so **CI's run is the real check**. Each rewrite is a
      mechanical `+".md"` on an entry address; the remaining
      `/api/v1/search?…` occurrences are queries, which take no path. I
      re-read the whole diff for that file rather than trusting the sweep,
      after it had already mangled `removeEntries` into
      `/api/v1/search/<id>`
- [x] Behavior changes come with tests — the existing suites cover it: the
      OpenAPI contract test validates every integration request and
      response against the spec, so a URL that moved without the spec
      moving fails

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — the `/api/v1/knowledge/{id}`
      block is removed from the spec, its unique prose (purge, the
      preconditions, the 415) folded into the bundle operations
- [x] Lands on every surface it belongs on: REST is the only one that
      changes. CLI, MCP and the web UI speak these URLs for the user —
      their behavior is untouched, only the paths they send. The web UI
      gained one helper, `conceptURL(id)`, so the address exists once
- [x] Widens a surface? It narrows one. `docs/surface.md` REST (19) → (16)

## Design docs

- [x] Alters an accepted decision? No — it *implements* 0046 §3.5, which
      is already Accepted. No new number, per 0048 §2.1
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyctQUDLJzdoQx7ph6tsCA)_