### PR TITLE
One write command, because the wire has one write (0046 §3.14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,35 @@ last entry.
 
 ### Added
 
+- **BREAKING** — `ochakai create` and `ochakai update` are one command,
+  `ochakai put` (design doc
+  [0046](docs/design/0046-bundle-address-space.md) §3.14):
+
+  ```
+  ochakai create <id> -f entry.md          →  ochakai put <id> -f entry.md --only-if-new
+  ochakai update <id> -f entry.md          →  ochakai put <id> -f entry.md
+  ochakai update <id> --if-match <version> →  ochakai put <id> --if-match <version>
+  ```
+
+  The wire has been create-or-replace since 0043 §3.5 — a write states
+  what the entry should say, and whether the id was free is a
+  precondition rather than a different act. The CLI kept two commands
+  over one endpoint, so a writer had to answer a question the format does
+  not ask, and guessing wrong meant a 409 or an overwrite. `--only-if-new`
+  is the `If-None-Match: *` that `create` always sent; without it, `put`
+  writes.
+
+  Output still distinguishes the three outcomes: `created`, `updated`,
+  `unchanged`. The CLI goes from 28 commands to 27 (docs/surface.md).
+
+  **Two renames 0046 §3.14 called for were not taken**, and the record
+  now says so: `browse` and `delete` keep their names rather than
+  becoming `ls` and `rm`, and `attach` / `detach` are not absorbed. The
+  reasons are in §3.14 — this project's CLI vocabulary is `verify` /
+  `reject` / `queues` rather than unix's, and absorbing the file commands
+  would split the CLI between path-taking and id-taking commands, which
+  is the split §3.5 just removed from REST.
+
 - **BREAKING** — `GET /api/v1/export` is retired. An archive is the
   bundle at a path, so it is a representation of that path (design doc
   [0046](docs/design/0046-bundle-address-space.md) §3.5):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Seed it and poke around:
 
 ```sh
 export OCHAKAI_URL=http://localhost:8080
-go run ./cmd/ochakai create queries/monthly-revenue -f examples/golden-query.md
+go run ./cmd/ochakai put queries/monthly-revenue -f examples/golden-query.md
 go run ./cmd/ochakai search "revenue"
 ```
 

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -31,8 +31,7 @@ var clientCommands = map[string]func(context.Context, []string) error{
 	"browse":    cmdBrowse,
 	"context":   cmdContext,
 	"get":       cmdGet,
-	"create":    cmdCreate,
-	"update":    cmdUpdate,
+	"put":       cmdPut,
 	"verify":    cmdVerify,
 	"reject":    cmdReject,
 	"delete":    cmdDelete,
@@ -785,7 +784,7 @@ func cmdBacklinks(ctx context.Context, args []string) error {
 func cmdGet(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
 		"get",
-		"Usage: ochakai get [flags] <id>\n\nPrint one knowledge entry as an OKF document (YAML frontmatter +\nmarkdown body), and nothing else, so the output round-trips through\n`ochakai update`. Who wrote and confirmed it is an observation rather\nthan part of the document, so it goes to stderr, as attachment metadata\ndoes; --download saves the attachment files themselves (an agent can\nthen read them from disk). --json prints the whole read instead: the\ndocument, the projection under .summary, and the provenance under\n.observed.",
+		"Usage: ochakai get [flags] <id>\n\nPrint one knowledge entry as an OKF document (YAML frontmatter +\nmarkdown body), and nothing else, so the output round-trips through\n`ochakai put`. Who wrote and confirmed it is an observation rather\nthan part of the document, so it goes to stderr, as attachment metadata\ndoes; --download saves the attachment files themselves (an agent can\nthen read them from disk). --json prints the whole read instead: the\ndocument, the projection under .summary, and the provenance under\n.observed.",
 		"  ochakai get metrics/revenue\n  ochakai get queries/sales/monthly-revenue --json | jq -r '.summary.content_hash'\n  ochakai get insights/reading-revenue --download ./img\n")
 	asJSON := fs.Bool("json", false, "print the whole read as JSON (document, summary, observed) instead of the document alone")
 	download := fs.String("download", "", "save the entry's attachments into this directory")
@@ -824,7 +823,7 @@ func cmdGet(ctx context.Context, args []string) error {
 		return err
 	}
 	// stdout stays the document and nothing else, so `ochakai get | …
-	// | ochakai update` is one pipe. What this instance observed is not
+	// | ochakai put` is one pipe. What this instance observed is not
 	// part of the document (design docs 0009, 0043 §3.5), so it goes
 	// where the attachment hints already go.
 	prov := "created by " + k.Observed.CreatedBy.String()
@@ -929,13 +928,30 @@ func cmdDetach(ctx context.Context, args []string) error {
 	return nil
 }
 
-func cmdCreate(ctx context.Context, args []string) error {
+// cmdPut writes an entry, whether or not one was there. The wire has
+// been create-or-replace since design doc 0043 §3.5 — a PUT states what
+// the entry should say, and whether the id was free is a precondition
+// rather than a different act — but the CLI kept `create` and `update`,
+// so a caller had to answer a question the format does not ask. Two
+// commands, one endpoint, and a writer who guessed wrong got 409 or
+// clobbered something.
+//
+// The preconditions are where existence is expressed, as on the wire:
+// --only-if-new is If-None-Match "*" (what `create` always sent), and
+// --if-match is the version `update` took. Neither is the default,
+// because "write this" is what most callers mean.
+//
+// Named `put` and not `write` or `set`: it is the method it sends, and
+// this CLI is a thin client of the REST API (design docs 0004, 0007).
+func cmdPut(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
-		"create",
-		"Usage: ochakai create [flags] [id]\n\nCreate a knowledge entry from -f or stdin. Input is an OKF document\n(--- frontmatter with type, markdown body — the format `ochakai get`\nprints; title is optional, the id's last segment is the display name\nwhen it is absent) or JSON (see api/openapi.yaml). The id is the\nentry's path; pass it as the argument (it overrides an id in the\ninput, and OKF documents carry none — the path is the id). Entries\ndefault to draft; provenance is recorded from your Google identity.",
-		"  ochakai get insights/revenue-seasonality | sed s/40%/45%/ | ochakai create insights/revenue-seasonality-v2\n  ochakai create runbook/restore -f entry.md\n")
+		"put",
+		"Usage: ochakai put [flags] <id>\n\nWrite a knowledge entry from -f or stdin, creating it or replacing\nwhat is there. Input is an OKF document (--- frontmatter with type,\nmarkdown body — the format `ochakai get` prints; title is optional,\nthe id's last segment is the display name when it is absent) or JSON\n(see api/openapi.yaml). The id is the entry's path; pass it as the\nargument (it overrides an id in the input, and OKF documents carry\nnone — the path is the id). New entries default to draft; provenance\nis recorded from your Google identity. Every change is kept as a\nrevision server-side.\nWith --only-if-new the write lands only if the id is free, and fails\ninstead of replacing. With --if-match it lands only if the entry still\nhas the version you read, and fails instead of overwriting someone\nelse's edit.",
+		"  ochakai put runbook/restore -f entry.md\n  ochakai get insights/revenue-seasonality | sed s/40%/45%/ | ochakai put insights/revenue-seasonality-v2 --only-if-new\n")
 	file := fs.String("f", "", "input file (default: stdin)")
-	asJSON := fs.Bool("json", false, "print the created entry as JSON")
+	onlyIfNew := fs.Bool("only-if-new", false, "write only if the id is free; a taken id fails instead of being replaced")
+	ifMatch := fs.String("if-match", "", "write only if the entry still has this `version` — its content hash (`ochakai get <id> --json` prints it as .summary.content_hash; a REST GET returns it as the ETag header); a stale version fails with a conflict instead of overwriting. Verifying or rejecting an entry does not move it: only an edit does")
+	asJSON := fs.Bool("json", false, "print the written entry as JSON")
 	pos, err := parseArgs(fs, args)
 	if err != nil {
 		return err
@@ -957,7 +973,7 @@ func cmdCreate(ctx context.Context, args []string) error {
 	// inputs can get one. Saying so here beats the server's `invalid id ""`,
 	// which describes the id format and not the missing argument.
 	if k.ID == "" {
-		return errors.New("no id: pass the entry's path as the argument (e.g. `ochakai create queries/monthly-revenue -f entry.md`)")
+		return errors.New("no id: pass the entry's path as the argument (e.g. `ochakai put queries/monthly-revenue -f entry.md`)")
 	}
 	c, err := newClient(ctx, *url)
 	if err != nil {
@@ -967,18 +983,26 @@ func cmdCreate(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	// If-None-Match "*": create means create. A PUT with no precondition
-	// would replace an entry that is already there, which is what
-	// `ochakai update` is for.
-	created, _, _, notes, err := c.Put(ctx, k.ID, doc, "", true)
+	written, created, changed, notes, err := c.Put(ctx, k.ID, doc, *ifMatch, *onlyIfNew)
 	if err != nil {
+		var apiErr *apiclient.APIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusPreconditionFailed {
+			return fmt.Errorf("conflict: ochakai://%s changed since the version in --if-match — `ochakai get %s` again, redo the edit, and retry with the new content_hash", k.ID, k.ID)
+		}
 		return err
 	}
-	reportNotes(okf.NoteStoredClaim(notes, claimed, created.Document))
+	reportNotes(okf.NoteStoredClaim(notes, claimed, written.Document))
 	if *asJSON {
-		return printJSON(created)
+		return printJSON(written)
 	}
-	fmt.Printf("created %s (%s)\n", created.URI(), created.Summary.Status)
+	switch {
+	case created:
+		fmt.Printf("created %s (%s)\n", written.URI(), written.Summary.Status)
+	case !changed:
+		fmt.Printf("unchanged %s (%s)\n", written.URI(), written.Summary.Status)
+	default:
+		fmt.Printf("updated %s (%s)\n", written.URI(), written.Summary.Status)
+	}
 	return nil
 }
 
@@ -1000,51 +1024,6 @@ func reportNotes(notes []string) {
 	}
 }
 
-func cmdUpdate(ctx context.Context, args []string) error {
-	fs, url := newFlagSet(
-		"update",
-		"Usage: ochakai update [flags] <id>\n\nReplace a knowledge entry from -f or stdin (OKF document or JSON;\nthe id comes from the argument, the type from the input). Every\nchange is kept as a revision server-side. With --if-match the update\nis conditional: it lands only if the entry still has the version you\nread, and fails instead of overwriting someone else's edit.",
-		"  ochakai get metrics/revenue | $EDITOR /dev/stdin | ochakai update metrics/revenue\n  ochakai update metrics/revenue -f revenue.md\n  ochakai update metrics/revenue -f revenue.md --if-match \"$(ochakai get metrics/revenue --json | jq -r .summary.content_hash)\"\n")
-	file := fs.String("f", "", "input file (default: stdin)")
-	ifMatch := fs.String("if-match", "", "update only if the entry still has this `version` — its content hash (`ochakai get <id> --json` prints it as .summary.content_hash; a REST GET returns it as the ETag header); a stale version fails with a conflict instead of overwriting. Verifying or rejecting an entry does not move it: only an edit does")
-	asJSON := fs.Bool("json", false, "print the updated entry as JSON")
-	id, _, err := idArgs(fs, args, 1)
-	if err != nil {
-		return err
-	}
-	k, claimed, err := readEntry(*file)
-	if err != nil {
-		return err
-	}
-	k.ID = id
-	c, err := newClient(ctx, *url)
-	if err != nil {
-		return err
-	}
-	doc, err := documentOf(k)
-	if err != nil {
-		return err
-	}
-	updated, _, changed, notes, err := c.Put(ctx, id, doc, *ifMatch, false)
-	if err != nil {
-		var apiErr *apiclient.APIError
-		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusPreconditionFailed {
-			return fmt.Errorf("conflict: ochakai://%s changed since the version in --if-match — `ochakai get %s` again, redo the edit, and retry with the new content_hash", id, id)
-		}
-		return err
-	}
-	reportNotes(okf.NoteStoredClaim(notes, claimed, updated.Document))
-	if *asJSON {
-		return printJSON(updated)
-	}
-	if !changed {
-		fmt.Printf("unchanged %s (%s)\n", updated.URI(), updated.Summary.Status)
-		return nil
-	}
-	fmt.Printf("updated %s (%s)\n", updated.URI(), updated.Summary.Status)
-	return nil
-}
-
 // cmdVerify records a verification. Re-verifying an entry that is already
 // verified is the point as much as promoting a draft: it is how a review
 // feed empties (design doc 0025 §6), and `update` cannot express it —
@@ -1052,7 +1031,7 @@ func cmdUpdate(ctx context.Context, args []string) error {
 func cmdVerify(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
 		"verify",
-		"Usage: ochakai verify [flags] <id>\n\nAppend a verification against the entry as it stands: you and the time\nare added to its ledger. The first confirmation and the tenth re-check\nare the same command, and re-checking is what takes an entry out of\nboth review feeds (--sort verified_at, --sort failed).\nIt does not edit the entry: the lifecycle status and the ETag stay put,\nbecause confirming knowledge and publishing it are different acts. Use\n`update` to move a draft to stable.\nVerifying a rejected entry lifts the rejection.",
+		"Usage: ochakai verify [flags] <id>\n\nAppend a verification against the entry as it stands: you and the time\nare added to its ledger. The first confirmation and the tenth re-check\nare the same command, and re-checking is what takes an entry out of\nboth review feeds (--sort verified_at, --sort failed).\nIt does not edit the entry: the lifecycle status and the ETag stay put,\nbecause confirming knowledge and publishing it are different acts. Use\n`put` to move a draft to stable.\nVerifying a rejected entry lifts the rejection.",
 		"  ochakai verify metrics/revenue\n  ochakai verify metrics/revenue --json | jq -r '.observed.verified[-1].at'\n")
 	asJSON := fs.Bool("json", false, "print the verified entry as JSON")
 	id, _, err := idArgs(fs, args, 1)

--- a/cmd/ochakai/client_test.go
+++ b/cmd/ochakai/client_test.go
@@ -135,12 +135,12 @@ func TestExtractTarGzRefusesEscapes(t *testing.T) {
 // Guard: the client dispatch table and domain types stay in sync with the
 // commands documented in usage().
 func TestClientCommandsCoverDesignDoc(t *testing.T) {
-	for _, name := range []string{"search", "queues", "browse", "context", "get", "create", "update", "verify", "reject", "delete", "purge", "reembed", "move", "attach", "detach", "usage", "stats", "report", "revisions", "log", "backlinks", "export", "import", "use", "whoami", "ui", "mcp-stdio", "completion"} {
+	for _, name := range []string{"search", "queues", "browse", "context", "get", "put", "verify", "reject", "delete", "purge", "reembed", "move", "attach", "detach", "usage", "stats", "report", "revisions", "log", "backlinks", "export", "import", "use", "whoami", "ui", "mcp-stdio", "completion"} {
 		if _, ok := clientCommands[name]; !ok {
 			t.Errorf("missing client command %q", name)
 		}
 	}
-	if len(clientCommands) != 28 {
+	if len(clientCommands) != 27 {
 		t.Errorf("unexpected extra client commands: %d", len(clientCommands))
 	}
 	_ = domain.Types // keep the import honest
@@ -353,10 +353,10 @@ func TestImportStrictRefusesBeforeWriting(t *testing.T) {
 	}
 }
 
-// `ochakai update --if-match` sends the version as the If-Match header,
+// `ochakai put --if-match` sends the version as the If-Match header,
 // and a 412 comes back as an actionable conflict message (re-read, redo,
 // retry) rather than the raw server error.
-func TestUpdateIfMatchSendsHeaderAndExplainsConflict(t *testing.T) {
+func TestPutIfMatchSendsHeaderAndExplainsConflict(t *testing.T) {
 	var gotIfMatch string
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /api/v1/bundle/{path...}", func(w http.ResponseWriter, r *http.Request) {
@@ -371,7 +371,7 @@ func TestUpdateIfMatchSendsHeaderAndExplainsConflict(t *testing.T) {
 	if err := os.WriteFile(doc, []byte("---\ntype: metric\ntitle: 売上\n---\n\nbody\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	err := cmdUpdate(context.Background(), []string{"metrics/revenue",
+	err := cmdPut(context.Background(), []string{"metrics/revenue",
 		"-f", doc, "--if-match", "2026-07-01T00:00:00.123456789Z", "--url", srv.URL})
 	if gotIfMatch != `"2026-07-01T00:00:00.123456789Z"` {
 		t.Errorf("If-Match on the wire = %q", gotIfMatch)

--- a/cmd/ochakai/completion.go
+++ b/cmd/ochakai/completion.go
@@ -80,8 +80,7 @@ _ochakai() {
     'browse:list one level of the ID hierarchy (folder view)'
     'context:the one-call read before a data question (full entries)'
     'get:print one entry as an OKF document'
-    'create:create an entry from OKF markdown or JSON'
-    'update:replace an entry (kept as a revision)'
+    'put:write an entry from OKF markdown or JSON, creating or replacing'
     'verify:append a verification (also re-affirms a verified entry)'
     'reject:record that an entry was reviewed and not accepted'
     'delete:soft-delete an entry'
@@ -172,11 +171,8 @@ _ochakai() {
     report)
       _arguments '--note[context recorded with the report]:note:' '--json[print JSON]' '--url[server URL]:url:' '2:outcome:(worked failed)'
       ;;
-    create)
-      _arguments '-f[input file]:file:_files' '--json[print the entry as JSON]' '--url[server URL]:url:'
-      ;;
-    update)
-      _arguments '-f[input file]:file:_files' '--if-match[update only if the entry still has this version (updated_at)]:version:' '--json[print the entry as JSON]' '--url[server URL]:url:'
+    put)
+      _arguments '-f[input file]:file:_files' '--only-if-new[write only if the id is free]' '--if-match[write only if the entry still has this version]:version:' '--json[print the entry as JSON]' '--url[server URL]:url:'
       ;;
     verify)
       _arguments '--json[print the entry as JSON]' '--url[server URL]:url:'
@@ -235,7 +231,7 @@ _ochakai() {
   cmd=${COMP_WORDS[1]}
 
   if [ "$COMP_CWORD" -eq 1 ]; then
-    COMPREPLY=($(compgen -W "search queues browse context get create update verify reject delete purge reembed move attach detach usage stats report revisions backlinks export import use whoami ui mcp-stdio completion serve serve-ui version help" -- "$cur"))
+    COMPREPLY=($(compgen -W "search queues browse context get put verify reject delete purge reembed move attach detach usage stats report revisions backlinks export import use whoami ui mcp-stdio completion serve serve-ui version help" -- "$cur"))
     return
   fi
 
@@ -263,8 +259,7 @@ _ochakai() {
         return
       fi
       opts="--note --json --url" ;;
-    create)        opts="-f --json --url" ;;
-    update)        opts="-f --if-match --json --url" ;;
+    put)           opts="-f --only-if-new --if-match --json --url" ;;
     verify)        opts="--json --url" ;;
     reject)        opts="--note --lift --json --url" ;;
     delete|purge|detach|move) opts="--url" ;;
@@ -303,8 +298,7 @@ complete -c ochakai -n __fish_use_subcommand -a queues -d 'how much work each re
 complete -c ochakai -n __fish_use_subcommand -a browse -d 'list one level of the ID hierarchy (folder view)'
 complete -c ochakai -n __fish_use_subcommand -a context -d 'the one-call read before a data question (full entries)'
 complete -c ochakai -n __fish_use_subcommand -a get -d 'print one entry as an OKF document'
-complete -c ochakai -n __fish_use_subcommand -a create -d 'create an entry from OKF markdown or JSON'
-complete -c ochakai -n __fish_use_subcommand -a update -d 'replace an entry (kept as a revision)'
+complete -c ochakai -n __fish_use_subcommand -a put -d 'write an entry from OKF markdown or JSON, creating or replacing'
 complete -c ochakai -n __fish_use_subcommand -a verify -d 'append a verification (also re-affirms a verified entry)'
 complete -c ochakai -n __fish_use_subcommand -a reject -d 'record that an entry was reviewed and not accepted'
 complete -c ochakai -n __fish_use_subcommand -a delete -d 'soft-delete an entry'
@@ -330,12 +324,12 @@ complete -c ochakai -n __fish_use_subcommand -a serve -d 'start the MCP + REST s
 complete -c ochakai -n __fish_use_subcommand -a serve-ui -d 'serve the team web UI as a deployed service'
 complete -c ochakai -n __fish_use_subcommand -a version -d 'print the version'
 
-complete -c ochakai -n '__fish_seen_subcommand_from search queues browse context get create update verify reject delete purge reembed move attach detach usage stats report revisions log backlinks export import whoami ui mcp-stdio' -l url -x -d 'server URL'
+complete -c ochakai -n '__fish_seen_subcommand_from search queues browse context get put verify reject delete purge reembed move attach detach usage stats report revisions log backlinks export import whoami ui mcp-stdio' -l url -x -d 'server URL'
 complete -c ochakai -n '__fish_seen_subcommand_from ui' -l port -x -d 'port on 127.0.0.1'
 complete -c ochakai -n '__fish_seen_subcommand_from import' -l dry-run -d 'parse and list, write nothing'
 complete -c ochakai -n '__fish_seen_subcommand_from import' -l strict -d 'fail on any note or skip'
 complete -c ochakai -n '__fish_seen_subcommand_from import' -F
-complete -c ochakai -n '__fish_seen_subcommand_from search queues browse context get create update verify reject reembed attach usage stats report revisions backlinks whoami' -l json -d 'print raw JSON'
+complete -c ochakai -n '__fish_seen_subcommand_from search queues browse context get put verify reject reembed attach usage stats report revisions backlinks whoami' -l json -d 'print raw JSON'
 complete -c ochakai -n '__fish_seen_subcommand_from stats' -l days -x -d 'flow window in days, 1-180'
 complete -c ochakai -n '__fish_seen_subcommand_from report' -l note -x -d 'context recorded with the report'
 complete -c ochakai -n '__fish_seen_subcommand_from report' -a 'worked failed'
@@ -362,8 +356,9 @@ complete -c ochakai -n '__fish_seen_subcommand_from reembed' -l limit -x -d 'max
 complete -c ochakai -n '__fish_seen_subcommand_from reembed' -l once -d 'a single pass'
 complete -c ochakai -n '__fish_seen_subcommand_from context' -l budget -x -d 'stop rendering after ~bytes'
 complete -c ochakai -n '__fish_seen_subcommand_from context' -l min-score -x -d 'drop hits below this score'
-complete -c ochakai -n '__fish_seen_subcommand_from create update' -s f -r -F -d 'input file'
-complete -c ochakai -n '__fish_seen_subcommand_from update' -l if-match -x -d 'update only if the entry still has this version (updated_at)'
+complete -c ochakai -n '__fish_seen_subcommand_from put' -s f -r -F -d 'input file'
+complete -c ochakai -n '__fish_seen_subcommand_from put' -l only-if-new -d 'write only if the id is free'
+complete -c ochakai -n '__fish_seen_subcommand_from put' -l if-match -x -d 'write only if the entry still has this version'
 complete -c ochakai -n '__fish_seen_subcommand_from use' -l name -x -d 'name to save the URL under'
 complete -c ochakai -n '__fish_seen_subcommand_from use' -a '(ochakai use 2>/dev/null | cut -c3- | cut -f1)'
 complete -c ochakai -n '__fish_seen_subcommand_from completion' -a 'zsh bash fish'

--- a/cmd/ochakai/main.go
+++ b/cmd/ochakai/main.go
@@ -92,8 +92,8 @@ Client commands (talk to a server; --url > $OCHAKAI_URL > "use" selection):
   browse [prefix]         list one level of the ID hierarchy (folder view)
   context <question>      the one-call read before a data question (full entries)
   get <id>                print one entry as an OKF document
-  create [id] [-f file]   create an entry from OKF markdown or JSON
-  update <id>             replace an entry (every change kept as a revision)
+  put <id> [-f file]      write an entry from OKF markdown or JSON, creating
+                          or replacing (every change kept as a revision)
   verify <id>             record a verification (re-affirms a verified entry too)
   delete <id>             soft-delete an entry (history retained)
   purge <id>              hard-delete a soft-deleted entry, freeing its id

--- a/cmd/ochakai/main_test.go
+++ b/cmd/ochakai/main_test.go
@@ -21,12 +21,12 @@ func TestUsageAddressesEntriesByPath(t *testing.T) {
 	}
 }
 
-// Guard: every `ochakai create` we ship names the entry's id. The id is an
+// Guard: every `ochakai put` we ship names the entry's id. The id is an
 // argument and an OKF document carries none (design doc 0017), so a
 // flags-only invocation is one an agent following our own instructions
 // cannot complete — it fails on the server with a format complaint about
 // an id it was never told to pass.
-func TestShippedCreateExamplesPassAnID(t *testing.T) {
+func TestShippedPutExamplesPassAnID(t *testing.T) {
 	for _, f := range []string{
 		"../../README.md",
 		"../../CONTRIBUTING.md",
@@ -39,18 +39,18 @@ func TestShippedCreateExamplesPassAnID(t *testing.T) {
 			t.Fatalf("read %s: %v", f, err)
 		}
 		for _, line := range strings.Split(string(content), "\n") {
-			_, rest, found := strings.Cut(line, "ochakai create")
+			_, rest, found := strings.Cut(line, "ochakai put")
 			if !found {
 				continue
 			}
 			rest = strings.TrimLeft(rest, " ")
-			// `ochakai create -h` prints the help that explains the id; it is
+			// `ochakai put -h` prints the help that explains the id; it is
 			// the one invocation that needs none.
 			if strings.HasPrefix(rest, "-h") || strings.HasPrefix(rest, "--help") {
 				continue
 			}
 			if rest == "" || strings.HasPrefix(rest, "-") {
-				t.Errorf("%s documents `ochakai create` without an id: %s", f, strings.TrimSpace(line))
+				t.Errorf("%s documents `ochakai put` without an id: %s", f, strings.TrimSpace(line))
 			}
 		}
 	}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -27,8 +27,8 @@ Client commands (talk to a server; --url > $OCHAKAI_URL > "use" selection):
   browse [prefix]         list one level of the ID hierarchy (folder view)
   context <question>      the one-call read before a data question (full entries)
   get <id>                print one entry as an OKF document
-  create [id] [-f file]   create an entry from OKF markdown or JSON
-  update <id>             replace an entry (every change kept as a revision)
+  put <id> [-f file]      write an entry from OKF markdown or JSON, creating
+                          or replacing (every change kept as a revision)
   verify <id>             record a verification (re-affirms a verified entry too)
   delete <id>             soft-delete an entry (history retained)
   purge <id>              hard-delete a soft-deleted entry, freeing its id
@@ -196,32 +196,6 @@ Examples:
   ochakai context "activation rate" --prefix teams/growth --prefix company
 ```
 
-## ochakai create
-
-```
-Usage: ochakai create [flags] [id]
-
-Create a knowledge entry from -f or stdin. Input is an OKF document
-(--- frontmatter with type, markdown body — the format `ochakai get`
-prints; title is optional, the id's last segment is the display name
-when it is absent) or JSON (see api/openapi.yaml). The id is the
-entry's path; pass it as the argument (it overrides an id in the
-input, and OKF documents carry none — the path is the id). Entries
-default to draft; provenance is recorded from your Google identity.
-
-Flags:
-  -f string
-    	input file (default: stdin)
-  -json
-    	print the created entry as JSON
-  -url ochakai use
-    	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
-
-Examples:
-  ochakai get insights/revenue-seasonality | sed s/40%/45%/ | ochakai create insights/revenue-seasonality-v2
-  ochakai create runbook/restore -f entry.md
-```
-
 ## ochakai delete
 
 ```
@@ -281,7 +255,7 @@ Usage: ochakai get [flags] <id>
 
 Print one knowledge entry as an OKF document (YAML frontmatter +
 markdown body), and nothing else, so the output round-trips through
-`ochakai update`. Who wrote and confirmed it is an observation rather
+`ochakai put`. Who wrote and confirmed it is an observation rather
 than part of the document, so it goes to stderr, as attachment metadata
 does; --download saves the attachment files themselves (an agent can
 then read them from disk). --json prints the whole read instead: the
@@ -441,6 +415,42 @@ Flags:
 Examples:
   ochakai delete terms/obsolete-kpi
   ochakai purge terms/obsolete-kpi
+```
+
+## ochakai put
+
+```
+Usage: ochakai put [flags] <id>
+
+Write a knowledge entry from -f or stdin, creating it or replacing
+what is there. Input is an OKF document (--- frontmatter with type,
+markdown body — the format `ochakai get` prints; title is optional,
+the id's last segment is the display name when it is absent) or JSON
+(see api/openapi.yaml). The id is the entry's path; pass it as the
+argument (it overrides an id in the input, and OKF documents carry
+none — the path is the id). New entries default to draft; provenance
+is recorded from your Google identity. Every change is kept as a
+revision server-side.
+With --only-if-new the write lands only if the id is free, and fails
+instead of replacing. With --if-match it lands only if the entry still
+has the version you read, and fails instead of overwriting someone
+else's edit.
+
+Flags:
+  -f string
+    	input file (default: stdin)
+  -if-match version
+    	write only if the entry still has this version — its content hash (`ochakai get <id> --json` prints it as .summary.content_hash; a REST GET returns it as the ETag header); a stale version fails with a conflict instead of overwriting. Verifying or rejecting an entry does not move it: only an edit does
+  -json
+    	print the written entry as JSON
+  -only-if-new
+    	write only if the id is free; a taken id fails instead of being replaced
+  -url ochakai use
+    	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
+
+Examples:
+  ochakai put runbook/restore -f entry.md
+  ochakai get insights/revenue-seasonality | sed s/40%/45%/ | ochakai put insights/revenue-seasonality-v2 --only-if-new
 ```
 
 ## ochakai queues
@@ -712,33 +722,6 @@ Examples:
   claude mcp add --transport http ochakai http://127.0.0.1:8098/mcp
 ```
 
-## ochakai update
-
-```
-Usage: ochakai update [flags] <id>
-
-Replace a knowledge entry from -f or stdin (OKF document or JSON;
-the id comes from the argument, the type from the input). Every
-change is kept as a revision server-side. With --if-match the update
-is conditional: it lands only if the entry still has the version you
-read, and fails instead of overwriting someone else's edit.
-
-Flags:
-  -f string
-    	input file (default: stdin)
-  -if-match version
-    	update only if the entry still has this version — its content hash (`ochakai get <id> --json` prints it as .summary.content_hash; a REST GET returns it as the ETag header); a stale version fails with a conflict instead of overwriting. Verifying or rejecting an entry does not move it: only an edit does
-  -json
-    	print the updated entry as JSON
-  -url ochakai use
-    	ochakai server URL (default: $OCHAKAI_URL, else the ochakai use selection)
-
-Examples:
-  ochakai get metrics/revenue | $EDITOR /dev/stdin | ochakai update metrics/revenue
-  ochakai update metrics/revenue -f revenue.md
-  ochakai update metrics/revenue -f revenue.md --if-match "$(ochakai get metrics/revenue --json | jq -r .summary.content_hash)"
-```
-
 ## ochakai usage
 
 ```
@@ -793,7 +776,7 @@ are the same command, and re-checking is what takes an entry out of
 both review feeds (--sort verified_at, --sort failed).
 It does not edit the entry: the lifecycle status and the ETag stay put,
 because confirming knowledge and publishing it are different acts. Use
-`update` to move a draft to stable.
+`put` to move a draft to stable.
 Verifying a rejected entry lifts the rejection.
 
 Flags:

--- a/docs/design/0046-bundle-address-space.md
+++ b/docs/design/0046-bundle-address-space.md
@@ -450,10 +450,33 @@ human-reviewed`** を出す。検証台帳(0043 §3.2)から導く: `human:` の
 
 - **REST = yes。** 唯一の契約。§3.5 の 8 面。`openapi.yaml` は
   `bundle` の 3 メソッドと、表現ごとのスキーマを記述する。
-- **CLI = yes。** `ochakai get` / `put`(旧 `update`)/ `rm` はパスを取る。
-  `ochakai ls`(旧 `browse`)は生成された `index.md`、`ochakai log` は
-  `log.md` を出す。`attach` / `detach` は `put` / `rm` に吸収される。
+- **CLI = yes。** `ochakai put`(旧 `create` + `update`)は 1 本になる —
+  ワイヤが create-or-replace である以上(0043 §3.5)、存在の有無は
+  precondition であって別の行為ではなく、2 本あることは呼び手に
+  フォーマットが訊いていない問いを答えさせていた。`--only-if-new` が
+  `create` の送っていた `If-None-Match: *`、`--if-match` が `update` の
+  取っていた版である。`ochakai log` は `log.md` を出す。
   `export` / `import` はほぼ恒等の tar 転送になる。
+
+  **実装時に採らなかったものが 2 つある**(0048 §2.3 に従い、本節を直接
+  直してある)。
+
+  1. **`ls` / `rm` という綴りは採らない。** `browse` と `delete` のまま
+     である。0049 §3.4 が `ochakai status` を退けたのと同じ理由で —
+     このプロジェクトの語彙は `verify` / `reject` / `queues` であって
+     unix の習慣ではなく、片方だけを unix 風にすると CLI の中に由来の
+     違う 2 つの語彙が並ぶ。改名は利用者が打つものを変える支払いであり、
+     ここではその対価が「他所の慣習に似ること」しかなかった。
+  2. **`attach` / `detach` は吸収しない。** 吸収するには
+     `get` / `put` / `delete` の引数をバンドルパス(`<id>.md`)に変える
+     必要があり、そうすると **id を取るコマンド**(`verify` / `reject` /
+     `usage` / `report` / `move` / `revisions`)と**パスを取るコマンド**が
+     CLI の中で割れる。REST では `bundle/{path}` と `verify/{id}` が
+     別の**住所**なので割れても筋が通るが、CLI では同じエントリを
+     指す 2 つの綴りになる — §3.5 が REST から取り除いたものそのものが
+     CLI に現れる。`.md` が全呼び出しと全ドキュメント例に付く支払いも、
+     1 の改名より大きい。ファイルを 1 本の書き込み面に畳むなら、
+     引数の形をどうするかを先に決める別の記録が要る。
 - **MCP = yes。** ツールは 8 本: `search_knowledge` / `get_context` /
   `get_knowledge` / `put_knowledge`(`{path, document}`)/ `report_outcome` /
   `delete_knowledge` / `get_knowledge_usage` / `get_attachment`。

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -110,14 +110,13 @@ verify・reject(2)・usage(2)・reembed で 12 操作。残る 2 つは §3.5 �
 - `report_outcome`
 - `search_knowledge`
 
-## CLI (28)
+## CLI (27)
 
 - `ochakai attach`
 - `ochakai backlinks`
 - `ochakai browse`
 - `ochakai completion`
 - `ochakai context`
-- `ochakai create`
 - `ochakai delete`
 - `ochakai detach`
 - `ochakai export`
@@ -127,6 +126,7 @@ verify・reject(2)・usage(2)・reembed で 12 操作。残る 2 つは §3.5 �
 - `ochakai mcp-stdio`
 - `ochakai move`
 - `ochakai purge`
+- `ochakai put`
 - `ochakai queues`
 - `ochakai reembed`
 - `ochakai reject`
@@ -135,7 +135,6 @@ verify・reject(2)・usage(2)・reembed で 12 操作。残る 2 つは §3.5 �
 - `ochakai search`
 - `ochakai stats`
 - `ochakai ui`
-- `ochakai update`
 - `ochakai usage`
 - `ochakai use`
 - `ochakai verify`

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@
 - **[claude-code/](claude-code)** — the recall and write-back loop as Claude Code
   instructions and hooks.
 - **[golden-query.md](golden-query.md)** — one entry on its own, for
-  `ochakai create -f`.
+  `ochakai put -f`.
 
 ## demo/: a knowledge base you can import
 

--- a/examples/claude-code/CLAUDE.md
+++ b/examples/claude-code/CLAUDE.md
@@ -34,7 +34,7 @@ a metric), glossary terms, and table catalog entries. Search it before writing a
 - `ochakai attach <id> <file>` — attach a file to an entry
   (png/jpeg/webp, pdf, plain text; reference it from the body so the
   caption is searchable). If you learn something by looking at an
-  attachment, write it into the body with `ochakai update` — knowledge
+  attachment, write it into the body with `ochakai put` — knowledge
   locked in pixels is invisible to search.
 - `ochakai report <id> worked|failed [--note "what went wrong"]`
   — after acting on knowledge (running an attested computation, running SQL you
@@ -42,8 +42,8 @@ a metric), glossary terms, and table catalog entries. Search it before writing a
   flag verified entries for re-verification, so the next agent doesn't
   trust a stale entry blind. Always report `failed` when a verified entry
   led you to a wrong number.
-- `ochakai create <id> -f entry.md` — write a learning back (OKF markdown
-  as printed by `get`, or JSON; see `ochakai create -h`). The id is the
+- `ochakai put <id> -f entry.md` — write a learning back (OKF markdown
+  as printed by `get`, or JSON; see `ochakai put -h`). The id is the
   entry's path (`queries/sales/monthly-revenue`) and it is an argument:
   an OKF document does not carry one. Entries start as `draft`; your
   identity is recorded as provenance automatically.

--- a/examples/claude-code/hooks/ochakai-write-back.sh
+++ b/examples/claude-code/hooks/ochakai-write-back.sh
@@ -28,5 +28,5 @@ grep -qiE 'SELECT|ochakai|bigquery|warehouse' "$transcript" || exit 0
 
 jq -n '{
   decision: "block",
-  reason: "Before finishing: this session did data work. If a query you wrote proved correct and reusable, or you learned how to read a metric (a baseline, a seasonality, a caveat), write it back to ochakai — search first (including --rejected) to avoid re-proposing, then `ochakai create <path>` (type \"Attested Computation\" with runtime, the SQL in a # Computation fence, and attrs.question; or type \"Insight\"). If nothing durable was learned, finish now without creating anything — do not invent knowledge."
+  reason: "Before finishing: this session did data work. If a query you wrote proved correct and reusable, or you learned how to read a metric (a baseline, a seasonality, a caveat), write it back to ochakai — search first (including --rejected) to avoid re-proposing, then `ochakai put <path>` (type \"Attested Computation\" with runtime, the SQL in a # Computation fence, and attrs.question; or type \"Insight\"). If nothing durable was learned, finish now without creating anything — do not invent knowledge."
 }'

--- a/internal/okf/parse.go
+++ b/internal/okf/parse.go
@@ -12,7 +12,7 @@ import (
 
 // Parse is the inverse of Document: it reads an OKF concept document
 // (YAML frontmatter + markdown body) into a knowledge entry, so
-// `ochakai get` output round-trips through `ochakai update`. Server-owned
+// `ochakai get` output round-trips through `ochakai put`. Server-owned
 // keys (generated, verified, created_by, rejected_*, and their v0.1
 // spellings) never reach a ledger — provenance comes from authentication,
 // never from the payload (design doc 0009) — but they are not thrown away


### PR DESCRIPTION
## What and why

```
ochakai create <id> -f entry.md          →  ochakai put <id> -f entry.md --only-if-new
ochakai update <id> -f entry.md          →  ochakai put <id> -f entry.md
ochakai update <id> --if-match <version> →  ochakai put <id> --if-match <version>
```

The wire has been create-or-replace since 0043 §3.5 — a write states what
the entry should say, and whether the id was free is a *precondition*, not
a different act. The CLI kept two commands over that one endpoint, so a
writer had to answer a question the format does not ask, and guessing
wrong meant a 409 or an overwrite of somebody's work.

`--only-if-new` is the `If-None-Match: *` that `create` always sent;
`--if-match` is the version `update` took. Neither is the default, because
"write this" is what most callers mean. The three outcomes are still
distinguished where it matters — in the output: `created`, `updated`,
`unchanged`.

**CLI: 28 commands → 27.**

## Two renames §3.14 called for, not taken

You picked **B**, and the record now says so rather than leaving a
decision that reads as pending. `docs/design/0046` §3.14 is amended in
place, per 0048 §2.3 and the precedent already set in that doc for
corrections the implementation revealed.

**`ls` / `rm` are not adopted** — `browse` and `delete` keep their names.
This is 0049 §3.4's reasoning applied again: this project's CLI vocabulary
is `verify` / `reject` / `queues`, not unix's, and making two commands
unix-shaped puts two vocabularies of different origin side by side in one
tool. A rename is paid for by everyone who types it, and what it bought
here was resemblance to somebody else's habit.

**`attach` / `detach` are not absorbed.** Absorbing them requires
`get` / `put` / `delete` to take bundle paths (`<id>.md`), which splits
the CLI between path-taking and id-taking commands (`verify`, `reject`,
`usage`, `report`, `move`, `revisions`). On REST that split is fine —
`bundle/{path}` and `verify/{id}` are different *addresses*. On the CLI
they would be two spellings of the same entry in one tool, which is
exactly what §3.5 just removed from REST. The `.md` on every invocation
and every documented example is a larger bill than the rename above.
Folding files into one write face needs the argument shape decided first,
and that is its own record.

### Which of the seven conditions

C4 (no forward-deployed engineer — a command you can run yourself, and one
fewer to learn). **The surface narrows**, so the three questions do not
apply; what folded away is a command, its help, its completions in three
shells, and a paragraph of "which one do I want".

## Checks

- [x] `scripts/check core` clean — `gofmt`, `go vet`, `go test -race`,
      build
- [ ] `scripts/check --db` could not run — no Docker here. This change
      touches no store or REST code, so the DB-gated tests are untouched;
      CI still runs them
- [x] Behavior changes come with tests — the `--if-match` conflict test
      now drives `put`, and the guard that every shipped example names an
      id follows the command rename

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — untouched; this is a CLI
      change over an unchanged wire
- [x] Lands on every surface it belongs on: CLI only. REST already had one
      write, MCP already had one (`put_knowledge`, 0046 §3.14), and the
      web UI's editor is one save
- [x] Widens a surface? It narrows one: `docs/surface.md` CLI (28) → (27)

## Design docs

- [x] Alters an accepted decision? Yes — `docs/design/0046` §3.14 is
      amended in place to record the two spellings not taken and why.
      0046 has not reached a release (its `Status:` says it ships with
      0043's implementation), so 0048 §2.3 makes this a revision of the
      doc rather than a new number, which is how §§2.4/3.3/3.5/3.14 were
      already corrected
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyctQUDLJzdoQx7ph6tsCA)_