### PR TITLE
List the files a directory holds (0046 §3.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -618,6 +618,27 @@ last entry.
 
 ### Fixed
 
+- **A directory's `index.md` lists the files in it** (design doc
+  [0046](docs/design/0046-bundle-address-space.md) §3.7). §3.7 names
+  three sections — subdirectories, concepts, files — and only the first
+  two were rendered, so a file at a path no concept shows was stored,
+  served at its own address, carried in the archive, and invisible in
+  the bundle's own navigation. It is listed now, under a `## Files`
+  heading, in all three places that render a listing: the generated
+  `index.md`, its JSON representation (`files[]`, so a web UI's
+  directory page can show them), and the copy the archive carries — the
+  same renderer, so a bundle's navigation does not depend on which asked.
+  `ochakai browse` prints them after the entries.
+
+  A subdirectory line still counts **concepts**, and a directory holding
+  nothing but files is still not a subdirectory: OKF's §8 listing is
+  navigation between concept documents, and a count mixing the kinds
+  would misdescribe every directory that has both. Asked about directly,
+  such a directory lists what it holds.
+
+  A bundle with no loose files exports byte-for-byte as it did — the
+  heading appears only where there is something under it.
+
 - `api/openapi.yaml` stopped promising fields the server never sent, and
   started declaring things it did. The contract test validates requests
   and responses against the spec, but JSON Schema only checks what is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -618,6 +618,23 @@ last entry.
 
 ### Fixed
 
+- **The archive carries the history.** Design doc
+  [0046](docs/design/0046-bundle-address-space.md) §3.8 ends "the history
+  becomes portable", and the archive carried the `index.md` of every
+  directory and no `log.md`: the ledger was readable only by calling the
+  instance that holds it, and a purge
+  ([0031](docs/design/0031-purge.md)) is the only thing that ever
+  removes a row from it. A `log.md` is written beside every `index.md`
+  now — the root's included — from the same renderer and the same
+  1000-line bound as the address, so a reader extracting the bundle and
+  a reader calling `GET /api/v1/bundle/{dir}/log.md` are not reading two
+  different histories, and from the export's own snapshot, so it
+  describes the same instant as the documents beside it.
+
+  An import still never reads one back (§2.3): what happened here is
+  this instance's observation, published the way `generated` and
+  `verified` are ([0009](docs/design/0009-provenance-portability.md)).
+
 - **A directory's `index.md` lists the files in it** (design doc
   [0046](docs/design/0046-bundle-address-space.md) §3.7). §3.7 names
   three sections — subdirectories, concepts, files — and only the first

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -439,9 +439,13 @@ paths:
 
         **`Accept: application/gzip` reads the path as a subtree** and
         streams it as an OKF bundle: a tar.gz of markdown + YAML
-        frontmatter, the generated `index.md` files, and every file under
-        the path — including one no entry shows, because what enters the
-        bundle leaves it (design doc 0046 §3.2). The root
+        frontmatter, the generated `index.md` and `log.md` of every
+        directory, and every file under the path — including one no
+        entry shows, because what enters the bundle leaves it (design
+        doc 0046 §3.2). The history travels with it (§3.8): a purge is
+        the only thing that removes a row from the ledger, and an
+        archive without it left the record readable only from the
+        instance holding it. An import never reads it back. The root
         (`/api/v1/bundle/`) is the whole knowledge base — this is what `GET /api/v1/export` was, at the address of
         the thing it returns (design doc 0046 §3.5). Your knowledge is
         yours.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2432,6 +2432,12 @@ components:
         web UI's navigator needs and what the markdown says in prose
         (design docs 0014, 0016). Two representations of one generated
         file, at one address; the JSON is not a second surface.
+
+        Three kinds of thing sit in a directory and the listing carries
+        all three (design doc 0046 §3.7): the subdirectories, the
+        concepts, and the files — a file is an object in the bundle
+        rather than a property of an entry (§3.3), so a directory can
+        hold one that no concept shows.
       properties:
         dirs:
           type: array
@@ -2439,7 +2445,14 @@ components:
             type: object
             properties:
               name: { type: string, description: Next ID segment. }
-              count: { type: integer, description: Entries anywhere beneath. }
+              count:
+                description: >
+                  Concepts anywhere beneath. Concepts only: a directory
+                  holding nothing but files is not a subdirectory here,
+                  because OKF's listing is navigation between concept
+                  documents and a mixed count would misdescribe every
+                  directory that has both.
+                type: integer
         entries:
           type: array
           items:
@@ -2451,9 +2464,21 @@ components:
               description: { type: string, description: The one-line summary, so a directory listing can render as an index page. }
               status: { $ref: "#/components/schemas/Status" }
               updated_at: { type: string, format: date-time }
