### PR TITLE
Carry the history in the archive (0046 §3.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -618,6 +618,23 @@ last entry.
 
 ### Fixed
 
+- **The archive carries the history.** Design doc
+  [0046](docs/design/0046-bundle-address-space.md) §3.8 ends "the history
+  becomes portable", and the archive carried the `index.md` of every
+  directory and no `log.md`: the ledger was readable only by calling the
+  instance that holds it, and a purge
+  ([0031](docs/design/0031-purge.md)) is the only thing that ever
+  removes a row from it. A `log.md` is written beside every `index.md`
+  now — the root's included — from the same renderer and the same
+  1000-line bound as the address, so a reader extracting the bundle and
+  a reader calling `GET /api/v1/bundle/{dir}/log.md` are not reading two
+  different histories, and from the export's own snapshot, so it
+  describes the same instant as the documents beside it.
+
+  An import still never reads one back (§2.3): what happened here is
+  this instance's observation, published the way `generated` and
+  `verified` are ([0009](docs/design/0009-provenance-portability.md)).
+
 - **A directory's `index.md` lists the files in it** (design doc
   [0046](docs/design/0046-bundle-address-space.md) §3.7). §3.7 names
   three sections — subdirectories, concepts, files — and only the first

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -439,9 +439,13 @@ paths:
 
         **`Accept: application/gzip` reads the path as a subtree** and
         streams it as an OKF bundle: a tar.gz of markdown + YAML
-        frontmatter, the generated `index.md` files, and every file under
-        the path — including one no entry shows, because what enters the
-        bundle leaves it (design doc 0046 §3.2). The root
+        frontmatter, the generated `index.md` and `log.md` of every
+        directory, and every file under the path — including one no
+        entry shows, because what enters the bundle leaves it (design
+        doc 0046 §3.2). The history travels with it (§3.8): a purge is
+        the only thing that removes a row from the ledger, and an
+        archive without it left the record readable only from the
+        instance holding it. An import never reads it back. The root
         (`/api/v1/bundle/`) is the whole knowledge base — this is what `GET /api/v1/export` was, at the address of
         the thing it returns (design doc 0046 §3.5). Your knowledge is
         yours.

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -126,6 +126,31 @@ func writeBundleArchive(w http.ResponseWriter, r *http.Request, svc *service.Ser
 			fail("index "+path, err)
 			return
 		}
+		// The other file OKF reserves, beside the one that names the
+		// directory's contents (design doc 0046 §3.8). This is what
+		// makes the history portable: an archive that carried the
+		// bundle but not what happened to it left the ledger reachable
+		// only from the instance that holds it, and a purge (0031) is
+		// the only thing that ever removes a row from it.
+		//
+		// One query per directory, bounded the same way the address is,
+		// so a log.md in an archive says what the one at its address
+		// says. Against a file's bytes — a round trip to GCS each — the
+		// cost of these does not register.
+		//
+		// An import never reads them back (§2.3): the history of what
+		// happened here is this instance's observation, published the
+		// way generated and verified are (design doc 0009).
+		dir := strings.TrimSuffix(strings.TrimSuffix(path, "index.md"), "/")
+		log, err := snap.RevisionsUnder(r.Context(), dir, service.MaxLogLines)
+		if err != nil {
+			fail("history "+dir, err)
+			return
+		}
+		if err := add(strings.TrimSuffix(path, "index.md")+"log.md", service.RenderLog(dir, log)); err != nil {
+			fail("log "+dir, err)
+			return
+		}
 	}
 	// Entries in batches: one batch in memory at a time. The snapshot
 	// does hold a pooled connection for the length of the download —

