### PR TITLE
Call the unit of knowledge what OKF calls it (0054)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,38 @@ last entry.
 
 ### Added
 
+- **BREAKING** — the five MCP tools carrying `knowledge` are renamed to
+  OKF's word for the unit of knowledge, `concept` (design doc
+  [0054](docs/design/0054-concept-is-the-okf-word.md)):
+
+  ```
+  search_knowledge      →  search_concepts
+  get_knowledge         →  get_concept
+  put_knowledge         →  put_concept
+  delete_knowledge      →  delete_concept
+  get_knowledge_usage   →  get_concept_usage
+  ```
+
+  OKF SPEC §2 defines a **concept** as "a single unit of knowledge within
+  a bundle", and a **concept ID** as its path without `.md`. ochakai's own
+  design records and code comments have said "concept" since 0046; once
+  §3.5's fold finished, these tool names were the only place on the wire
+  still saying `knowledge` — REST and the CLI carry none. It is the third
+  time this project has chosen OKF's spelling over its own (0023, 0038),
+  and the last double vocabulary.
+
+  Search alone is plural: `concept` is countable, a search returns many
+  and the rest act on one. `get_context`, `report_outcome` and
+  `get_attachment` keep their names — none of them names the unit. **The
+  tool count stays at 8**, and no argument, response or capability
+  changes.
+
+  Breaking for a client that names these tools in its configuration — an
+  allow-list, a hook, a prompt. A client that reads the advertised tool
+  list needs nothing. Shipping both names was refused: tool schemas are
+  paid for out of the agent's context, and 8 tools would have become 13
+  (0054 §4).
+
 - **BREAKING** — `ochakai create` and `ochakai update` are one command,
   `ochakai put` (design doc
   [0046](docs/design/0046-bundle-address-space.md) §3.14):

--- a/README.md
+++ b/README.md
@@ -385,12 +385,12 @@ And it stays small by refusing things:
 | Tool | Description |
 |---|---|
 | `get_context` | The one call before answering a data question: full entries behind the top hits, links expanded both ways |
-| `search_knowledge` | Cross-type search; verified entries rank higher |
-| `get_knowledge` | Fetch one entry as an OKF document, with its links and attachment metadata |
+| `search_concepts` | Cross-type search; verified entries rank higher |
+| `get_concept` | Fetch one entry as an OKF document, with its links and attachment metadata |
 | `get_attachment` | Fetch a file attached to an entry (dashboard screenshots, ER diagrams, seeds files) |
-| `put_knowledge` | Write learnings back — creates if the id is free, replaces if it is taken; every change is kept as a revision |
-| `delete_knowledge` | Soft-delete (history retained) |
-| `get_knowledge_usage` | Usage totals per entry — draft-promotion evidence, staleness signal |
+| `put_concept` | Write learnings back — creates if the id is free, replaces if it is taken; every change is kept as a revision |
+| `delete_concept` | Soft-delete (history retained) |
+| `get_concept_usage` | Usage totals per entry — draft-promotion evidence, staleness signal |
 | `report_outcome` | Report worked/failed after acting on knowledge — failed reports flag verified entries for re-verification |
 
 Every one of these is a knowledge operation: ochakai never executes SQL
@@ -404,8 +404,8 @@ Every entry is also an **MCP resource** addressable by its canonical URI —
 or `ochakai://queries/sales/top-customers`. Clients that
 support resource references (`@`-mentions) can pull an entry in as an OKF
 document — frontmatter and body — without a tool call; discovery
-stays with `get_context`/`search_knowledge`. Read tools carry `readOnly`
-annotations and `delete_knowledge` a `destructive` one, so client
+stays with `get_context`/`search_concepts`. Read tools carry `readOnly`
+annotations and `delete_concept` a `destructive` one, so client
 auto-approval policies work without parsing descriptions.
 
 `import` is the one place the CLI is more than a thin client: there is no

--- a/cmd/ochakai/mcpstdio_test.go
+++ b/cmd/ochakai/mcpstdio_test.go
@@ -26,7 +26,7 @@ func remoteMCP(t *testing.T) (base string, tools []string) {
 	type args struct {
 		Q string `json:"q" jsonschema:"a query"`
 	}
-	mcp.AddTool(s, &mcp.Tool{Name: "search_knowledge", Description: "search"},
+	mcp.AddTool(s, &mcp.Tool{Name: "search_concepts", Description: "search"},
 		func(ctx context.Context, _ *mcp.CallToolRequest, in args) (*mcp.CallToolResult, any, error) {
 			return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "hit:" + in.Q}}}, nil, nil
 		})
@@ -37,7 +37,7 @@ func remoteMCP(t *testing.T) (base string, tools []string) {
 
 	srv := httptest.NewServer(mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return s }, nil))
 	t.Cleanup(srv.Close)
-	return srv.URL, []string{"get_context", "search_knowledge"}
+	return srv.URL, []string{"get_context", "search_concepts"}
 }
 
 // The bridge carries whatever the remote offers. It must not hold a copy
