### PR TITLE
Let one spelling decide what is reserved (0046 §§3.2, 3.7-3.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -618,6 +618,19 @@ last entry.
 
 ### Fixed
 
+- **One spelling decides what is reserved.** "Is this index.md or
+  log.md" was answered in four places — `domain.ReservedBundleName`,
+  which folded case, and three inline comparisons that did not (the
+  bundle address's write refusal, the import skip, and a copy in
+  `internal/okf` with no callers). The halves of one address disagreed:
+  at `Index.md` a concept was accepted and a file was refused with
+  "index.md and log.md are generated rather than stored". OKF SPEC §3.1
+  reserves exactly the two spellings it writes, so that is what
+  `ReservedBundleName` answers now, and it is the only one that answers.
+  `Index.md` is a file OKF says nothing about, and a bundle that carried
+  one gets it back (design doc
+  [0046](docs/design/0046-bundle-address-space.md) §3.2).
+
 - `api/openapi.yaml` stopped promising fields the server never sent, and
   started declaring things it did. The contract test validates requests
   and responses against the spec, but JSON Schema only checks what is

--- a/cmd/ochakai/retired_test.go
+++ b/cmd/ochakai/retired_test.go
@@ -145,3 +145,46 @@ func repoTextFiles(t *testing.T) []string {
 	}
 	return out
 }
+
+// A reservation answered in two places is a path one half accepts and
+// the other refuses, which is what the four spellings of "is this
+// index.md or log.md" had become: domain.ReservedBundleName folded case
+// while restapi, okf and the import skip each compared the two literals
+// inline, and okf's copy had no callers at all. The address took a
+// concept at "Index.md" and refused a file there.
+//
+// domain.ReservedBundleName is the only one now. This reads the tree for
+// the shape that grew the others — a comparison against the reserved
+// filenames written out by hand — because nothing else would notice a
+// fifth appearing beside it. Prose may name them; only code that decides
+// is a hit, which is what the quotes around the literal pick out.
+func TestOneSpellingDecidesWhatIsReserved(t *testing.T) {
+	forms := []string{`== "index.md"`, `== "log.md"`, `!= "index.md"`, `!= "log.md"`,
+		`"index.md", "log.md"`, `"log.md", "index.md"`}
+	const decides = "internal/domain/attachment.go" // where the decision lives
+	found := false
+	for _, path := range repoTextFiles(t) {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if filepath.Ext(path) != ".go" {
+			continue
+		}
+		rel := filepath.ToSlash(strings.TrimPrefix(filepath.ToSlash(path), "../../"))
+		for _, form := range forms {
+			if !strings.Contains(string(content), form) {
+				continue
+			}
+			if rel == decides {
+				found = true
+				continue
+			}
+			t.Errorf("%s decides what is reserved by comparing %s — call domain.ReservedBundleName instead",
+				rel, form)
+		}
+	}
+	if !found {
+		t.Errorf("%s no longer spells the reserved names: this check now guards nothing", decides)
+	}
+}

--- a/internal/domain/attachment.go
+++ b/internal/domain/attachment.go
@@ -164,11 +164,20 @@ func ValidBundlePath(p string) bool {
 
 // ReservedBundleName reports whether a filename is one OKF reserves per
 // directory: index.md and log.md, which ochakai generates from the
-// bundle rather than storing (design doc 0046 §§3.7-3.8).
+// bundle rather than storing (design doc 0046 §§3.7-3.8). It is the one
+// place that decides — a reservation answered differently in two places
+// is a path one half accepts and the other refuses.
+//
+// Exactly those two spellings, as SPEC §3.1 writes them. Folding case
+// looks like the safer reading and is not: "Index.md" is a file OKF says
+// nothing about, and refusing it would drop it from a bundle that
+// carried it (design doc 0046 §3.2) while ValidID went on accepting the
+// concept id "Index" — the address would take a concept and refuse a
+// file. Two objects whose paths differ only by case do collide when a
+// bundle is extracted on a case-insensitive filesystem, but that is true
+// of "Revenue.md" beside "revenue.md" as well: it is a property of
+// bundles, not of these two names, and the place to notice it is the
+// export rather than here.
 func ReservedBundleName(name string) bool {
-	switch strings.ToLower(name) {
-	case "index.md", "log.md":
-		return true
-	}
-	return false
+	return name == "index.md" || name == "log.md"
 }

--- a/internal/domain/attachment_test.go
+++ b/internal/domain/attachment_test.go
@@ -113,3 +113,39 @@ func TestInlineServable(t *testing.T) {
 		}
 	}
 }
+
+// The reservation is exactly the two spellings SPEC §3.1 writes, and the
+// two validators either side of an address have to agree about it: at
+// one path a concept is accepted and a file refused only if they
+// disagree, which is what folding case here produced. "Index.md" is a
+// file OKF says nothing about — a bundle that carried one gets it back
+// (design doc 0046 §3.2), and the concept id "Index" was never refused.
+func TestReservedNamesAreTheTwoSpellingsTheSpecWrites(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		reserved bool
+	}{
+		{"index.md", true},
+		{"log.md", true},
+		{"Index.md", false},
+		{"LOG.md", false},
+		{"index.MD", false},
+		{"index.md.md", false},
+		{"reindex.md", false},
+	} {
+		if got := ReservedBundleName(tc.name); got != tc.reserved {
+			t.Errorf("ReservedBundleName(%q) = %v, want %v", tc.name, got, tc.reserved)
+		}
+		// The two halves of one address have to answer alike: a name a
+		// file may be written under is an id a concept may be written
+		// under, and a reserved one is neither.
+		if got, want := ValidBundlePath(tc.name), !tc.reserved; got != want {
+			t.Errorf("ValidBundlePath(%q) = %v, want %v", tc.name, got, want)
+		}
+		id := strings.TrimSuffix(tc.name, ".md")
+		if got, want := ValidID(id), !tc.reserved; got != want {
+			t.Errorf("ValidID(%q) = %v, want %v — a path a file may take is an id a concept may take",
+				id, got, want)
+		}
+	}
+}