--- a/internal/restapi/restapi_integration_test.go
+++ b/internal/restapi/restapi_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -1972,5 +1973,76 @@ func TestRESTIntegrationIndexListsTheFilesInADirectory(t *testing.T) {
 	if archived != generated {
 		t.Errorf("the archive's index.md and the generated one differ:\n--- archive ---\n%s\n--- generated ---\n%s",
 			archived, generated)
+	}
+}
+
+// The archive carries the other file OKF reserves (design doc 0046
+// §3.8). An export that held the bundle but not what happened to it left
+// the ledger readable only from the instance that holds it, and a purge
+// is the only thing that ever removes a row from it (0031) — so the
+// history was portable in the record and not in the artifact.
+//
+// The copy in the archive is the copy at the address: one renderer, one
+// bound, so a reader extracting the bundle and a reader calling the
+// endpoint are not reading two different histories.
+func TestRESTIntegrationTheArchiveCarriesTheHistory(t *testing.T) {
+	srv, _ := newIntegrationServer(t)
+
+	typ := fmt.Sprintf("restlog%d", time.Now().UnixNano())
+	id := typ + "/revenue"
+	removeEntries(t, srv, id)
+	resp := putDoc(t, srv.URL, id, docFrom(t, map[string]any{
+		"type": typ, "id": id, "title": "Revenue"}), true)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create status = %d", resp.StatusCode)
+	}
+
+	archived := map[string]string{}
+	resp, err := getArchive(t, srv.URL+"/api/v1/bundle/", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	gz, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for tr := tar.NewReader(gz); ; {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		b, err := io.ReadAll(tr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		archived[hdr.Name] = string(b)
+	}
+
+	// One beside every index.md, the root's included.
+	for path := range archived {
+		if !strings.HasSuffix(path, "index.md") {
+			continue
+		}
+		if _, ok := archived[strings.TrimSuffix(path, "index.md")+"log.md"]; !ok {
+			t.Errorf("%s has no log.md beside it", path)
+		}
+	}
+	if got := archived[typ+"/log.md"]; !strings.Contains(got, "**Create**") ||
+		!strings.Contains(got, "[Revenue](/"+id+".md)") {
+		t.Errorf("the directory's history does not record the write:\n%s", got)
+	}
+	if root := archived["log.md"]; !strings.Contains(root, "# Update Log") {
+		t.Errorf("the root history is not titled as one:\n%s", root)
+	}
+
+	// And it is the same document the address serves.
+	if served := getMarkdown(t, srv.URL+"/api/v1/bundle/"+typ+"/log.md"); served != archived[typ+"/log.md"] {
+		t.Errorf("the archived history and the served one differ:\n--- archive ---\n%s\n--- served ---\n%s",
+			archived[typ+"/log.md"], served)
 	}
 }

--- a/internal/service/browse.go
+++ b/internal/service/browse.go
@@ -143,13 +143,26 @@ func (s *Service) LogDocument(ctx context.Context, prefix string, limit int) ([]
 	if err != nil {
 		return nil, err
 	}
-	if limit <= 0 || limit > maxLogLines {
-		limit = maxLogLines
+	if limit <= 0 || limit > MaxLogLines {
+		limit = MaxLogLines
 	}
 	rows, err := s.Store.ListRevisionsUnder(ctx, prefix, limit)
 	if err != nil {
 		return nil, err
 	}
+	return RenderLog(prefix, rows), nil
+}
+
+// RenderLog is the log.md of one directory, given the ledger rows under
+// it. Split from the read above because the export renders the same
+// file from a snapshot of its own (design doc 0046 §3.8), and a log.md
+// whose shape depended on which caller asked would be two formats — the
+// same reason the index.md renderer is shared.
+//
+// prefix is already normalized. The root's document is titled for what
+// it is; every other one is titled by its path, which is what a reader
+// extracting the bundle sees above the list.
+func RenderLog(prefix string, rows []store.LogRow) []byte {
 	lines := make([]okf.LogLine, 0, len(rows))
 	for _, r := range rows {
 		lines = append(lines, okf.LogLine{
@@ -160,11 +173,14 @@ func (s *Service) LogDocument(ctx context.Context, prefix string, limit int) ([]
 	if prefix != "" {
 		title = prefix
 	}
-	return okf.LogDocument(title, lines), nil
+	return okf.LogDocument(title, lines)
 }
 
-// maxLogLines bounds a generated history the way the tree listing is
+// MaxLogLines bounds a generated history the way the tree listing is
 // bounded: a log is for reading, and a directory with a hundred thousand
 // changes under it does not become more readable by containing all of
 // them. The whole ledger is still there — ask a narrower path.
-const maxLogLines = 1000
+//
+// The export applies it per directory too, so a log.md in an archive
+// says the same thing the one at its address says.
+const MaxLogLines = 1000

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -140,6 +140,19 @@ func (e *ExportSnapshot) FileMeta(ctx context.Context, prefix string) ([]domain.
 	return atts, nil
 }
 
+// RevisionsUnder is ListRevisionsUnder inside the export's snapshot, so
+// the log.md files an archive carries describe the same instant as the
+// documents beside them (design doc 0046 §3.8). A history read outside
+// the snapshot could name a change to an entry the archive does not
+// contain, or miss one it does.
+func (e *ExportSnapshot) RevisionsUnder(ctx context.Context, prefix string, limit int) ([]LogRow, error) {
+	rows, err := e.tx.Query(ctx, revisionsUnderSQL, prefix, limit)
+	if err != nil {
+		return nil, err
+	}
+	return pgx.CollectRows(rows, scanLogRow)
+}
+
 // underPrefix scopes an export to one subtree, matched on segment
 // boundaries like every other path scope (design doc 0041 §2.2): a
 // "metrics" scope covers metrics itself and everything under "metrics/",

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1414,22 +1414,27 @@ type LogRow struct {
 // starts_with, not LIKE: a path may contain "_", which LIKE reads as a
 // wildcard (browse.go says the same about ids).
 func (s *Store) ListRevisionsUnder(ctx context.Context, prefix string, limit int) ([]LogRow, error) {
-	rows, err := s.pool.Query(ctx,
-		`SELECT r.path, COALESCE(k.title, ''), r.change,
-		        r.changed_by_kind, r.changed_by_name, r.changed_by_via, r.changed_by_producer, r.changed_at
-		 FROM knowledge_revision r
-		 LEFT JOIN object k ON k.path = r.path
-		 WHERE $1 = '' OR r.path = $1 || '.md' OR starts_with(r.path, $1 || '/')
-		 ORDER BY r.changed_at DESC, r.path, r.rev DESC LIMIT $2`,
-		prefix, limit)
+	rows, err := s.pool.Query(ctx, revisionsUnderSQL, prefix, limit)
 	if err != nil {
 		return nil, err
 	}
-	return pgx.CollectRows(rows, func(row pgx.CollectableRow) (LogRow, error) {
-		var l LogRow
-		return l, row.Scan(&l.Path, &l.Title, &l.Change,
-			&l.ChangedBy.Kind, &l.ChangedBy.Name, &l.ChangedBy.Via, &l.ChangedBy.Producer, &l.ChangedAt)
-	})
+	return pgx.CollectRows(rows, scanLogRow)
+}
+
+// revisionsUnderSQL is the query behind both callers: the read at a
+// log.md address and the export writing the same file from a snapshot.
+// One statement, because two that drifted would be two histories.
+const revisionsUnderSQL = `SELECT r.path, COALESCE(k.title, ''), r.change,
+	        r.changed_by_kind, r.changed_by_name, r.changed_by_via, r.changed_by_producer, r.changed_at
+	 FROM knowledge_revision r
+	 LEFT JOIN object k ON k.path = r.path
+	 WHERE $1 = '' OR r.path = $1 || '.md' OR starts_with(r.path, $1 || '/')
+	 ORDER BY r.changed_at DESC, r.path, r.rev DESC LIMIT $2`
+
+func scanLogRow(row pgx.CollectableRow) (LogRow, error) {
+	var l LogRow
+	return l, row.Scan(&l.Path, &l.Title, &l.Change,
+		&l.ChangedBy.Kind, &l.ChangedBy.Name, &l.ChangedBy.Via, &l.ChangedBy.Producer, &l.ChangedAt)
 }
 
 func (s *Store) addRevision(ctx context.Context, tx pgx.Tx, k *domain.Knowledge, change string, actor domain.Actor) error {


### PR DESCRIPTION
Item 2 of the five left open on #325. **Stacked on #329** — both write the archive's generated files, so they would conflict as siblings. Base it on `main` once #329 lands.

## What and why

0046 §3.8 ends *"the history becomes portable"*, and §4 lists `log.md` starting to be emitted among what this release changes. The archive carried the `index.md` of every directory and no `log.md`.

That left the ledger readable only by calling the instance that holds it — which is exactly backwards for the thing it is. A purge ([0031](https://github.com/na0fu3y/ochakai/blob/main/docs/design/0031-purge.md)) is the only thing that ever removes a row from that ledger, so it is the durable record of what happened to the bundle, and the copy you keep did not have it.

One `log.md` beside every `index.md` now, the root's included:

- **Same renderer, same bound as the address.** `service.RenderLog` is split out of `LogDocument` and both call it, and the export applies the same 1000-line cap. A reader extracting the bundle and a reader calling `GET /api/v1/bundle/{dir}/log.md` must not be reading two different histories — the test asserts the two documents are byte-identical, the way #329 does for `index.md`.
- **From the export's own snapshot.** `ExportSnapshot.RevisionsUnder` runs the same SQL as `ListRevisionsUnder` inside the REPEATABLE READ transaction, so the history describes the same instant as the documents beside it rather than naming a change to an entry the archive does not contain.
- **One query per directory, not one for the bundle.** A single global fetch would under-fill a quiet subtree — its newest thousand changes are older than the bundle's thousandth — and against a file's bytes, a round trip to GCS each, the cost of these does not register.

An import still never reads one back (§2.3): what happened here is this instance's observation, published the way `generated` and `verified` are ([0009](https://github.com/na0fu3y/ochakai/blob/main/docs/design/0009-provenance-portability.md)). Checked by hand — export → import → export against a real server is byte-identical, and the re-import reports `10 unchanged, 0 skipped`.

## Checks

- [x] `scripts/check` is clean — add `--db` when the change touches the store
- [x] Behavior changes come with tests

`scripts/check core` and `scripts/check lint` are clean against PostgreSQL 17 with pgvector. `scripts/check vuln` is not verifiable in this environment (the proxy refuses `vuln.go.dev`); CI runs it.

`TestRESTIntegrationTheArchiveCarriesTheHistory`: a `log.md` beside every `index.md` in the archive, the write recorded in its directory's copy, the root's titled as the root's, and the archived document compared against the one the address serves.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and `internal/apiclient` say the same thing — the archive's description now names both reserved files
- [x] The change lands on every surface it belongs on — REST / MCP / CLI / Web UI — and what it stays off is deliberate: `ochakai export` gets it for free (it is the same archive), and nothing else addresses an archive
- [x] Widens a surface? No. No endpoint, tool, command or environment variable is added; no count in `docs/surface.md` moves. What changes is what an existing response body contains.

## Design docs

- [x] Alters an accepted decision? No — this implements 0046 §§3.8 and §4 as written.
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xtrzd3JFhLg9S9WFqRUoJK)_