+        files:
+          description: >
+            The files sitting directly in this directory, in path order.
+          type: array
+          items:
+            type: object
+            properties:
+              name: { type: string, description: The last path segment — what the directory holds it under. }
+              path: { type: string, description: The object's bundle path, which is what it is addressed by. }
+              media_type: { type: string, description: Sniffed from the bytes when it was written, never taken from the caller. }
+              size: { type: integer, description: Bytes. }
+              updated_at: { type: string, format: date-time }
         truncated:
           type: boolean
-          description: The entry list hit the 1000-per-level cap.
+          description: The entry or file list hit the 1000-per-level cap.
     BundleLog:
       type: object
       description: >

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -414,7 +414,7 @@ func cmdQueues(ctx context.Context, args []string) error {
 func cmdBrowse(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
 		"browse",
-		"Usage: ochakai browse [flags] [prefix]\n\nList one level of the ID hierarchy (the folder view of design docs\n0014 and 0017, the CLI counterpart of the web UI's Browse tab).\nWithout an argument, the top-level directories with their entry\ncounts; with a prefix, the subdirectories and entries directly under\nit. Directories print as \"name/\tcount\", entries as\n\"segment\ttype\tstatus\ttitle\". Rejected entries are hidden, as in search.",
+		"Usage: ochakai browse [flags] [prefix]\n\nList one level of the ID hierarchy (the folder view of design docs\n0014 and 0017, the CLI counterpart of the web UI's Browse tab).\nWithout an argument, the top-level directories with their entry\ncounts; with a prefix, the subdirectories and entries directly under\nit. Directories print as \"name/\tcount\", entries as\n\"segment\ttype\tstatus\ttitle\", and the files in the directory as\n\"name\tfile\tmedia-type\tbytes\". Rejected entries are hidden, as in\nsearch.",
 		"  ochakai browse\n  ochakai browse queries\n  ochakai browse ga4/tables\n")
 	asJSON := fs.Bool("json", false, "print the raw JSON response")
 	pos, err := parseArgs(fs, args)
@@ -450,6 +450,13 @@ func cmdBrowse(ctx context.Context, args []string) error {
 			seg = strings.TrimPrefix(seg, prefix+"/")
 		}
 		fmt.Printf("%s\t%s\t%s\t%s\n", seg, e.Type, e.Status, domain.DisplayTitle(e.Title, e.ID))
+	}
+	// The files in the directory, after the concepts and marked as what
+	// they are: a file is an object in the bundle (design doc 0046 §3.3)
+	// and has no type or status to print, so the column that would hold
+	// them holds what it does have.
+	for _, f := range res.Files {
+		fmt.Printf("%s\tfile\t%s\t%d\n", f.Name, f.MediaType, f.Size)
 	}
 	if res.Truncated {
 		fmt.Fprintln(os.Stderr, "note: showing the first 1000 entries at this level (server cap)")

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -119,7 +119,9 @@ List one level of the ID hierarchy (the folder view of design docs
 Without an argument, the top-level directories with their entry
 counts; with a prefix, the subdirectories and entries directly under
 it. Directories print as "name/	count", entries as
-"segment	type	status	title". Rejected entries are hidden, as in search.
+"segment	type	status	title", and the files in the directory as
+"name	file	media-type	bytes". Rejected entries are hidden, as in
+search.
 
 Flags:
   -json

--- a/internal/apiclient/types.go
+++ b/internal/apiclient/types.go
@@ -8,20 +8,34 @@ import (
 
 // BrowseResult mirrors the JSON representation of a directory's index.md
 // (design docs 0014, 0016, and 0046 §3.7 for where it now lives): one
-// level of the ID hierarchy — the subdirectories and entries directly
-// under the prefix ("" is the root). TestBrowseResultMatchesServerWire
-// pins it to service.BrowseResult.
+// level of the ID hierarchy — the subdirectories, entries and files
+// directly under the prefix ("" is the root).
+// TestBrowseResultMatchesServerWire pins it to service.BrowseResult.
 type BrowseResult struct {
 	Dirs      []BrowseDir   `json:"dirs,omitempty"`
 	Entries   []BrowseEntry `json:"entries,omitempty"`
+	Files     []BrowseFile  `json:"files,omitempty"`
 	Truncated bool          `json:"truncated,omitempty"`
 }
 
-// BrowseDir is one subdirectory (ID segment) with the number of entries
-// anywhere beneath it.
+// BrowseDir is one subdirectory (ID segment) with the number of concepts
+// anywhere beneath it. Concepts only: a directory holding nothing but
+// files is not one of these (design doc 0046 §3.7).
 type BrowseDir struct {
 	Name  string `json:"name"`
 	Count int    `json:"count"`
+}
+
+// BrowseFile is one file sitting directly in the directory — the third
+// thing an index.md lists. A file is an object in the bundle rather than
+// a property of an entry (design doc 0046 §3.3), so a directory can hold
+// one that no concept shows.
+type BrowseFile struct {
+	Name      string    `json:"name"`
+	Path      string    `json:"path"`
+	MediaType string    `json:"media_type"`
+	Size      int64     `json:"size"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 // BrowseEntry is the light projection of an entry in a tree listing:

--- a/internal/okf/bundle_test.go
+++ b/internal/okf/bundle_test.go
@@ -32,7 +32,7 @@ func knowledgeOf(docs []Doc) []domain.Knowledge {
 
 func bundle(t *testing.T, entries []domain.Knowledge) map[string][]byte {
 	t.Helper()
-	files := Indexes(entries)
+	files := Indexes(entries, nil)
 	for i := range entries {
 		doc, err := Document(&entries[i])
 		if err != nil {

--- a/internal/okf/okf.go
+++ b/internal/okf/okf.go
@@ -260,22 +260,35 @@ var reservedKeys = func() map[string]bool {
 // sorting entries by id on the way (Bundle's ordering). Split out so a
 // streaming exporter can render one concept document at a time — the
 // indexes need every id, but only the ids.
-func Indexes(entries []domain.Knowledge) map[string][]byte {
+//
+// files are the bundle's file objects, listed in the directory each one
+// sits in (design doc 0046 §3.7). A file in a directory that holds no
+// concept is not listed: the index.md tree is navigation between concept
+// documents, and OKF says nothing about a directory of pure data, so
+// there is no index.md there to list it in. The file is in the archive
+// either way, at its own path — what enters the bundle leaves it (§3.2).
+func Indexes(entries []domain.Knowledge, files []domain.Attachment) map[string][]byte {
 	sort.Slice(entries, func(i, j int) bool { return entries[i].ID < entries[j].ID })
 	root := &dir{}
 	for _, k := range entries {
 		root.insert(strings.Split(k.ID, "/"), k)
 	}
-	files := map[string][]byte{}
-	root.writeIndexes(files, "")
-	return files
+	sorted := append([]domain.Attachment(nil), files...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Path < sorted[j].Path })
+	for _, f := range sorted {
+		root.insertFile(strings.Split(f.Path, "/"), f)
+	}
+	out := map[string][]byte{}
+	root.writeIndexes(out, "")
+	return out
 }
 
 // dir is one directory level of a bundle, used to generate index.md files.
 type dir struct {
 	subdirs map[string]*dir
-	entries []dirEntry // concepts directly in this directory, in bundle order
-	count   int        // concepts in this directory and below
+	entries []dirEntry          // concepts directly in this directory, in bundle order
+	files   []domain.Attachment // file objects directly in this directory, by path
+	count   int                 // concepts in this directory and below
 }
 
 type dirEntry struct {
@@ -298,6 +311,21 @@ func (d *dir) insert(segs []string, k domain.Knowledge) {
 		d.subdirs[segs[0]] = sub
 	}
 	sub.insert(segs[1:], k)
+}
+
+// insertFile files one file object under the directory it sits in, if
+// that directory is in the tree. It creates none: a directory exists
+// here because a concept put it there, and count stays the number of
+// concepts beneath — a subdirectory line saying "4 concepts" for four
+// data files would misdescribe every directory that has both.
+func (d *dir) insertFile(segs []string, f domain.Attachment) {
+	if len(segs) == 1 {
+		d.files = append(d.files, f)
+		return
+	}
+	if sub := d.subdirs[segs[0]]; sub != nil {
+		sub.insertFile(segs[1:], f)
+	}
 }
 
 // subdirNames lists subdirectories alphabetically — every level the
@@ -338,8 +366,12 @@ func (d *dir) writeIndexes(files map[string][]byte, prefix string) {
 	// a read generates one directory, and a bundle whose index.md
 	// changed shape depending on which asked would be two formats
 	// (design doc 0046 §3.7).
+	var fileLines []IndexLine
+	for _, f := range d.files {
+		fileLines = append(fileLines, FileIndexLine(f.Name, f.MediaType, f.Size))
+	}
 	files[prefix+"index.md"] = IndexDocument(strings.TrimSuffix(prefix, "/"),
-		[]IndexSection{{Lines: dirs}, {Lines: concepts}})
+		[]IndexSection{{Lines: dirs}, {Lines: concepts}, {Heading: FileSection, Lines: fileLines}})
 	for name, sub := range d.subdirs {
 		sub.writeIndexes(files, prefix+name+"/")
 	}

--- a/internal/okf/okf_test.go
+++ b/internal/okf/okf_test.go
@@ -655,3 +655,44 @@ func TestDocumentOmitsAnUnnamedProducer(t *testing.T) {
 		t.Errorf("document carries an empty producer key:\n%s", doc)
 	}
 }
+
+// The generated index.md lists the files sitting in a directory beside
+// the concepts (design doc 0046 §3.7), under a heading — a subdirectory
+// line ends in "/" and a concept line does not, so those two read as one
+// list, and a file line would not.
+//
+// A file in a directory that holds no concept is not listed anywhere:
+// the index.md tree is navigation between concept documents, and there
+// is no index.md in such a directory to list it in. It is in the archive
+// at its own path either way (§3.2), which is what the promise is.
+func TestIndexesListFilesBesideTheConcepts(t *testing.T) {
+	entries := sample()
+	files := []domain.Attachment{
+		{Name: "chart.png", Path: "insights/chart.png", MediaType: "image/png", Size: 2048},
+		{Name: "orders.csv", Path: "seeds/orders.csv", MediaType: "text/csv", Size: 12},
+	}
+	idx := Indexes(entries, files)
+
+	got := string(idx["insights/index.md"])
+	if !strings.Contains(got, "## Files") {
+		t.Errorf("no Files heading:\n%s", got)
+	}
+	if !strings.Contains(got, "[chart.png](chart.png) - image/png, 2.0 kB") {
+		t.Errorf("the file is not listed as a file:\n%s", got)
+	}
+	// The concepts are still there, above it.
+	if !strings.Contains(got, "revenue-seasonality.md") {
+		t.Errorf("the concepts went missing:\n%s", got)
+	}
+	if _, ok := idx["seeds/index.md"]; ok {
+		t.Error("a directory of pure data got an index.md, which nothing links to")
+	}
+
+	// A bundle with no loose files renders exactly as it did before the
+	// section existed: no heading, no blank section.
+	for path, doc := range Indexes(entries, nil) {
+		if strings.Contains(string(doc), "Files") {
+			t.Errorf("%s carries a Files section with no files:\n%s", path, doc)
+		}
+	}
+}

--- a/internal/okf/reserved.go
+++ b/internal/okf/reserved.go
@@ -76,6 +76,39 @@ type IndexSection struct {
 	Lines   []IndexLine
 }
 
+// FileSection is the heading the files of a directory are listed under
+// (design doc 0046 §3.7). Subdirectory lines end in "/" and concept
+// lines do not, so those two read as one list without help; a file line
+// would not, and this is where the reader is told which kind it is.
+const FileSection = "Files"
+
+// FileIndexLine is one file's row in a directory's index.md. The name is
+// what the directory holds it under and what the link resolves to; the
+// description is what the file is, because OKF's §8 line wants one and
+// nobody wrote prose for a .csv.
+//
+// Both callers render it here — the export writes the whole tree and a
+// read generates one directory, and an index.md whose shape depended on
+// which asked would be two formats (design doc 0046 §3.7).
+func FileIndexLine(name, mediaType string, size int64) IndexLine {
+	return IndexLine{Text: name, Target: name, Description: mediaType + ", " + humanSize(size)}
+}
+
+// humanSize renders a size the way a listing should read it — whole
+// units, one decimal past a kilobyte. The listing is for a person
+// deciding whether to open something, and "1.4 MB" answers that where
+// 1428406 does not.
+func humanSize(n int64) string {
+	switch {
+	case n >= 1<<20:
+		return fmt.Sprintf("%.1f MB", float64(n)/(1<<20))
+	case n >= 1<<10:
+		return fmt.Sprintf("%.1f kB", float64(n)/(1<<10))
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
+}
+
 // LogLine is one recorded change, as log.md lists it.
 type LogLine struct {
 	At     time.Time

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -126,6 +126,31 @@ func writeBundleArchive(w http.ResponseWriter, r *http.Request, svc *service.Ser
 			fail("index "+path, err)
 			return
 		}
+		// The other file OKF reserves, beside the one that names the
+		// directory's contents (design doc 0046 §3.8). This is what
+		// makes the history portable: an archive that carried the
+		// bundle but not what happened to it left the ledger reachable
+		// only from the instance that holds it, and a purge (0031) is
+		// the only thing that ever removes a row from it.
+		//
+		// One query per directory, bounded the same way the address is,
+		// so a log.md in an archive says what the one at its address
+		// says. Against a file's bytes — a round trip to GCS each — the
+		// cost of these does not register.
+		//
+		// An import never reads them back (§2.3): the history of what
+		// happened here is this instance's observation, published the
+		// way generated and verified are (design doc 0009).
+		dir := strings.TrimSuffix(strings.TrimSuffix(path, "index.md"), "/")
+		log, err := snap.RevisionsUnder(r.Context(), dir, service.MaxLogLines)
+		if err != nil {
+			fail("history "+dir, err)
+			return
+		}
+		if err := add(strings.TrimSuffix(path, "index.md")+"log.md", service.RenderLog(dir, log)); err != nil {
+			fail("log "+dir, err)
+			return
+		}
 	}
 	// Entries in batches: one batch in memory at a time. The snapshot
 	// does hold a pooled connection for the length of the download —

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -82,7 +82,11 @@ func writeBundleArchive(w http.ResponseWriter, r *http.Request, svc *service.Ser
 			return
 		}
 	}
-	indexes := okf.Indexes(rows) // also sorts rows by id
+	// The generated index.md files list the concepts and the files that
+	// sit beside them (design doc 0046 §3.7). With ?attachments=false
+	// there are no file bytes to carry, and an index naming files the
+	// archive does not contain would describe a bundle nobody received.
+	indexes := okf.Indexes(rows, atts) // also sorts rows by id
 	ids := make([]string, len(rows))
 	for i := range rows {
 		ids[i] = rows[i].ID

--- a/internal/restapi/restapi_integration_test.go
+++ b/internal/restapi/restapi_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -1972,5 +1973,76 @@ func TestRESTIntegrationIndexListsTheFilesInADirectory(t *testing.T) {
 	if archived != generated {
 		t.Errorf("the archive's index.md and the generated one differ:\n--- archive ---\n%s\n--- generated ---\n%s",
 			archived, generated)
+	}
+}
+
+// The archive carries the other file OKF reserves (design doc 0046
+// §3.8). An export that held the bundle but not what happened to it left
+// the ledger readable only from the instance that holds it, and a purge
+// is the only thing that ever removes a row from it (0031) — so the
+// history was portable in the record and not in the artifact.
+//
+// The copy in the archive is the copy at the address: one renderer, one
+// bound, so a reader extracting the bundle and a reader calling the
+// endpoint are not reading two different histories.
+func TestRESTIntegrationTheArchiveCarriesTheHistory(t *testing.T) {
+	srv, _ := newIntegrationServer(t)
+
+	typ := fmt.Sprintf("restlog%d", time.Now().UnixNano())
+	id := typ + "/revenue"
+	removeEntries(t, srv, id)
+	resp := putDoc(t, srv.URL, id, docFrom(t, map[string]any{
+		"type": typ, "id": id, "title": "Revenue"}), true)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create status = %d", resp.StatusCode)
+	}
+
+	archived := map[string]string{}
+	resp, err := getArchive(t, srv.URL+"/api/v1/bundle/", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	gz, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for tr := tar.NewReader(gz); ; {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		b, err := io.ReadAll(tr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		archived[hdr.Name] = string(b)
+	}
+
+	// One beside every index.md, the root's included.
+	for path := range archived {
+		if !strings.HasSuffix(path, "index.md") {
+			continue
+		}
+		if _, ok := archived[strings.TrimSuffix(path, "index.md")+"log.md"]; !ok {
+			t.Errorf("%s has no log.md beside it", path)
+		}
+	}
+	if got := archived[typ+"/log.md"]; !strings.Contains(got, "**Create**") ||
+		!strings.Contains(got, "[Revenue](/"+id+".md)") {
+		t.Errorf("the directory's history does not record the write:\n%s", got)
+	}
+	if root := archived["log.md"]; !strings.Contains(root, "# Update Log") {
+		t.Errorf("the root history is not titled as one:\n%s", root)
+	}
+
+	// And it is the same document the address serves.
+	if served := getMarkdown(t, srv.URL+"/api/v1/bundle/"+typ+"/log.md"); served != archived[typ+"/log.md"] {
+		t.Errorf("the archived history and the served one differ:\n--- archive ---\n%s\n--- served ---\n%s",
+			archived[typ+"/log.md"], served)
 	}
 }

--- a/internal/restapi/restapi_integration_test.go
+++ b/internal/restapi/restapi_integration_test.go
@@ -564,6 +564,26 @@ func getJSON(t *testing.T, url string, v any) {
 	}
 }
 
+// getMarkdown fetches a generated file as the file it is — no Accept,
+// which is what a browser or a curl sends and what the reserved paths
+// answer with (design doc 0046 §§3.7-3.8).
+func getMarkdown(t *testing.T, url string) string {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s = %d: %s", url, resp.StatusCode, body)
+	}
+	return string(body)
+}
+
 // POST /api/v1/review/{id} {"ruling":"verified"} records a verification
 // against the entry as it stands. The second call is the point:
 // re-affirming an entry that is already verified is what empties the
@@ -1861,5 +1881,96 @@ func TestRESTIntegrationPurgeOnAFileRemovesIt(t *testing.T) {
 	got.Body.Close()
 	if got.StatusCode != http.StatusNotFound {
 		t.Errorf("the file is still there after the purge: %d", got.StatusCode)
+	}
+}
+
+// A directory's index.md lists the files in it, in both of its
+// representations and in the archive (design doc 0046 §3.7). A file is
+// an object in the bundle, not a property of an entry (§3.3), so a
+// listing that showed only concepts described a directory that was not
+// there — and the archive's index.md and the generated one have to say
+// the same thing, or a bundle's navigation depends on which asked.
+func TestRESTIntegrationIndexListsTheFilesInADirectory(t *testing.T) {
+	lockLiveAttachments(t)
+	srv, s := newIntegrationServer(t)
+	s.UseBlobStore(memBlobStore{})
+
+	typ := fmt.Sprintf("restfiles%d", time.Now().UnixNano())
+	id := typ + "/revenue"
+	loose := typ + "/seed-data.csv"
+	removeEntries(t, srv, id)
+	defer func() {
+		req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/api/v1/bundle/"+loose, nil)
+		if resp, err := http.DefaultClient.Do(req); err == nil {
+			resp.Body.Close()
+		}
+	}()
+
+	resp := putDoc(t, srv.URL, id, docFrom(t, map[string]any{
+		"type": typ, "id": id, "title": "Revenue"}), true)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create status = %d", resp.StatusCode)
+	}
+	req, err := http.NewRequest(http.MethodPut, srv.URL+"/api/v1/bundle/"+loose,
+		bytes.NewReader([]byte("region,orders\napac,12\n")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp, err = http.DefaultClient.Do(req); err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("writing the file = %d", resp.StatusCode)
+	}
+
+	// JSON: the third kind, beside dirs and entries.
+	var listing service.BrowseResult
+	getJSON(t, srv.URL+"/api/v1/bundle/"+typ+"/index.md", &listing)
+	if len(listing.Files) != 1 || listing.Files[0].Name != "seed-data.csv" ||
+		listing.Files[0].Path != loose || listing.Files[0].MediaType == "" {
+		t.Errorf("files in the listing = %+v", listing.Files)
+	}
+	if len(listing.Entries) != 1 {
+		t.Errorf("entries in the listing = %+v", listing.Entries)
+	}
+
+	// Markdown: the same listing, in the shape the format has a place for.
+	generated := getMarkdown(t, srv.URL+"/api/v1/bundle/"+typ+"/index.md")
+	if !strings.Contains(generated, "## Files") || !strings.Contains(generated, "[seed-data.csv](seed-data.csv)") {
+		t.Errorf("the generated index.md does not list the file:\n%s", generated)
+	}
+
+	// And the archive's copy of that same file says the same thing.
+	resp, err = getArchive(t, srv.URL+"/api/v1/bundle/", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	gz, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var archived string
+	for tr := tar.NewReader(gz); ; {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if hdr.Name == typ+"/index.md" {
+			b, err := io.ReadAll(tr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			archived = string(b)
+		}
+	}
+	if archived != generated {
+		t.Errorf("the archive's index.md and the generated one differ:\n--- archive ---\n%s\n--- generated ---\n%s",
+			archived, generated)
 	}
 }

--- a/internal/service/browse.go
+++ b/internal/service/browse.go
@@ -143,13 +143,26 @@ func (s *Service) LogDocument(ctx context.Context, prefix string, limit int) ([]
 	if err != nil {
 		return nil, err
 	}
-	if limit <= 0 || limit > maxLogLines {
-		limit = maxLogLines
+	if limit <= 0 || limit > MaxLogLines {
+		limit = MaxLogLines
 	}
 	rows, err := s.Store.ListRevisionsUnder(ctx, prefix, limit)
 	if err != nil {
 		return nil, err
 	}
+	return RenderLog(prefix, rows), nil
+}
+
+// RenderLog is the log.md of one directory, given the ledger rows under
+// it. Split from the read above because the export renders the same
+// file from a snapshot of its own (design doc 0046 §3.8), and a log.md
+// whose shape depended on which caller asked would be two formats — the
+// same reason the index.md renderer is shared.
+//
+// prefix is already normalized. The root's document is titled for what
+// it is; every other one is titled by its path, which is what a reader
+// extracting the bundle sees above the list.
+func RenderLog(prefix string, rows []store.LogRow) []byte {
 	lines := make([]okf.LogLine, 0, len(rows))
 	for _, r := range rows {
 		lines = append(lines, okf.LogLine{
@@ -160,11 +173,14 @@ func (s *Service) LogDocument(ctx context.Context, prefix string, limit int) ([]
 	if prefix != "" {
 		title = prefix
 	}
-	return okf.LogDocument(title, lines), nil
+	return okf.LogDocument(title, lines)
 }
 
-// maxLogLines bounds a generated history the way the tree listing is
+// MaxLogLines bounds a generated history the way the tree listing is
 // bounded: a log is for reading, and a directory with a hundred thousand
 // changes under it does not become more readable by containing all of
 // them. The whole ledger is still there — ask a narrower path.
-const maxLogLines = 1000
+//
+// The export applies it per directory too, so a log.md in an archive
+// says the same thing the one at its address says.
+const MaxLogLines = 1000

--- a/internal/service/browse.go
+++ b/internal/service/browse.go
@@ -16,17 +16,19 @@ import (
 // Not a search — no usage is recorded: walking the tree to see what
 // exists is not the demand signal search hits measure.
 
-// BrowseResult is one level of the tree: the subdirectories and entries
-// directly under the prefix.
+// BrowseResult is one level of the tree: the subdirectories, entries and
+// files directly under the prefix — the three sections the index.md OKF
+// SPEC §8 describes carries (design doc 0046 §3.7).
 type BrowseResult struct {
 	Dirs      []store.DirCount    `json:"dirs,omitempty"`
 	Entries   []store.BrowseEntry `json:"entries,omitempty"`
+	Files     []store.BrowseFile  `json:"files,omitempty"`
 	Truncated bool                `json:"truncated,omitempty"`
 }
 
-// Browse lists one level of the knowledge hierarchy: the subdirectories
-// and entries directly under prefix ("" is the root). prefix accepts
-// "a/b" or "a/b/".
+// Browse lists one level of the knowledge hierarchy: the subdirectories,
+// entries and files directly under prefix ("" is the root). prefix
+// accepts "a/b" or "a/b/".
 func (s *Service) Browse(ctx context.Context, prefix string) (*BrowseResult, error) {
 	prefix, err := normalizePrefix(prefix)
 	if err != nil {
@@ -35,11 +37,11 @@ func (s *Service) Browse(ctx context.Context, prefix string) (*BrowseResult, err
 	if prefix != "" {
 		prefix += "/"
 	}
-	dirs, entries, truncated, err := s.Store.Browse(ctx, prefix)
+	lvl, err := s.Store.Browse(ctx, prefix)
 	if err != nil {
 		return nil, err
 	}
-	return &BrowseResult{Dirs: dirs, Entries: entries, Truncated: truncated}, nil
+	return &BrowseResult{Dirs: lvl.Dirs, Entries: lvl.Entries, Files: lvl.Files, Truncated: lvl.Truncated}, nil
 }
 
 // normalizePrefix cleans one path prefix, for every surface that takes
@@ -65,8 +67,15 @@ func normalizePrefix(p string) (string, error) {
 // IndexDocument renders one directory as the index.md OKF SPEC §8
 // defines (design doc 0046 §3.7). It is the same listing Browse
 // returns — one level, subdirectories with counts, entries with their
-// descriptions, cut off at the same limit — in the shape the format
-// already has a place for.
+// descriptions, files with their size and type, cut off at the same
+// limit — in the shape the format already has a place for.
+//
+// The files carry a heading and the other two do not. A subdirectory
+// line ends in "/" and a concept line does not, so those two read
+// unambiguously as one list; a file line would not, and the heading is
+// where the reader is told which kind they are looking at. It also
+// leaves every index.md of a bundle that holds no loose files
+// byte-for-byte as it was.
 //
 // Two representations of one thing, at one address: a caller that wants
 // to render the tree asks for JSON, a caller that wants the file gets
@@ -101,6 +110,13 @@ func (s *Service) IndexDocument(ctx context.Context, prefix string) ([]byte, err
 		}
 		concepts = append(concepts, okf.IndexLine{Text: title, Target: name + ".md", Description: e.Description})
 	}
+	// A file is listed by the name it lives under, described by what it
+	// is: OKF's §8 line wants a description, and for a file the honest
+	// one is its media type and size rather than prose nobody wrote.
+	var files []okf.IndexLine
+	for _, f := range res.Files {
+		files = append(files, okf.FileIndexLine(f.Name, f.MediaType, f.Size))
+	}
 	var notes []string
 	if res.Truncated {
 		// The cut-off says so in the document. A listing that stops
@@ -109,7 +125,9 @@ func (s *Service) IndexDocument(ctx context.Context, prefix string) ([]byte, err
 		// the file rather than only to whoever read the JSON).
 		notes = append(notes, fmt.Sprintf("_This listing was cut off at %d entries._", store.MaxBrowseEntries))
 	}
-	return okf.IndexDocument(dir, []okf.IndexSection{{Lines: dirs}, {Lines: concepts}}, notes...), nil
+	return okf.IndexDocument(dir, []okf.IndexSection{
+		{Lines: dirs}, {Lines: concepts}, {Heading: okf.FileSection, Lines: files},
+	}, notes...), nil
 }
 
 // LogDocument renders a subtree's history as the log.md OKF SPEC §9

--- a/internal/store/browse.go
+++ b/internal/store/browse.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -19,9 +20,33 @@ import (
 
 // DirCount is one subdirectory (ID segment) with the number of entries
 // anywhere beneath it.
+//
+// Concepts are what it counts, and a directory holding only files is not
+// one of these: OKF's §8 listing is navigation between concept
+// documents, and a count that mixed the two would answer "31 concepts"
+// for a directory holding four. What sits in a directory is what that
+// directory's own index.md says (BrowseFile), which is the level where
+// the format has a place for it.
 type DirCount struct {
 	Name  string `json:"name"`
 	Count int    `json:"count"`
+}
+
+// BrowseFile is one file sitting directly in a directory: the third
+// section of the index.md OKF SPEC §8 describes (design doc 0046 §3.7).
+//
+// A file is an object in the bundle rather than a property of an entry
+// (§3.3), so a directory can hold one that no concept shows — a
+// producer's seed data, a diagram two entries link — and a listing that
+// omits it describes a directory that is not there. The name is the last
+// segment, which is what the listing links to; the path is what the
+// object is addressed by.
+type BrowseFile struct {
+	Name      string    `json:"name"`
+	Path      string    `json:"path"`
+	MediaType string    `json:"media_type"`
+	Size      int64     `json:"size"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 // BrowseEntry is the light projection of an entry for tree listings:
@@ -55,13 +80,30 @@ const browseNotRejected = `deleted_at IS NULL AND id IS NOT NULL
 // truncation note instead of paginating.
 const MaxBrowseEntries = 1000
 
+// Level is one directory of the bundle as browsing reads it: what sits
+// directly under a prefix, in the three kinds SPEC §8 lists.
+type Level struct {
+	Dirs      []DirCount    `json:"dirs,omitempty"`
+	Entries   []BrowseEntry `json:"entries,omitempty"`
+	Files     []BrowseFile  `json:"files,omitempty"`
+	Truncated bool          `json:"truncated,omitempty"`
+}
+
 // Browse returns what sits directly under prefix: the subdirectories
-// (with entry counts beneath them) and the entries at this level, both
-// in name order; truncated reports that the entry list hit
-// MaxBrowseEntries. prefix is "" for the root, or segments with a
-// trailing slash ("sales/"). Prefix matching is by string, not LIKE —
-// IDs may contain "_", which LIKE would treat as a wildcard.
-func (s *Store) Browse(ctx context.Context, prefix string) (dirs []DirCount, entries []BrowseEntry, truncated bool, err error) {
+// (with concept counts beneath them), the entries at this level and the
+// files at this level, each in name order; Truncated reports that the
+// entry list hit MaxBrowseEntries. prefix is "" for the root, or
+// segments with a trailing slash ("sales/"). Prefix matching is by
+// string, not LIKE — paths may contain "_", which LIKE would treat as a
+// wildcard.
+//
+// Three queries because there are three kinds of row and one of them is
+// a grouping. The subdirectory query counts concepts only, which is why
+// a directory holding nothing but files is not a subdirectory here: OKF
+// says nothing about such a directory, and a count that mixed the kinds
+// would misdescribe every directory that has both.
+func (s *Store) Browse(ctx context.Context, prefix string) (*Level, error) {
+	var lvl Level
 	rows, err := s.pool.Query(ctx, `
 		SELECT split_part(substr(id, length($1::text)+1), '/', 1) AS dir, count(*)
 		FROM object
@@ -70,15 +112,15 @@ func (s *Store) Browse(ctx context.Context, prefix string) (dirs []DirCount, ent
 		  AND strpos(substr(id, length($1::text)+1), '/') > 0
 		GROUP BY dir ORDER BY dir`, prefix)
 	if err != nil {
-		return nil, nil, false, err
+		return nil, err
 	}
-	dirs, err = pgx.CollectRows(rows, func(row pgx.CollectableRow) (DirCount, error) {
+	lvl.Dirs, err = pgx.CollectRows(rows, func(row pgx.CollectableRow) (DirCount, error) {
 		var d DirCount
 		err := row.Scan(&d.Name, &d.Count)
 		return d, err
 	})
 	if err != nil {
-		return nil, nil, false, err
+		return nil, err
 	}
 	rows, err = s.pool.Query(ctx, fmt.Sprintf(`
 		SELECT type, id, title, description, status, updated_at
@@ -88,19 +130,48 @@ func (s *Store) Browse(ctx context.Context, prefix string) (dirs []DirCount, ent
 		  AND strpos(substr(id, length($1::text)+1), '/') = 0
 		ORDER BY id LIMIT %d`, MaxBrowseEntries+1), prefix)
 	if err != nil {
-		return nil, nil, false, err
+		return nil, err
 	}
-	entries, err = pgx.CollectRows(rows, func(row pgx.CollectableRow) (BrowseEntry, error) {
+	lvl.Entries, err = pgx.CollectRows(rows, func(row pgx.CollectableRow) (BrowseEntry, error) {
 		var e BrowseEntry
 		err := row.Scan(&e.Type, &e.ID, &e.Title, &e.Description, &e.Status, &e.UpdatedAt)
 		return e, err
 	})
 	if err != nil {
-		return nil, nil, false, err
+		return nil, err
 	}
-	if len(entries) > MaxBrowseEntries {
-		entries = entries[:MaxBrowseEntries]
-		truncated = true
+	if len(lvl.Entries) > MaxBrowseEntries {
+		lvl.Entries = lvl.Entries[:MaxBrowseEntries]
+		lvl.Truncated = true
 	}
-	return dirs, entries, truncated, nil
+	// The files at this level. A file has no id, so it is matched on its
+	// path — and the same cap applies, because a directory of ten
+	// thousand files is as unreadable as a directory of ten thousand
+	// concepts.
+	rows, err = s.pool.Query(ctx, fmt.Sprintf(`
+		SELECT path, media_type, size, updated_at
+		FROM object
+		WHERE id IS NULL AND deleted_at IS NULL
+		  AND left(path, length($1::text)) = $1
+		  AND strpos(substr(path, length($1::text)+1), '/') = 0
+		ORDER BY path LIMIT %d`, MaxBrowseEntries+1), prefix)
+	if err != nil {
+		return nil, err
+	}
+	lvl.Files, err = pgx.CollectRows(rows, func(row pgx.CollectableRow) (BrowseFile, error) {
+		var f BrowseFile
+		if err := row.Scan(&f.Path, &f.MediaType, &f.Size, &f.UpdatedAt); err != nil {
+			return f, err
+		}
+		f.Name = f.Path[strings.LastIndex(f.Path, "/")+1:]
+		return f, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(lvl.Files) > MaxBrowseEntries {
+		lvl.Files = lvl.Files[:MaxBrowseEntries]
+		lvl.Truncated = true
+	}
+	return &lvl, nil
 }

--- a/internal/store/browse_integration_test.go
+++ b/internal/store/browse_integration_test.go
@@ -64,49 +64,49 @@ func TestIntegrationBrowse(t *testing.T) {
 
 	// The root is the top-level segments of the shared test DB; our
 	// directory must be there with its subtree count.
-	rootDirs, _, _, err := s.Browse(ctx, "")
+	root, err := s.Browse(ctx, "")
 	if err != nil {
 		t.Fatal(err)
 	}
 	rootCounts := map[string]int{}
-	for _, d := range rootDirs {
+	for _, d := range root.Dirs {
 		rootCounts[d.Name] = d.Count
 	}
 	if rootCounts["it-br-sales"] != 2 || rootCounts["it-br_x"] != 1 {
 		t.Errorf("root dir counts wrong: %v", rootCounts)
 	}
 
-	dirs, entries, truncated, err := s.Browse(ctx, "it-br-sales/")
+	lvl, err := s.Browse(ctx, "it-br-sales/")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if truncated {
+	if lvl.Truncated {
 		t.Error("small listing must not truncate")
 	}
-	if len(dirs) != 1 || dirs[0].Name != "regions" || dirs[0].Count != 1 {
-		t.Errorf("dirs = %+v, want regions(1)", dirs)
+	if len(lvl.Dirs) != 1 || lvl.Dirs[0].Name != "regions" || lvl.Dirs[0].Count != 1 {
+		t.Errorf("dirs = %+v, want regions(1)", lvl.Dirs)
 	}
-	if len(entries) != 1 || entries[0].ID != "it-br-sales/monthly" || entries[0].Type != domain.TypeComputations ||
-		entries[0].Title != "t:it-br-sales/monthly" || entries[0].Description != "d:it-br-sales/monthly" ||
-		entries[0].Status != domain.StatusStable {
-		t.Errorf("entries = %+v", entries)
+	if e := lvl.Entries; len(e) != 1 || e[0].ID != "it-br-sales/monthly" || e[0].Type != domain.TypeComputations ||
+		e[0].Title != "t:it-br-sales/monthly" || e[0].Description != "d:it-br-sales/monthly" ||
+		e[0].Status != domain.StatusStable {
+		t.Errorf("entries = %+v", lvl.Entries)
 	}
 
 	// The underscore ID lives in its own directory, not under it-br-sales.
-	dirs, entries, _, err = s.Browse(ctx, "it-br_x/")
+	lvl, err = s.Browse(ctx, "it-br_x/")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(dirs) != 0 || len(entries) != 1 || entries[0].ID != "it-br_x/deep" {
-		t.Errorf("underscore prefix: dirs=%+v entries=%+v", dirs, entries)
+	if len(lvl.Dirs) != 0 || len(lvl.Entries) != 1 || lvl.Entries[0].ID != "it-br_x/deep" {
+		t.Errorf("underscore prefix: dirs=%+v entries=%+v", lvl.Dirs, lvl.Entries)
 	}
 
 	// Root level: the rejected entry is invisible.
-	_, entries, _, err = s.Browse(ctx, "")
+	lvl, err = s.Browse(ctx, "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, e := range entries {
+	for _, e := range lvl.Entries {
 		if e.ID == "it-br-rejected" {
 			t.Error("rejected entry visible in browse")
 		}

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -140,6 +140,19 @@ func (e *ExportSnapshot) FileMeta(ctx context.Context, prefix string) ([]domain.
 	return atts, nil
 }
 
+// RevisionsUnder is ListRevisionsUnder inside the export's snapshot, so
+// the log.md files an archive carries describe the same instant as the
+// documents beside them (design doc 0046 §3.8). A history read outside
+// the snapshot could name a change to an entry the archive does not
+// contain, or miss one it does.
+func (e *ExportSnapshot) RevisionsUnder(ctx context.Context, prefix string, limit int) ([]LogRow, error) {
+	rows, err := e.tx.Query(ctx, revisionsUnderSQL, prefix, limit)
+	if err != nil {
+		return nil, err
+	}
+	return pgx.CollectRows(rows, scanLogRow)
+}
+
 // underPrefix scopes an export to one subtree, matched on segment
 // boundaries like every other path scope (design doc 0041 §2.2): a
 // "metrics" scope covers metrics itself and everything under "metrics/",

--- a/internal/store/objectpath_integration_test.go
+++ b/internal/store/objectpath_integration_test.go
@@ -235,3 +235,67 @@ func TestIntegrationConceptCannotLandOnAFile(t *testing.T) {
 		t.Errorf("the file did not survive the refused create: %v", err)
 	}
 }
+
+// A directory holds three kinds of thing and the listing carries all
+// three (design doc 0046 §3.7). The one that was missing is the file: a
+// file is an object in the bundle rather than a property of an entry
+// (§3.3), so a directory can hold one nothing shows, and a listing that
+// leaves it out describes a directory that is not there.
+//
+// What the listing still does not do is invent a subdirectory for a
+// directory of pure data. OKF's §8 listing is navigation between concept
+// documents, and a count mixing the kinds would misdescribe every
+// directory that has both.
+func TestIntegrationBrowseListsTheFilesInADirectory(t *testing.T) {
+	s, ctx, root := newObjectPathStore(t)
+	actor := domain.Actor{Kind: "human", Name: "test"}
+	mkConcept(t, s, ctx, root+"/revenue")
+	// One file beside the concept, one under it, one in a directory that
+	// holds nothing else.
+	for _, p := range []string{root + "/seed.csv", root + "/revenue/chart.png", root + "/seeds/orders.csv"} {
+		if _, err := s.PutFile(ctx, p, "text/plain", []byte("bytes here"), actor); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	lvl, err := s.Browse(ctx, root+"/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lvl.Files) != 1 || lvl.Files[0].Name != "seed.csv" || lvl.Files[0].Path != root+"/seed.csv" {
+		t.Errorf("files at this level = %+v, want seed.csv alone", lvl.Files)
+	}
+	if lvl.Files[0].Size == 0 || lvl.Files[0].MediaType == "" {
+		t.Errorf("a file line has nothing to describe it: %+v", lvl.Files[0])
+	}
+	if len(lvl.Entries) != 1 || lvl.Entries[0].ID != root+"/revenue" {
+		t.Errorf("entries = %+v", lvl.Entries)
+	}
+	// "revenue" is a subdirectory because a file sits under it, but it
+	// holds no concept, so it is not one of these — and neither is
+	// "seeds". Directories exist here through the concepts in them.
+	for _, d := range lvl.Dirs {
+		t.Errorf("a directory of files was listed as a subdirectory: %+v", d)
+	}
+
+	// Asked about directly, a directory of pure data lists what it holds.
+	lvl, err = s.Browse(ctx, root+"/seeds/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lvl.Files) != 1 || lvl.Files[0].Name != "orders.csv" {
+		t.Errorf("a directory of files lists nothing: %+v", lvl)
+	}
+
+	// A deleted file leaves the listing with it.
+	if err := s.DeleteFile(ctx, root+"/seed.csv", actor); err != nil {
+		t.Fatal(err)
+	}
+	lvl, err = s.Browse(ctx, root+"/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lvl.Files) != 0 {
+		t.Errorf("a deleted file is still listed: %+v", lvl.Files)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1414,22 +1414,27 @@ type LogRow struct {
 // starts_with, not LIKE: a path may contain "_", which LIKE reads as a
 // wildcard (browse.go says the same about ids).
 func (s *Store) ListRevisionsUnder(ctx context.Context, prefix string, limit int) ([]LogRow, error) {
-	rows, err := s.pool.Query(ctx,
-		`SELECT r.path, COALESCE(k.title, ''), r.change,
-		        r.changed_by_kind, r.changed_by_name, r.changed_by_via, r.changed_by_producer, r.changed_at
-		 FROM knowledge_revision r
-		 LEFT JOIN object k ON k.path = r.path
-		 WHERE $1 = '' OR r.path = $1 || '.md' OR starts_with(r.path, $1 || '/')
-		 ORDER BY r.changed_at DESC, r.path, r.rev DESC LIMIT $2`,
-		prefix, limit)
+	rows, err := s.pool.Query(ctx, revisionsUnderSQL, prefix, limit)
 	if err != nil {
 		return nil, err
 	}
-	return pgx.CollectRows(rows, func(row pgx.CollectableRow) (LogRow, error) {
-		var l LogRow
-		return l, row.Scan(&l.Path, &l.Title, &l.Change,
-			&l.ChangedBy.Kind, &l.ChangedBy.Name, &l.ChangedBy.Via, &l.ChangedBy.Producer, &l.ChangedAt)
-	})
+	return pgx.CollectRows(rows, scanLogRow)
+}
+
+// revisionsUnderSQL is the query behind both callers: the read at a
+// log.md address and the export writing the same file from a snapshot.
+// One statement, because two that drifted would be two histories.
+const revisionsUnderSQL = `SELECT r.path, COALESCE(k.title, ''), r.change,
+	        r.changed_by_kind, r.changed_by_name, r.changed_by_via, r.changed_by_producer, r.changed_at
+	 FROM knowledge_revision r
+	 LEFT JOIN object k ON k.path = r.path
+	 WHERE $1 = '' OR r.path = $1 || '.md' OR starts_with(r.path, $1 || '/')
+	 ORDER BY r.changed_at DESC, r.path, r.rev DESC LIMIT $2`
+
+func scanLogRow(row pgx.CollectableRow) (LogRow, error) {
+	var l LogRow
+	return l, row.Scan(&l.Path, &l.Title, &l.Change,
+		&l.ChangedBy.Kind, &l.ChangedBy.Name, &l.ChangedBy.Via, &l.ChangedBy.Producer, &l.ChangedAt)
 }
 
 func (s *Store) addRevision(ctx context.Context, tx pgx.Tx, k *domain.Knowledge, change string, actor domain.Actor) error {

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -3009,16 +3009,16 @@ func TestIntegrationFilesAreObjectsAttributedByPathOrBody(t *testing.T) {
 			t.Errorf("search returned a non-entry: %q", h.ID)
 		}
 	}
-	dirs, entries, _, err := s.Browse(ctx, base)
+	lvl, err := s.Browse(ctx, base)
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, e := range entries {
+	for _, e := range lvl.Entries {
 		if e.ID != id {
 			t.Errorf("browse listed a non-entry: %q", e.ID)
 		}
 	}
-	for _, d := range dirs {
+	for _, d := range lvl.Dirs {
 		if d.Name == "seeds" && d.Count != 0 {
 			t.Errorf("a directory of files counts as %d entries", d.Count)
 		}

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -1391,6 +1391,21 @@ function dirCard(prefix, d) {
   </article>`;
 }
 
+// fileCard is one file object sitting in this directory — the third
+// thing an index.md lists (design doc 0046 §3.7). It links to the
+// object's own address, because that is where the bytes are; a file
+// belongs to no entry unless one shows it.
+function fileCard(f) {
+  const href = BASE + '/api/v1/bundle/' + idPath(f.path);
+  return `<article class="card">
+    <div class="head">
+      <span class="type-ico">📄</span>
+      <a class="title mono" href="${href}" target="_blank" rel="noopener">${esc(f.name)}</a>
+      <span class="meta">${esc(f.media_type || '')} · ${fmtSize(f.size)}</span>
+    </div>
+  </article>`;
+}
+
 // loadDirIndex fetches one browse level and renders it into container
 // (which the caller seeded with a placeholder). Entry cards reuse the
 // search result card — browse entries carry no attrs/attachments, so
@@ -1401,10 +1416,11 @@ async function loadDirIndex(container, prefix, emptyText) {
     if (!container.isConnected) return; // navigated away while loading
     const dirs = (res.dirs || []).map(d => dirCard(prefix, d)).join('');
     const entries = (res.entries || []).map(hitCard).join('');
+    const files = (res.files || []).map(fileCard).join('');
     const note = res.truncated
       ? `<div class="truncation-note">Showing the first 1000 entries at this level — a directory this wide is
          better split into subdirectories.</div>` : '';
-    container.innerHTML = (dirs + entries + note) || `<div class="empty">${emptyText}</div>`;
+    container.innerHTML = (dirs + entries + files + note) || `<div class="empty">${emptyText}</div>`;
   } catch (e) {
     if (!container.isConnected) return;
     container.innerHTML = `<div class="error-banner">Browse failed: ${esc(e.message)}</div>`;


### PR DESCRIPTION
Item 1 of the five left open on #325. Independent of #328.

## What and why

0046 §3.7 names three sections for a directory's `index.md` — subdirectories, concepts, **files** — and only the first two were rendered. `browse.go`'s own comment already said the third existed:

> `id IS NOT NULL` keeps files out: browsing lists the concepts in a directory, and **a file in the same directory is listed as a file (design doc 0046 §3.7)**, not as an entry with no title.

The half that keeps files out of the *entry* list shipped; the half that lists them never did. So a file at a path no concept shows — a producer's seed data, a diagram two entries link — was stored, served at its own address, carried in the archive (since #325), and invisible in the bundle's own navigation and in the web UI's directory page.

All three renderings carry it now, from **one renderer** (`okf.FileIndexLine`), because an `index.md` whose shape depended on which caller asked would be two formats:

- the generated `index.md` (`GET /api/v1/bundle/{dir}/index.md`)
- its JSON representation — `files[]`, which is what the web UI's directory page reads
- the copy the archive writes, which a test compares byte-for-byte against the generated one

`ochakai browse` prints them after the entries, as `name<TAB>file<TAB>media-type<TAB>bytes`.

### What it deliberately does not do

**A subdirectory line still counts concepts, and a directory holding nothing but files is still not a subdirectory.** OKF's §8 listing is navigation between concept documents; a count mixing the kinds would misdescribe every directory that has both, and a directory of pure data is outside what the format says anything about. So it gets no line in its parent and no generated `index.md` in the archive — asked about directly, it lists what it holds. That was the one open question in the review and it is the maintainer's call, recorded here.

**A bundle with no loose files exports byte-for-byte as it did.** The `## Files` heading appears only where there is something under it, which is also why the heading is on the files alone: a subdirectory line ends in `/` and a concept line does not, so those two read as one list without help.

## Checks

- [x] `scripts/check` is clean — add `--db` when the change touches the store
- [x] Behavior changes come with tests

`scripts/check core` and `scripts/check lint` are clean against PostgreSQL 17 with pgvector. `scripts/check vuln` is not verifiable in this environment (the proxy refuses `vuln.go.dev`); CI runs it.

- `TestIntegrationBrowseListsTheFilesInADirectory` — the file beside a concept, the one under it, the directory of pure data, and a deleted file leaving the listing.
- `TestIndexesListFilesBesideTheConcepts` — the archive's renderer, including "no files, no heading" and "no `index.md` for a directory of pure data".
- `TestRESTIntegrationIndexListsTheFilesInADirectory` — JSON, markdown, and the archive's copy compared against the generated one.

Also checked by hand against a real server: a bundle with no loose files imports, browses, renders and round-trips exactly as before.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and `internal/apiclient` say the same thing; `TestBrowseResultMatchesServerWire` pins the client type to the server's, and `TestOpenAPISchemasMatchGoTypes` (#326) pins `BundleListing` to `service.BrowseResult`
- [x] The change lands on every surface it belongs on — REST / MCP / CLI / Web UI — and what it stays off is deliberate: **MCP stays out**. Its default is no (0015 §3.1), an agent reads by search and `get_context`, and no tool of the eight lists a directory.
- [x] Widens a surface? No endpoint, tool, command or environment variable is added, so no count in `docs/surface.md` moves. What grows is one existing response — `BundleListing` gains `files[]` — and one existing generated file gains a section it was specified to have.

## Design docs

- [x] Alters an accepted decision? No — this implements 0046 §3.7 as written. The one thing §3.7 leaves open, whether a files-only directory is a subdirectory, is answered "no" above and in the code's comments rather than by changing the record.
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xtrzd3JFhLg9S9WFqRUoJK)_