@@ -79,7 +79,7 @@ func TestBridgePassesMessagesThrough(t *testing.T) {
 
 	// A call has to survive the round trip too, arguments and all.
 	out, err := cs.CallTool(ctx, &mcp.CallToolParams{
-		Name:      "search_knowledge",
+		Name:      "search_concepts",
 		Arguments: map[string]any{"q": "revenue"},
 	})
 	if err != nil {

--- a/docs/design/0054-concept-is-the-okf-word.md
+++ b/docs/design/0054-concept-is-the-okf-word.md
@@ -1,0 +1,130 @@
+# ochakai 設計ドキュメント 0054: 知識の単位は concept と呼ぶ
+
+Status: Accepted(2026-07-29)。MCP のツール名 5 本が持つ `knowledge` を、
+OKF SPEC §2 が定義する語 `concept` に改める — `search_concepts` /
+`get_concept` / `put_concept` / `delete_concept` / `get_concept_usage`。
+リソーステンプレートの表示名も同じ語に揃える。**ツールは 8 本のまま**で、
+引数・応答・スキーマ・能力はどれも変わらない。ツール名を設定に書いて
+いるクライアントが壊れる
+Date: 2026-07-29
+
+## 1. 問題: 同じものに二つの名前が残っている
+
+[0046](0046-bundle-address-space.md) §3.5 の畳み込みが終わった時点で、
+**ワイヤ上に残る `knowledge` は MCP のツール名 5 本だけ**になった。
+
+| 面 | `knowledge` を含む要素 |
+|---|---|
+| REST | 0(`/api/v1/knowledge` は `/search` に、`/knowledge/{id}` は `/bundle/{path}` に) |
+| CLI | 0(元から) |
+| MCP | **5**(`search_knowledge` / `get_knowledge` / `put_knowledge` / `delete_knowledge` / `get_knowledge_usage`) |
+
+一方 OKF SPEC §2 は、バンドルの中の知識の単位を **concept** と定義して
+いる — 「A single unit of knowledge within a bundle, represented as one
+markdown document」。パスから `.md` を除いたものが **concept ID** で
+ある。
+
+そして**ochakai 自身が既にその語で書いている**。0046 §2 の表は
+「**概念(concept)**」と書き、§3.5 は「概念かファイルかを決めるのは
+frontmatter の `type` キー」と書く。`internal/restapi` のコメントは
+"a concept at `<id>.md`" と書く。残っているのはツール名だけである。
+
+> **同じものを、文書では concept と呼び、エージェントには knowledge と
+> 名乗っている。**
+
+## 2. 世界観: 綴りが割れたら OKF を採る — 既に二度した判断
+
+これは新しい判断ではない。
+
+- [0023](0023-okf-type-vocabulary.md) は内部スラグと OKF 表示名の
+  二重語彙を廃し、型の値を OKF の綴りそのものにした。
+- [0038](0038-type-vocabulary-realignment.md) は推奨型の語彙を OKF の
+  証拠に合わせ直した。
+
+どちらも「ochakai の語と OKF の語が割れたとき、OKF を採る」という同じ形
+である。今回は**単位そのものの名前**で、二重語彙としては最後に残った
+ものである。
+
+理由は 0023 が書いたのと同じで、**二つの語彙は利用者に翻訳表を持たせる**
+から。ochakai のバンドルを読む者は SPEC の語に必ず出会う。そこで
+concept と呼ばれているものが、ツールでは knowledge と呼ばれていると、
+覚えることが一つ増える。
+
+## 3. 決定
+
+### 3.1 改名する 5 本
+
+| 旧 | 新 |
+|---|---|
+| `search_knowledge` | `search_concepts` |
+| `get_knowledge` | `get_concept` |
+| `put_knowledge` | `put_concept` |
+| `delete_knowledge` | `delete_concept` |
+| `get_knowledge_usage` | `get_concept_usage` |
+
+**検索だけ複数形**である。`knowledge` は不可算名詞なので単複を問われ
+なかったが、`concept` は可算で、検索は複数を返し残りは一つを扱う。
+名前が数を偽らないほうがよい。
+
+### 3.2 変えないもの
+
+- **`get_context` / `report_outcome`** — どちらも concept を名指して
+  いない。前者は問いに対する読み、後者は結果の報告である。
+- **`get_attachment`** — 0046 が「添付」という概念を溶かしたので、この
+  名前も古びている。だが**それは別の問い**(ファイルを何と呼ぶか)で
+  あり、OKF はファイルをファイルと呼ぶ。本ドキュメントは知識の単位の
+  名前に限る。
+- **ツールの本数 8**、引数、応答、スキーマ、`ochakai://` の URI 形。
+  改名であって、能力の変更ではない。
+
+### 3.3 リソーステンプレートの表示名
+
+`Name: "knowledge"` / `Title: "Knowledge entry"` も `concept` に揃える。
+エージェントが `@` で参照するときに見える名前であり、ツール名と別の語で
+あってよい理由がない。
+
+### 3.4 `domain.Knowledge` は改名しない
+
+Go の型名は 281 箇所にあるが、**利用者は内部パッケージを覚えなくてよい**
+([docs/surface.md](../surface.md) の「数えていないもの」)。外形を 1
+バイトも変えない機械的差分は、この決定の一部ではない。いつか触るとすれば
+それ自身の理由でであって、この記録の射程ではない。
+
+### 3.5 各サーフェス(0015)
+
+**MCP のみ。** REST と CLI は既に `knowledge` を持たず(§1)、Web UI は
+画面の語で、`ochakai://` の URI はパスである。1 面だけの変更になるのは、
+他の面が先に畳まれたからである。
+
+## 4. 反対の論拠と、採らなかった案
+
+**いちばん強い反対は「`search_knowledge` はエージェントに『このサーバは
+何屋か』を伝えている」**である。初見のエージェントが `search_concepts`
+を見ても、OKF を知らなければ何の concept か分からない。`knowledge` は
+その一語で用途を名乗る。
+
+採らなかった理由は二つある。ツール名が担うのは**他サーバのツールと並べて
+曖昧でないこと**であり(`internal/mcpserver` の冒頭がそう書いている)、
+何屋かを伝えるのは **description** である — description は
+「knowledge base」と言い続ける。そして OKF を知らないエージェントも、
+ochakai のバンドルを読めば SPEC の語に出会う。二つの語を覚えさせるほうが
+高い。
+
+- **両方の名前を出す(別名)。** ツールが 8 本から 13 本になる。
+  スキーマはエージェントのコンテキストから支払われるので本数は予算で
+  ある(0015 §3.1)。互換のために予算を 6 割増やすのは、この
+  プロジェクトが最も避けてきた形の支払いである。
+- **`search_okf_concepts` のように出自を名前に書く。** 冗長で、
+  ochakai のツールが OKF のものであることはツール名の仕事ではない。
+- **何もしない。** §1 の二重語彙が残る。0023 と 0038 で二度同じ判断を
+  している以上、ここだけ残す理由がない。
+
+## 5. 壊れるもの
+
+- **ツール名を設定に書いているクライアント** — allow-list、フック、
+  プロンプトの中の名指し。MCP はツール一覧を接続時に配るので、名前を
+  書いていないクライアントは何もしなくてよい。
+- 0.x では互換を保証しない([docs/compatibility.md](../compatibility.md))。
+  changelog に旧名と新名の対応表を置く。
+- **サーバの能力は変わらない。** 同じ 8 本、同じ引数、同じ応答。
+  改名だけである。

--- a/docs/design/README.en.md
+++ b/docs/design/README.en.md
@@ -395,6 +395,25 @@ For the shape of the system rather than the history of it, read
   *For a user:* sending `links` on write is ignored; write a markdown link
   in the body instead.
 
+- **[0054 The unit of knowledge is called a concept](0054-concept-is-the-okf-word.md)**
+  — *Accepted.* Renames the five MCP tools carrying `knowledge` to OKF
+  SPEC §2's word: `search_concepts`, `get_concept`, `put_concept`,
+  `delete_concept`, `get_concept_usage`. Once 0046 §3.5's fold was done,
+  those tool names were the only `knowledge` left on the wire — REST and
+  the CLI carry none, and both the design records and the code comments
+  already said "concept". It is the third application of "when ochakai's
+  spelling and OKF's disagree, OKF wins" (after 0023 and 0038), and the
+  last of the double vocabularies. Search alone is plural because
+  `concept` is countable. The tool count stays at 8 and no argument,
+  response or capability changes; `get_attachment` is a different
+  question and `domain.Knowledge` is internal, so both stay. §4 records
+  the argument against — a tool name is what tells an unfamiliar agent
+  what the server is for — and why shipping both names (13 tools) was
+  refused.
+  *For a user:* breaking for any client that names these tools in its
+  configuration; a client that only reads the advertised list needs
+  nothing.
+
 ## Attachments
 
 - **[0008 Image attachments](0008-image-attachments.md)** — *Superseded by

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -33,6 +33,7 @@ PR の説明で足り、まだリリースに乗っていない決定の改訂�
 | OKF 互換・バンドル・保存形 | [0046](0046-bundle-address-space.md) が現行。[0047](0047-fm-carries-okf-keys.md)(フィルタの語彙)、[0037](0037-stale-and-source-lookup.md)(期限と引用元)、[0024](0024-links-from-body.md)(リンク)、[0022](0022-filename-as-name.md)(名前)、[0019](0019-release-review-adjustments.md)(ID 文字種) |
 | 住所とパス | [0017](0017-path-addressing.md)、[0041](0041-path-scoped-search.md)(prefix)、[0021](0021-move-and-webui-refinements.md)(move) |
 | 型の語彙 | [0038](0038-type-vocabulary-realignment.md) |
+| 知識の単位の呼び名 | [0054](0054-concept-is-the-okf-word.md) |
 | 添付ファイル | [0046](0046-bundle-address-space.md)(バンドルのオブジェクト)、[0020](0020-attachment-search.md)(検索) |
 | 検索と埋め込み | [0053](0053-embeddings-by-default.md)(既定・次元変更)、[0020](0020-attachment-search.md)(添付)、[0041](0041-path-scoped-search.md)(prefix)、[0033](0033-context-hits-are-a-ranking.md)(context) |
 | サーフェスの配分 | [0015](0015-surface-consistency.md)、[0004](0004-cli.md)(CLI)、[0007](0007-api-only-cli.md)、[0033](0033-context-hits-are-a-ranking.md)(context)、[0039](0039-mcp-stdio-bridge.md)(MCP stdio)、[0050](0050-listings-page-rankings-do-not.md)(一覧と順位の分け方) |
@@ -225,6 +226,20 @@ index の現行 / Superseded の表示が本体のヘッダと一致すること
   `Golden Query` を外し、`Skill` / `Playbook` / `Policy` / `API Endpoint` を
   足して 11 型に(退役した綴りは自由型として存続、マイグレーションなし)。
   語彙を述べる 11 箇所を `domain.TypesHint()` と外側のテストで固定する。
+- [0054 知識の単位は concept と呼ぶ](0054-concept-is-the-okf-word.md)
+  — **Accepted**。MCP のツール名 5 本の `knowledge` を OKF SPEC §2 の語
+  `concept` に改める(`search_concepts` / `get_concept` / `put_concept` /
+  `delete_concept` / `get_concept_usage`)。0046 §3.5 の畳み込みが終わった
+  時点で、ワイヤ上の `knowledge` は MCP のツール名だけになっていた
+  — REST も CLI も 0 で、設計文書(0046 §2)もコードのコメントも既に
+  「概念(concept)」と書いていた。0023・0038 と同じ「綴りが割れたら OKF
+  を採る」の三度目で、二重語彙としては最後に残ったものである。検索だけ
+  複数形なのは concept が可算だから(§3.1)。ツールは 8 本のまま、
+  引数も応答も変わらない。`get_attachment` は別の問い、
+  `domain.Knowledge` は内部なので射程外(§3.2、§3.4)。反対の論拠
+  ——「`search_knowledge` はエージェントに何屋かを伝えている」—— と、
+  別名を並べる案(ツールが 13 本になる)を退けた理由は §4。
+
 - [0024 リンクは本文から導出する](0024-links-from-body.md) —
   **Accepted**(本文の `ochakai://` は 0046 §3.6 が退役させ、SPEC §6 の
   バンドル絶対と相対だけが正準形になる)。構造化 `links` フィールドを

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -79,7 +79,7 @@ index — about 16 ms across 5000 entries.
 
 ### Can an agent overwrite or delete knowledge a human verified?
 
-Not over MCP. `put_knowledge` and `delete_knowledge` both refuse an entry
+Not over MCP. `put_concept` and `delete_concept` both refuse an entry
 a human has ruled on — verified, rejected or deprecated — and the refusal
 says what to do instead:
 
@@ -87,7 +87,7 @@ says what to do instead:
 > this surface has no If-Match precondition to replace curated knowledge
 > safely. If it is wrong, say so with report_outcome failed — that puts it
 > in the re-verification feed. If you have something better,
-> put_knowledge a new draft. A human changes curated entries from the
+> put_concept a new draft. A human changes curated entries from the
 > web UI or CLI.
 
 This is not authorization — a human on the same deployment can edit

--- a/docs/guides/golden-query-canary.md
+++ b/docs/guides/golden-query-canary.md
@@ -39,7 +39,7 @@ the document — question, `runtime` and `# Computation` fence included.
 
 Straight REST is
 `GET /api/v1/search?type=Attested%20Computation&trust=human-reviewed&sort=verified_at&limit=100`;
-over MCP, `search_knowledge` with `sort: "verified_at"` returns the same
+over MCP, `search_concepts` with `sort: "verified_at"` returns the same
 feed. `sort=verified_at` orders by verification time, oldest first, with
 unverified entries last. "Verified queries not re-checked in 90 days" is
 where a canary run starts. Checking out an OKF export
@@ -90,7 +90,7 @@ canonicalize a run against. ochakai takes no part in this step.
   accumulated failures can be picked up for re-verification first. **The
   `sort=failed` re-verification feed** (`ochakai search --sort failed
   --trust human-reviewed`, REST: `GET /api/v1/search?sort=failed`, MCP:
-  `search_knowledge` with `sort: "failed"`) lists them in order of how
+  `search_concepts` with `sort: "failed"`) lists them in order of how
   often they were reported wrong. It is the evidence-based entrance,
   complementing the time-based `sort=verified_at` (design doc 0025).
 
@@ -149,7 +149,7 @@ aggregates as an artifact and diffing those is the easy version.
 ## A supporting signal: usage telemetry
 
 `ochakai usage queries/<id>` (REST: `GET /api/v1/usage/queries/<id>`,
-MCP: `get_knowledge_usage`) returns how often that query was actually
+MCP: `get_concept_usage`) returns how often that query was actually
 returned by a search or fetched, the worked and failed report counts, and
 when it was last used. **A verified entry nobody has used in a long time**
 is a reason to lower its canary priority — or to consider deprecating it.

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -101,14 +101,19 @@ verify・reject(2)・usage(2)・reembed で 12 操作。残る 2 つは §3.5 �
 
 ## MCP (8)
 
