### PR TITLE
Read an archive at the path it archives — 0046 §3.5's fold is done (19 → 14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,35 @@ last entry.
 
 ### Added
 
+- **BREAKING** — `GET /api/v1/export` is retired. An archive is the
+  bundle at a path, so it is a representation of that path (design doc
+  [0046](docs/design/0046-bundle-address-space.md) §3.5):
+
+  ```
+  GET /api/v1/export                     →  GET /api/v1/bundle/          + Accept: application/gzip
+  GET /api/v1/export?attachments=false   →  GET /api/v1/bundle/?attachments=false + the same header
+  ```
+
+  **This completes §3.5's fold: REST is 14 operations, from 19.** The
+  address space is the bundle, and what is not an object of it — a
+  ranking, a judgment, a measurement — is addressed outside it.
+
+  The archive gains a scope it did not have: **any path is a subtree**.
+  `GET /api/v1/bundle/metrics/` with the header archives `metrics/` and
+  everything under it, matched on segment boundaries as every other path
+  scope is (design doc 0041). Paths inside are not re-rooted — an archive
+  of `metrics/` carries `metrics/revenue.md` and imports back where it
+  came from, because this is a copy of a subtree and not a move of one.
+
+  `ochakai export` is unchanged and asks this way underneath. **The web
+  UI's "Export OKF" now downloads through the page rather than streaming
+  from a link**: a plain `<a href>` cannot send an `Accept` header, so the
+  archive lands in the browser's memory before it lands on disk. That is
+  the price of the bundle having one address instead of an endpoint named
+  after downloading, and it is bounded by what a curated base holds — a
+  real backup belongs in CI, where `ochakai export` streams it
+  ([operating guide](docs/guides/operating.md)).
+
 - **BREAKING** — `GET /api/v1/backlinks/{id}` is retired. What points at
   an entry is a filter on the search face now (design doc
   [0046](docs/design/0046-bundle-address-space.md) §3.5):

--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ is that the bundle semantics — attributing loose files to entries,
 skipping what does not belong, ignoring the frontmatter keys the server
 owns — live in the client. To load OKF bundles from something other than
 this binary, [api/openapi.yaml](api/openapi.yaml) spells out what that
