### PR TITLE
Rebuild this schema's vector space, not whatever the path finds first

### DIFF
--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -480,9 +480,26 @@ func (s *Store) resizeVectorSpace(ctx context.Context, dim int) error {
 	var stored int
 	// to_regclass rather than a cast: the cast raises when the table is
 	// absent, and "absent" is the one case with nothing to disagree about.
+	//
+	// Qualified by current_schema(), and so is the drop below. Both used
+	// to name the tables bare, which resolves through the whole
+	// search_path — so a store whose path is "<schema>,public" could
+	// probe or drop *another schema's* table. The creates a few lines
+	// down are unqualified and therefore land in current_schema(), so
+	// that is the schema this function is about; reading or dropping
+	// anywhere else was never what it meant.
+	//
+	// Nothing in a deployment has a second schema on its path, which is
+	// why this held in production. It did not hold under test: the
+	// scoped store used for the destructive migration tests puts public
+	// second, has knowledge_embedding of its own and no
+	// attachment_embedding — so the bare drop took its own table and
+	// then public's, and the tests sharing public failed later,
+	// intermittently and somewhere else.
 	err := s.pool.QueryRow(ctx,
 		`SELECT atttypmod FROM pg_attribute
-		 WHERE attrelid = to_regclass('knowledge_embedding') AND attname = 'embedding'`).
+		 WHERE attrelid = to_regclass(quote_ident(current_schema()) || '.knowledge_embedding')
+		   AND attname = 'embedding'`).
 		Scan(&stored)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil
@@ -494,7 +511,10 @@ func (s *Store) resizeVectorSpace(ctx context.Context, dim int) error {
 		return nil
 	}
 	if _, err := s.pool.Exec(ctx,
-		`DROP TABLE IF EXISTS knowledge_embedding, attachment_embedding`); err != nil {
+		`DO $$ BEGIN
+			EXECUTE format('DROP TABLE IF EXISTS %I.knowledge_embedding, %I.attachment_embedding',
+				current_schema(), current_schema());
+		 END $$`); err != nil {
 		return fmt.Errorf("%w: drop the vector tables of the previous dimension: %w",
 			ErrEmbeddingUnavailable, err)
 	}

--- a/internal/store/migrate_integration_test.go
+++ b/internal/store/migrate_integration_test.go
@@ -684,8 +684,35 @@ func TestIntegrationEmbeddingDimChangeRebuilds(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// What public holds before the resize. The rebuild drops the vector
+	// tables, and it must drop *this* schema's — the store's path is
+	// "<schema>,public", so a bare table name in that DROP reaches past
+	// the scope this test declares (there is no attachment_embedding
+	// here, and there is one in public). It took public's, and the tests
+	// that share public failed afterwards, somewhere else and not every
+	// time.
+	publicHas := func(table string) bool {
+		t.Helper()
+		var exists bool
+		if err := s.pool.QueryRow(ctx,
+			`SELECT to_regclass('public.'||$1) IS NOT NULL`, table).Scan(&exists); err != nil {
+			t.Fatal(err)
+		}
+		return exists
+	}
+	before := map[string]bool{
+		"knowledge_embedding":  publicHas("knowledge_embedding"),
+		"attachment_embedding": publicHas("attachment_embedding"),
+	}
+
 	if err := s.Migrate(ctx, 8); err != nil {
 		t.Fatalf("a changed embedding dimension must rebuild rather than refuse: %v", err)
+	}
+	for table, had := range before {
+		if had && !publicHas(table) {
+			t.Errorf("the resize dropped public.%s: a scoped store rebuilt its own vector space "+
+				"and took another schema's table with it", table)
+		}
 	}
 	// The space is the new one, and empty: the old vectors were in a
 	// space nothing would query, and nothing was carried into this one


### PR DESCRIPTION
## What and why

#319's CI failed on a vector search that returned nothing, in a test that
change did not touch. It passed on re-run. This is what was underneath.

`resizeVectorSpace` (0053 §3) probed and dropped by **bare table name**:

```sql
to_regclass('knowledge_embedding')
DROP TABLE IF EXISTS knowledge_embedding, attachment_embedding
```

A bare name resolves through the whole `search_path`. The creates a few
lines below are unqualified and therefore land in `current_schema()`, so
that is the schema the function is about — reaching past it was never the
intent.

**No deployment has a second schema on its path**, which is why this held
in production and still would. It did not hold under test.
`scopedStore` builds a store with `search_path = <schema>,public`, and
`TestIntegrationEmbeddingDimChangeRebuilds` pre-creates only
`knowledge_embedding` in its own schema. So the drop resolved:

| name | resolved to |
|---|---|
| `knowledge_embedding` | the scoped schema's — intended |
| `attachment_embedding` | **`public`'s** — not in the scoped schema at all |

That test declares in its own comment that it is "scoped to its own
schema: this one is destructive by design, and the other store tests
share the database." It was not scoped. Files run in name order, so
`migrate_integration_test.go` goes before `store_integration_test.go`,
and the tests sharing `public` failed afterwards — somewhere else,
intermittently, depending on what had recreated what.

Both statements are qualified with `current_schema()` now.

## The test

The assertion has to live in the test that does the damage, because the
damage was never visible there: it captures what `public` holds before
the rebuild and requires it to still be there afterwards. Written as
"whatever was there must survive" rather than "these two tables exist",
so it is self-contained and asserts nothing about what else has run.

## Scope

Not part of the 0046 §3.5 fold — a detour, taken now because it makes CI
intermittently red for every PR in that sequence, and I had already spent
two CI cycles establishing that it was not the fold's doing. It is one
function and one test.

### Which of the seven conditions

C2 (Google Cloud, and the database it runs on) and C7 indirectly — a
measurable loop needs checks that mean what they say. **No surface
changes**; `docs/surface.md` is untouched.

## Checks

- [x] `gofmt`, `go vet`, `go test -race`, build — clean
- [ ] **`scripts/check --db` could not run — no Docker here.** CI is the
      real check, and for this change specifically: the behavior being
      fixed only exists against a real PostgreSQL with two schemas on the
      path
- [x] Behavior changes come with tests — the regression assertion, above

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` — untouched
- [x] Lands on every surface it belongs on — none; this is below the wire
- [x] Widens a surface? No

## Design docs

- [x] Alters an accepted decision? No. 0053 §3 decided that a changed
      dimension rebuilds rather than refuses, and that is unchanged —
      this is which schema it rebuilds in
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyctQUDLJzdoQx7ph6tsCA)_