-- `delete_knowledge`
+- `delete_concept`
 - `get_attachment`
+- `get_concept`
+- `get_concept_usage`
 - `get_context`
-- `get_knowledge`
-- `get_knowledge_usage`
-- `put_knowledge`
+- `put_concept`
 - `report_outcome`
-- `search_knowledge`
+- `search_concepts`
+
+8 本のまま、[0054](design/0054-concept-is-the-okf-word.md) が 5 本を
+改名した — 知識の単位は OKF SPEC §2 の語で **concept** であり、文書が
+既にその語で書いていたのにツール名だけが `knowledge` を名乗っていた。
+能力も引数も応答も変わらない。
 
 ## CLI (27)
 

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -159,7 +159,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"After acting on knowledge (running an attested computation, writing SQL from a metric definition), report " +
 			"whether it actually worked with report_outcome — failed reports are how stale " +
 			"verified knowledge gets caught. " +
-			"Write learnings back with put_knowledge; leave new entries as drafts for a human to " +
+			"Write learnings back with put_concept; leave new entries as drafts for a human to " +
 			"confirm — status is how ready an entry is (draft, stable, deprecated), and whether " +
 			"anyone checked it is recorded separately, by whoever checked it. Knowledge that was " +
 			"reviewed and not accepted is marked rejected by a human, with the reason; " +
@@ -170,18 +170,18 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 	// Expose entries as MCP resources so clients can @-mention them by their
 	// canonical ochakai:// URI. Only the template is advertised — enumerating
 	// every entry in resources/list would flood the client, so discovery stays