--- a/internal/okf/bundle.go
+++ b/internal/okf/bundle.go
@@ -54,7 +54,7 @@ func FromBundle(files map[string][]byte) (entries []Doc, atts []BundleAttachment
 		if hiddenPath(clean) {
 			continue
 		}
-		if base := path.Base(clean); base == "index.md" || base == "log.md" {
+		if domain.ReservedBundleName(path.Base(clean)) {
 			continue
 		}
 		if !strings.HasSuffix(clean, ".md") {

--- a/internal/okf/reserved.go
+++ b/internal/okf/reserved.go
@@ -116,14 +116,3 @@ func LogDocument(title string, lines []LogLine) []byte {
 	}
 	return []byte(b.String())
 }
-
-// ReservedName reports whether a bundle path's last segment is one of the
-// two names SPEC §3.1 reserves. Both are derived here, so a write to one
-// is refused and a read of one is generated.
-func ReservedName(path string) bool {
-	base := path
-	if i := strings.LastIndex(path, "/"); i >= 0 {
-		base = path[i+1:]
-	}
-	return base == "index.md" || base == "log.md"
-}

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -371,7 +371,7 @@ func Handler(svc *service.Service) http.Handler {
 	for _, m := range []string{"PUT", "DELETE"} {
 		mux.HandleFunc(m+" /api/v1/bundle/{path...}", func(w http.ResponseWriter, r *http.Request) {
 			path := r.PathValue("path")
-			if _, base := splitReserved(path); isReserved(base) {
+			if _, base := splitReserved(path); domain.ReservedBundleName(base) {
 				writeJSON(w, http.StatusConflict, map[string]string{
 					"error": fmt.Sprintf("%s is generated from the bundle, not stored in it (design doc 0046 §§3.7-3.8)", base),
 				})
@@ -812,12 +812,6 @@ func splitReserved(path string) (dir, base string) {
 		return path[:i], path[i+1:]
 	}
 	return "", path
-}
-
-// isReserved reports whether a bundle path's last segment is one of the
-// two filenames OKF reserves (SPEC §3.1) — the generated ones.
-func isReserved(base string) bool {
-	return base == "index.md" || base == "log.md"
 }
 
 // wantsJSON reports whether the caller asked for the structured form of


### PR DESCRIPTION
Item 4 of the five left open on #325, now merged. Independent of the other three.

## What and why

"Is this `index.md` or `log.md`" was answered in **four** places, with two answers:

| where | answer |
|---|---|
| `domain.ReservedBundleName` | folds case |
| `restapi.isReserved` (the bundle address's write refusal) | exact |
| `internal/okf/bundle.go` (the import skip) | exact, inline |
| `okf.ReservedName` | exact — and no callers at all |

So the two halves of one address disagreed. `PUT /api/v1/bundle/Index.md` carrying a `type` wrote a concept; the same path without one was refused with *"index.md and log.md are generated rather than stored"*. A bundle carrying `Index.md` was half-accepted.

SPEC §3.1 reserves exactly the two spellings it writes, so that is what `ReservedBundleName` answers now — and it is the only thing that answers. The other two call it; the dead copy is gone.

Folding case is the tempting reading and it is the wrong one. `Index.md` is a file OKF says nothing about, refusing it drops it from a bundle that carried it (0046 §3.2), and `ValidID` never refused the concept id `Index` either way — so folding case would have to reach into `ValidID` too, and there it would refuse a foreign concept over a name the spec permits. Two paths differing only by case do collide when a bundle is extracted on a case-insensitive filesystem, but that is as true of `Revenue.md` beside `revenue.md`: a property of bundles, not of these two names, and the place to notice it would be the export.

## Checks

- [x] `scripts/check` is clean — add `--db` when the change touches the store
- [x] Behavior changes come with tests

`scripts/check core` and `scripts/check lint` are clean against PostgreSQL 17 with pgvector. `scripts/check vuln` is not verifiable in this environment (the proxy refuses `vuln.go.dev`); CI runs it.

Two guards, both checked against the unfixed code:

- `TestReservedNamesAreTheTwoSpellingsTheSpecWrites` reads `ReservedBundleName`, `ValidBundlePath` and `ValidID` for the same answer about the same name — the disagreement was only visible by asking two of them.
- `TestOneSpellingDecidesWhatIsReserved` reads the tree for a hand-written comparison against the reserved filenames anywhere but the one place that decides, which is the shape that grew the other three (design doc 0035: read the invariant from outside rather than trust the convention).

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and `internal/apiclient` say the same thing
- [x] The change lands on every surface it belongs on — REST / MCP / CLI / Web UI — and what it stays off is deliberate (design doc 0015)
- [x] Widens a surface? No. Nothing is added and no count moves. What changes is which paths the existing bundle address accepts a *file* at: `Index.md` and `LOG.md` now behave like any other filename, which is what it already did for concepts.

## Design docs

- [x] Alters an accepted decision? No — 0046 §§3.7-3.8 reserve the two names the spec reserves, and this makes the implementation say that once instead of four times.
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xtrzd3JFhLg9S9WFqRUoJK)_