### PR TITLE
Run the store tests where Docker cannot pull an image

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,127 @@
+#!/bin/sh
+# session-start: SessionStart hook — make the store tests runnable in the
+# Claude Code cloud environment, and say what still cannot be checked there.
+#
+# That environment ships the docker CLI without a daemon, and starting
+# dockerd does not help: its egress policy answers 403 for Docker Hub's
+# blob CDN, so pgvector/pgvector:pg17 can never be pulled and the store
+# integration tests would silently skip for the whole session.
+# `scripts/check --db` already falls back to a cluster built from the
+# machine's own PostgreSQL; what that fallback needs and a stock image
+# lacks is pgvector beside it. One package, installed here rather than
+# per session, because the container image is cached once this completes.
+#
+# Only the cloud environment is touched (CLAUDE_CODE_REMOTE) — a hook that
+# installed system packages on a contributor's laptop would be a bug. It
+# is idempotent, and it fails silently: a hook must never be the reason a
+# session refuses to start.
+#
+# shellcheck disable=SC2016 # the notes below are prose: the backticks are
+# Markdown, and $HTTPS_PROXY is a command for the agent to run, not for
+# this script to expand.
+set -eu
+
+[ "${CLAUDE_CODE_REMOTE:-}" = "true" ] || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+# Everything below is written to a log, never to stdout: stdout is the
+# hook's JSON reply.
+log=${TMPDIR:-/tmp}/ochakai-session-start.log
+
+docker_note='Two things this environment cannot check, both because of its
+egress policy rather than anything in the tree:
+
+- Docker cannot run a container. The CLI is installed but no daemon
+  answers, and starting dockerd does not help: the policy replies 403 for
+  Docker Hub'"'"'s blob CDN, so no image is pullable. Do not spend a turn on
+  it. What that costs is the Dockerfile and deploy/compose.yaml — leave
+  those to CI.
+- `scripts/check vuln` may fail with `Forbidden` fetching vuln.go.dev.
+  That is the proxy refusing the host, not a vulnerability. Confirm with
+  `curl -sS "$HTTPS_PROXY/__agentproxy/status"`, then report it as
+  unverifiable here — never as a failing check, and never work around it.
+
+So `scripts/check core` and `scripts/check lint` are the ones to run, and
+a green run of those is what you can honestly claim.'
+
+note() {
+	jq -nc --arg t "$docker_note
+
+$1" '{
+		hookSpecificOutput: {
+			hookEventName: "SessionStart",
+			additionalContext: $t,
+		},
+	}'
+	exit 0
+}
+
+# pgvector, beside any PostgreSQL this machine has.
+have_pgvector() {
+	for d in /usr/lib/postgresql/*/bin; do
+		[ -x "$d/pg_config" ] || continue
+		[ -f "$("$d/pg_config" --sharedir)/extension/vector.control" ] || continue
+		return 0
+	done
+	return 1
+}
+
+# The newest PostgreSQL major version installed, if any.
+pg_major() {
+	v=""
+	for d in /usr/lib/postgresql/*/bin; do
+		if [ -x "$d/pg_config" ]; then v=$(basename "$(dirname "$d")"); fi
+	done
+	[ -n "$v" ] || return 1
+	echo "$v"
+}
+
+works='The store integration tests do run here. `scripts/check --db` starts
+a throwaway cluster from the PostgreSQL installed on this machine instead
+of the container CI uses; its closing line names which database it ran
+against, because that one is not pgvector/pgvector:pg17.'
+
+if have_pgvector; then
+	note "$works"
+fi
+
+command -v apt-get >/dev/null 2>&1 || note 'The store integration tests
+cannot run here: Docker cannot pull a database image, and this machine has
+no PostgreSQL with pgvector for `scripts/check --db` to fall back on. Say
+so rather than reporting a `scripts/check` run as the run CI will do.'
+
+install() {
+	DEBIAN_FRONTEND=noninteractive apt-get install -y -q "$@" >>"$log" 2>&1
+}
+
+{
+	echo "=== $(date -u +%FT%TZ) ensuring PostgreSQL with pgvector"
+} >>"$log" 2>&1
+
+# A first install without updating the package lists: on an image whose
+# lists are still current that is the whole job, and it is much the faster
+# half of the two.
+if ! v=$(pg_major); then
+	install postgresql || {
+		apt-get update -q >>"$log" 2>&1 || :
+		install postgresql || :
+	}
+	v=$(pg_major) || note 'The store integration tests cannot run here:
+Docker cannot pull a database image, and installing PostgreSQL locally for
+`scripts/check --db` to fall back on failed too. Say so rather than
+reporting a `scripts/check` run as the run CI will do.'
+fi
+
+install "postgresql-$v-pgvector" || {
+	apt-get update -q >>"$log" 2>&1 || :
+	install "postgresql-$v-pgvector" || :
+}
+
+if have_pgvector; then
+	note "$works"
+fi
+
+note 'The store integration tests cannot run here: Docker cannot pull a
+database image, and pgvector could not be installed beside the local
+PostgreSQL for `scripts/check --db` to fall back on (see '"$log"'). Say so
+rather than reporting a `scripts/check` run as the run CI will do.'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,17 @@
 {
   "$comment": "Checked-in Claude Code settings for this repository. Hooks only — permissions are a personal choice and belong in the untracked settings.local.json.",
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-start.sh",
+            "timeout": 180
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write|MultiEdit",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,19 +81,38 @@ placeholder; see [Releases](#releases).
 
 The store integration test is skipped unless a real PostgreSQL is
 available (CI runs one as a service container). `scripts/check --db`
-starts one in Docker and removes it afterwards; by hand it is:
+starts one and removes it afterwards; by hand it is:
 
 ```sh
 docker run -d --rm -p 55433:5432 -e POSTGRES_PASSWORD=t -e POSTGRES_USER=t -e POSTGRES_DB=t pgvector/pgvector:pg17
 OCHAKAI_TEST_DATABASE_URL='postgres://t:t@localhost:55433/t?sslmode=disable' go test ./internal/store/
 ```
 
+`--db` prefers Docker, because `pgvector/pgvector:pg17` is the database
+CI runs. Where Docker cannot serve one — no daemon, or a network that
+will not let the image be pulled — it builds a throwaway cluster out of
+whatever PostgreSQL the machine has installed, provided pgvector is
+installed beside it, and deletes it on exit. That is a real run of the
+store tests but not CI's, so the script's closing line names which
+database it used.
+
 ## Working with Claude Code
 
-The repository checks in a `.claude/settings.json` with **hooks only** —
-currently one that runs `gofmt` on Go files as they are written, since
-that is the cheapest CI failure to avoid. Permissions are a personal
-choice and belong in `.claude/settings.local.json`, which is not tracked.
+The repository checks in a `.claude/settings.json` with **hooks only**.
+One runs `gofmt` on Go files as they are written, since that is the
+cheapest CI failure to avoid. The other runs at session start and does
+nothing at all unless `CLAUDE_CODE_REMOTE` says the session is a
+disposable cloud container, where it installs pgvector beside the
+container's PostgreSQL so `scripts/check --db` has something to fall back
+to, and tells the agent what that environment cannot check. Docker has a
+CLI there but no daemon, and starting `dockerd` does not help because the
+egress policy refuses Docker Hub's blob CDN; the same policy refuses
+`vuln.go.dev`. So the store tests run, `core` and `lint` are honest there,
+and the `Dockerfile`, `deploy/compose.yaml` and `govulncheck` are CI's to
+verify — which is worth saying plainly, because an agent that reports a
+blocked host as a failing check is the expensive outcome. Permissions
+are a personal choice and belong in `.claude/settings.local.json`, which
+is not tracked.
 
 `.claude/skills/` holds the procedures that are long enough to get wrong
 from memory: `release` and `design-doc`. They are the same procedures

--- a/scripts/check
+++ b/scripts/check
@@ -14,14 +14,18 @@
 # ci.yaml rather than pinning a second copy of it.
 #
 # The store integration test is skipped unless a PostgreSQL is reachable.
-# `--db` starts one in Docker on port 55433 and removes it on exit;
-# without it, an already-exported OCHAKAI_TEST_DATABASE_URL is used as is.
+# `--db` starts one on port 55433 and removes it on exit — in Docker for
+# CI's own pgvector/pgvector:pg17, or, where Docker cannot serve one, as a
+# throwaway cluster built from the machine's own PostgreSQL programs.
+# Without `--db`, an already-exported OCHAKAI_TEST_DATABASE_URL is used as
+# is.
 set -eu
 
 cd "$(git rev-parse --show-toplevel)"
 
 want_db=no
 skipped_store=no
+db_note=""
 steps=""
 for arg in "$@"; do
 	case $arg in
@@ -57,14 +61,26 @@ start_db() {
 		return
 	fi
 
-	command -v docker >/dev/null 2>&1 || {
-		echo "check: --db needs docker, or a PostgreSQL on port 55433" >&2
-		exit 2
+	# Docker first: it is the one that runs the image CI runs. When it
+	# cannot — no daemon, or a network that will not let the image be
+	# pulled — a cluster built from the machine's own PostgreSQL is a
+	# closer approximation than skipping the store tests entirely.
+	start_db_docker && return 0
+	start_db_local && return 0
+	echo "check: --db needs Docker able to pull pgvector/pgvector:pg17, or PostgreSQL server programs with pgvector installed, or a PostgreSQL already on port 55433" >&2
+	exit 2
+}
+
+start_db_docker() {
+	command -v docker >/dev/null 2>&1 || return 1
+	docker info >/dev/null 2>&1 || {
+		echo "check: the docker CLI is here but its daemon is not answering" >&2
+		return 1
 	}
-	step "starting PostgreSQL for the store tests"
+	step "starting PostgreSQL for the store tests (docker, pgvector/pgvector:pg17)"
 	cid=$(docker run -d --rm -p 55433:5432 --name ochakai-test-pg \
 		-e POSTGRES_USER=t -e POSTGRES_PASSWORD=t -e POSTGRES_DB=t \
-		pgvector/pgvector:pg17)
+		pgvector/pgvector:pg17) || return 1
 	# shellcheck disable=SC2064 # $cid is meant to expand now, not at exit
 	trap "docker stop $cid >/dev/null" EXIT INT TERM
 	i=0
@@ -76,6 +92,77 @@ start_db() {
 		}
 		sleep 1
 	done
+}
+
+# pg_bindir prints the programs of a PostgreSQL installed on this machine
+# that can serve the store tests, or fails if there is none. pgvector is
+# part of the requirement: the tests migrate a vector schema, and a
+# cluster that cannot `CREATE EXTENSION vector` fails them for a reason
+# that has nothing to do with the change under test.
+pg_bindir() {
+	dirs=""
+	if command -v pg_ctl >/dev/null 2>&1; then
+		dirs=$(dirname "$(command -v pg_ctl)")
+	fi
+	# Debian and its derivatives keep the server programs off PATH.
+	for d in /usr/lib/postgresql/*/bin /usr/local/pgsql/bin \
+		/opt/homebrew/opt/postgresql@*/bin; do
+		if [ -d "$d" ]; then dirs="$dirs $d"; fi
+	done
+	# Newest first, so a machine with several offers the one closest to
+	# the pg17 CI runs.
+	# shellcheck disable=SC2086 # $dirs is a list, and meant to split
+	for d in $(printf '%s\n' $dirs | sort -r); do
+		if [ -x "$d/initdb" ] && [ -x "$d/pg_ctl" ] && [ -x "$d/pg_config" ] &&
+			[ -f "$("$d/pg_config" --sharedir)/extension/vector.control" ]; then
+			echo "$d"
+			return 0
+		fi
+	done
+	return 1
+}
+
+# as_pg runs a server program as a user PostgreSQL will accept. It
+# refuses to run as root, and root is the usual account in a container.
+as_pg() {
+	if [ -n "${pg_as:-}" ]; then
+		su "$pg_as" -c "$1"
+	else
+		sh -c "$1"
+	fi
+}
+
+start_db_local() {
+	bin=$(pg_bindir) || {
+		echo "check: no PostgreSQL server programs with pgvector on this machine" >&2
+		return 1
+	}
+	dir=$(mktemp -d "${TMPDIR:-/tmp}/ochakai-check-pg.XXXXXX")
+	pg_as=
+	if [ "$(id -u)" = 0 ]; then
+		id postgres >/dev/null 2>&1 || {
+			echo "check: running as root, and there is no postgres user to run the server as" >&2
+			rm -rf "$dir"
+			return 1
+		}
+		pg_as=postgres
+		chown postgres "$dir"
+	fi
+	step "starting PostgreSQL for the store tests ($("$bin/pg_ctl" --version))"
+	# shellcheck disable=SC2064 # the paths are meant to expand now, not at exit
+	trap "as_pg \"$bin/pg_ctl -D $dir/data -m immediate -w stop\" >/dev/null 2>&1; rm -rf $dir" EXIT INT TERM
+	as_pg "$bin/initdb -D $dir/data -U t --auth=trust --no-sync" >"$dir/initdb.log" 2>&1 || {
+		cat "$dir/initdb.log" >&2
+		return 1
+	}
+	# -k keeps the socket in the throwaway directory: the default one
+	# belongs to whatever server this machine runs for itself.
+	as_pg "$bin/pg_ctl -D $dir/data -l $dir/log -w -o '-p 55433 -k $dir -c listen_addresses=localhost -c fsync=off' start" >/dev/null 2>&1 || {
+		cat "$dir/log" >&2
+		return 1
+	}
+	"$bin/createdb" -h localhost -p 55433 -U t t || return 1
+	db_note="$("$bin/pg_config" --version), not the pgvector/pgvector:pg17 CI runs"
 }
 
 # The version the golangci-lint action installs in CI. Parsed rather than
@@ -150,9 +237,12 @@ done
 
 # What the last line says is what gets remembered, and CI runs these steps
 # against a database while a local run without --db does not. "ok" alone
-# would let a run that never touched the store read as the run CI will do.
+# would let a run that never touched the store read as the run CI will do
+# — and so would a run against a PostgreSQL that is not the one CI runs.
 if [ "$skipped_store" = yes ]; then
 	step "ok — store tests skipped (rerun with --db; CI runs them)"
+elif [ -n "$db_note" ]; then
+	step "ok — store tests ran against $db_note"
 else
 	step "ok"
 fi


### PR DESCRIPTION
## What and why

The Claude Code cloud environment ships the docker CLI without a daemon, and
starting `dockerd` by hand does not help: the egress policy answers 403 for
Docker Hub's blob CDN, so `pgvector/pgvector:pg17` is unpullable there. Every
session in that environment ran `scripts/check` with the store integration
tests silently skipped — the exact failure mode the script's closing line was
written to prevent, arrived at from the other direction.

**`scripts/check --db` gains a fallback.** Docker stays first, because that
image is the database CI runs. When Docker cannot serve one — no daemon, or a
network that will not let the image be pulled — the script now builds a
throwaway cluster out of the machine's own PostgreSQL programs: `initdb` into
a temp directory, a server on the same port 55433, dropped on exit. Finding
those programs includes checking that pgvector is installed beside them, since
a cluster that cannot `CREATE EXTENSION vector` fails the tests for a reason
that has nothing to do with the change under test. The closing line names which
database the tests ran against, because this one is not CI's:

```
==> ok — store tests ran against PostgreSQL 16.13 (…), not the pgvector/pgvector:pg17 CI runs
```

**A SessionStart hook carries the rest as knowledge**, rather than as a
rediscovery each session. It does nothing at all unless `CLAUDE_CODE_REMOTE`
marks the session as a disposable cloud container — installing system packages
on a contributor's laptop would be a bug — where it installs the one package
the fallback needs beside the image's PostgreSQL, and states what that
environment genuinely cannot check: the `Dockerfile` and `deploy/compose.yaml`,
and `govulncheck`, whose `vuln.go.dev` the same policy refuses. An agent
reporting a blocked host as a *failing check* is the expensive outcome, so the
hook names it as unverifiable and says `core` and `lint` are what can honestly
be claimed there.

No surface moves: this is contributor tooling, and REST, MCP, CLI and the
environment variables are untouched.

## Checks

- [x] `scripts/check` is clean — add `--db` when the change touches the store
- [x] Behavior changes come with tests

`scripts/check --db core lint` is green from a clean slate, via the new
fallback, with the store tests running (`internal/store` and
`internal/service` included) and the temp cluster removed on exit.
`scripts/check vuln` cannot run in this environment — `vuln.go.dev` is refused
by the egress proxy, confirmed against its status endpoint, so that job is
CI's to verify here.

Both fallback triggers were exercised end to end: daemon absent, and daemon
running with the pull refused. `shellcheck -s sh` is clean on `scripts/check`
and the new hook. The hook was tested on all four paths — not remote (silent,
no side effects), remote with pgvector already present, remote installing it
from a state with the package removed, and the JSON reply it emits.

## Surfaces and contract

- [ ] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — n/a, no wire change
- [ ] The change lands on every surface it belongs on — n/a, no surface change
- [ ] Widens a surface — no. Nothing is added to `docs/surface.md`'s four
      counts: `--db` is an existing flag of a contributor script, and the hook
      is repository setup

## Design docs

- [ ] Alters an accepted decision? It does not — nobody using ochakai can
      observe this. Per CLAUDE.md, internal work that leaves the outside
      unchanged belongs in the PR description, which is where it is
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJfAMCC9SiBZFN9o8pXGWJ)_