-	// with search_knowledge/get_context and the URI is the addressing scheme.
+	// with search_concepts/get_context and the URI is the addressing scheme.
 	// {+id} (RFC 6570 reserved expansion) lets the slash-separated id match;
 	// a plain {id} would stop at the first slash.
 	s.AddResourceTemplate(&mcp.ResourceTemplate{
-		Name:     "knowledge",
-		Title:    "Knowledge entry",
+		Name:     "concept",
+		Title:    "Concept",
 		MIMEType: "text/markdown",
 		Description: "A single knowledge entry as an OKF document: YAML frontmatter (title, " +
 			"status, provenance, type-specific attrs) followed by the markdown body and its " +
 			"links. Address by canonical URI — the scheme plus the entry's id (its path), " +
 			"e.g. ochakai://metrics/revenue or ochakai://queries/sales/top-customers. Discover " +
-			"URIs with search_knowledge or get_context; get_knowledge returns the same entry " +
+			"URIs with search_concepts or get_context; get_concept returns the same entry " +
 			"as JSON.",
 		URITemplate: "ochakai://{+id}",
 	}, func(ctx context.Context, req *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
@@ -214,7 +214,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 	})
 
 	mcp.AddTool(s, &mcp.Tool{
-		Name:        "search_knowledge",
+		Name:        "search_concepts",
 		Annotations: readOnly,
 		Description: "Search the knowledge base across all types (recommended: " + domain.TypesHint() + "; custom types welcome). " +
 			"Verified entries rank higher. Filter with types/statuses/tags. Returns scored hits. " +
@@ -258,9 +258,9 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"base (verified entries rank higher), returns the full entries behind the top hits, " +
 			"and expands one hop through links so the insight explaining a metric and the " +
 			"computation answering the question arrive together. Prefer this over search+get chains; " +
-			"fall back to search_knowledge/get_knowledge for precise lookups. \"entries\" is the " +
+			"fall back to search_concepts/get_concept for precise lookups. \"entries\" is the " +
 			"knowledge; \"hits\" is only the ranking behind it. Entries that do not fit the byte " +
-			"budget are listed under \"outline\" — fetch any of them by id with get_knowledge.",
+			"budget are listed under \"outline\" — fetch any of them by id with get_concept.",
 	}, tool(svc, func(ctx context.Context, _ domain.Actor, in contextIn) (*mcp.CallToolResult, contextOut, error) {
 		budget := in.Budget
 		if budget <= 0 {
@@ -284,7 +284,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 	}))
 
 	mcp.AddTool(s, &mcp.Tool{
-		Name:        "get_knowledge",
+		Name:        "get_concept",
 		Annotations: readOnly,
 		Description: "Get one knowledge entry by id, including its full markdown body, structured attrs, " +
 			"links, and attachment metadata (files the body references: images, PDFs, plain-text data — " +
@@ -301,7 +301,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 		return nil, knowledgeOut{Knowledge: v}, nil
 	}))
 
-	// put_knowledge is the one write face (design doc 0046 §3.14). It was
+	// put_concept is the one write face (design doc 0046 §3.14). It was
 	// create_knowledge and update_knowledge, which asked the agent a
 	// question the document does not answer: a write states what the
 	// entry should say, and whether an id was already taken is not part
