### PR TITLE
Split the README: keep what decides, move what explains

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,69 +15,16 @@ humans and agents together, and served to Claude Code and every other
 data agent over [MCP](https://modelcontextprotocol.io), REST, a CLI, and
 a bundled web UI. More at [ochak.ai](https://ochak.ai).
 
-[Quick start](#quick-start) · [Requirements](#requirements) ·
-[All docs](docs/README.md) · [Architecture](docs/architecture.md) ·
-[Deploy on Cloud Run](deploy/cloudrun/README.md) ·
-[REST API](api/openapi.yaml) · [Changelog](CHANGELOG.md) ·
-[Roadmap](ROADMAP.md) · [Support](SUPPORT.md) ·
-[Contributing](CONTRIBUTING.md)
+One Go binary and Postgres: Cloud Run + Cloud SQL for
+[about $10/month](deploy/cloudrun/README.md), or Docker and nothing else
+locally.
 
-The whole thing is one Go binary and Postgres, deployable on Cloud Run +
-Cloud SQL for [about $10/month](deploy/cloudrun/README.md). The local
-stack is Docker and nothing else.
+[Quick start](#quick-start) · [Why ochakai](#why-ochakai) ·
+[Requirements](#requirements) · [All docs](docs/README.md) ·
+[REST API](api/openapi.yaml) · [Changelog](CHANGELOG.md)
 
 ![The draft review queue: entries agents wrote back, waiting for a human
 to verify or reject them](docs/images/webui-review.png)
-
-This README describes `main`. For what is in the version you are running,
-see the [changelog](CHANGELOG.md) — features documented here may not have
-reached a tagged release yet.
-
-## Requirements
-
-**Running it for real means Google Cloud.** Cloud Run's IAM check decides
-who reaches a deployment and Cloud SQL authenticates the service account,
-which is how ochakai holds no secret of its own — and it is also why
-there is no supported way to run it on another cloud or on-prem (design
-docs [0002](docs/design/0002-authn-authz.md),
-[0003](docs/design/0003-gcp-only.md)). What is portable is the knowledge,
-not the runtime: it round-trips through OKF bundles, so leaving does not
-depend on what you are leaving. `deploy/compose.yaml` runs the same
-binary locally with authentication switched off — a development harness,
-not the small end of production.
-
-**There is no authorization.** Whoever can reach a deployment can read
-and write everything. If you need per-entry permissions, this is the
-wrong tool; see the [refusals](#why-ochakai) for what that buys.
-
-**PostgreSQL, plus `pg_trgm`.** The first migration creates the
-extension, so a database whose user may not `CREATE EXTENSION` needs an
-admin to create it once — that is what the deploy guide's bootstrap SQL
-is for. Semantic search adds `vector` (pgvector) the same way — it is on
-by default on Google Cloud, and a database that cannot hold vectors makes
-a discovered deployment fall back to lexical search rather than fail.
-Without it, plain PostgreSQL is enough. CI and the deploy guide both
-exercise Postgres 17.
-
-**The server needs Docker; the client commands need a binary.** The quick
-start below runs the CLI with `go run`, which wants the toolchain named
-in `go.mod` — Go 1.21 and newer download it for you. To stay
-toolchain-free, take a
-[release archive](https://github.com/na0fu3y/ochakai/releases) instead,
-or talk to the API directly, since that is all the CLI does:
-
-```sh
-curl -X PUT http://localhost:8080/api/v1/bundle/metrics/revenue.md \
-  -H 'content-type: text/markdown' \
-  --data-binary $'---\ntype: Metric\n---\n\nCompleted orders only, net of refunds.\n'
-```
-
-Knowledge is written as an OKF document — the frontmatter is the
-metadata, the markdown is the body, and the path is the address: a
-concept lives in the bundle at its id plus `.md`, which is the same place
-an export writes it and the same place `ochakai get` reads it from. So
-reading an entry, editing it and sending it back is one loop with no
-translation in it.
 
 ## Quick start
 
@@ -86,9 +33,9 @@ git clone https://github.com/na0fu3y/ochakai && cd ochakai
 docker compose -f deploy/compose.yaml up
 ```
 
-Load the demo knowledge base — ten entries about one invented retail
-domain — and try a search; everything goes through the API, so plain curl
-works too:
+Load the demo knowledge base — [ten entries](examples/demo) about one
+invented retail domain, linked to each other, some of them drafts — and
+search it. Everything goes through the API, so plain curl works too:
 
 ```sh
 export OCHAKAI_URL=http://localhost:8080
@@ -96,211 +43,49 @@ go run ./cmd/ochakai import examples/demo
 curl 'http://localhost:8080/api/v1/search?q=revenue'
 ```
 
-[examples/demo](examples/demo) is a knowledge base rather than a sample
-file: metrics, attested computations, an insight on how to read the
-numbers, a glossary term the others depend on, a table catalog entry.
-They link to each other, so `get_context` and backlinks have something to
-expand; two are drafts, so the review queue is not empty; one is past the
-expiry its author declared, so the stale feed has an occupant. The
-numbers and table names are invented — it is there to be explored, not
-copied into your warehouse. For a single entry instead, there is
-[examples/golden-query.md](examples/golden-query.md).
-
-Every client command needs to know which server it is talking to. The
-environment variable is the explicit way and the right one for a trial;
-`ochakai use` (below) saves the choice once you install the CLI.
-
-### Connect Claude Code
+## Connect an agent
 
 For Claude Code — and anything else with a shell (headless agents, CI) —
 the recommended interface is the bundled CLI, a thin client of the same
-REST API: tool schemas don't occupy the agent's context (`--help` is
-read on demand), output composes
+REST API: tool schemas don't occupy the agent's context, output composes
 with pipes, and it resolves Google ID tokens itself, so no proxy process
-is needed against Cloud Run.
-
-Install it from the [releases page](https://github.com/na0fu3y/ochakai/releases)
-— each release carries archives for linux, macOS and Windows on amd64 and
-arm64, a `checksums.txt`, and build provenance you can verify the same way
-as the image (see [Supply chain](#supply-chain)). With a Go toolchain,
-`go install` works too:
+is needed against Cloud Run. Take a
+[release archive](https://github.com/na0fu3y/ochakai/releases), or:
 
 ```sh
 go install github.com/na0fu3y/ochakai/cmd/ochakai@latest
 
-ochakai use http://localhost:8080  # Cloud Run: ochakai use https://your-service.run.app (auth = gcloud login / ADC, no tokens to configure)
-ochakai whoami                     # which server, as whom, reachable?
-ochakai context "why is revenue down?"  # the one-call read before a data question: full entries, links expanded
+ochakai use http://localhost:8080   # Cloud Run: ochakai use https://your-service.run.app
+ochakai whoami                      # which server, as whom, reachable?
+ochakai context "why is revenue down?"  # the one-call read before a data question
 ochakai search "revenue" --type Metric --trust human-reviewed
-ochakai search --sort stale_after   # past the expiry their author declared
-ochakai search --source https://wiki.example/revenue-policy  # what derives from this
-ochakai search "revenue" --prefix queries/sales   # only what lives under one subtree
-ochakai get queries/sales/monthly-revenue
-ochakai verify metrics/revenue      # promotes a draft — and re-affirms a verified entry, clearing the review feeds
-ochakai attach insights/reading-revenue weekly.png   # files travel with the entry
-ochakai export ./knowledge   # or: ochakai export - > okf.tar.gz
-ochakai import ./knowledge   # the inverse; works with any OKF bundle (a client-side loop — see below)
-ochakai ui                   # web UI at http://127.0.0.1:8098, acting as you (no deploy)
+ochakai verify metrics/revenue      # promotes a draft; re-affirms a verified entry
+ochakai ui                          # web UI at http://127.0.0.1:8098, acting as you
 ```
 
-`ochakai use` saves the selection locally (name more servers with
-`--name` and switch by name); `--url` and `OCHAKAI_URL` always override
-it, so scripts and CI stay explicit. Tab completion:
-`source <(ochakai completion zsh)` (also bash, fish).
+Auth is `gcloud login` / ADC — there are no tokens to configure. Every
+command carries its flags and worked examples in `ochakai <command> -h`;
+[docs/cli.md](docs/cli.md) is that same text rendered, for reading before
+you install anything.
 
-Every command carries its own flags and worked examples in
-`ochakai <command> -h`. [docs/cli.md](docs/cli.md) is that same text
-rendered, for reading before you install anything.
-
-Then copy [examples/claude-code/CLAUDE.md](examples/claude-code/CLAUDE.md)
-into your project's CLAUDE.md — it teaches the agent the commands and the
-write-learnings-back habit. To make the loop automatic instead of
-habitual, install the [hooks](examples/claude-code): a UserPromptSubmit
-hook injects relevant knowledge before the agent starts (recall), and a
-Stop hook asks it once per data session to save what it learned
-(write-back) — both without an LLM.
-
-### MCP
-
-Agents without a shell (Claude Desktop, Gemini Enterprise managed
-agents) connect over MCP, which remains the primary interface. Claude Code
-can use it too:
+Agents without a shell (Claude Desktop, hosted agents) connect over MCP,
+which remains the primary interface. Claude Code can use it too:
 
 ```sh
 claude mcp add --transport http ochakai http://localhost:8080/mcp
 ```
 
-Clients that take a JSON config want the same URL:
+Against Cloud Run, and for clients that only speak stdio, `ochakai
+mcp-stdio` is the bridge — it forwards each message and resolves your
+identity, so the client itself holds no credentials. Which form each
+client wants, and the eight tools it will see:
+[connecting an MCP client](docs/guides/mcp-clients.md).
 
-```json
-{
-  "mcpServers": {
-    "ochakai": {
-      "type": "http",
-      "url": "http://localhost:8080/mcp"
-    }
-  }
-}
-```
-
-The server speaks streamable HTTP. Two kinds of client need something in
-front of it: one that can only launch a command and talk over stdio, and
-*any* client pointed at Cloud Run, where the request has to carry a Google
-ID token the client cannot mint. `ochakai mcp-stdio` is both answers —
-it speaks MCP on stdin/stdout and forwards every message to the server,
-resolving your identity the way every other client command does, so the
-client itself is configured with no credentials:
-
-```sh
-claude mcp add ochakai -- ochakai mcp-stdio
-```
-
-```json
-{
-  "mcpServers": {
-    "ochakai": { "command": "ochakai", "args": ["mcp-stdio"] }
-  }
-}
-```
-
-It listens on no port and holds no state; it copies JSON-RPC messages, so
-it carries whatever the server offers rather than a second copy of the
-tool list that could go stale (design doc
-[0039](docs/design/0039-mcp-stdio-bridge.md)). Add `--url` to point it at
-a specific server. `ochakai ui` exposes the same authenticated `/mcp` over
-HTTP for clients that would rather have a URL, and
-`gcloud run services proxy` is the third way, documented in the
-[deploy guide §5](deploy/cloudrun/README.md).
-
-Opening this repository in Claude Code connects automatically via the
-committed [.mcp.json](.mcp.json), which expects ochakai (or the Cloud Run
-proxy) on `localhost:8787`.
-
-Which of the two forms a given client wants, where it keeps its config,
-and which clients cannot reach an IAM-restricted deployment at all:
-[docs/guides/mcp-clients.md](docs/guides/mcp-clients.md).
-
-### Try a prompt
-
-Once an agent is connected, four prompts walk the whole loop. Run them
-against the quick start's knowledge base — the demo bundle has enough in
-it that each one comes back with something.
-
-**Recall.** Ask something the knowledge base can answer and watch the
-agent reach for it rather than guess:
-
-> What do we already know about revenue? Use ochakai before answering.
-
-One `get_context` call comes back with the entries in full, so the agent
-starts from your definitions instead of inventing one.
-
-**Write back.** Tell it something worth keeping:
-
-> Revenue in August runs about 15% below a normal month — it's seasonal,
-> not a problem. Save that to ochakai so the next session has it.
-
-It lands as a **draft**, attributed to the agent that wrote it. It is not
-trusted yet, and search says so.
-
-**Review.** Open `ochakai ui`, find it in the review queue, and press
-Verify — or Reject with a reason, which is kept so agents stop
-re-proposing it. This is the half no agent does for you.
-
-**Close the loop.** When knowledge turns out to be wrong, say so:
-
-> That golden query returned a number that doesn't match the finance
-> close. Report it as failed in ochakai, with why.
-
-`report_outcome` moves the entry into the re-verification feed instead of
-letting the next agent trust it blind. Verifying it again empties the
-feed.
-
-If nothing comes back on the first prompt, the agent has not actually
-connected — `ochakai whoami` says which server it is talking to and as
-whom.
-
-### Web UI: the human half of the loop
-
-Agents write drafts; somebody has to read them. The bundled web UI is
-where a human reviews what agents learned — search and filter by status,
-browse the knowledge as a folder tree (hierarchical IDs are
-directories), read an entry with its links and usage counts, then
-verify / deprecate / reject (with the reason) in one click. Two feeds
-put the re-verification queue in front of that reviewer: a *verification
-age* feed (oldest `verified_at` first) so stale golden queries surface,
-and a *needs review* feed (`sort=failed`) that lists the entries agents
-reported wrong, worst first. Both empty the same way: re-verifying an
-entry — "I checked it again and it is still right" — stamps a fresh
-`verified_at` and takes it out of either feed, so the queues are
-something a reviewer can finish rather than a ledger that only grows.
-A third feed, *stale* (`sort=stale_after`), lists entries past the expiry
-their own author declared — that one clears by editing the entry to
-re-declare the date, since the date is a claim the writer made rather
-than something the server observed. Whether any of the three is holding
-anything is one call — `ochakai queues`, and the Review tab's badge —
-so a queue going quiet stops looking like a queue being empty; with
-`--exit-code` it is a cron job away from telling your team
-(design doc [0049](docs/design/0049-queue-counts.md)).
-And when a cited document changes,
-`?source=<uri>` answers the other direction: every entry derived from it,
-straight from the source's own line on the entry page. One
-self-contained page, no build step; deliberately **not** a BI tool — no
-charts, no query execution, no chat.
-
-![The knowledge base as a folder tree: an entry's id is its path, so the
-sidebar is the way in](docs/images/webui-tree.png)
-
-![An entry: status, provenance, and the tabs for its attributes, links,
-backlinks, usage and revision history](docs/images/webui-entry.png)
-
-![The re-verification feed, filtered to entries agents reported wrong,
-with the type and status filters above it](docs/images/webui-wrong.png)
-
-Same page, two identities:
-`ochakai ui` serves it on loopback acting as *you* (zero deploy, edits
-recorded as `human:<you>`), and `ochakai serve-ui` deploys it as a
-team-shared service — same container image as the server, just
-`--args=serve-ui` ([deploy guide §5b](deploy/cloudrun/README.md)).
+Then copy [examples/claude-code/CLAUDE.md](examples/claude-code/CLAUDE.md)
+into your project's CLAUDE.md, or install the
+[hooks](examples/claude-code) to make recall and write-back automatic
+instead of habitual — both without an LLM.
+**[Walk the whole loop in four prompts →](docs/loop.md)**
 
 ## Why ochakai
 
@@ -313,348 +98,95 @@ for what they still don't do:
   tribal knowledge that never fits in a semantic-model YAML and today
   travels by Slack. Your agent gets it in the same search that returns
   the metric definition.
-- **A write-back loop with a memory.** Agents are encouraged to write
-  learnings back; entries start as drafts and a human promotes
-  them to `verified`, with provenance (who wrote it, who verified it,
-  when) on every entry and every change kept as a revision. Proposals that
-  don't make it are kept as `rejected` with the reason, so agents stop
-  re-proposing them — a memory of *no* that verified-answer stores
-  elsewhere don't keep. And the loop closes: per-entry usage counts show
-  whether it's working, a *verification-age* feed surfaces knowledge that
-  has gone too long unchecked (time-based staleness), and outcome reports
-  (`report_outcome`: worked / failed) add the evidence-based half — an
-  agent that ran a golden query and got a wrong number says so, and the
-  entry rises in a *re-verification* feed (`sort=failed`) for a human or
-  agent to re-check, instead of the next agent trusting the same entry
-  blind. Re-checking is itself recorded (`ochakai verify`, or the web
-  UI's Verify), which is what empties the feed (design doc 0025).
+- **A write-back loop with a memory.** Agents write learnings back as
+  drafts and a human promotes them, with provenance on every entry and
+  every change kept as a revision. Proposals that don't make it are kept
+  as `rejected` with the reason, so agents stop re-proposing them — a
+  memory of *no*. And the loop is measured: usage counts, a
+  verification-age feed, and outcome reports from agents that acted on an
+  entry and found it wrong ([the loop](docs/loop.md)).
 - **No forward-deployed engineers, by design.** Encoding what your data
   means is labor, and it doesn't vanish — the only question is *who* does
-  it. Palantir's answer is forward-deployed engineers who hand-build an
-  ontology on-site; the dbt and warehouse-native answer is self-serve,
-  folding curation into the engineering workflow that already ships the
-  data. ochakai's bet is a third path: the agent *is* the forward-deployed
-  labor — it drafts the breadth every time it learns something — and a
-  human verifies the judgment-heavy core, which is what keeps a knowledge
-  base from rotting into a stale, confidently-wrong graveyard. No FDE army
-  and no dedicated data steward: the smallest team that sustains a living
-  knowledge base is one reviewer already in the loop, with the gate built
-  into the workflow they already run — the bundled
-  [hooks](examples/claude-code) and the CI
-  [canary](docs/guides/golden-query-canary.md).
+  it. Palantir's answer is engineers on-site; the warehouse-native answer
+  folds it into the data team's workflow. ochakai's bet is a third path:
+  the agent *is* the forward-deployed labor, drafting breadth every time
+  it learns something, while a human verifies the judgment-heavy core.
+  The smallest team that sustains a living knowledge base is one reviewer
+  already in the loop.
 - **Not a memory layer — the other half of one.** Memory layers (mem0,
   Zep, Letta) auto-extract per-user memories with an LLM and inject them
-  back, unaudited: nobody reviews what got remembered, and a wrong
-  memory persists silently. ochakai is the opposite trade: team-shared
-  knowledge that passes through human review, with provenance on every
-  entry. *Memory layers remember what happened; ochakai curates what's
-  true.* They compose — preferences in your memory layer, verified data
-  knowledge here. The delivery trick memory layers got right (no agent
-  judgment needed) ochakai keeps: one `get_context` call returns the
-  relevant entries in full, and the bundled
-  [Claude Code hooks](examples/claude-code) make recall and write-back
-  automatic, no LLM involved.
-- **Verified answers for any client.** Verified-query stores exist — inside
-  Snowflake Cortex Analyst, inside Databricks Genie, inside each
-  AI-analyst SaaS — and each one feeds only its own chat. ochakai is
-  client-agnostic by construction: the same verified knowledge serves
-  Claude Code, hosted MCP agents, CI jobs, and whatever you build next.
-- **An exit, guaranteed.** The whole knowledge base round-trips through
+  back unaudited. ochakai is the opposite trade: team-shared knowledge
+  that passes through human review. *Memory layers remember what
+  happened; ochakai curates what's true.* They compose — preferences
+  there, verified data knowledge here.
+- **Verified answers for any client, and an exit.** Verified-query stores
+  exist inside Snowflake Cortex Analyst, inside Databricks Genie, inside
+  each AI-analyst SaaS — each feeding only its own chat. The same
+  knowledge here serves Claude Code, hosted MCP agents and CI jobs alike,
+  and the whole base round-trips through
   [OKF v0.2](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf)
-  bundles (`ochakai export` / `ochakai import`) — plain markdown + YAML
-  frontmatter that lives happily in git, with provenance and trust in the
-  spec's own keys (`generated`, `verified`, `status`, `stale_after`), so
-  any OKF consumer can read how much to trust an entry. Import accepts any
-  producer's OKF bundle, v0.1 or v0.2, not just ochakai's own. MIT-licensed
-  and self-hostable per tenant: your knowledge is never a hostage.
+  bundles — plain markdown + YAML frontmatter that lives happily in git,
+  with trust in the spec's own keys. MIT-licensed and self-hosted per
+  tenant: your knowledge is never a hostage.
 
-And it stays small by refusing things:
+### What it refuses
 
 | ochakai has no… | because |
 |---|---|
 | LLM | it returns human-verified golden queries verbatim, and the definitions and caveats around them. Interpretation is the client agent's job |
 | SQL execution | it holds no warehouse credentials. Your agent executes |
-| connector ingestion | knowledge is curated by humans and agents, not harvested by pipelines. Trust density over volume. A harvester in the server would also need warehouse credentials it does not hold — so when you do want a catalog projected in, it runs as an ordinary client under your own service account: [examples/bigquery-catalog](examples/bigquery-catalog) |
+| connector ingestion | knowledge is curated, not harvested. Trust density over volume — and a harvester would need warehouse credentials the server does not hold, so a catalog projection runs as an ordinary client under your own service account ([example](examples/bigquery-catalog)) |
 | chat UI or dashboards | it feeds your agents; it doesn't compete with them. The bundled web UI is a curation surface, not a BI tool |
-| secrets | Cloud Run IAM decides who reaches it, callers are identified by their Google identity, and Cloud SQL authenticates the service account — nothing to issue or rotate |
-| authorization | reachability is the whole access model: **whoever can reach the deployment can read and write everything**. ochakai identifies the caller and records it as provenance, and stops there. Deciding who may reach it is Cloud Run IAM's job, and running it publicly invokable is a misconfiguration, not a deployment mode (design doc [0002](docs/design/0002-authn-authz.md)). If you need per-entry permissions, this is the wrong tool |
-| telemetry | nothing is reported anywhere. The only hosts ochakai ever contacts are Google Cloud APIs in your own project — Cloud SQL, GCS if you configure a bucket, and Vertex AI where semantic search is enabled (on Google Cloud that is the default, and `OCHAKAI_EMBEDDINGS=off` declines it). Usage counts are rows in your own database |
+| secrets | Cloud Run IAM decides who reaches it and Cloud SQL authenticates the service account — nothing to issue or rotate |
+| authorization | reachability is the whole access model: **whoever can reach the deployment can read and write everything** (design doc [0002](docs/design/0002-authn-authz.md)). If you need per-entry permissions, this is the wrong tool |
+| telemetry | nothing is reported anywhere. The only hosts ochakai contacts are Google Cloud APIs in your own project |
 
-## MCP tools
+## Requirements
 
-| Tool | Description |
-|---|---|
-| `get_context` | The one call before answering a data question: full entries behind the top hits, links expanded both ways |
-| `search_concepts` | Cross-type search; verified entries rank higher |
-| `get_concept` | Fetch one entry as an OKF document, with its links and attachment metadata |
-| `get_attachment` | Fetch a file attached to an entry (dashboard screenshots, ER diagrams, seeds files) |
-| `put_concept` | Write learnings back — creates if the id is free, replaces if it is taken; every change is kept as a revision |
-| `delete_concept` | Soft-delete (history retained) |
-| `get_concept_usage` | Usage totals per entry — draft-promotion evidence, staleness signal |
-| `report_outcome` | Report worked/failed after acting on knowledge — failed reports flag verified entries for re-verification |
+- **Google Cloud**, for a real deployment: Cloud Run IAM and Cloud SQL
+  IAM are how ochakai holds no secret of its own, and there is no
+  supported way to run it elsewhere. What is portable is the knowledge,
+  not the runtime.
+- **PostgreSQL 17 with `pg_trgm`**; `vector` (pgvector) as well where
+  semantic search is on, which on Google Cloud is the default.
+- **No authorization**, as above. Deciding who may reach a deployment is
+  Cloud Run IAM's job.
 
-Every one of these is a knowledge operation: ochakai never executes SQL
-and never calls an LLM. `compile_sql` — deterministic SQL generation from
-a semantic model — existed until 0.13.0 and was retired (design doc 0028):
-what an agent actually needs is the verified query and the caveat around
-it, and both arrive from `get_context`.
+Details, and every environment variable:
+[requirements and configuration](docs/configuration.md).
 
-Every entry is also an **MCP resource** addressable by its canonical URI —
-`ochakai://` plus its id (the entry's path), e.g. `ochakai://metrics/revenue`
-or `ochakai://queries/sales/top-customers`. Clients that
-support resource references (`@`-mentions) can pull an entry in as an OKF
-document — frontmatter and body — without a tool call; discovery
-stays with `get_context`/`search_concepts`. Read tools carry `readOnly`
-annotations and `delete_concept` a `destructive` one, so client
-auto-approval policies work without parsing descriptions.
+## Documentation
 
-`import` is the one place the CLI is more than a thin client: there is no
-bulk import endpoint, because loading a bundle is a loop over endpoints
-that already exist, and a server-side second path to the same outcome
-buys convenience rather than capability (design doc 0015 §3.2). The cost
-is that the bundle semantics — attributing loose files to entries,
-skipping what does not belong, ignoring the frontmatter keys the server
-owns — live in the client. To load OKF bundles from something other than
-this binary, [api/openapi.yaml](api/openapi.yaml) spells out what that
-loop does, under `GET /api/v1/bundle/{path}`.
+This README describes `main`; the [changelog](CHANGELOG.md) says what is
+in the version you are running.
 
-The REST API (`/api/v1`) is a superset of these tools, adding bulk
-export, the human-facing reads (the bundle's `index.md` and `log.md`,
-the `links_to` reverse lookup), and file writes — see
-[api/openapi.yaml](api/openapi.yaml). To keep golden queries trustworthy
-over time, run them as canaries from your CI:
-[docs/guides/golden-query-canary.md](docs/guides/golden-query-canary.md).
-
-## Knowledge types
-
-| Type | What it holds |
-|---|---|
-| `Metric` | Semantic metric definition, synonyms |
-| `Attested Computation` | A sanctioned computation and the means to check a run of it: the computation in a `# Computation` body fence, the contract in the `runtime` / `parameters` / `executor` / `attester` fields. ochakai records it and never runs it. A golden query is one of these: `runtime` says where the SQL runs, and a producer key such as `question` carries the question it answers |
-| `Skill` | A procedure an entry's `executor.resource` points at — how to actually run a computation on a given runtime |
-| `Playbook` | An operational procedure people and agents follow, bound to no resource: incident triage, an on-call runbook |
-| `Insight` | How to read a metric: baselines, seasonality, caveats, thresholds |
-| `Policy` | The rule that decides a number — revenue recognition, cost allocation. What an entry's `sources[].resource` cites |
-| `Glossary Term` | Glossary term |
-| `BigQuery Dataset` | BigQuery dataset catalog entry: a container grouping tables |
-| `BigQuery Table` | BigQuery table catalog entry: source, column notes, known issues |
-| `API Endpoint` | Catalog entry for an asset that is not a BigQuery one |
-| `Reference` | Mirror of external material: enum definitions, licenses, schema docs |
-
-These are recommendations, not a closed set — any single-line value works as a type for your
-own document kinds, and IDs may be hierarchical
-(`queries/sales/monthly-revenue`) to organize knowledge into directories.
-The type values are the [OKF knowledge-catalog](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf/bundles)
-vocabulary verbatim: OKF registers no taxonomy, so the spelling is the
-meaning, and a bundle's types survive an import/export round-trip unchanged
-with no translation layer (design docs 0023, 0038). Matching is case-insensitive;
-the spelling you write is the one stored. A type is not an address — the
-directory layout of an exported bundle comes from entry IDs alone (design
-doc 0017), so you are free to organize files however you like.
-
-Because an ID is an address, it is also something to search within.
-`--prefix` (REST `?prefix=`, MCP `prefixes`) narrows a search or a
-`context` call to a subtree, and repeating it ORs the scopes, so one call
-can cover two parts of the tree and each hit's ID says which it came from
-(design doc 0041). Matching is on segment boundaries: `--prefix metrics`
-does not reach `metrics-legacy`. Whether that is worth using depends on
-your layout — `examples/demo` groups by kind (`metrics/`, `glossary/`,
-`queries/sales/`), where `--type` already does most of this; it earns its
-keep when directories mean something `--type` cannot say, such as one
-team's own vocabulary beside a shared one. ochakai reads no meaning into
-any path either way. Note that this is a filter, not a permission —
-anyone who can reach the server can pass any prefix, or none.
-
-Entries relate to each other through **the markdown links in their body**
-— there is no links field to fill in. Write `[revenue](/metrics/revenue.md)`
-in the prose and the entry links to `metrics/revenue`; the target gains a
-backlink, and `get_context` expands the edge in both directions. Relative
-paths (`./gross.md`) work too — those two are the forms SPEC §6 defines,
-and they are the only ones, so an exported bundle's links resolve for
-whoever reads it. This is OKF SPEC §5 taken at its word: a link
-asserts a relationship, and what kind of relationship it is comes from the
-surrounding prose, so ochakai stores no relationship type of its own
-(design doc 0024). Links inside fenced code blocks (``` or ~~~) and
-inline `` `code spans` `` are examples, not edges, and are skipped —
-indented code is not detected, so a link four spaces deep is read as
-prose. Renaming an entry rewrites the links pointing at it, prose
-included.
-
-Entries can carry file attachments — the dashboard screenshot behind an
-insight, the ER diagram behind a table entry, the seeds.txt or spec PDF
-behind a dataset. Accepted formats are the intersection of what Claude
-reads and what Gemini embeds (png/jpeg/webp, pdf, plain text —
-sniffed from the bytes). Attachments are searchable: filenames match in
-every search, and contents join hybrid search wherever embeddings are
-enabled — text with any embedding model, images and PDFs with
-`gemini-embedding-2` — and a hit is always the owning entry (design
-doc 0020).
-Attachment bytes live in GCS and are fetched on demand, and attachments
-round-trip through OKF bundles as plain files next to their entry.
-
-**Trust travels with the knowledge.** OKF v0.2's schema is ochakai's
-schema: every key the spec defines is a first-class field, so an exported
-entry carries its provenance, trust and lifecycle (SPEC §5) where a
-consumer that has never heard of ochakai will look for them.
-
-```yaml
-type: Attested Computation
-runtime: bigquery
-title: Monthly revenue by channel
-sources:
-  - id: rev-policy
-    resource: https://wiki.example/finance/revenue-recognition
-    title: Revenue Recognition Policy (FY2026)
-    author: human:jsmith@example.co.jp
-    last_modified: "2026-06-15"
-usage_window: { from: "2026-06-01", to: "2026-06-30" }
-generated: { by: process:analyst@example.iam.gserviceaccount.com, producer: insightflow/1.4.0, at: 2026-07-26T04:12:00Z }
-verified:
-  - { by: human:tanaka@example.co.jp, at: 2026-07-26T09:30:00Z }
-status: stable                 # draft | stable | deprecated
-stale_after: "2026-12-31"      # advisory: re-check on and after this day
-```
-
-`sources` is the material an entry derives from — give one an `id` and a
-markdown footnote in the body can attribute a single claim to it.
-`generated` is who the content stands by and when it last changed;
-`verified` is who confirmed it — absent means unverified, and a `human:`
-entry is what makes it human-reviewed (SPEC §5.3). The `producer` beside
-`by` is the software that made the write, as the caller declared it
-(`<producer>/<version>`, SPEC §7): it says *what* wrote, never *who*, so
-it sits next to the authenticated identity rather than in it (design doc
-[0052](docs/design/0052-producer-beside-the-actor.md)). ochakai holds these
-the way the spec defines them: `status` is the lifecycle value alone
-(`draft`, `stable`, `deprecated`) and `verified` is a ledger of every
-confirmation, so the two signals stay independent. A draft somebody
-checked and a stable entry nobody has are both states the model can hold,
-and a foreign bundle's lifecycle value survives the trip unaltered.
-
-A rejection — reviewed and *not* accepted — is this instance's ruling
-rather than a stage of the concept, so it is not a status either. It
-exports as `rejected_by` / `rejected_at` beside the entry's real status,
-and import never reads it back: a bundle carries knowledge, not one
-instance's judgments.
-
-ochakai **records** these; it never acts on them. It does not fetch a
-source's `resource`, score its credibility signals, or run an Attested
-Computation's `executor` and `attester` — weighing the signals and
-running the computation belong to whoever consumes the entry (SPEC §5.1,
-§10.5). Keys OKF does not define pass through untouched and in place —
-at the top level, and inside a `sources` entry, a `parameter`, an
-`executor` or an `attester` too. Provenance itself is never read back
-from a bundle: it is what this instance observed, not what a document
-claims (design docs 0009, 0043).
-
-**Japanese knowledge bases need embeddings, which is why they are the
-default.** PostgreSQL's
-full-text search does not tokenize Japanese, so the lexical half of search
-matches a query by its fragments against a stored haystack — id, title,
-description, tags, body, attachment filenames. Latin words stay whole;
-Japanese, which has no spaces, is cut into two-character windows, and only
-the windows carrying a kanji or katakana are kept, because an all-hiragana
-window is grammar and matches nearly everything. Entries are then ranked
-by how much of the *rare* part of the query they contain.
-
-That finds the right entries for a keyword and for a Japanese question,
-but it is still a bag of words: ask an English question and an entry
-sharing three of its function words can outrank the one that names the
-subject. It is also not fully indexed. A trigram index cannot serve a
-two-character pattern — there is no whole trigram in one — so Japanese
-terms like 売上 or 原価 are answered by scanning the table: about 16 ms
-per search across 5000 entries, against 0.2 ms for a latin word. That
-is fine at the scale a curated knowledge base reaches and does not stay
-fine forever. `gemini-embedding-001` handles Japanese well, and where
-embeddings are reachable — on Google Cloud, that is the default and takes
-no configuration (design doc
-[0053](docs/design/0053-embeddings-by-default.md)) — ranking comes from
-rank fusion across both halves rather than from term overlap alone.
-
-Scores are not comparable across the two modes and are not calibrated:
-matched-fragment weight plus boosts in the lexical-only mode, RRF rank
-fusion (~0.02 scale) in the hybrid one. Treat them as an ordering, not a
-measure — `min_score` is for callers who have calibrated against their own
-corpus, which is why the MCP surface does not offer it. To bound a
-response, use `budget` instead: it caps the whole payload — the entries
-delivered in full and the `outline` rows naming the rest — so what comes
-back fits what you asked for.
-
-## Configuration
-
-| Env var | Description |
-|---|---|
-| `OCHAKAI_DATABASE_URL` | Cloud SQL connection string (required) |
-| `OCHAKAI_DB_IAM_AUTH` | `true` enables Cloud SQL IAM database authentication: the connection password is a short-lived IAM token, so the connection string carries no secret |
-| `OCHAKAI_GCS_BUCKET` | Bucket for attachment bytes (auth is ADC — no keys). Default: unset — the instance stores markdown entries only and attach operations return an error |
-| `OCHAKAI_EMBEDDINGS` | `off` runs lexical-only on a deployment that would otherwise get hybrid semantic search. Running on Google Cloud, ochakai reads its own project from the metadata server and turns embeddings on with it — there is nothing to set, and whether it can actually call Vertex AI is decided by IAM (`roles/aiplatform.user`) rather than by configuration, asked once at startup (design doc [0053](docs/design/0053-embeddings-by-default.md)). Off Google Cloud there is no metadata server and nothing is enabled. Takes `on` or `off`; any other spelling is a startup error rather than a guess. Default: on where it is discovered |
-| `OCHAKAI_VERTEX_PROJECT` | Names the Vertex AI project explicitly — for a project other than the one ochakai runs in, or for running it outside Google Cloud. A deployment that names one has asked for semantic search: if Vertex AI or pgvector is not there it refuses to start, where a discovered one falls back to lexical search. Auth is ADC — no API keys |
-| `OCHAKAI_VERTEX_LOCATION` / `OCHAKAI_VERTEX_MODEL` / `OCHAKAI_EMBEDDING_DIM` | Embedding details (defaults: `us-central1`, `gemini-embedding-001`, 768). For image/PDF attachment search set model `gemini-embedding-2` with location `global` (or `us`/`eu`). Vectors are written when an entry is written, so a base loaded before embeddings were reachable — or a changed model — leaves entries unembedded until you run `ochakai reembed` (design doc 0020). Dimensions above 2000 exceed pgvector's indexing limit, so those deployments fall back to an exact scan. Changing `OCHAKAI_EMBEDDING_DIM` on a base that already holds vectors rebuilds the vector tables at the new width on the next start: a vector is derived from the entry it describes, so nothing curated is lost, and `ochakai reembed` refills them |
-| `OCHAKAI_DELEGATING_CALLERS` | Comma-separated caller identities allowed to forward an end user's identity with `X-Ochakai-On-Behalf-Of: human:tanaka@example.co.jp` (`*` for any authenticated caller). For applications that embed ochakai and serve many people — without it, every one of their users collapses into the application's one service account. Both identities are recorded (`human:tanaka@… via process:app-sa@…`), never just the forwarded one. Default: empty, delegation off; a header from an unlisted caller is a 403, not a silent downgrade (design doc 0027) |
-| `OCHAKAI_PRODUCER` | `ochakai` CLI only: the software running the CLI, as `<producer>/<version>` — e.g. `claude-code/2026.07`. It goes out as `X-Ochakai-Producer` and is recorded **beside** the actor (`human:tanaka@… using claude-code/2026.07`), never in its place, so an agent shelling out to the CLI stops writing under the operator's name alone. Any authenticated caller may send the header — it names the caller's own build, not somebody else's identity, so no allowlist gates it — and a malformed value is a 400, not a silent drop. On the MCP surface the same value is taken from the client's `initialize` info when the header is absent. Default: unset, nothing declared (design doc [0052](docs/design/0052-producer-beside-the-actor.md)) |
-| `OCHAKAI_IAP_AUDIENCE` | `ochakai serve-ui` only: the IAP JWT audience to verify, which turns browser edits from `process:<webui-sa>` into the person signed in (`human:tanaka@… via process:<webui-sa>`). Requires the webui's service account in the server's `OCHAKAI_DELEGATING_CALLERS`. Once set, a request IAP did not sign is refused rather than recorded as the service account. Default: empty, per-user provenance off (design doc 0032) |
-| `OCHAKAI_READ_ONLY` | `true` makes the deployment serve knowledge without changing it: every write is a 403, MCP does not offer the write tools at all, and the web UI stops drawing buttons that would only fail. For a reference-only instance or freezing a base during a migration; a *public* demo needs `OCHAKAI_PUBLIC_READ_ONLY` below, because read-only alone still refuses anonymous callers. It is not authorization — it does not look at the caller, and it refuses the operator too (design doc [0040](docs/design/0040-read-only-mode.md)). Usage telemetry still records, being the server's own observation. Default: off |
-| `OCHAKAI_PUBLIC_READ_ONLY` | `true` is the posture for a deployment anyone may reach — a demo, or a reference-only copy handed out. It **reads no identity at all**: the `Authorization` header is ignored (without Cloud Run IAM in front nothing verified its signature, so believing it would let any caller name any person), delegation is ignored, every caller is `human:anonymous`, and nobody is refused. It **implies** `OCHAKAI_READ_ONLY` and cannot be separated from it — not recording who asked is only defensible because nothing is written, so a publicly readable *and writable* ochakai is not a configuration this program accepts (design doc [0042](docs/design/0042-public-read-only.md)). Setting it together with `OCHAKAI_INSECURE_DEV` is refused at startup. Default: off |
-| `OCHAKAI_RECORD_MISSES` | `false` stops ochakai keeping the searches that found nothing. A miss is the one thing here that a caller typed rather than curated, so it has a switch: with it off, `ochakai stats` reports `misses -` rather than zero, and the rest of the loop is measured as before. A public deployment (`OCHAKAI_PUBLIC_READ_ONLY`) keeps none either way — it reads no identity, so it does not collect what strangers asked for. Kept 180 days, like the raw usage events (design doc [0051](docs/design/0051-instance-metrics-and-search-misses.md)). Default: on |
-| `OCHAKAI_INSECURE_DEV` | Local development only: disables auth, everything acts as human:anonymous |
-| `PORT` | Listen port (default `8080`) |
-
-Authentication has no configuration: ochakai reads the caller identity
-that Cloud Run forwards after its IAM check (`human:<email>` for people,
-`process:<sa-email>` for service accounts) and records it as provenance.
-Reachability is Cloud Run IAM's job; ochakai does no authorization.
-
-The complete, cost-minimized deployment walkthrough (~$10/month) lives in
-[deploy/cloudrun/README.md](deploy/cloudrun/README.md), including a
-security hardening checklist (org-policy guardrails, private IP,
-retiring the last password, and more).
-
-## Supply chain
-
-Images are published to `ghcr.io/na0fu3y/ochakai` by GitHub Actions with
-SBOM and SLSA provenance; workflow actions are pinned by commit SHA. The
-binary is a static, trimmed-path Go build on `distroless/static`. Verify:
-
-```sh
-gh attestation verify oci://ghcr.io/na0fu3y/ochakai:<tag> -R na0fu3y/ochakai
-```
-
-## Design
-
-[docs/architecture.md](docs/architecture.md) is the English overview: how
-the pieces fit, what the data model is, and why there is no authorization
-layer. [docs/surface.md](docs/surface.md) is the shorter question — what
-ochakai is for and how big it is allowed to get: seven conditions, and
-every endpoint, tool, command and variable that serves one of them,
-counted.
-
-Underneath it, the decisions themselves live in
-[docs/design](docs/design) as numbered, immutable decision records — the
-[index](docs/design/README.md) groups them by area and marks which ones
-still describe the current state. They are **mostly Japanese**, and they
-are authoritative where they and the prose here disagree — which is why
-[README.en.md](docs/design/README.en.md) sits beside the index and
-summarizes every record in English: what was decided, and what it means
-if you are using ochakai rather than building it.
-[0001](docs/design/0001-architecture.md) carries the survey of prior art:
-OpenAI's and Meta's in-house data agents, Airbnb Minerva, Uber uMetric,
-Snowflake's Verified Query Repository, dbt-mcp, Vanna, WrenAI, and the
-2026 context-layer landscape (OpenMetadata, DataHub, Atlan,
-warehouse-native semantic layers).
+- **Evaluating** — [FAQ](docs/faq.md) ·
+  [Architecture](docs/architecture.md) ·
+  [Compatibility and support](docs/compatibility.md) ·
+  [Roadmap](ROADMAP.md)
+- **Using** — [The improvement loop](docs/loop.md) ·
+  [Writing knowledge](docs/knowledge.md) · [CLI reference](docs/cli.md) ·
+  [MCP clients](docs/guides/mcp-clients.md) ·
+  [Troubleshooting](docs/guides/troubleshooting.md)
+- **Running** — [Deploy on Cloud Run](deploy/cloudrun/README.md) ·
+  [Configuration](docs/configuration.md) ·
+  [Operating](docs/guides/operating.md) ·
+  [Golden query canary](docs/guides/golden-query-canary.md)
+- **Building on it** — [REST API](api/openapi.yaml) ·
+  [Examples](examples) · [All docs](docs/README.md)
+- **Deciding** — [The surface](docs/surface.md), the seven conditions
+  ochakai exists to satisfy and everything counted against them, and
+  [docs/design](docs/design/README.md), the numbered decision records
+  behind it (mostly Japanese, [summarized in
+  English](docs/design/README.en.md)).
 
 ## Contributing
 
 Issues and PRs welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for the
 local setup and the checks CI runs. A design doc in Japanese is the
 project's own habit, not a requirement: propose in whichever language you
-think in, and say so in the PR.
-
-- [docs/faq.md](docs/faq.md) — the questions this shape invites, and
-  [troubleshooting](docs/guides/troubleshooting.md) for the symptoms
-- [SUPPORT.md](SUPPORT.md) — where to ask a question
-- [ROADMAP.md](ROADMAP.md) — what is being worked on, and what is
-  deliberately refused
-- [CHANGELOG.md](CHANGELOG.md) — what changed between releases
-- [SECURITY.md](SECURITY.md) — reporting vulnerabilities
+think in, and say so in the PR. [SUPPORT.md](SUPPORT.md) is where to ask
+a question, [SECURITY.md](SECURITY.md) where to report a vulnerability.
 
 ## License
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -28,8 +28,9 @@ Most answers are already written down, and the docs are short enough to check:
 - [docs/guides/troubleshooting.md](docs/guides/troubleshooting.md) — symptoms
   and their causes on the local and client side, from an empty search to a
   skipped import to a 412.
-- [README](README.md) — what ochakai is, the configuration table, and the
-  things it deliberately does not do.
+- [README](README.md) — what ochakai is, and the things it deliberately does
+  not do. [docs/configuration.md](docs/configuration.md) has the requirements
+  and every environment variable.
 - [deploy/cloudrun/README.md](deploy/cloudrun/README.md) — the full Cloud Run +
   Cloud SQL walkthrough, including the hardening checklist.
 - [docs/design/README.md](docs/design/README.md) — the index of numbered design

--- a/cmd/ochakai/clidocs_test.go
+++ b/cmd/ochakai/clidocs_test.go
@@ -32,8 +32,8 @@ below is one HTTP call against the server named by ` + "`--url`" + `, ` + "`$OCH
 or the ` + "`ochakai use`" + ` selection, in that order (design docs
 [0004](design/0004-cli.md), [0007](design/0007-api-only-cli.md)). ` + "`serve`" + `
 and ` + "`serve-ui`" + ` are the exception: they are the deployed services, and they
-take their configuration from the environment rather than from flags — the
-README's [Configuration](../README.md#configuration) table lists it.
+take their configuration from the environment rather than from flags —
+[Requirements and configuration](configuration.md) lists it.
 
 The same text is what ` + "`ochakai <command> -h`" + ` prints, so nothing here can
 disagree with the binary you are running.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,7 @@
 # Documentation
 
-Start with the [README](../README.md) — it is the manual as much as the
-pitch, and it carries the quick start, the MCP tool list, the knowledge
-types, and every environment variable.
+Start with the [README](../README.md) — what ochakai is, the quick start,
+and what it refuses to do. It is deliberately short; the manual is here.
 
 ## For someone evaluating ochakai
 
@@ -19,8 +18,27 @@ types, and every environment variable.
   deliberately refused.
 - [Changelog](../CHANGELOG.md) — what changed between releases.
 
+## For someone using it
+
+- [Writing knowledge](knowledge.md) — what goes in an entry: the type
+  vocabulary, ids as addresses, links that come from the prose,
+  attachments, the OKF frontmatter that carries trust, and what search
+  does with all of it.
+- [The improvement loop](loop.md) — recall, write-back, review, outcome
+  reports: four prompts that walk it end to end, the web UI's three
+  feeds, and what gets measured.
+- [CLI reference](cli.md) — every command's synopsis, flags and worked
+  examples. It is `ochakai <command> -h` rendered, and a test fails when
+  the two disagree, so it is readable before you have a binary and cannot
+  go stale after you do.
+- [Connecting an MCP client](guides/mcp-clients.md) — the eight tools an
+  agent sees, and the URL or the `mcp-stdio` bridge per client, with the
+  config file each one reads.
+
 ## For someone running it
 
+- [Requirements and configuration](configuration.md) — what ochakai needs
+  before it starts, and every environment variable it reads.
 - [Deploy on Cloud Run](../deploy/cloudrun/README.md) — the complete
   walkthrough, ~$10/month, including private IP, the IAP-fronted web UI,
   a security hardening checklist, and the upgrade path.
@@ -48,13 +66,6 @@ types, and every environment variable.
   `get_context` have something to show.
 - [examples/claude-code](../examples/claude-code) — drop-in agent
   instructions and the recall / write-back hooks.
-- [Connecting an MCP client](guides/mcp-clients.md) — the URL or the
-  `mcp-stdio` bridge, per client, with the config file each one reads and
-  the ones that cannot reach an IAM-restricted deployment at all.
-- [CLI reference](cli.md) — every command's synopsis, flags and worked
-  examples. It is `ochakai <command> -h` rendered, and a test fails when
-  the two disagree, so it is readable before you have a binary and cannot
-  go stale after you do.
 
 ## For someone changing it
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -8,8 +8,8 @@ below is one HTTP call against the server named by `--url`, `$OCHAKAI_URL`,
 or the `ochakai use` selection, in that order (design docs
 [0004](design/0004-cli.md), [0007](design/0007-api-only-cli.md)). `serve`
 and `serve-ui` are the exception: they are the deployed services, and they
-take their configuration from the environment rather than from flags — the
-README's [Configuration](../README.md#configuration) table lists it.
+take their configuration from the environment rather than from flags —
+[Requirements and configuration](configuration.md) lists it.
 
 The same text is what `ochakai <command> -h` prints, so nothing here can
 disagree with the binary you are running.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,67 @@
+# Requirements and configuration
+
+## Requirements
+
+**Running it for real means Google Cloud.** Cloud Run's IAM check decides who
+reaches a deployment and Cloud SQL authenticates the service account, which
+is how ochakai holds no secret of its own — and it is also why there is no
+supported way to run it on another cloud or on-prem (design docs
+[0002](design/0002-authn-authz.md), [0003](design/0003-gcp-only.md)). What is
+portable is the knowledge, not the runtime: it round-trips through OKF
+bundles, so leaving does not depend on what you are leaving.
+`deploy/compose.yaml` runs the same binary locally with authentication
+switched off — a development harness, not the small end of production.
+
+**There is no authorization.** Whoever can reach a deployment can read and
+write everything. If you need per-entry permissions, this is the wrong tool;
+the [README's refusal table](../README.md#what-it-refuses) says what that
+buys.
+
+**PostgreSQL, plus `pg_trgm`.** The first migration creates the extension, so
+a database whose user may not `CREATE EXTENSION` needs an admin to create it
+once — that is what the deploy guide's bootstrap SQL is for. Semantic search
+adds `vector` (pgvector) the same way — it is on by default on Google Cloud,
+and a database that cannot hold vectors makes a discovered deployment fall
+back to lexical search rather than fail. Without it, plain PostgreSQL is
+enough. CI and the deploy guide both exercise Postgres 17.
+
+**The server needs Docker; the client commands need a binary.** The README's
+quick start runs the CLI with `go run`, which wants the toolchain named in
+`go.mod` — Go 1.21 and newer download it for you. To stay toolchain-free,
+take a [release archive](https://github.com/na0fu3y/ochakai/releases)
+instead, or talk to the API directly, since that is all the CLI does — see
+[Writing knowledge](knowledge.md) for the one-line `curl` version of a write.
+
+## Environment variables
+
+| Env var | Description |
+|---|---|
+| `OCHAKAI_DATABASE_URL` | Cloud SQL connection string (required) |
+| `OCHAKAI_DB_IAM_AUTH` | `true` enables Cloud SQL IAM database authentication: the connection password is a short-lived IAM token, so the connection string carries no secret |
+| `OCHAKAI_GCS_BUCKET` | Bucket for attachment bytes (auth is ADC — no keys). Default: unset — the instance stores markdown entries only and attach operations return an error |
+| `OCHAKAI_EMBEDDINGS` | `off` runs lexical-only on a deployment that would otherwise get hybrid semantic search. Running on Google Cloud, ochakai reads its own project from the metadata server and turns embeddings on with it — there is nothing to set, and whether it can actually call Vertex AI is decided by IAM (`roles/aiplatform.user`) rather than by configuration, asked once at startup (design doc [0053](design/0053-embeddings-by-default.md)). Off Google Cloud there is no metadata server and nothing is enabled. Takes `on` or `off`; any other spelling is a startup error rather than a guess. Default: on where it is discovered |
+| `OCHAKAI_VERTEX_PROJECT` | Names the Vertex AI project explicitly — for a project other than the one ochakai runs in, or for running it outside Google Cloud. A deployment that names one has asked for semantic search: if Vertex AI or pgvector is not there it refuses to start, where a discovered one falls back to lexical search. Auth is ADC — no API keys |
+| `OCHAKAI_VERTEX_LOCATION` / `OCHAKAI_VERTEX_MODEL` / `OCHAKAI_EMBEDDING_DIM` | Embedding details (defaults: `us-central1`, `gemini-embedding-001`, 768). For image/PDF attachment search set model `gemini-embedding-2` with location `global` (or `us`/`eu`). Vectors are written when an entry is written, so a base loaded before embeddings were reachable — or a changed model — leaves entries unembedded until you run `ochakai reembed` (design doc [0020](design/0020-attachment-search.md)). Dimensions above 2000 exceed pgvector's indexing limit, so those deployments fall back to an exact scan. Changing `OCHAKAI_EMBEDDING_DIM` on a base that already holds vectors rebuilds the vector tables at the new width on the next start: a vector is derived from the entry it describes, so nothing curated is lost, and `ochakai reembed` refills them |
+| `OCHAKAI_DELEGATING_CALLERS` | Comma-separated caller identities allowed to forward an end user's identity with `X-Ochakai-On-Behalf-Of: human:tanaka@example.co.jp` (`*` for any authenticated caller). For applications that embed ochakai and serve many people — without it, every one of their users collapses into the application's one service account. Both identities are recorded (`human:tanaka@… via process:app-sa@…`), never just the forwarded one. Default: empty, delegation off; a header from an unlisted caller is a 403, not a silent downgrade (design doc [0027](design/0027-delegated-provenance.md)) |
+| `OCHAKAI_PRODUCER` | `ochakai` CLI only: the software running the CLI, as `<producer>/<version>` — e.g. `claude-code/2026.07`. It goes out as `X-Ochakai-Producer` and is recorded **beside** the actor (`human:tanaka@… using claude-code/2026.07`), never in its place, so an agent shelling out to the CLI stops writing under the operator's name alone. Any authenticated caller may send the header — it names the caller's own build, not somebody else's identity, so no allowlist gates it — and a malformed value is a 400, not a silent drop. On the MCP surface the same value is taken from the client's `initialize` info when the header is absent. Default: unset, nothing declared (design doc [0052](design/0052-producer-beside-the-actor.md)) |
+| `OCHAKAI_IAP_AUDIENCE` | `ochakai serve-ui` only: the IAP JWT audience to verify, which turns browser edits from `process:<webui-sa>` into the person signed in (`human:tanaka@… via process:<webui-sa>`). Requires the webui's service account in the server's `OCHAKAI_DELEGATING_CALLERS`. Once set, a request IAP did not sign is refused rather than recorded as the service account. Default: empty, per-user provenance off (design doc [0032](design/0032-webui-iap-identity.md)) |
+| `OCHAKAI_READ_ONLY` | `true` makes the deployment serve knowledge without changing it: every write is a 403, MCP does not offer the write tools at all, and the web UI stops drawing buttons that would only fail. For a reference-only instance or freezing a base during a migration; a *public* demo needs `OCHAKAI_PUBLIC_READ_ONLY` below, because read-only alone still refuses anonymous callers. It is not authorization — it does not look at the caller, and it refuses the operator too (design doc [0040](design/0040-read-only-mode.md)). Usage telemetry still records, being the server's own observation. Default: off |
+| `OCHAKAI_PUBLIC_READ_ONLY` | `true` is the posture for a deployment anyone may reach — a demo, or a reference-only copy handed out. It **reads no identity at all**: the `Authorization` header is ignored (without Cloud Run IAM in front nothing verified its signature, so believing it would let any caller name any person), delegation is ignored, every caller is `human:anonymous`, and nobody is refused. It **implies** `OCHAKAI_READ_ONLY` and cannot be separated from it — not recording who asked is only defensible because nothing is written, so a publicly readable *and writable* ochakai is not a configuration this program accepts (design doc [0042](design/0042-public-read-only.md)). Setting it together with `OCHAKAI_INSECURE_DEV` is refused at startup. Default: off |
+| `OCHAKAI_RECORD_MISSES` | `false` stops ochakai keeping the searches that found nothing. A miss is the one thing here that a caller typed rather than curated, so it has a switch: with it off, `ochakai stats` reports `misses -` rather than zero, and the rest of the loop is measured as before. A public deployment (`OCHAKAI_PUBLIC_READ_ONLY`) keeps none either way — it reads no identity, so it does not collect what strangers asked for. Kept 180 days, like the raw usage events (design doc [0051](design/0051-instance-metrics-and-search-misses.md)). Default: on |
+| `OCHAKAI_INSECURE_DEV` | Local development only: disables auth, everything acts as human:anonymous |
+| `PORT` | Listen port (default `8080`) |
+
+Client commands read `OCHAKAI_URL` — the server to talk to, overriding the
+`ochakai use` selection. [CLI reference](cli.md) has the rest.
+
+## Authentication has no configuration
+
+ochakai reads the caller identity that Cloud Run forwards after its IAM check
+(`human:<email>` for people, `process:<sa-email>` for service accounts) and
+records it as provenance. Reachability is Cloud Run IAM's job; ochakai does
+no authorization.
+
+The complete, cost-minimized deployment walkthrough (~$10/month) lives in
+[deploy/cloudrun/README.md](../deploy/cloudrun/README.md), including a
+security hardening checklist (org-policy guardrails, private IP, retiring the
+last password, and more).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -168,8 +168,8 @@ Yes, two ways. Take a
 [release archive](https://github.com/na0fu3y/ochakai/releases) — linux,
 macOS and Windows on amd64 and arm64, with checksums and build provenance
 — or skip the client entirely and talk to the REST API, which is all the
-CLI does. The README's [Requirements](../README.md#requirements) section
-has a `curl` that creates an entry.
+CLI does. [Writing knowledge](knowledge.md) opens with a `curl` that
+creates an entry.
 
 ### What is an "entry", exactly?
 

--- a/docs/guides/mcp-clients.md
+++ b/docs/guides/mcp-clients.md
@@ -39,6 +39,41 @@ transcribed from each client's own documentation as of July 2026 and
 marked where nobody here has run it — a config that turns out to be wrong
 is worth an issue.
 
+## What an agent gets
+
+| Tool | Description |
+|---|---|
+| `get_context` | The one call before answering a data question: full entries behind the top hits, links expanded both ways |
+| `search_concepts` | Cross-type search; verified entries rank higher |
+| `get_concept` | Fetch one entry as an OKF document, with its links and attachment metadata |
+| `get_attachment` | Fetch a file attached to an entry (dashboard screenshots, ER diagrams, seeds files) |
+| `put_concept` | Write learnings back — creates if the id is free, replaces if it is taken; every change is kept as a revision |
+| `delete_concept` | Soft-delete (history retained) |
+| `get_concept_usage` | Usage totals per entry — draft-promotion evidence, staleness signal |
+| `report_outcome` | Report worked/failed after acting on knowledge — failed reports flag verified entries for re-verification |
+
+Every one of these is a knowledge operation: ochakai never executes SQL and
+never calls an LLM. `compile_sql` — deterministic SQL generation from a
+semantic model — existed until 0.13.0 and was retired (design doc
+[0028](../design/0028-retire-compile-sql.md)): what an agent actually needs
+is the verified query and the caveat around it, and both arrive from
+`get_context`.
+
+Every entry is also an **MCP resource** addressable by its canonical URI —
+`ochakai://` plus its id (the entry's path), e.g. `ochakai://metrics/revenue`
+or `ochakai://queries/sales/top-customers`. Clients that support resource
+references (`@`-mentions) can pull an entry in as an OKF document —
+frontmatter and body — without a tool call; discovery stays with
+`get_context`/`search_concepts`. Read tools carry `readOnly` annotations and
+`delete_concept` a `destructive` one, so client auto-approval policies work
+without parsing descriptions.
+
+The tool count is a budget, not a mirror of REST: schemas are paid for out of
+the agent's context window, so the REST API is a superset — bulk export, the
+human-facing reads, file writes, and no bulk import at all (design doc
+[0015 §3.1-3.2](../design/0015-surface-consistency.md)). For an agent with a
+shell, the [CLI](../cli.md) covers everything and costs no schema.
+
 ## What the bridge needs
 
 Every config below that launches a command needs `ochakai` on the
@@ -88,7 +123,7 @@ opening it in Claude Code connects automatically.
 Claude Code also has a shell, which is the other way in and often the
 better one: the CLI's tool schemas cost the agent no context, because
 `--help` is read on demand. See the README's
-[Connect Claude Code](../../README.md#connect-claude-code).
+[Connect an agent](../../README.md#connect-an-agent).
 
 ## Claude Desktop
 
@@ -309,7 +344,7 @@ supported path.
   serves.
 - **Searches come back empty on a base that has entries.** Not a
   connection problem. Japanese knowledge bases want embeddings on; see
-  the README's [search notes](../../README.md#configuration).
+  [what search does with it](../knowledge.md#what-search-does-with-it).
 
 `ochakai mcp-stdio` writes diagnostics to stderr and keeps stdout for the
 protocol, so a client that surfaces server logs will show you what it

--- a/docs/guides/operating.md
+++ b/docs/guides/operating.md
@@ -300,6 +300,22 @@ thing is to say so in
 [Discussions](https://github.com/na0fu3y/ochakai/discussions) with what
 you actually see. That is how this section gets numbers.
 
+## Supply chain
+
+Images are published to `ghcr.io/na0fu3y/ochakai` by GitHub Actions with
+SBOM and SLSA provenance; workflow actions are pinned by commit SHA. The
+binary is a static, trimmed-path Go build on `distroless/static`. Verify
+what you are about to deploy:
+
+```sh
+gh attestation verify oci://ghcr.io/na0fu3y/ochakai:<tag> -R na0fu3y/ochakai
+```
+
+Release archives for the CLI carry the same attestations, plus a
+`checksums.txt`. Binary Authorization can enforce the check at deploy time —
+the deploy guide's [§6](../../deploy/cloudrun/README.md) has that and the
+rest of the hardening checklist.
+
 ## Upgrades
 
 Migrations run automatically at startup, so an upgrade is a new image

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -1,0 +1,187 @@
+# Writing knowledge
+
+An entry is an [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf)
+v0.2 document — YAML frontmatter is the metadata, the markdown below it is
+the body — and its **id is its address**: the entry lives in the bundle at
+its id plus `.md`, which is the same place an export writes it and the same
+place `ochakai get` reads it from. Reading an entry, editing it, and sending
+it back is one loop with no translation in it.
+
+```sh
+curl -X PUT http://localhost:8080/api/v1/bundle/metrics/revenue.md \
+  -H 'content-type: text/markdown' \
+  --data-binary $'---\ntype: Metric\n---\n\nCompleted orders only, net of refunds.\n'
+```
+
+This page is the reference for what goes in one.
+[Architecture](architecture.md) explains why the model has this shape; the
+decision records it links are authoritative.
+
+## Types
+
+| Type | What it holds |
+|---|---|
+| `Metric` | Semantic metric definition, synonyms |
+| `Attested Computation` | A sanctioned computation and the means to check a run of it: the computation in a `# Computation` body fence, the contract in the `runtime` / `parameters` / `executor` / `attester` fields. ochakai records it and never runs it. A golden query is one of these: `runtime` says where the SQL runs, and a producer key such as `question` carries the question it answers |
+| `Skill` | A procedure an entry's `executor.resource` points at — how to actually run a computation on a given runtime |
+| `Playbook` | An operational procedure people and agents follow, bound to no resource: incident triage, an on-call runbook |
+| `Insight` | How to read a metric: baselines, seasonality, caveats, thresholds |
+| `Policy` | The rule that decides a number — revenue recognition, cost allocation. What an entry's `sources[].resource` cites |
+| `Glossary Term` | Glossary term |
+| `BigQuery Dataset` | BigQuery dataset catalog entry: a container grouping tables |
+| `BigQuery Table` | BigQuery table catalog entry: source, column notes, known issues |
+| `API Endpoint` | Catalog entry for an asset that is not a BigQuery one |
+| `Reference` | Mirror of external material: enum definitions, licenses, schema docs |
+
+These are recommendations, not a closed set — any single-line value works as
+a type for your own document kinds. The spellings are the
+[OKF knowledge-catalog](https://github.com/GoogleCloudPlatform/knowledge-catalog/tree/main/okf/bundles)
+vocabulary verbatim: OKF registers no taxonomy, so the spelling is the
+meaning, and a bundle's types survive an import/export round-trip unchanged
+with no translation layer (design docs
+[0023](design/0023-okf-type-vocabulary.md),
+[0038](design/0038-type-vocabulary-realignment.md)). Matching is
+case-insensitive; the spelling you write is the one stored.
+
+## IDs are paths, and paths are searchable
+
+IDs may be hierarchical (`queries/sales/monthly-revenue`) to organize
+knowledge into directories. A type is not an address — the directory layout
+of an exported bundle comes from entry IDs alone (design doc
+[0017](design/0017-path-addressing.md)) — so you are free to organize files
+however you like.
+
+Because an ID is an address, it is also something to search within.
+`--prefix` (REST `?prefix=`, MCP `prefixes`) narrows a search or a `context`
+call to a subtree, and repeating it ORs the scopes, so one call can cover two
+parts of the tree and each hit's ID says which it came from (design doc
+[0041](design/0041-path-scoped-search.md)). Matching is on segment
+boundaries: `--prefix metrics` does not reach `metrics-legacy`. Whether that
+is worth using depends on your layout — [examples/demo](../examples/demo)
+groups by kind (`metrics/`, `glossary/`, `queries/sales/`), where `--type`
+already does most of this; it earns its keep when directories mean something
+`--type` cannot say, such as one team's own vocabulary beside a shared one.
+ochakai reads no meaning into any path either way. Note that this is a
+filter, not a permission — anyone who can reach the server can pass any
+prefix, or none.
+
+## Links come from the prose
+
+Entries relate to each other through **the markdown links in their body** —
+there is no links field to fill in. Write `[revenue](/metrics/revenue.md)` in
+the prose and the entry links to `metrics/revenue`; the target gains a
+backlink, and `get_context` expands the edge in both directions. Relative
+paths (`./gross.md`) work too — those two are the forms SPEC §6 defines, and
+they are the only ones, so an exported bundle's links resolve for whoever
+reads it. This is OKF SPEC §5 taken at its word: a link asserts a
+relationship, and what kind of relationship it is comes from the surrounding
+prose, so ochakai stores no relationship type of its own (design doc
+[0024](design/0024-links-from-body.md)). Links inside fenced code blocks
+(``` or ~~~) and inline `` `code spans` `` are examples, not edges, and are
+skipped — indented code is not detected, so a link four spaces deep is read
+as prose. Renaming an entry rewrites the links pointing at it, prose
+included.
+
+## Attachments
+
+Entries can carry file attachments — the dashboard screenshot behind an
+insight, the ER diagram behind a table entry, the seeds.txt or spec PDF
+behind a dataset. Accepted formats are the intersection of what Claude reads
+and what Gemini embeds (png/jpeg/webp, pdf, plain text — sniffed from the
+bytes). Attachments are searchable: filenames match in every search, and
+contents join hybrid search wherever embeddings are enabled — text with any
+embedding model, images and PDFs with `gemini-embedding-2` — and a hit is
+always the owning entry (design doc
+[0020](design/0020-attachment-search.md)). Attachment bytes live in GCS and
+are fetched on demand, and attachments round-trip through OKF bundles as
+plain files next to their entry.
+
+## Trust travels with the knowledge
+
+OKF v0.2's schema is ochakai's schema: every key the spec defines is a
+first-class field, so an exported entry carries its provenance, trust and
+lifecycle (SPEC §5) where a consumer that has never heard of ochakai will
+look for them.
+
+```yaml
+type: Attested Computation
+runtime: bigquery
+title: Monthly revenue by channel
+sources:
+  - id: rev-policy
+    resource: https://wiki.example/finance/revenue-recognition
+    title: Revenue Recognition Policy (FY2026)
+    author: human:jsmith@example.co.jp
+    last_modified: "2026-06-15"
+usage_window: { from: "2026-06-01", to: "2026-06-30" }
+generated: { by: process:analyst@example.iam.gserviceaccount.com, producer: insightflow/1.4.0, at: 2026-07-26T04:12:00Z }
+verified:
+  - { by: human:tanaka@example.co.jp, at: 2026-07-26T09:30:00Z }
+status: stable                 # draft | stable | deprecated
+stale_after: "2026-12-31"      # advisory: re-check on and after this day
+```
+
+`sources` is the material an entry derives from — give one an `id` and a
+markdown footnote in the body can attribute a single claim to it.
+`generated` is who the content stands by and when it last changed; `verified`
+is who confirmed it — absent means unverified, and a `human:` entry is what
+makes it human-reviewed (SPEC §5.3). The `producer` beside `by` is the
+software that made the write, as the caller declared it
+(`<producer>/<version>`, SPEC §7): it says *what* wrote, never *who*, so it
+sits next to the authenticated identity rather than in it (design doc
+[0052](design/0052-producer-beside-the-actor.md)). ochakai holds these the
+way the spec defines them: `status` is the lifecycle value alone (`draft`,
+`stable`, `deprecated`) and `verified` is a ledger of every confirmation, so
+the two signals stay independent. A draft somebody checked and a stable entry
+nobody has are both states the model can hold, and a foreign bundle's
+lifecycle value survives the trip unaltered.
+
+A rejection — reviewed and *not* accepted — is this instance's ruling rather
+than a stage of the concept, so it is not a status either. It exports as
+`rejected_by` / `rejected_at` beside the entry's real status, and import
+never reads it back: a bundle carries knowledge, not one instance's
+judgments.
+
+ochakai **records** these; it never acts on them. It does not fetch a
+source's `resource`, score its credibility signals, or run an Attested
+Computation's `executor` and `attester` — weighing the signals and running
+the computation belong to whoever consumes the entry (SPEC §5.1, §10.5).
+Keys OKF does not define pass through untouched and in place — at the top
+level, and inside a `sources` entry, a `parameter`, an `executor` or an
+`attester` too. Provenance itself is never read back from a bundle: it is
+what this instance observed, not what a document claims (design docs
+[0009](design/0009-provenance-portability.md),
+[0043](design/0043-document-first.md)).
+
+## What search does with it
+
+**Japanese knowledge bases need embeddings, which is why they are the
+default.** PostgreSQL's full-text search does not tokenize Japanese, so the
+lexical half of search matches a query by its fragments against a stored
+haystack — id, title, description, tags, body, attachment filenames. Latin
+words stay whole; Japanese, which has no spaces, is cut into two-character
+windows, and only the windows carrying a kanji or katakana are kept, because
+an all-hiragana window is grammar and matches nearly everything. Entries are
+then ranked by how much of the *rare* part of the query they contain.
+
+That finds the right entries for a keyword and for a Japanese question, but
+it is still a bag of words: ask an English question and an entry sharing
+three of its function words can outrank the one that names the subject. It is
+also not fully indexed. A trigram index cannot serve a two-character pattern
+— there is no whole trigram in one — so Japanese terms like 売上 or 原価 are
+answered by scanning the table: about 16 ms per search across 5000 entries,
+against 0.2 ms for a latin word. That is fine at the scale a curated
+knowledge base reaches and does not stay fine forever.
+`gemini-embedding-001` handles Japanese well, and where embeddings are
+reachable — on Google Cloud, that is the default and takes no configuration
+(design doc [0053](design/0053-embeddings-by-default.md)) — ranking comes
+from rank fusion across both halves rather than from term overlap alone.
+
+Scores are not comparable across the two modes and are not calibrated:
+matched-fragment weight plus boosts in the lexical-only mode, RRF rank fusion
+(~0.02 scale) in the hybrid one. Treat them as an ordering, not a measure —
+`min_score` is for callers who have calibrated against their own corpus,
+which is why the MCP surface does not offer it. To bound a response, use
+`budget` instead: it caps the whole payload — the entries delivered in full
+and the `outline` rows naming the rest — so what comes back fits what you
+asked for.

--- a/docs/loop.md
+++ b/docs/loop.md
@@ -1,0 +1,114 @@
+# The improvement loop
+
+Agents draft, a human verifies, and what happened next is measured. This
+page walks that loop once, end to end, against the quick start's knowledge
+base — the [demo bundle](../examples/demo) has enough in it that each step
+comes back with something.
+
+## Try four prompts
+
+Once an agent is connected ([README](../README.md#connect-an-agent)), four
+prompts walk the whole thing.
+
+**Recall.** Ask something the knowledge base can answer and watch the agent
+reach for it rather than guess:
+
+> What do we already know about revenue? Use ochakai before answering.
+
+One `get_context` call comes back with the entries in full, so the agent
+starts from your definitions instead of inventing one.
+
+**Write back.** Tell it something worth keeping:
+
+> Revenue in August runs about 15% below a normal month — it's seasonal,
+> not a problem. Save that to ochakai so the next session has it.
+
+It lands as a **draft**, attributed to the agent that wrote it. It is not
+trusted yet, and search says so.
+
+**Review.** Open `ochakai ui`, find it in the review queue, and press
+Verify — or Reject with a reason, which is kept so agents stop re-proposing
+it. This is the half no agent does for you.
+
+**Close the loop.** When knowledge turns out to be wrong, say so:
+
+> That golden query returned a number that doesn't match the finance
+> close. Report it as failed in ochakai, with why.
+
+`report_outcome` moves the entry into the re-verification feed instead of
+letting the next agent trust it blind. Verifying it again empties the feed.
+
+If nothing comes back on the first prompt, the agent has not actually
+connected — `ochakai whoami` says which server it is talking to and as whom.
+
+To make the loop automatic rather than habitual, install the
+[Claude Code hooks](../examples/claude-code): a UserPromptSubmit hook injects
+relevant knowledge before the agent starts (recall), and a Stop hook asks it
+once per data session to save what it learned (write-back) — both without an
+LLM.
+
+## The web UI: the human half
+
+Agents write drafts; somebody has to read them. The bundled web UI is where a
+human reviews what agents learned — search and filter by status, browse the
+knowledge as a folder tree (hierarchical IDs are directories), read an entry
+with its links and usage counts, then verify / deprecate / reject (with the
+reason) in one click. One self-contained page, no build step; deliberately
+**not** a BI tool — no charts, no query execution, no chat.
+
+![The draft review queue: entries agents wrote back, waiting for a human to
+verify or reject them](images/webui-review.png)
+
+![The knowledge base as a folder tree: an entry's id is its path, so the
+sidebar is the way in](images/webui-tree.png)
+
+![An entry: status, provenance, and the tabs for its attributes, links,
+backlinks, usage and revision history](images/webui-entry.png)
+
+Same page, two identities: `ochakai ui` serves it on loopback acting as *you*
+(zero deploy, edits recorded as `human:<you>`), and `ochakai serve-ui`
+deploys it as a team-shared service — same container image as the server,
+just `--args=serve-ui`
+([deploy guide §5b](../deploy/cloudrun/README.md)).
+
+## Three feeds, and finishing them
+
+Two feeds put the re-verification queue in front of that reviewer: a
+*verification age* feed (oldest `verified_at` first) so stale golden queries
+surface, and a *needs review* feed (`sort=failed`) that lists the entries
+agents reported wrong, worst first. Both empty the same way: re-verifying an
+entry — "I checked it again and it is still right" — stamps a fresh
+`verified_at` and takes it out of either feed, so the queues are something a
+reviewer can finish rather than a ledger that only grows.
+
+![The re-verification feed, filtered to entries agents reported wrong, with
+the type and status filters above it](images/webui-wrong.png)
+
+A third feed, *stale* (`sort=stale_after`), lists entries past the expiry
+their own author declared — that one clears by editing the entry to
+re-declare the date, since the date is a claim the writer made rather than
+something the server observed.
+
+Whether any of the three is holding anything is one call — `ochakai queues`,
+and the Review tab's badge — so a queue going quiet stops looking like a
+queue being empty; with `--exit-code` it is a cron job away from telling your
+team (design doc [0049](design/0049-queue-counts.md)). And when a cited
+document changes, `?source=<uri>` answers the other direction: every entry
+derived from it, straight from the source's own line on the entry page.
+
+## What is measured
+
+Per-entry usage counts show whether the knowledge is being used;
+`ochakai stats` reports the instance's totals, including the searches that
+came back with nothing (design doc
+[0051](design/0051-instance-metrics-and-search-misses.md)). Outcome reports
+(`report_outcome`: worked / failed) are the evidence-based half of staleness,
+next to the time-based `verified_at` and `stale_after` — an agent that ran a
+golden query and got a wrong number says so, and the entry rises in the
+re-verification feed for a human or agent to re-check. Re-checking is itself
+recorded (`ochakai verify`, or the web UI's Verify), which is what empties
+the feed (design doc [0025](design/0025-closing-the-loop.md)).
+
+To keep golden queries trustworthy without waiting for an agent to trip over
+one, run them as canaries from your CI:
+[golden query canary](guides/golden-query-canary.md).


### PR DESCRIPTION
## What and why

The README had grown to 661 lines and was carrying four jobs at once: the pitch,
the manual, the configuration reference and the knowledge model. For a product
whose whole argument is that it stays small, the front page being the largest
document in the tree is the wrong first impression — and the information
somebody uses to *choose* ochakai was spread thin between reference tables they
only need after they have chosen.

The README is now 192 lines and answers one question: is this the right tool?
What it is, the quick start, how an agent connects, why it exists, what it
refuses, what it requires, and a map to everything else. **Nothing was dropped**
— the reference halves moved to pages that name their audience:

| Moved out | To | Why there |
|---|---|---|
| Knowledge types, ids as addresses, links from the prose, attachments, the OKF frontmatter that carries trust, what search does with Japanese and embeddings | **`docs/knowledge.md`** (new) | It is the reference somebody reads while writing an entry, not while evaluating |
| The four prompts, the review queue, the three feeds, `ochakai queues`, what is measured | **`docs/loop.md`** (new) | The improvement loop is one story; it was split across three README sections |
| Requirements, every environment variable, the auth note | **`docs/configuration.md`** (new) | Read once, by whoever deploys |
| The 8 MCP tools, resources, tool annotations | `docs/guides/mcp-clients.md` | Where somebody connecting a client already is |
| Image/archive attestation and `gh attestation verify` | `docs/guides/operating.md` | Beside the upgrade path, next to the deploy guide's §6 |

Cross-references follow: the CLI reference's generated header (`docs/cli.md`
regenerated with `-update`), the FAQ, the MCP guide, `SUPPORT.md` and the docs
index, which grows a "For someone using it" section.

## Checks

- [x] `scripts/check core` and `scripts/check lint` are clean (0 issues). The
      store is untouched, so `--db` adds nothing here; `scripts/check vuln`
      cannot reach vuln.go.dev from this environment and was not run
- [x] Behavior changes come with tests — none: documentation only. The one Go
      change is the header constant in `cmd/ochakai/clidocs_test.go`, which is
      the generated preamble of `docs/cli.md` and now links
      `docs/configuration.md` instead of a README section that no longer exists

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver` and
      `internal/apiclient` are untouched — no contract change
- [x] Nothing lands on or leaves a surface
- [x] **No surface is widened.** No REST operation, MCP tool, CLI command or
      environment variable is added, renamed or removed, so `docs/surface.md`
      is unchanged and its counts still hold. This PR moves the other direction:
      the surface a reader pays in attention gets smaller

## Design docs

- [x] Not applicable — no accepted decision is altered. This is documentation
      structure, which by CLAUDE.md's rule belongs in a PR description rather
      than a numbered record: a reader can observe where the text lives, but
      nothing about the wire, the stored form, identity, provenance or what
      ochakai refuses has changed
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2NR89s79EFVVMgTSVGCqA)_