-loop does under `/api/v1/export`.
+loop does, under `GET /api/v1/bundle/{path}`.
 
 The REST API (`/api/v1`) is a superset of these tools, adding bulk
 export, the human-facing reads (the bundle's `index.md` and `log.md`,

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -502,6 +502,14 @@ paths:
             The object's bundle path — "metrics/revenue.md",
             "metrics/revenue/chart.png", or a reserved "index.md" /
             "metrics/log.md". Slashes are real path separators.
+
+            **The empty path is the bundle itself**: `/api/v1/bundle/`
+            with `Accept: application/gzip` is the archive of everything,
+            and with `Accept: application/json` the root `index.md` is at
+            `/api/v1/bundle/index.md`. A path template parameter cannot
+            be written as empty in OpenAPI, so this is said here rather
+            than in the path — as with the slashes above, the prose is as
+            precise as the format allows.
           schema: { type: string }
         - name: limit
           in: query

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -24,10 +24,9 @@ info:
     it is neither. `/api/v1/backlinks/{id}` is gone the same way: what
     points at an entry is a set of entries, so it is `links_to=` on the
     search face beside `source=`, the reverse lookup that was already
-    there. One address named by §3.5 is still its old self —
-    `/api/v1/export`, whose successor is a subtree under
-    `Accept: application/gzip` — and it carries no deprecation mark
-    because that successor is not built.
+    there. `/api/v1/export` is gone too: an archive is the bundle at a
+    path, so it is `Accept: application/gzip` on that path, and the root
+    is the whole knowledge base. §3.5's fold is complete.
 
     Every interface is unstable while the major version is 0
     (docs/compatibility.md): a removal arrives in a minor release with a
@@ -438,6 +437,44 @@ paths:
         `Content-Security-Policy: sandbox`, and `nosniff` is always set
         (design doc 0046 §3.2).
 
+        **`Accept: application/gzip` reads the path as a subtree** and
+        streams it as an OKF bundle: a tar.gz of markdown + YAML
+        frontmatter, the generated `index.md` files, and the files
+        entries show. The root (`/api/v1/bundle/`) is the whole knowledge
+        base — this is what `GET /api/v1/export` was, at the address of
+        the thing it returns (design doc 0046 §3.5). Your knowledge is
+        yours.
+
+        Paths inside the archive are not re-rooted: an archive of
+        `metrics/` carries `metrics/revenue.md` and imports back to where
+        it came from, because this is a copy of a subtree rather than a
+        move of one.
+
+        Written as it is read — indexes first, then entries in batches,
+        then one file at a time — so the server never holds the whole
+        bundle in memory. Because the response starts before the last
+        file is read, a failure mid-archive can only truncate the stream:
+        verify a backup by reading the archive, not by the status code.
+        The server logs every such failure at error level, naming the
+        file it stopped on.
+
+        There is no matching import endpoint, and that is deliberate
+        (design doc 0015 §3.2): importing a bundle is a loop over this
+        very address, so a server-side version would add a second path to
+        the same outcome without adding a capability. To write your own
+        importer against any OKF bundle: walk the tar.gz and PUT every
+        member to `/api/v1/bundle/{path}` at the path it arrived at. One
+        address takes both kinds — the bytes decide which — so there is
+        nothing to attribute and nothing to route. `index.md` files are
+        generated and are not entries. Frontmatter keys the server owns
+        — `generated`, `verified`, `created_by`, `rejected_by`,
+        `rejected_at`, and the pre-v0.2 spellings `timestamp` /
+        `verified_by` / `verified_at` — are ignored on write; provenance
+        comes from the caller's identity (design docs 0009, 0036 §3.2).
+        The one exception is that the presence of a `verified` key
+        decides how OKF's `stable` status maps onto ochakai's (design doc
+        0036 §3.4).
+
         `index.md` is one level of the tree — the subdirectories directly
         under the path, each with the count of entries beneath, plus the
         entries at that level (design docs 0014, 0016). Rejected and
@@ -470,18 +507,31 @@ paths:
           in: query
           description: log.md only — maximum entries (default and max 1000).
           schema: { type: integer }
+        - name: attachments
+          in: query
+          description: >
+            `Accept: application/gzip` only — `false` archives the
+            markdown without the files entries show. Their bytes live in
+            GCS, so a periodic backup can copy them from there directly
+            instead of pulling them through here. A value that is neither
+            `true` nor `false` is a 400.
+          schema: { type: boolean, default: true }
       responses:
         "200":
           description: >
-            The object: a concept's document or View, a file's bytes, or
-            a generated file and its structured form.
+            The object: a concept's document or View, a file's bytes, a
+            generated file and its structured form, or — under
+            `Accept: application/gzip` — the subtree at this path as an
+            OKF bundle.
           headers:
             Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
             ETag: { $ref: "#/components/headers/ETag" }
             Content-Disposition:
-              description: Files only — inline for an image, a PDF or plain text; attachment otherwise (design doc 0046 §3.2).
+              description: Files and archives — inline for an image, a PDF or plain text; attachment otherwise (design doc 0046 §3.2).
               schema: { type: string }
           content:
+            application/gzip:
+              schema: { type: string, format: binary, description: The subtree at this path as an OKF bundle. }
             "*/*":
               schema: { type: string, format: binary, description: A file's bytes, under the media type sniffed when it was stored. }
             text/markdown:
@@ -1581,64 +1631,6 @@ paths:
                       drafts: 0
                       reported_wrong: 0
                       past_expiry: 0
-        "400": { $ref: "#/components/responses/Error" }
-        "403": { $ref: "#/components/responses/Forbidden" }
-  /api/v1/export:
-    get:
-      operationId: exportOKF
-      summary: Export the knowledge base as an OKF bundle
-      description: >
-        Streams a tar.gz of the whole knowledge base in Open Knowledge
-        Format (markdown + YAML frontmatter, one concept per entry, with
-        index.md files), attachment files included. Your knowledge is
-        yours.
-
-
-        Written as it is read — indexes first, then entries in batches,
-        then one attachment at a time — so the server never holds the
-        whole bundle in memory. Because the response starts before the
-        last file is read, a failure mid-export can only truncate the
-        stream: verify a backup by reading the archive, not by the status
-        code. The server logs every such failure at error level, naming
-        the file it stopped on.
-
-
-        There is no matching import endpoint, and that is deliberate
-        (design doc 0015 §3.2): importing a bundle is a loop over the
-        endpoints already here, so a server-side version would add a
-        second path to the same outcome without adding a capability.
-        To write your own importer against any OKF bundle: walk the
-        tar.gz and PUT every member to /api/v1/bundle/{path} at the path
-        it arrived at. One address takes both kinds — the bytes decide
-        which — so there is nothing to attribute and nothing to route.
-        `index.md` files are generated on export and are not entries.
-        Frontmatter keys the server owns — `generated`, `verified`,
-        `created_by`, `rejected_by`, `rejected_at`, and the pre-v0.2
-        spellings `timestamp` / `verified_by` / `verified_at` — are
-        ignored on write; provenance comes from the caller's identity
-        (design docs 0009, 0036 §3.2). The one exception is that the
-        presence of a `verified` key decides how OKF's `stable` status
-        maps onto ochakai's (design doc 0036 §3.4). `ochakai import`
-        walks the same loop, still routing a concept and an attachment
-        through the older addresses it was written against — the same
-        outcome by a longer route, until they go.
-      parameters:
-        - name: attachments
-          in: query
-          description: >
-            `false` exports the markdown only. Attachment bytes live in
-            GCS, so a periodic backup can copy them from there directly
-            instead of pulling them through this endpoint. A value that
-            is neither `true` nor `false` is a 400.
-          schema: { type: boolean, default: true }
-      responses:
-        "200":
-          description: OKF bundle.
-          headers:
-            Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
-          content:
-            application/gzip:
-              schema: { type: string, format: binary }
         "400": { $ref: "#/components/responses/Error" }
         "403": { $ref: "#/components/responses/Forbidden" }
   /api/v1/reembed:

--- a/docs/guides/golden-query-canary.md
+++ b/docs/guides/golden-query-canary.md
@@ -43,7 +43,8 @@ over MCP, `search_knowledge` with `sort: "verified_at"` returns the same
 feed. `sort=verified_at` orders by verification time, oldest first, with
 unverified entries last. "Verified queries not re-checked in 90 days" is
 where a canary run starts. Checking out an OKF export
-(`ochakai export` / `GET /api/v1/export`) in CI works just as well.
+(`ochakai export`, or `GET /api/v1/bundle/` with
+`Accept: application/gzip`) in CI works just as well.
 
 ### 2. Run — with your own credentials
 

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -69,13 +69,12 @@ ochakai を使う人が払うのは実装の行数ではなく**表面**であ�
 規則の下で動く運用であって、規則の変更ではない。増やしたくないものを
 数える仕組みが、自分の数え先を増やすのでは筋が通らない。
 
-## REST (15)
+## REST (14)
 
 - `DELETE /api/v1/bundle/{path}`
 - `DELETE /api/v1/reject/{id}`
 - `GET /api/v1/bundle/{path}`
 - `GET /api/v1/context`
-- `GET /api/v1/export`
 - `GET /api/v1/queues`
 - `GET /api/v1/search`
 - `GET /api/v1/stats`
@@ -87,15 +86,18 @@ ochakai を使う人が払うのは実装の行数ではなく**表面**であ�
 - `POST /api/v1/verify/{id}`
 - `PUT /api/v1/bundle/{path}`
 
-19 → 16 → 15。[0046 §3.5](design/0046-bundle-address-space.md) の畳み込み
-で、**消えているのは面であって能力ではない**。concept の第二の住所
-(`/api/v1/knowledge/{id}` の 3 操作)が消え、一覧は `/api/v1/search` に
-なり、`/api/v1/backlinks/{id}` は同じ面の `links_to=` フィルタになった —
-「これを指しているのは何か」は entry の集合を返す問いで、`source=` と
-同じ形の逆引きだったからである。
+19 → 14。[0046 §3.5](design/0046-bundle-address-space.md) の畳み込みが
+**完了した**。消えたのは面であって能力ではない — concept の第二の住所
+(`/api/v1/knowledge/{id}` 3 操作)、`/api/v1/backlinks/{id}`(検索の
+`links_to=` へ)、`/api/v1/export`(バンドルのパスに
+`Accept: application/gzip` で、ルートが全体)。一覧は `/api/v1/search`
+に改名した。
 
-残るは **`/api/v1/export`** 1 つ。`Accept: application/gzip` の部分木に
-吸収されると §3.5 が決めているが、後継がまだ無い。畳み終えると 14。
+**8 面**という §3.5 の数え方では、bundle(3)・search・context・move・
+verify・reject(2)・usage(2)・reembed で 12 操作。残る 2 つは §3.5 より
+後の決定で足された `queues`([0049](design/0049-queue-counts.md))と
+`stats`([0051](design/0051-instance-metrics-and-search-misses.md))で、
+どちらもループの測定である。
 
 ## MCP (8)
 

--- a/internal/apiclient/apiclient.go
+++ b/internal/apiclient/apiclient.go
@@ -591,12 +591,17 @@ func (c *Client) Stats(ctx context.Context, days int) (*domain.Stats, error) {
 
 // Export streams the knowledge base as an OKF tar.gz bundle. The caller
 // must close the reader.
+//
+// It is a read of the bundle root asking for the archive representation
+// (design doc 0046 §3.5): an archive is the bundle at a path, so it is
+// answered at the address of that path rather than at an endpoint named
+// after downloading.
 func (c *Client) Export(ctx context.Context, attachments bool) (io.ReadCloser, error) {
 	var q url.Values
 	if !attachments {
 		q = url.Values{"attachments": {"false"}}
 	}
-	resp, err := c.get(ctx, "/api/v1/export", q)
+	resp, err := c.doAccept(ctx, http.MethodGet, "/api/v1/bundle/", q, nil, "application/gzip")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/apiclient/apiclient_test.go
+++ b/internal/apiclient/apiclient_test.go
@@ -337,8 +337,11 @@ func TestExportStreamsBody(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			c := newTestPair(t, func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/api/v1/export" {
+				if r.URL.Path != "/api/v1/bundle/" {
 					t.Errorf("path = %s", r.URL.Path)
+				}
+				if a := r.Header.Get("Accept"); a != "application/gzip" {
+					t.Errorf("Accept = %q, want the archive representation", a)
 				}
 				if got := r.URL.Query().Get("attachments"); got != tc.wantParam {
 					t.Errorf("attachments = %q, want %q", got, tc.wantParam)

--- a/internal/restapi/openapi_test.go
+++ b/internal/restapi/openapi_test.go
@@ -96,7 +96,20 @@ var idAddressed = []string{
 // only as `type: string`, and any single segment satisfies that. The
 // method, query, headers, both bodies and the status code stay under the
 // spec's eye, which is the whole of what drifts.
+//
+// The bundle root is the same gap seen from the other end. "" is a
+// legal bundle path — it is the whole bundle, and GET /api/v1/bundle/
+// with Accept: application/gzip is how the archive of everything is
+// asked for (design doc 0046 §3.5) — but a path *template* parameter
+// cannot match the empty string in OpenAPI, and there is no syntax that
+// would let it. Standing one placeholder segment in keeps the request
+// under the same checks as any other, which is the point; the spec says
+// in prose that the root is spelled with an empty path, because that is
+// as precise as the format allows.
 func forSpecRouting(p string) string {
+	if p == bundlePath {
+		return bundlePath + "-"
+	}
 	for _, prefix := range idAddressed {
 		if rest, ok := strings.CutPrefix(p, prefix); ok && strings.Contains(rest, "/") {
 			return prefix + strings.ReplaceAll(rest, "/", "-")
@@ -104,6 +117,10 @@ func forSpecRouting(p string) string {
 	}
 	return p
 }
+
+// bundlePath is the address every object of the bundle lives under, and
+// with nothing after it, the bundle itself.
+const bundlePath = "/api/v1/bundle/"
 
 // carriesOpaqueBytes reports whether this request stores raw bytes: a
 // PUT of a file, whose body is the file and whose Content-Type is
@@ -115,7 +132,7 @@ func forSpecRouting(p string) string {
 // `{type: string, format: binary}` asserts nothing about the bytes,
 // which is the whole point of a file.
 func carriesOpaqueBytes(r *http.Request) bool {
-	return r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/api/v1/bundle/")
+	return r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, bundlePath)
 }
 
 // sniffedResponse reports whether a response's media type was decided by

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -39,6 +39,140 @@ import (
 // large enough that the round trips disappear against the transfer.
 const exportBatch = 100
 
+// writeBundleArchive streams a subtree of the bundle as OKF: the tar.gz
+// a caller asks for with Accept: application/gzip. The root is the whole
+// knowledge base, which is what GET /api/v1/export was until design doc
+// 0046 §3.5 folded it here — an archive is the bundle at a path, so it is
+// answered at the address of that path rather than at an endpoint named
+// after the act of downloading. `prefix` has already been normalized.
+//
+// Your knowledge is yours.
+func writeBundleArchive(w http.ResponseWriter, r *http.Request, svc *service.Service, prefix string) {
+	// Every read below comes from one snapshot. Streaming means the id
+	// list, the attachment metadata and the entries are read at
+	// different moments, and a write landing between them produces an
+	// archive that disagrees with its own index — an index.md naming a
+	// file that is not there, an entry that moved appearing twice or
+	// not at all. The archive would look fine.
+	// Parsed before the snapshot: a rejected parameter should not
+	// have held a pooled connection open, however briefly.
+	withAttachments, err := queryBool(r.URL.Query(), "attachments", true)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	snap, err := svc.Store.BeginExport(r.Context())
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	defer snap.Close(context.WithoutCancel(r.Context()))
+	// index.md files need every id, but only the id, title and
+	// description — never a body.
+	rows, err := snap.IndexRows(r.Context(), prefix)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	var atts []store.ExportAttachment
+	if withAttachments {
+		// Metadata only; bytes are pulled one attachment at a time below.
+		if atts, err = snap.AttachmentMeta(r.Context(), prefix); err != nil {
+			writeError(w, err)
+			return
+		}
+	}
+	indexes := okf.Indexes(rows) // also sorts rows by id
+	ids := make([]string, len(rows))
+	for i := range rows {
+		ids[i] = rows[i].ID
+	}
+
+	// Past this point the status is already sent, so a failure can only
+	// truncate the stream. Everything that can fail cheaply — the
+	// listings above — has already run; everything below is logged,
+	// because a silently short archive is the worst possible outcome
+	// for the backup this endpoint exists to serve.
+	w.Header().Set("Content-Type", "application/gzip")
+	w.Header().Set("Content-Disposition", `attachment; filename="ochakai-okf.tar.gz"`)
+	tgz := okf.NewTarGzWriter(w, time.Now())
+	written := make(map[string]bool, len(ids)+len(indexes))
+	fail := func(what string, err error) {
+		svc.Log.Error("export truncated after the response began",
+			"at", what, "error", err, "files_written", len(written))
+	}
+	add := func(p string, data []byte) error {
+		if err := tgz.Add(p, data); err != nil {
+			return err
+		}
+		written[p] = true
+		return nil
+	}
+	// Sorted so the archive's file order is stable across runs: map
+	// iteration order is not an ordering. The bytes still differ run to
+	// run — every tar header carries the export's timestamp — so this
+	// buys a diffable listing, not a checksum.
+	indexPaths := make([]string, 0, len(indexes))
+	for path := range indexes {
+		indexPaths = append(indexPaths, path)
+	}
+	sort.Strings(indexPaths)
+	for _, path := range indexPaths {
+		if err := add(path, indexes[path]); err != nil {
+			fail("index "+path, err)
+			return
+		}
+	}
+	// Entries in batches: one batch in memory at a time. The snapshot
+	// does hold a pooled connection for the length of the download —
+	// the trade a point-in-time backup makes (see ExportSnapshot);
+	// batching bounds the memory, not the connection.
+	for start := 0; start < len(ids); start += exportBatch {
+		end := min(start+exportBatch, len(ids))
+		batch, err := snap.ListByIDs(r.Context(), ids[start:end])
+		if err != nil {
+			fail(fmt.Sprintf("entries %d-%d", start, end), err)
+			return
+		}
+		for i := range batch {
+			doc, err := okf.Document(&batch[i])
+			if err != nil {
+				fail("render "+batch[i].ID, err)
+				return
+			}
+			if err := add(batch[i].ID+".md", doc); err != nil {
+				fail("write "+batch[i].ID, err)
+				return
+			}
+		}
+	}
+	// Attachments go next to their entries: "<id>/<name>", or the
+	// foreign path they were imported at (okf_path) so original body
+	// links keep working. A foreign path already taken by a concept
+	// document falls back to the canonical layout — identical content
+	// at the same path (the same image referenced by two entries) is
+	// no conflict.
+	for i := range atts {
+		a := &atts[i]
+		data, err := svc.Store.AttachmentBytes(r.Context(), a.Att.SHA256)
+		if err != nil {
+			fail("fetch attachment "+a.ID+"/"+a.Att.Name, err)
+			return
+		}
+		p := okf.AttachmentPath(a.ID, &a.Att)
+		if written[p] {
+			p = a.ID + "/" + a.Att.Name
+		}
+		if err := add(p, data); err != nil {
+			fail("write attachment "+p, err)
+			return
+		}
+	}
+	if err := tgz.Close(); err != nil {
+		fail("close", err)
+	}
+}
+
 func Handler(svc *service.Service) http.Handler {
 	mux := http.NewServeMux()
 
@@ -120,6 +254,21 @@ func Handler(svc *service.Service) http.Handler {
 	// of them has (design doc 0046 §3.5).
 	mux.HandleFunc("GET /api/v1/bundle/{path...}", func(w http.ResponseWriter, r *http.Request) {
 		path := r.PathValue("path")
+		// An archive is the bundle at a path: everything under it, as
+		// OKF, in the layout it lives at (design doc 0046 §3.5). The
+		// root is the whole knowledge base, which is what
+		// GET /api/v1/export was. Paths inside the archive are not
+		// re-rooted — an export of metrics/ imports back to metrics/,
+		// because this is a copy of a subtree and not a move of one.
+		if wantsArchive(r) {
+			scope, err := service.NormalizePrefix(path)
+			if err != nil {
+				writeError(w, err)
+				return
+			}
+			writeBundleArchive(w, r, svc, scope)
+			return
+		}
 		dir, base := splitReserved(path)
 		switch base {
 		case "index.md":
@@ -500,144 +649,6 @@ func Handler(svc *service.Service) http.Handler {
 		writeView(w, http.StatusOK, moved)
 	})
 
-	// GET /api/v1/export — the whole knowledge base as an OKF bundle
-	// (tar.gz of markdown + YAML frontmatter, plus attachment files).
-	// Your knowledge is yours.
-	//
-	// Written straight to the response, a batch of entries and one
-	// attachment at a time. Collecting the bundle first would mean holding
-	// every entry and every attachment's bytes in memory at once — a
-	// periodic CI backup would be the largest allocation the process ever
-	// makes, on the instance size Cloud Run runs it at. With
-	// ?attachments=false the bytes are skipped entirely: they live in GCS,
-	// so a backup can copy them from there far more cheaply than through
-	// this endpoint.
-	mux.HandleFunc("GET /api/v1/export", func(w http.ResponseWriter, r *http.Request) {
-		// Every read below comes from one snapshot. Streaming means the id
-		// list, the attachment metadata and the entries are read at
-		// different moments, and a write landing between them produces an
-		// archive that disagrees with its own index — an index.md naming a
-		// file that is not there, an entry that moved appearing twice or
-		// not at all. The archive would look fine.
-		// Parsed before the snapshot: a rejected parameter should not
-		// have held a pooled connection open, however briefly.
-		withAttachments, err := queryBool(r.URL.Query(), "attachments", true)
-		if err != nil {
-			writeError(w, err)
-			return
-		}
-		snap, err := svc.Store.BeginExport(r.Context())
-		if err != nil {
-			writeError(w, err)
-			return
-		}
-		defer snap.Close(context.WithoutCancel(r.Context()))
-		// index.md files need every id, but only the id, title and
-		// description — never a body.
-		rows, err := snap.IndexRows(r.Context())
-		if err != nil {
-			writeError(w, err)
-			return
-		}
-		var atts []store.ExportAttachment
-		if withAttachments {
-			// Metadata only; bytes are pulled one attachment at a time below.
-			if atts, err = snap.AttachmentMeta(r.Context()); err != nil {
-				writeError(w, err)
-				return
-			}
-		}
-		indexes := okf.Indexes(rows) // also sorts rows by id
-		ids := make([]string, len(rows))
-		for i := range rows {
-			ids[i] = rows[i].ID
-		}
-
-		// Past this point the status is already sent, so a failure can only
-		// truncate the stream. Everything that can fail cheaply — the
-		// listings above — has already run; everything below is logged,
-		// because a silently short archive is the worst possible outcome
-		// for the backup this endpoint exists to serve.
-		w.Header().Set("Content-Type", "application/gzip")
-		w.Header().Set("Content-Disposition", `attachment; filename="ochakai-okf.tar.gz"`)
-		tgz := okf.NewTarGzWriter(w, time.Now())
-		written := make(map[string]bool, len(ids)+len(indexes))
-		fail := func(what string, err error) {
-			svc.Log.Error("export truncated after the response began",
-				"at", what, "error", err, "files_written", len(written))
-		}
-		add := func(p string, data []byte) error {
-			if err := tgz.Add(p, data); err != nil {
-				return err
-			}
-			written[p] = true
-			return nil
-		}
-		// Sorted so the archive's file order is stable across runs: map
-		// iteration order is not an ordering. The bytes still differ run to
-		// run — every tar header carries the export's timestamp — so this
-		// buys a diffable listing, not a checksum.
-		indexPaths := make([]string, 0, len(indexes))
-		for path := range indexes {
-			indexPaths = append(indexPaths, path)
-		}
-		sort.Strings(indexPaths)
-		for _, path := range indexPaths {
-			if err := add(path, indexes[path]); err != nil {
-				fail("index "+path, err)
-				return
-			}
-		}
-		// Entries in batches: one batch in memory at a time. The snapshot
-		// does hold a pooled connection for the length of the download —
-		// the trade a point-in-time backup makes (see ExportSnapshot);
-		// batching bounds the memory, not the connection.
-		for start := 0; start < len(ids); start += exportBatch {
-			end := min(start+exportBatch, len(ids))
-			batch, err := snap.ListByIDs(r.Context(), ids[start:end])
-			if err != nil {
-				fail(fmt.Sprintf("entries %d-%d", start, end), err)
-				return
-			}
-			for i := range batch {
-				doc, err := okf.Document(&batch[i])
-				if err != nil {
-					fail("render "+batch[i].ID, err)
-					return
-				}
-				if err := add(batch[i].ID+".md", doc); err != nil {
-					fail("write "+batch[i].ID, err)
-					return
-				}
-			}
-		}
-		// Attachments go next to their entries: "<id>/<name>", or the
-		// foreign path they were imported at (okf_path) so original body
-		// links keep working. A foreign path already taken by a concept
-		// document falls back to the canonical layout — identical content
-		// at the same path (the same image referenced by two entries) is
-		// no conflict.
-		for i := range atts {
-			a := &atts[i]
-			data, err := svc.Store.AttachmentBytes(r.Context(), a.Att.SHA256)
-			if err != nil {
-				fail("fetch attachment "+a.ID+"/"+a.Att.Name, err)
-				return
-			}
-			p := okf.AttachmentPath(a.ID, &a.Att)
-			if written[p] {
-				p = a.ID + "/" + a.Att.Name
-			}
-			if err := add(p, data); err != nil {
-				fail("write attachment "+p, err)
-				return
-			}
-		}
-		if err := tgz.Close(); err != nil {
-			fail("close", err)
-		}
-	})
-
 	// POST /api/v1/reembed?limit=N&cursor=... — fill in vectors for
 	// entries and attachments that have none for the configured model.
 	// The response's cursor feeds the next call: a pass whose entries all
@@ -801,6 +812,14 @@ func writeMarkdown(w http.ResponseWriter, doc []byte) {
 // a browser sends */* and wants the JSON every existing client reads.
 func wantsDocument(r *http.Request) bool {
 	return strings.Contains(r.Header.Get("Accept"), "text/markdown")
+}
+
+// wantsArchive reports whether the caller asked for a path as an OKF
+// bundle rather than as one object. Explicit only, like the other two: a
+// browser sending */* is asking to look at something, not to download
+// the knowledge base under it.
+func wantsArchive(r *http.Request) bool {
+	return strings.Contains(r.Header.Get("Accept"), "application/gzip")
 }
 
 // onlyIfAbsent reports an If-None-Match "*" precondition: write only if

--- a/internal/restapi/restapi_integration_test.go
+++ b/internal/restapi/restapi_integration_test.go
@@ -207,7 +207,7 @@ func TestRESTIntegration(t *testing.T) {
 	}
 
 	// Export: the bundle carries the entry at its canonical path.
-	resp, err = http.Get(srv.URL + "/api/v1/export")
+	resp, err = getArchive(t, srv.URL+"/api/v1/bundle/", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -239,7 +239,7 @@ func TestRESTIntegration(t *testing.T) {
 	// ?attachments=false skips the bytes: a CI backup can take the
 	// entries from here and the files straight from GCS, which is both
 	// cheaper and the only sane path once attachments outweigh the text.
-	resp, err = http.Get(srv.URL + "/api/v1/export?attachments=false")
+	resp, err = getArchive(t, srv.URL+"/api/v1/bundle/", "attachments=false")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -284,7 +284,7 @@ func TestRESTIntegration(t *testing.T) {
 		resp.Body.Close()
 	}
 	removeEntries(t, srv, planted...)
-	resp, err = http.Get(srv.URL + "/api/v1/export?attachments=false")
+	resp, err = getArchive(t, srv.URL+"/api/v1/bundle/", "attachments=false")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1687,4 +1687,20 @@ func TestRESTQueuesCountsTheReviewQueues(t *testing.T) {
 	if elsewhere.Queues != (domain.QueueCounts{}) {
 		t.Errorf("a neighbouring prefix counted %+v, want all zero", elsewhere.Queues)
 	}
+}
+
+// getArchive asks a bundle path for its OKF archive: the representation
+// an Accept header selects (design doc 0046 §3.5), which is why this is
+// not a plain http.Get.
+func getArchive(t *testing.T, url, query string) (*http.Response, error) {
+	t.Helper()
+	if query != "" {
+		url += "?" + query
+	}
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Accept", "application/gzip")
+	return http.DefaultClient.Do(req)
 }

--- a/internal/restapi/restapi_test.go
+++ b/internal/restapi/restapi_test.go
@@ -302,17 +302,24 @@ func TestJSONWriteSaysToSendADocument(t *testing.T) {
 func TestBooleanQueryParamsRejectUnreadableValues(t *testing.T) {
 	h := Handler(&service.Service{})
 	cases := []struct {
-		name, method, url, wantSubstr string
+		name, method, url, accept, wantSubstr string
 	}{
-		{"purge=1", http.MethodDelete, "/api/v1/bundle/metrics/revenue.md?purge=1", "invalid purge"},
-		{"purge=True", http.MethodDelete, "/api/v1/bundle/metrics/revenue.md?purge=True", "invalid purge"},
-		{"purge=yes", http.MethodDelete, "/api/v1/bundle/metrics/revenue.md?purge=yes", "invalid purge"},
-		{"attachments=0", http.MethodGet, "/api/v1/export?attachments=0", "invalid attachments"},
+		{"purge=1", http.MethodDelete, "/api/v1/bundle/metrics/revenue.md?purge=1", "", "invalid purge"},
+		{"purge=True", http.MethodDelete, "/api/v1/bundle/metrics/revenue.md?purge=True", "", "invalid purge"},
+		{"purge=yes", http.MethodDelete, "/api/v1/bundle/metrics/revenue.md?purge=yes", "", "invalid purge"},
+		// The archive of the whole bundle: the parameter is read before
+		// the snapshot is opened, which is what lets this run against a
+		// service with no store at all.
+		{"attachments=0", http.MethodGet, "/api/v1/bundle/?attachments=0", "application/gzip", "invalid attachments"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			rec := httptest.NewRecorder()
-			h.ServeHTTP(rec, httptest.NewRequest(c.method, c.url, nil))
+			req := httptest.NewRequest(c.method, c.url, nil)
+			if c.accept != "" {
+				req.Header.Set("Accept", c.accept)
+			}
+			h.ServeHTTP(rec, req)
 			if rec.Code != http.StatusBadRequest {
 				t.Fatalf("%s %s = %d, want 400 (body: %s)", c.method, c.url, rec.Code, rec.Body)
 			}

--- a/internal/service/browse.go
+++ b/internal/service/browse.go
@@ -49,6 +49,11 @@ func (s *Service) Browse(ctx context.Context, prefix string) (*BrowseResult, err
 // a path pasted from a macOS filesystem arrives decomposed; no trailing
 // slash because "a/b/" and "a/b" name the same directory. The empty
 // prefix is the root, and valid.
+// NormalizePrefix is normalizePrefix for callers outside this package —
+// the archive face reads a bundle path as a subtree scope, and what a
+// scope means has to be decided in one place (design doc 0015 §2).
+func NormalizePrefix(p string) (string, error) { return normalizePrefix(p) }
+
 func normalizePrefix(p string) (string, error) {
 	p = domain.Normalize(strings.TrimSuffix(p, "/"))
 	if !domain.ValidIDPrefix(p) {

--- a/internal/store/blob_integration_test.go
+++ b/internal/store/blob_integration_test.go
@@ -85,7 +85,7 @@ func TestIntegrationBlobStoreOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	metas, err := snap.AttachmentMeta(ctx)
+	metas, err := snap.AttachmentMeta(ctx, "")
 	snap.Close(ctx)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -64,10 +64,11 @@ func (e *ExportSnapshot) Close(ctx context.Context) {
 // entry, in id order — what index.md files are built from, and the id list
 // the rest of the export walks. Never a body: the index names entries, it
 // does not carry them.
-func (e *ExportSnapshot) IndexRows(ctx context.Context) ([]domain.Knowledge, error) {
+func (e *ExportSnapshot) IndexRows(ctx context.Context, prefix string) ([]domain.Knowledge, error) {
 	rows, err := e.tx.Query(ctx,
 		`SELECT type, id, title, description FROM object
-		  WHERE deleted_at IS NULL AND id IS NOT NULL ORDER BY id`)
+		  WHERE deleted_at IS NULL AND id IS NOT NULL`+underPrefix("", "$1")+`
+		  ORDER BY id`, prefix)
 	if err != nil {
 		return nil, err
 	}
@@ -104,11 +105,11 @@ func (e *ExportSnapshot) ListByIDs(ctx context.Context, ids []string) ([]domain.
 // still fails when it is reached. The metadata being consistent is what
 // makes that failure visible as a missing file rather than as an archive
 // quietly disagreeing with its own index.
-func (e *ExportSnapshot) AttachmentMeta(ctx context.Context) ([]ExportAttachment, error) {
+func (e *ExportSnapshot) AttachmentMeta(ctx context.Context, prefix string) ([]ExportAttachment, error) {
 	rows, err := e.tx.Query(ctx, `SELECT k.id, `+fileCols+`
 		FROM object k JOIN object f ON `+attributedTo+`
-		WHERE k.id IS NOT NULL AND k.deleted_at IS NULL
-		ORDER BY k.id, f.path`)
+		WHERE k.id IS NOT NULL AND k.deleted_at IS NULL`+underPrefix("k.", "$1")+`
+		ORDER BY k.id, f.path`, prefix)
 	if err != nil {
 		return nil, err
 	}
@@ -131,4 +132,19 @@ func (e *ExportSnapshot) AttachmentMeta(ctx context.Context) ([]ExportAttachment
 		return nil, errNoBlobStore
 	}
 	return atts, nil
+}
+
+// underPrefix scopes an export to one subtree, matched on segment
+// boundaries like every other path scope (design doc 0041 §2.2): a
+// "metrics" scope covers metrics itself and everything under "metrics/",
+// and leaves "metrics-legacy/churn" alone. An empty prefix is the whole
+// bundle and adds no predicate, so the archive of everything runs the
+// query it always ran.
+//
+// The parameter is always bound, empty or not: a query text that changed
+// with the argument would be a second prepared statement for the same
+// question.
+func underPrefix(col, arg string) string {
+	return " AND (" + arg + " = '' OR " + col + "id = " + arg +
+		" OR left(" + col + "id, length(" + arg + ") + 1) = " + arg + " || '/')"
 }

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -2080,7 +2080,7 @@ func TestIntegrationExportSnapshotIsConsistent(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer snap.Close(ctx)
-	rows, err := snap.IndexRows(ctx)
+	rows, err := snap.IndexRows(ctx, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -698,6 +698,31 @@ function setReadOnly(on) {
   document.body.classList.toggle('read-only', on);
 }
 
+// The archive is a representation of the bundle root, asked for with an
+// Accept header (design doc 0046 §3.5) — and a plain <a href> cannot
+// send one, so the download goes through fetch and a blob URL.
+//
+// That means the archive lands in the page's memory before it lands on
+// disk, which a streaming <a download> would not have done. It is the
+// price of the bundle having one address instead of an endpoint named
+// after downloading, and it is bounded by what a curated knowledge base
+// holds. A real backup belongs in CI, where `ochakai export` streams it
+// (docs/guides/operating.md).
+async function downloadBundle(e) {
+  e.preventDefault();
+  const res = await fetch(BASE + '/api/v1/bundle/', { headers: { Accept: 'application/gzip' } });
+  if (!res.ok) {
+    toast('Export failed: ' + res.status);
+    return;
+  }
+  const url = URL.createObjectURL(await res.blob());
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'ochakai-okf.tar.gz';
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
 async function api(path, opts = {}) {
   // Every call here wants the structured form. It matters at the paths
   // that serve a file by default — index.md and log.md are documents,
@@ -1419,13 +1444,14 @@ function viewHome() {
       <a href="#/review">Review queue</a> — verify or reject what agents drafted ·
       <a href="#/search/reported-wrong">Reported wrong</a> — verified knowledge that came back wrong ·
       <a class="write-only" href="#/new">＋ New entry</a> ·
-      <a href="${BASE}/api/v1/export" title="Download the knowledge base as an OKF bundle (tar.gz)">Export OKF</a>
+      <a href="#" id="home-export" title="Download the knowledge base as an OKF bundle (tar.gz)">Export OKF</a>
     </p>
     <div id="home-index" style="margin-top:1.4rem"><div class="empty">…</div></div>`;
   $('#home-q').addEventListener('keydown', e => {
     if (e.key === 'Enter') { explore.q = e.target.value; location.hash = '#/search'; }
   });
   $('#home-go').addEventListener('click', () => { explore.q = $('#home-q').value; });
+  $('#home-export').addEventListener('click', downloadBundle);
   if (matchMedia('(pointer: fine)').matches) $('#home-q').focus({ preventScroll: true });
   loadDirIndex($('#home-index'), '', 'No knowledge yet — create the first entry.');
 }


### PR DESCRIPTION
## What and why

`GET /api/v1/export` was named after the act of downloading, and could
only ever download one thing. An archive is *the bundle at a path*, so it
is a representation of that path:

```
GET /api/v1/export                    →  GET /api/v1/bundle/   + Accept: application/gzip
GET /api/v1/export?attachments=false  →  GET /api/v1/bundle/?attachments=false + the same header
```

**This completes the fold.** REST: **19 → 14**.

| what went | where it went |
|---|---|
| `GET|PUT|DELETE /api/v1/knowledge/{id}` | `/api/v1/bundle/{id}.md` (#318) |
| `GET /api/v1/knowledge` | `GET /api/v1/search` — a ranking, not a collection (#318) |
| `GET /api/v1/backlinks/{id}` | `links_to=` on search (#319) |
| `GET /api/v1/export` | `Accept: application/gzip` on a bundle path (this) |

What is still addressed outside the bundle is what is not an object of it:
a ranking, a judgment (`verify`, `reject`), a measurement (`usage`,
`queues`, `stats`), an operator task (`move`, `reembed`).

**The archive gains a scope it never had**: any path is a subtree.
`GET /api/v1/bundle/metrics/` archives `metrics/` and everything under it,
matched on segment boundaries like every other path scope (0041). Paths
inside are **not re-rooted** — an archive of `metrics/` carries
`metrics/revenue.md` and imports back where it came from, because this is
a copy of a subtree, not a move of one.

## One thing is genuinely worse

The web UI's "Export OKF" was a plain `<a href>` the browser streamed
straight to disk. **A link cannot send an `Accept` header**, so it now
fetches and hands over a blob — the archive passes through the page's
memory before it reaches disk.

I considered the alternatives and rejected them:

- an `?accept=` query override — a second spelling for the representation,
  which is exactly what this fold exists to remove;
- dropping the button — the web UI is the curation surface, and the
  escape hatch is C1.

So the cost is paid where it is smallest and said out loud in the
changelog: it is bounded by what a curated base holds, and a real backup
belongs in CI, where `ochakai export` still streams it. If that turns out
to be wrong for somebody's base, the fix is a UI-side note pointing at the
CLI, not a second address.

### Which of the seven conditions

C1 (the knowledge leaves whole) and C3 (it leaves as OKF). **The surface
narrows**, so the three questions do not apply — but the third has an
answer: an endpoint, its parameter, its spec block, and a handler are
folded into a representation that already existed.

## Checks

- [x] `gofmt`, `go vet`, `go test -race`, build — clean
- [ ] **`scripts/check --db` could not run — no Docker here.** CI is the
      real check. The export integration tests now go through a
      `getArchive` helper that sets the header, which is the whole
      behavioural difference; `snap.IndexRows` / `AttachmentMeta` gained a
      prefix argument, passed `""` at their existing call sites so those
      assertions are unchanged
- [x] Behavior changes come with tests — the boolean-parameter test moved
      to the new address with the header, and asserts what it always did:
      the parameter is rejected before a snapshot is opened

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — the `/export` block is
      removed and its prose (the streaming caveat, the "no import
      endpoint" reasoning, the server-owned frontmatter keys) folded into
      the bundle `GET`, where the capability now lives
- [x] Lands on every surface it belongs on: REST (the representation), CLI
      (`ochakai export` unchanged, new request underneath), Web UI (same
      button, different mechanism — above). MCP has no bulk export by
      design (0015 §3.1) and still does not
- [x] Widens a surface? It narrows one: `docs/surface.md` REST (15) → (14)

## Design docs

- [x] Alters an accepted decision? No — it finishes implementing 0046
      §3.5, already Accepted. No new number per 0048 §2.1
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyctQUDLJzdoQx7ph6tsCA)_