@@ -309,7 +309,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 	// agent's context than the three this surface was going to drop put
 	// together — the merge is where the saving actually was.
 	mcp.AddTool(s, &mcp.Tool{
-		Name:        "put_knowledge",
+		Name:        "put_concept",
 		Annotations: nonDestructive,
 		Description: "Write a knowledge entry: create it if the id is free, replace it if it is taken. " +
 			"Write back what you learned: metric caveats, confirmed answers, glossary terms. " +
@@ -317,12 +317,12 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"names no status reads as stable (OKF SPEC §5.4). Your identity is recorded as created_by, " +
 			"and the entry stays unverified until a person confirms it. " +
 			"The document you send is the whole entry: a key you leave out is cleared, so on a replace, " +
-			"get_knowledge first, change what you mean to change, and send the rest back as it came. " +
+			"get_concept first, change what you mean to change, and send the rest back as it came. " +
 			"Every change is kept as a revision; a write identical to the stored content writes nothing. " +
 			"Before writing something new, search with rejected=true to avoid re-proposing knowledge " +
 			"that was already rejected (the ruling records why). " +
 			"Entries a human has ruled on — verified, rejected, or deprecated — cannot be replaced from " +
-			"this surface: if a verified entry is wrong, report_outcome failed; otherwise put_knowledge " +
+			"this surface: if a verified entry is wrong, report_outcome failed; otherwise put_concept " +
 			"a better draft at a different id and let a human promote it. " +
 			"status is the lifecycle only — draft, stable, deprecated (OKF SPEC §5.4). Whether anyone " +
 			"has confirmed the entry is not yours to set: it comes from the verification ledger, and " +
@@ -378,10 +378,10 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 	}))
 
 	mcp.AddTool(s, &mcp.Tool{
-		Name:        "delete_knowledge",
+		Name:        "delete_concept",
 		Annotations: destructive,
 		Description: "Soft-delete a knowledge entry. History is retained as revisions; " +
-			"put_knowledge on the same id revives it. Entries a human has ruled on — verified, " +
+			"put_concept on the same id revives it. Entries a human has ruled on — verified, " +
 			"rejected, or deprecated — cannot be deleted from this surface; deleting a rejected " +
 			"entry and recreating it would erase the record of why it was turned down.",
 	}, tool(svc, func(ctx context.Context, actor domain.Actor, in getIn) (*mcp.CallToolResult, deleteOut, error) {
@@ -400,13 +400,13 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "get_attachment",
 		Annotations: readOnly,
-		Description: "Fetch one file of the bundle by its path (get_knowledge lists the files an " +
+		Description: "Fetch one file of the bundle by its path (get_concept lists the files an " +
 			"entry shows under \"attachments\", each with its path: images, PDFs, plain-text data " +
 			"files, anything a producer put there). Returns the file as content plus its metadata. Attachments are context-heavy — fetch them " +
 			"deliberately, when the entry's body references one you need to see (a dashboard's " +
 			"normal shape, an ER diagram, a seeds file). ochakai never interprets attachments; " +
 			"if you learn something from one, write it back into the entry's body with " +
-			"put_knowledge so the knowledge becomes searchable text.",
+			"put_concept so the knowledge becomes searchable text.",
 	}, tool(svc, func(ctx context.Context, _ domain.Actor, in attachmentIn) (*mcp.CallToolResult, attachmentOut, error) {
 		att, data, err := svc.GetFile(ctx, in.Path)
 		if err != nil {
@@ -433,7 +433,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 	}))
 
 	mcp.AddTool(s, &mcp.Tool{
-		Name:        "get_knowledge_usage",
+		Name:        "get_concept_usage",
 		Annotations: readOnly,
 		Description: "Usage totals for one knowledge entry: how often it appeared in search results, " +
 			"was fetched individually, and how it was reported to have worked, with last_used_at. " +
@@ -453,7 +453,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 		Description: "Report whether knowledge you acted on actually worked — the last edge of the " +
 			"write-back loop. After running an attested computation or SQL you wrote from an entry, report worked " +
 			"(the result was correct) or failed (wrong or unusable; say what went wrong in note). " +
-			"Reports feed the entry's usage totals (get_knowledge_usage), where failed counts " +
+			"Reports feed the entry's usage totals (get_concept_usage), where failed counts " +
 			"against verified entries flag them for re-verification. Your identity is recorded " +
 			"with each report. Returns the entry's updated usage totals.",
 	}, tool(svc, func(ctx context.Context, _ domain.Actor, in outcomeIn) (*mcp.CallToolResult, usageOut, error) {
@@ -485,7 +485,7 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 // deployment. The service refuses these operations anyway (that is the
 // guarantee); removing them here is what stops an agent from wasting a
 // turn discovering it.
-var writeTools = []string{"put_knowledge", "delete_knowledge", "report_outcome"}
+var writeTools = []string{"put_concept", "delete_concept", "report_outcome"}
 
 // Tool annotations let clients apply auto-approval policies without reading
 // prose. readOnlyHint here describes the knowledge domain: search/get
@@ -524,7 +524,7 @@ type searchIn struct {
 	Types    []string          `json:"types,omitempty" jsonschema:"filter by type (Metric, Attested Computation, Skill, Playbook, Insight, Policy, Glossary Term, BigQuery Dataset, BigQuery Table, API Endpoint, Reference, or any custom type); matched case-insensitively"`
 	Statuses []string          `json:"statuses,omitempty" jsonschema:"filter by lifecycle status: draft, stable, deprecated. Whether anyone confirmed an entry is a separate question — use verified"`
 	Trust    []string          `json:"trust,omitempty" jsonschema:"filter by who confirmed the entry: unverified, machine-confirmed, human-reviewed (OKF SPEC §5.3); repeat to OR them, omit to not ask. Independent of status: a draft can be human-reviewed and a stable entry unverified"`
-	FM       map[string]string `json:"fm,omitempty" jsonschema:"filter by an OKF frontmatter key, exactly: {\"resource\": \"bigquery://p.d.t\"} finds entries whose frontmatter names that resource, matching a scalar or a member of a list. Every pair must match. A value spelling a number or a boolean also matches the typed frontmatter, so {\"required\": \"true\"} finds required: true and {\"usage_count\": \"5\"} finds usage_count: 5. The keys it answers are the ones OKF defines that have no field of their own: attester, computation, description, executor, id, parameters, resource, runtime, status_note, title, usage_window. A key a producer invented is kept and handed back exactly as written but is not part of the query vocabulary; type, status, tags, sources and stale_after are read through columns that answer a different question (a document that says no status reads as stable to a status filter and as nothing to fm), so ask those with the field of that name, on this tool or on search_knowledge"`
+	FM       map[string]string `json:"fm,omitempty" jsonschema:"filter by an OKF frontmatter key, exactly: {\"resource\": \"bigquery://p.d.t\"} finds entries whose frontmatter names that resource, matching a scalar or a member of a list. Every pair must match. A value spelling a number or a boolean also matches the typed frontmatter, so {\"required\": \"true\"} finds required: true and {\"usage_count\": \"5\"} finds usage_count: 5. The keys it answers are the ones OKF defines that have no field of their own: attester, computation, description, executor, id, parameters, resource, runtime, status_note, title, usage_window. A key a producer invented is kept and handed back exactly as written but is not part of the query vocabulary; type, status, tags, sources and stale_after are read through columns that answer a different question (a document that says no status reads as stable to a status filter and as nothing to fm), so ask those with the field of that name, on this tool or on search_concepts"`
 	Rejected *bool             `json:"rejected,omitempty" jsonschema:"true to list only entries a human turned down — how you check whether a proposal was already rejected before making it again. Omit and rejected entries stay out of results"`
 	Tags     []string          `json:"tags,omitempty" jsonschema:"filter by tag"`
 	Source   string            `json:"source,omitempty" jsonschema:"only entries citing this resource, matched exactly against sources[].resource — the reverse lookup for \"this material changed, what derives from it?\"; a filter, so it combines with query or sort"`
@@ -552,11 +552,11 @@ type contextIn struct {
 	Types    []string          `json:"types,omitempty" jsonschema:"filter by type (Metric, Attested Computation, Skill, Playbook, Insight, Policy, Glossary Term, BigQuery Dataset, BigQuery Table, API Endpoint, Reference, or any custom type); matched case-insensitively"`
 	Statuses []string          `json:"statuses,omitempty" jsonschema:"filter by lifecycle status: draft, stable, deprecated. Whether anyone confirmed an entry is a separate question — use verified"`
 	Trust    []string          `json:"trust,omitempty" jsonschema:"filter by who confirmed the entry: unverified, machine-confirmed, human-reviewed (OKF SPEC §5.3); repeat to OR them, omit to not ask. Independent of status: a draft can be human-reviewed and a stable entry unverified"`
-	FM       map[string]string `json:"fm,omitempty" jsonschema:"filter by an OKF frontmatter key, exactly: {\"resource\": \"bigquery://p.d.t\"} finds entries whose frontmatter names that resource, matching a scalar or a member of a list. Every pair must match. A value spelling a number or a boolean also matches the typed frontmatter, so {\"required\": \"true\"} finds required: true and {\"usage_count\": \"5\"} finds usage_count: 5. The keys it answers are the ones OKF defines that have no field of their own: attester, computation, description, executor, id, parameters, resource, runtime, status_note, title, usage_window. A key a producer invented is kept and handed back exactly as written but is not part of the query vocabulary; type, status, tags, sources and stale_after are read through columns that answer a different question (a document that says no status reads as stable to a status filter and as nothing to fm), so ask those with the field of that name, on this tool or on search_knowledge"`
+	FM       map[string]string `json:"fm,omitempty" jsonschema:"filter by an OKF frontmatter key, exactly: {\"resource\": \"bigquery://p.d.t\"} finds entries whose frontmatter names that resource, matching a scalar or a member of a list. Every pair must match. A value spelling a number or a boolean also matches the typed frontmatter, so {\"required\": \"true\"} finds required: true and {\"usage_count\": \"5\"} finds usage_count: 5. The keys it answers are the ones OKF defines that have no field of their own: attester, computation, description, executor, id, parameters, resource, runtime, status_note, title, usage_window. A key a producer invented is kept and handed back exactly as written but is not part of the query vocabulary; type, status, tags, sources and stale_after are read through columns that answer a different question (a document that says no status reads as stable to a status filter and as nothing to fm), so ask those with the field of that name, on this tool or on search_concepts"`
 	Tags     []string          `json:"tags,omitempty" jsonschema:"filter by tag"`
 	Prefixes []string          `json:"prefixes,omitempty" jsonschema:"only entries addressed under these paths, e.g. [\"teams/growth\", \"company\"] — an id is a path, so this scopes the search to a subtree; listing several ORs them, which is how you ask your own scope and the shared one in one call. It scopes the search, not the link expansion: an entry in scope that cites a term outside it still arrives with that term"`
 	Limit    int               `json:"limit,omitempty" jsonschema:"max primary entries: default 5, max 20 (out-of-range falls back to the default); linked companions share a 2x limit total cap"`
-	Budget   int               `json:"budget,omitempty" jsonschema:"max bytes of the knowledge in the response — the entries plus the outline rows naming the rest (default 12000); nothing else carries a body, since \"hits\" is the ranking only. Entries past it are listed under \"outline\" with their size, fetchable by id with get_knowledge, and those rows count against the same budget. Raise it when you need whole entries, lower it when context is tight"`
+	Budget   int               `json:"budget,omitempty" jsonschema:"max bytes of the knowledge in the response — the entries plus the outline rows naming the rest (default 12000); nothing else carries a body, since \"hits\" is the ranking only. Entries past it are listed under \"outline\" with their size, fetchable by id with get_concept, and those rows count against the same budget. Raise it when you need whole entries, lower it when context is tight"`
 }
 
 type contextOut struct {
@@ -581,11 +581,11 @@ const defaultContextBudget = 12000
 func contextHint(truncated int) string {
 	hint := "After acting on this knowledge, call report_outcome (worked/failed) on the entries you " +
 		"used — failed reports are how stale verified knowledge gets caught. If this session " +
-		"produced reusable knowledge, write it back with put_knowledge as a draft; search " +
+		"produced reusable knowledge, write it back with put_concept as a draft; search " +
 		"statuses=[\"rejected\"] first so you do not re-propose something already turned down."
 	if truncated > 0 {
 		hint += fmt.Sprintf(" %d entries did not fit the budget and are listed under \"outline\" — "+
-			"fetch any of them by id with get_knowledge.", truncated)
+			"fetch any of them by id with get_concept.", truncated)
 	}
 	return hint
 }

--- a/internal/mcpserver/mcpserver_integration_test.go
+++ b/internal/mcpserver/mcpserver_integration_test.go
@@ -87,14 +87,14 @@ func TestIntegrationDelegatedActorFollowsEachCall(t *testing.T) {
 	sw.set("human:bob@example.co.jp")
 	id := fmt.Sprintf("mcpit%d/delegation", time.Now().UnixNano())
 	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
-		Name:      "put_knowledge",
+		Name:      "put_concept",
 		Arguments: map[string]any{"id": id, "document": "---\ntype: glossary\n---\n\nwritten on behalf of bob\n"},
 	})
 	if err != nil {
-		t.Fatalf("put_knowledge: %v", err)
+		t.Fatalf("put_concept: %v", err)
 	}
 	if res.IsError {
-		t.Fatalf("put_knowledge failed: %+v", res.Content)
+		t.Fatalf("put_concept failed: %+v", res.Content)
 	}
 
 	k, err := svc.Get(context.Background(), id)
@@ -143,7 +143,7 @@ func TestIntegrationDelegatedActorFollowsEachCall(t *testing.T) {
 	}
 }
 
-// put_knowledge creates on a free id and replaces on a taken one, and
+// put_concept creates on a free id and replaces on a taken one, and
 // the guards that used to belong to two tools still apply to the right
 // half: reviving a curated tombstone is refused on the create side, and
 // replacing a curated entry on the other (design docs 0015 §3.1, 0046
@@ -181,14 +181,14 @@ func TestIntegrationPutKnowledgeCreatesThenReplaces(t *testing.T) {
 	put := func(t *testing.T, doc string) *mcp.CallToolResult {
 		t.Helper()
 		res, err := cs.CallTool(ctx, &mcp.CallToolParams{
-			Name:      "put_knowledge",
+			Name:      "put_concept",
 			Arguments: map[string]any{"id": id, "document": doc},
 		})
 		if err != nil {
-			t.Fatalf("put_knowledge: %v", err)
+			t.Fatalf("put_concept: %v", err)
 		}
 		if res.IsError {
-			t.Fatalf("put_knowledge failed: %+v", res.Content)
+			t.Fatalf("put_concept failed: %+v", res.Content)
 		}
 		return res
 	}
@@ -224,14 +224,14 @@ func TestIntegrationPutKnowledgeCreatesThenReplaces(t *testing.T) {
 		t.Fatal(err)
 	}
 	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
-		Name:      "put_knowledge",
+		Name:      "put_concept",
 		Arguments: map[string]any{"id": id, "document": "---\ntype: Metric\ntitle: 上書き\n---\n\nx\n"},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !res.IsError {
-		t.Fatal("put_knowledge replaced a verified entry")
+		t.Fatal("put_concept replaced a verified entry")
 	}
 	var said string
 	for _, c := range res.Content {

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -30,7 +30,7 @@ func connect(t *testing.T) *mcp.ClientSession {
 	return cs
 }
 
-// TestSearchQueryNotRequired pins the search_knowledge input schema:
+// TestSearchQueryNotRequired pins the search_concepts input schema:
 // query must stay optional so sort="verified_at" calls can omit it
 // (the handler rejects the combination of both).
 func TestSearchQueryNotRequired(t *testing.T) {
@@ -40,7 +40,7 @@ func TestSearchQueryNotRequired(t *testing.T) {
 		t.Fatalf("ListTools: %v", err)
 	}
 	for _, tool := range res.Tools {
-		if tool.Name != "search_knowledge" {
+		if tool.Name != "search_concepts" {
 			continue
 		}
 		raw, err := json.Marshal(tool.InputSchema)
@@ -55,12 +55,12 @@ func TestSearchQueryNotRequired(t *testing.T) {
 		}
 		for _, r := range schema.Required {
 			if r == "query" {
-				t.Errorf("search_knowledge schema requires %q; it must stay optional for sort mode", r)
+				t.Errorf("search_concepts schema requires %q; it must stay optional for sort mode", r)
 			}
 		}
 		return
 	}
-	t.Fatal("search_knowledge tool not found")
+	t.Fatal("search_concepts tool not found")
 }
 
 // TestLimitContractsInSchema pins that the tool schemas document the
@@ -73,8 +73,8 @@ func TestLimitContractsInSchema(t *testing.T) {
 		t.Fatalf("ListTools: %v", err)
 	}
 	want := map[string][]string{
-		"search_knowledge": {"default 10", "max 50", "default 100", "max 1000"},
-		"get_context":      {"default 5", "max 20"},
+		"search_concepts": {"default 10", "max 50", "default 100", "max 1000"},
+		"get_context":     {"default 5", "max 20"},
 	}
 	for _, tool := range res.Tools {
 		substrs, ok := want[tool.Name]
@@ -117,7 +117,7 @@ func TestFMSchemaListsTheAskableKeys(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListTools: %v", err)
 	}
-	tools := map[string]bool{"search_knowledge": true, "get_context": true}
+	tools := map[string]bool{"search_concepts": true, "get_context": true}
 	for _, tool := range res.Tools {
 		if !tools[tool.Name] {
 			continue
@@ -168,7 +168,7 @@ func TestSearchSortValidation(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			res, err := cs.CallTool(context.Background(), &mcp.CallToolParams{
-				Name: "search_knowledge", Arguments: c.args,
+				Name: "search_concepts", Arguments: c.args,
 			})
 			if err != nil {
 				t.Fatalf("CallTool: %v", err)
@@ -279,13 +279,13 @@ func TestToolAnnotations(t *testing.T) {
 	}
 	yes, no := true, false
 	want := map[string]ann{
-		"search_knowledge":    {readOnly: true},
-		"get_context":         {readOnly: true},
-		"get_knowledge":       {readOnly: true},
-		"get_attachment":      {readOnly: true},
-		"get_knowledge_usage": {readOnly: true},
-		"put_knowledge":       {destructive: &no},
-		"delete_knowledge":    {destructive: &yes},
+		"search_concepts":   {readOnly: true},
+		"get_context":       {readOnly: true},
+		"get_concept":       {readOnly: true},
+		"get_attachment":    {readOnly: true},
+		"get_concept_usage": {readOnly: true},
+		"put_concept":       {destructive: &no},
+		"delete_concept":    {destructive: &yes},
 	}
 	seen := map[string]bool{}
 	for _, tool := range res.Tools {
@@ -406,7 +406,7 @@ func TestContextSchemaBoundsResponse(t *testing.T) {
 // so this string is the only copy it will ever see.
 func TestContextHint(t *testing.T) {
 	plain := contextHint(0)
-	for _, want := range []string{"report_outcome", "put_knowledge", "rejected"} {
+	for _, want := range []string{"report_outcome", "put_concept", "rejected"} {
 		if !strings.Contains(plain, want) {
 			t.Errorf("hint does not mention %q: %s", want, plain)
 		}
@@ -415,7 +415,7 @@ func TestContextHint(t *testing.T) {
 		t.Errorf("nothing was dropped; hint must not mention the outline: %s", plain)
 	}
 	truncated := contextHint(3)
-	for _, want := range []string{"3 entries", "outline", "get_knowledge"} {
+	for _, want := range []string{"3 entries", "outline", "get_concept"} {
 		if !strings.Contains(truncated, want) {
 			t.Errorf("truncated hint does not mention %q: %s", want, truncated)
 		}
@@ -434,11 +434,11 @@ func TestCuratedGuardIsAdvertised(t *testing.T) {
 	}
 	want := map[string][]string{
 
-		"delete_knowledge": {"verified, rejected, or deprecated", "erase the record of why"},
+		"delete_concept": {"verified, rejected, or deprecated", "erase the record of why"},
 		// Reviving a curated tombstone is the third way to overwrite a
 		// ruling, and an agent that only learns of it from an error has
 		// already written the draft (design doc 0015 §3.1).
-		"put_knowledge": {"deleted can be reused", "verified, rejected, deprecated", "different id",
+		"put_concept": {"deleted can be reused", "verified, rejected, deprecated", "different id",
 			"verified, rejected, or deprecated", "report_outcome failed"},
 	}
 	for _, tool := range res.Tools {
@@ -537,7 +537,7 @@ func TestRequestActorFallsBackToContext(t *testing.T) {
 	}
 }
 
-// Both lookups design doc 0037 adds ride on search_knowledge rather than
+// Both lookups design doc 0037 adds ride on search_concepts rather than
 // on new tools — tool count is a budget (0015 §2). An argument an agent
 // cannot see is an argument it will not use, so the schema has to carry
 // both, and the descriptions have to say what they match.
@@ -548,7 +548,7 @@ func TestSearchToolOffersTheStaleFeedAndSourceLookup(t *testing.T) {
 		t.Fatalf("ListTools: %v", err)
 	}
 	for _, tool := range res.Tools {
-		if tool.Name != "search_knowledge" {
+		if tool.Name != "search_concepts" {
 			continue
 		}
 		raw, err := json.Marshal(tool.InputSchema)
@@ -565,7 +565,7 @@ func TestSearchToolOffersTheStaleFeedAndSourceLookup(t *testing.T) {
 		}
 		src, ok := schema.Properties["source"]
 		if !ok {
-			t.Fatal("search_knowledge has no source argument")
+			t.Fatal("search_concepts has no source argument")
 		}
 		if !strings.Contains(src.Description, "sources[].resource") {
 			t.Errorf("the source argument does not say what it matches: %q", src.Description)
@@ -580,7 +580,7 @@ func TestSearchToolOffersTheStaleFeedAndSourceLookup(t *testing.T) {
 		}
 		return
 	}
-	t.Fatal("search_knowledge is gone")
+	t.Fatal("search_concepts is gone")
 }
 
 // The listing modes live in one list so no surface can offer a value
@@ -611,8 +611,8 @@ func TestToolSchemasCarryTheTypeVocabulary(t *testing.T) {
 		t.Fatalf("ListTools: %v", err)
 	}
 	// Only the tools that take a type: the read filters and the writes.
-	want := map[string]bool{"search_knowledge": true, "get_context": true,
-		"put_knowledge": true}
+	want := map[string]bool{"search_concepts": true, "get_context": true,
+		"put_concept": true}
 	seen := 0
 	for _, tool := range res.Tools {
 		if !want[tool.Name] {
@@ -734,7 +734,7 @@ func TestOneWriteFace(t *testing.T) {
 	}
 	for _, gone := range []string{"create_knowledge", "update_knowledge"} {
 		if names[gone] {
-			t.Errorf("%s is back; the write face is put_knowledge", gone)
+			t.Errorf("%s is back; the write face is put_concept", gone)
 		}
 	}
 	// The eight the surface carries (design doc 0046 §3.14, issue #272).
@@ -742,8 +742,8 @@ func TestOneWriteFace(t *testing.T) {
 	// went the other way: they are the cheapest tools here, and the
 	// saving was in the merge above.
 	want := []string{
-		"search_knowledge", "get_context", "get_knowledge", "put_knowledge", "report_outcome",
-		"delete_knowledge", "get_knowledge_usage", "get_attachment",
+		"search_concepts", "get_context", "get_concept", "put_concept", "report_outcome",
+		"delete_concept", "get_concept_usage", "get_attachment",
 	}
 	for _, w := range want {
 		if !names[w] {

--- a/internal/mcpserver/readonly_test.go
+++ b/internal/mcpserver/readonly_test.go
@@ -56,7 +56,7 @@ func TestReadOnlyServerOffersNoWriteTools(t *testing.T) {
 	if len(got) == 0 {
 		t.Fatal("read-only server offers no tools at all; it should still serve reads")
 	}
-	for _, want := range []string{"get_context", "search_knowledge", "get_knowledge"} {
+	for _, want := range []string{"get_context", "search_concepts", "get_concept"} {
 		found := false
 		for _, name := range got {
 			if name == want {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -152,18 +152,18 @@ func (s *Service) explainOccupiedID(ctx context.Context, id string, err error) e
 	switch ruling {
 	case domain.RulingRejected:
 		instead = "The rejection is the record of a decision and carries the reason; read it " +
-			"(get_knowledge) before proposing this again. If you disagree, put_knowledge a new " +
+			"(get_concept) before proposing this again. If you disagree, put_concept a new " +
 			"entry at a different id and let a human judge it."
 	case domain.RulingVerified:
 		instead = "If it is wrong, say so with report_outcome failed — that puts it in the " +
-			"re-verification feed. If you have something better, put_knowledge it at a " +
+			"re-verification feed. If you have something better, put_concept it at a " +
 			"different id and let a human judge it."
 	case domain.RulingDeprecated:
 		instead = "Deprecated means it was correct and is no longer recommended. If it is worth " +
-			"reviving, put_knowledge a draft at a different id that says why."
+			"reviving, put_concept a draft at a different id that says why."
 	default:
 		return fmt.Errorf("%w: %s is a live %s entry. Nobody has ruled on it: "+
-			"put_knowledge replaces it in place", err, id, k.Status)
+			"put_concept replaces it in place", err, id, k.Status)
 	}
 	return fmt.Errorf("%w: %s is a live %s entry. %s", err, id, ruling, instead)
 }
@@ -341,14 +341,14 @@ func (s *Service) RefuseIfCurated(ctx context.Context, id, op string) (*string, 
 	switch ruling {
 	case domain.RulingVerified:
 		instead = "If it is wrong, say so with report_outcome failed — that puts it in the " +
-			"re-verification feed. If you have something better, put_knowledge a new draft."
+			"re-verification feed. If you have something better, put_concept a new draft."
 	case domain.RulingRejected:
 		instead = "The rejection is the record of a decision and carries the reason; read it " +
-			"before proposing this again. If you disagree, put_knowledge a new entry at a " +
+			"before proposing this again. If you disagree, put_concept a new entry at a " +
 			"different id and let a human judge it."
 	case domain.RulingDeprecated:
 		instead = "Deprecated means it was correct and is no longer recommended. If it is worth " +
-			"reviving, put_knowledge a draft that says why."
+			"reviving, put_concept a draft that says why."
 	default:
 		return &k.ContentHash, nil
 	}
@@ -388,14 +388,14 @@ func (s *Service) RefuseIfRevivingCurated(ctx context.Context, id string) error 
 	switch ruling {
 	case domain.RulingRejected:
 		instead = "The rejection is the record of a decision and carries the reason; read it " +
-			"(search_knowledge with rejected=true) before proposing this again. If you disagree, " +
-			"put_knowledge a new entry at a different id and let a human judge it."
+			"(search_concepts with rejected=true) before proposing this again. If you disagree, " +
+			"put_concept a new entry at a different id and let a human judge it."
 	case domain.RulingVerified:
 		instead = "It was verified knowledge when it was deleted. Propose the replacement at a " +
 			"different id and let a human judge it against the history this id still holds."
 	case domain.RulingDeprecated:
 		instead = "Deprecated means it was correct and is no longer recommended. If it is worth " +
-			"reviving, put_knowledge a draft at a different id that says why."
+			"reviving, put_concept a draft at a different id that says why."
 	default:
 		return nil
 	}
@@ -968,7 +968,7 @@ func jsonSize(v any) int {
 }
 
 // SearchOrList answers the query surface REST (GET /api/v1/search) and
-// MCP (search_knowledge) both expose, so the two cannot drift: one place
+// MCP (search_concepts) both expose, so the two cannot drift: one place
 // decides whether a request searches or lists, validates the mode, and
 // runs it. A sort mode names one of the listing feeds (see list); with no
 // sort, a source filter and no query is the reverse lookup; otherwise it

--- a/internal/service/service_integration_test.go
+++ b/internal/service/service_integration_test.go
@@ -349,7 +349,7 @@ func TestRefuseIfCuratedIntegration(t *testing.T) {
 	advice := map[domain.Ruling]string{
 		domain.RulingVerified:   "report_outcome failed",
 		domain.RulingRejected:   "the reason",
-		domain.RulingDeprecated: "put_knowledge",
+		domain.RulingDeprecated: "put_concept",
 	}
 	for _, tc := range rulings {
 		t.Run(string(tc.ruling)+" is refused", func(t *testing.T) {
@@ -514,7 +514,7 @@ func TestRefuseIfCuratedIntegration(t *testing.T) {
 			domain.RulingRejected:   "the reason",
 			domain.RulingVerified:   "report_outcome failed",
 			domain.RulingDeprecated: "no longer recommended",
-			"":                      "put_knowledge",
+			"":                      "put_concept",
 		}
 		cases := append([]struct {
 			ruling domain.Ruling


### PR DESCRIPTION
## What and why

```
search_knowledge     →  search_concepts
get_knowledge        →  get_concept
put_knowledge        →  put_concept
delete_knowledge     →  delete_concept
get_knowledge_usage  →  get_concept_usage
```

OKF SPEC §2 defines a **concept** as "a single unit of knowledge within a
bundle", and a **concept ID** as its path without `.md`. ochakai's design
records have said 「概念(concept)」 since 0046 §2, and so have the code
comments (`a concept at <id>.md`). The MCP tool names said `knowledge`.

Until this week that was one inconsistency among several. **Once 0046
§3.5's fold finished it was the only one:**

| surface | elements carrying `knowledge` |
|---|---|
| REST | 0 — the list is `/search`, the entry is `/bundle/{path}.md` |
| CLI | 0 |
| MCP | **5** |

Five tool names were the last place the product called the same thing by
a second name — and they are the names an agent reads.

**Search alone is plural.** `knowledge` is a mass noun and was never asked
the question; `concept` is countable, a search returns many and the rest
act on one, and a name should not be wrong about that.

This is the third time the project has chosen OKF's spelling over its own
— 0023 retired the internal type slugs, 0038 realigned the type
vocabulary — and it is the last double vocabulary. The reason is 0023's:
two vocabularies make the reader carry a translation table, and anyone who
reads an ochakai bundle meets SPEC's word.

## What stays

`get_context`, `report_outcome` and `get_attachment` keep their names —
none of them names the unit. `get_attachment` *is* stale for a different
reason (0046 dissolved "attachment"), and 0054 §3.2 records that as out of
scope rather than folding it in quietly. `domain.Knowledge` keeps its name
too: 281 references that no user pays for (§3.4).

**The tool count stays at 8**, and no argument, response or capability
changes.

## The argument against, recorded

The strongest objection is that **`search_knowledge` tells an unfamiliar
agent what the server is for**, and `search_concepts` does not unless the
agent knows OKF. 0054 §4 records it and why it did not win: a tool *name*
carries unambiguity next to other servers' tools (`internal/mcpserver`
says so at the top), while what the server is for is the *description*'s
job — and the description still says "knowledge base".

Shipping both names was refused outright: tool schemas are paid for out of
the agent's context window, so 8 tools would have become 13 (0015 §3.1).
Raising the budget 60% for compatibility is the shape of payment this
project avoids most.

### Which of the seven conditions

C3 (OKF v0.2 is the format — including its words) and C5 (usable from
Claude Code — one vocabulary to learn, not two). **No surface widens**:
`docs/surface.md` MCP stays at (8).

## Checks

- [x] `scripts/check core` clean — `gofmt`, `go vet`, `go test -race`,
      build
- [ ] `scripts/check --db` could not run — no Docker here. The MCP
      integration tests are among those CI runs; the rename is mechanical
      and the tool-list assertions moved with it
- [x] Behavior changes come with tests — there is no behavior change; the
      existing MCP tests assert the new names, including the read-only
      test that checks which tools a read-only deployment withholds

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — REST is untouched (it has
      no `knowledge` left to rename)
- [x] Lands on every surface it belongs on: **MCP only**, because the
      others already use the word or have no word (0054 §3.5). The
      resource template's display name moves with the tools — it is the
      name an agent sees when it `@`-mentions an entry
- [x] Widens a surface? No — MCP stays at 8

## Design docs

- [x] Alters an accepted decision? **Yes, and it is a new record:**
      `docs/design/0054-concept-is-the-okf-word.md`, with entries in both
      indexes. A wire vocabulary is something a user observes (0048 §2.1),
      and 0046 has shipped nothing that names these tools, so this is an
      addition rather than a revision of it
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyctQUDLJzdoQx7ph6tsCA)_