### PR TITLE
Give a test its rows back when it ends

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,16 @@ docker run -d --rm -p 55433:5432 -e POSTGRES_PASSWORD=t -e POSTGRES_USER=t -e PO
 OCHAKAI_TEST_DATABASE_URL='postgres://t:t@localhost:55433/t?sslmode=disable' go test ./internal/store/
 ```
 
+The database is shared: CI runs one container for a whole run, and by
+hand you keep one up across sessions. So **an integration test takes its
+ids from `internal/testdb`.Unique**, which appends a run-unique number
+and registers the sweep that removes every row written under it. A test
+that rolls its own token instead leaves its rows behind, and the corpus
+grows until a bounded ranking assertion somewhere else stops finding its
+own entry — a failure that reads as a search bug in whatever change
+happens to cross the threshold. `TestNoTestRollsItsOwnNamespace` fails
+on a hand-rolled one.
+
 `--db` prefers Docker, because `pgvector/pgvector:pg17` is the database
 CI runs. Where Docker cannot serve one — no daemon, or a network that
 will not let the image be pulled — it builds a throwaway cluster out of

--- a/cmd/ochakai/surface_test.go
+++ b/cmd/ochakai/surface_test.go
@@ -462,7 +462,10 @@ func TestSurfaceDocCountsCLICommands(t *testing.T) {
 // variable exists the moment something asks the environment for it, and
 // a second list would be one more thing to keep true. Test files are
 // skipped — a variable only a test sets is not something a user
-// configures.
+// configures — and so is internal/testdb, which is a test file by every
+// measure except its name: nothing outside a _test.go imports it, and
+// the only variable it reads is the one that says where the test
+// database is. TestNothingShipsTestSupport keeps that true.
 func TestSurfaceDocCountsEnvironmentVariables(t *testing.T) {
 	varRe := regexp.MustCompile(`"(OCHAKAI_[A-Z_]+)"`)
 	seen := map[string]bool{}
@@ -470,6 +473,9 @@ func TestSurfaceDocCountsEnvironmentVariables(t *testing.T) {
 		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return err
+			}
+			if d.IsDir() && d.Name() == testSupportPkg {
+				return fs.SkipDir
 			}
 			if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
 				return nil
@@ -495,4 +501,99 @@ func TestSurfaceDocCountsEnvironmentVariables(t *testing.T) {
 		names = append(names, name)
 	}
 	compareSurface(t, "ENV", names)
+}
+
+// testSupportPkg is the one package under internal that ships with the
+// tests rather than with the program.
+const testSupportPkg = "testdb"
+
+// The exception TestSurfaceDocCountsEnvironmentVariables makes for
+// internal/testdb holds only while that package is what it says it is.
+// A guard with a named exception is a place to hide something, so the
+// exception is checked rather than trusted (design doc 0035): nothing
+// the program ships may import it.
+func TestNothingShipsTestSupport(t *testing.T) {
+	imported := false
+	for _, path := range repoTextFiles(t) {
+		if filepath.Ext(path) != ".go" {
+			continue
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if !strings.Contains(string(content), "internal/"+testSupportPkg+`"`) {
+			continue
+		}
+		imported = true
+		t.Errorf("%s imports internal/%s, which ships with the tests: "+
+			"the environment-variable count skips that package, so anything it reads "+
+			"would be a knob nobody counts", path, testSupportPkg)
+	}
+	if imported {
+		return
+	}
+	// And it is imported by tests, or the exception guards nothing.
+	found, err := filepath.Glob("../../internal/*/*_test.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range found {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if strings.Contains(string(content), "internal/"+testSupportPkg+`"`) {
+			return
+		}
+	}
+	t.Errorf("no test imports internal/%s: the exception in the environment-variable "+
+		"count now covers a package nothing uses", testSupportPkg)
+}
+
+// A test that builds its own run-unique id builds one nothing gives
+// back. That is how the shared test database grew: every integration
+// test wrote under `fmt.Sprintf("name%d", time.Now().UnixNano())`, which
+// collides with nobody and is cleaned up by nobody, so the corpus grew
+// by seventy entries a run until a bounded ranking assertion tipped over
+// and read as a search bug (issue #278, twice).
+//
+// internal/testdb.Unique is the same token with the sweep attached. This
+// reads the tree for the shape it replaced, because nothing else would
+// notice the next one: the hand-rolled version works perfectly, right up
+// until the run that pushes somebody else's entry out of a top-ten.
+func TestNoTestRollsItsOwnNamespace(t *testing.T) {
+	unique := regexp.MustCompile(`time\.Now\(\)\.UnixNano\(\)`)
+	// Where a unique number is not an address: a model name, a query
+	// nobody else asks. Those leave no row keyed by an id, so testdb has
+	// nothing to sweep and no claim on them.
+	allowed := map[string]bool{
+		"internal/store/stats_integration_test.go":        true, // a search query, not an id
+		"internal/service/attachment_integration_test.go": true, // an embedding model name
+	}
+	found, checked := false, 0
+	paths, err := filepath.Glob("../../internal/*/*_test.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range paths {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		checked++
+		rel := filepath.ToSlash(strings.TrimPrefix(filepath.ToSlash(path), "../../"))
+		if !unique.Match(content) {
+			continue
+		}
+		found = true
+		if allowed[rel] {
+			continue
+		}
+		t.Errorf("%s builds a run-unique token by hand — use testdb.Unique, "+
+			"which is the same token with the sweep that gives it back", rel)
+	}
+	if checked == 0 || !found {
+		t.Error("no test builds a run-unique token: this check now guards nothing")
+	}
 }

--- a/internal/mcpserver/mcpserver_integration_test.go
+++ b/internal/mcpserver/mcpserver_integration_test.go
@@ -2,7 +2,6 @@ package mcpserver
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -10,7 +9,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -20,6 +18,7 @@ import (
 	"github.com/na0fu3y/ochakai/internal/httpauth"
 	"github.com/na0fu3y/ochakai/internal/service"
 	"github.com/na0fu3y/ochakai/internal/store"
+	"github.com/na0fu3y/ochakai/internal/testdb"
 )
 
 // headerSwitcher injects the delegation header into every outgoing MCP
@@ -85,7 +84,7 @@ func TestIntegrationDelegatedActorFollowsEachCall(t *testing.T) {
 	// The session now exists, initialized under alice's identity. The
 	// next call arrives on the same session but on behalf of bob.
 	sw.set("human:bob@example.co.jp")
-	id := fmt.Sprintf("mcpit%d/delegation", time.Now().UnixNano())
+	id := testdb.Unique(t, "mcpit") + "/delegation"
 	res, err := cs.CallTool(ctx, &mcp.CallToolParams{
 		Name:      "put_concept",
 		Arguments: map[string]any{"id": id, "document": "---\ntype: glossary\n---\n\nwritten on behalf of bob\n"},
@@ -173,7 +172,7 @@ func TestIntegrationPutKnowledgeCreatesThenReplaces(t *testing.T) {
 	}
 	defer cs.Close()
 
-	id := fmt.Sprintf("mcpput%d/revenue", time.Now().UnixNano())
+	id := testdb.Unique(t, "mcpput") + "/revenue"
 	defer func() {
 		_ = svc.Delete(context.Background(), id, domain.Actor{Kind: domain.ActorHuman, Name: "t"})
 	}()

--- a/internal/restapi/restapi_integration_test.go
+++ b/internal/restapi/restapi_integration_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/na0fu3y/ochakai/internal/okf"
 	"github.com/na0fu3y/ochakai/internal/service"
 	"github.com/na0fu3y/ochakai/internal/store"
+	"github.com/na0fu3y/ochakai/internal/testdb"
 )
 
 // testDatabaseURL is the test database, or a skip (see the store
@@ -122,7 +123,7 @@ func TestRESTIntegration(t *testing.T) {
 	lockLiveAttachments(t) // the export step scans every live attachment
 	srv, _ := newIntegrationServer(t)
 
-	typ := fmt.Sprintf("restit%d", time.Now().UnixNano())
+	typ := testdb.Unique(t, "restit")
 	id := typ + "/sales/orders"
 	entry := map[string]any{"type": typ, "id": id, "title": "REST round trip"}
 	payload := docFrom(t, entry)
@@ -354,7 +355,7 @@ func TestRESTIntegrationAttachments(t *testing.T) {
 	srv, s := newIntegrationServer(t)
 	s.UseBlobStore(memBlobStore{})
 
-	typ := fmt.Sprintf("restatt%d", time.Now().UnixNano())
+	typ := testdb.Unique(t, "restatt")
 	payload := docFrom(t, map[string]any{"type": typ, "id": typ + "/reading", "title": "attachment hits"})
 	resp := putDoc(t, srv.URL, typ+"/reading", payload, true)
 	resp.Body.Close()
@@ -607,7 +608,7 @@ func getMarkdown(t *testing.T, url string) string {
 func TestRESTIntegrationVerify(t *testing.T) {
 	srv, _ := newIntegrationServer(t)
 
-	typ := fmt.Sprintf("restit%d", time.Now().UnixNano())
+	typ := testdb.Unique(t, "restit")
 	id := typ + "/verify-me"
 	payload := docFrom(t, map[string]any{"type": typ, "id": id, "title": "verify round trip"})
 	resp := putDoc(t, srv.URL, id, payload, true)
@@ -705,7 +706,7 @@ func TestRESTIntegrationVerify(t *testing.T) {
 func TestRESTContextBudgetGovernsTheResponse(t *testing.T) {
 	srv, _ := newIntegrationServer(t)
 
-	typ := fmt.Sprintf("ctxbudget%d", time.Now().UnixNano())
+	typ := testdb.Unique(t, "ctxbudget")
 	body := strings.Repeat("x", 2000)
 	var ids []string
 	for i := range 4 {
@@ -774,7 +775,7 @@ func TestRESTContextBudgetGovernsTheResponse(t *testing.T) {
 func TestRESTIntegrationUsageBacklinksAndMove(t *testing.T) {
 	srv, _ := newIntegrationServer(t)
 
-	root := fmt.Sprintf("restumb%d", time.Now().UnixNano())
+	root := testdb.Unique(t, "restumb")
 	metric, insight := root+"/revenue", root+"/revenue-reading"
 	create := func(id, title, body string) {
 		t.Helper()
@@ -892,7 +893,7 @@ func TestRESTIntegrationPrefixScopesSearchNotLinks(t *testing.T) {
 
 	// A run-unique root keeps other tests' rows (and reruns) out of the
 	// assertions, the way the other REST integration tests do it.
-	root := fmt.Sprintf("scope%d", time.Now().UnixNano())
+	root := testdb.Unique(t, "scope")
 	term := root + "/company/glossary/activation"
 	entries := []struct{ id, body string }{
 		// The team metric cites the shared term, so context must reach it.
@@ -1006,7 +1007,7 @@ func TestRESTIntegrationPrefixScopesSearchNotLinks(t *testing.T) {
 func TestRESTIntegrationDocumentWrites(t *testing.T) {
 	srv, _ := newIntegrationServer(t)
 
-	id := fmt.Sprintf("restdoc%d/revenue", time.Now().UnixNano())
+	id := testdb.Unique(t, "restdoc") + "/revenue"
 	removeEntries(t, srv, id)
 	const doc = "---\ntype: Metric\ntitle: 売上\nowner: finance\n---\n\n本文。\n"
 
@@ -1103,7 +1104,7 @@ func TestRESTIntegrationDocumentWrites(t *testing.T) {
 func TestRESTIntegrationDocumentSurvivesTheRoundTrip(t *testing.T) {
 	srv, _ := newIntegrationServer(t)
 
-	id := fmt.Sprintf("restbytes%d/revenue", time.Now().UnixNano())
+	id := testdb.Unique(t, "restbytes") + "/revenue"
 	removeEntries(t, srv, id)
 
 	// Everything a rendering would quietly normalize: a comment, the
@@ -1175,7 +1176,7 @@ func TestRESTIntegrationDocumentSurvivesTheRoundTrip(t *testing.T) {
 func TestRESTIntegrationForeignTrustFamilyIsKeptAsAClaim(t *testing.T) {
 	srv, _ := newIntegrationServer(t)
 
-	id := fmt.Sprintf("restclaim%d/revenue", time.Now().UnixNano())
+	id := testdb.Unique(t, "restclaim") + "/revenue"
 	removeEntries(t, srv, id)
 
 	// The export form of another instance: a human wrote it there, and a
@@ -1267,7 +1268,7 @@ func TestRESTIntegrationAnyFileIsAcceptedAndServedInert(t *testing.T) {
 	srv, s := newIntegrationServer(t)
 	s.UseBlobStore(memBlobStore{})
 
-	typ := fmt.Sprintf("restany%d", time.Now().UnixNano())
+	typ := testdb.Unique(t, "restany")
 	id := typ + "/diagram"
 	// Purge at the end, like every other test that holds live files: the
 	// shared test database is scanned whole by the export and by the
@@ -1364,7 +1365,7 @@ func TestRESTIntegrationBundleAddressWritesEveryObject(t *testing.T) {
 	srv, s := newIntegrationServer(t)
 	s.UseBlobStore(memBlobStore{})
 
-	typ := fmt.Sprintf("restbundle%d", time.Now().UnixNano())
+	typ := testdb.Unique(t, "restbundle")
 	id := typ + "/revenue"
 	bundle := srv.URL + "/api/v1/bundle/"
 	defer func() {
@@ -1491,7 +1492,7 @@ func TestRESTIntegrationBundleAddressWritesEveryObject(t *testing.T) {
 func TestRESTIntegrationStats(t *testing.T) {
 	srv, s := newIntegrationServer(t)
 
-	root := fmt.Sprintf("stats%d", time.Now().UnixNano())
+	root := testdb.Unique(t, "stats")
 	id := root + "/revenue"
 	resp := putDoc(t, srv.URL, id, docFrom(t, map[string]any{
 		"type": root, "id": id, "title": "Revenue", "status": "draft",
@@ -1610,7 +1611,7 @@ func TestRESTIntegrationListingsPage(t *testing.T) {
 	// A run-unique root, as the other REST integration tests do it: the
 	// feed below is filtered to this test's own entries, so a shared test
 	// database cannot change what the walk should see.
-	root := fmt.Sprintf("page%d", time.Now().UnixNano())
+	root := testdb.Unique(t, "page")
 	var ids []string
 	for i := range 5 {
 		id := fmt.Sprintf("%s/e%d", root, i)
@@ -1709,7 +1710,7 @@ func cursorOf(t *testing.T, page func(string) ([]string, string), feed string) s
 func TestRESTQueuesCountsTheReviewQueues(t *testing.T) {
 	srv, _ := newIntegrationServer(t)
 
-	root := fmt.Sprintf("queuesit%d", time.Now().UnixNano())
+	root := testdb.Unique(t, "queuesit")
 	draft := root + "/proposals/margin"
 	broken := root + "/queries/revenue"
 	expired := root + "/insights/seasonality"
@@ -1800,7 +1801,7 @@ func TestRESTIntegrationTheArchiveCarriesAFileNothingOwns(t *testing.T) {
 	srv, s := newIntegrationServer(t)
 	s.UseBlobStore(memBlobStore{})
 
-	root := fmt.Sprintf("restloose%d", time.Now().UnixNano())
+	root := testdb.Unique(t, "restloose")
 	loose := root + "/seed-data.csv"
 	// A defer rather than t.Cleanup: cleanups run after this function's
 	// defers, by which time the server is closed.
@@ -1865,7 +1866,7 @@ func TestRESTIntegrationPurgeOnAFileRemovesIt(t *testing.T) {
 	srv, s := newIntegrationServer(t)
 	s.UseBlobStore(memBlobStore{})
 
-	path := fmt.Sprintf("restpurge%d/seed.csv", time.Now().UnixNano())
+	path := testdb.Unique(t, "restpurge") + "/seed.csv"
 	req, err := http.NewRequest(http.MethodPut, srv.URL+"/api/v1/bundle/"+path,
 		bytes.NewReader([]byte("a,b\n1,2\n")))
 	if err != nil {
@@ -1910,7 +1911,7 @@ func TestRESTIntegrationIndexListsTheFilesInADirectory(t *testing.T) {
 	srv, s := newIntegrationServer(t)
 	s.UseBlobStore(memBlobStore{})
 
-	typ := fmt.Sprintf("restfiles%d", time.Now().UnixNano())
+	typ := testdb.Unique(t, "restfiles")
 	id := typ + "/revenue"
 	loose := typ + "/seed-data.csv"
 	removeEntries(t, srv, id)
@@ -2002,7 +2003,7 @@ func TestRESTIntegrationIndexListsTheFilesInADirectory(t *testing.T) {
 func TestRESTIntegrationTheArchiveCarriesTheHistory(t *testing.T) {
 	srv, _ := newIntegrationServer(t)
 
-	typ := fmt.Sprintf("restlog%d", time.Now().UnixNano())
+	typ := testdb.Unique(t, "restlog")
 	id := typ + "/revenue"
 	removeEntries(t, srv, id)
 	resp := putDoc(t, srv.URL, id, docFrom(t, map[string]any{
@@ -2076,7 +2077,7 @@ func TestRESTIntegrationHistoryIsAtTheObjectAndTheDirectory(t *testing.T) {
 	srv, s := newIntegrationServer(t)
 	s.UseBlobStore(memBlobStore{})
 
-	typ := fmt.Sprintf("resthist%d", time.Now().UnixNano())
+	typ := testdb.Unique(t, "resthist")
 	id := typ + "/revenue"
 	file := id + "/chart.png"
 	removeEntries(t, srv, id)

--- a/internal/service/attachment_integration_test.go
+++ b/internal/service/attachment_integration_test.go
@@ -8,13 +8,13 @@ import (
 	"log/slog"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/jackc/pgx/v5"
 
 	"github.com/na0fu3y/ochakai/internal/domain"
 	"github.com/na0fu3y/ochakai/internal/embed"
 	"github.com/na0fu3y/ochakai/internal/store"
+	"github.com/na0fu3y/ochakai/internal/testdb"
 )
 
 // lockLiveAttachments serializes, across the test packages sharing the
@@ -114,7 +114,7 @@ func TestAttachmentSearchIntegration(t *testing.T) {
 	// of the code under test. The shared test database (CONTRIBUTING)
 	// grows past that, and the test would then fail for a reason that has
 	// nothing to do with attachments. Scoping the search fixes the field.
-	typ := domain.Type(fmt.Sprintf("svcatt%d", time.Now().UnixNano()))
+	typ := domain.Type(testdb.Unique(t, "svcatt"))
 	id := string(typ) + "/z-target" // sorts last: an RRF tie must not favor it
 	content := "quarterly revenue by region, expected results"
 	query := "四半期の地域別売上の検証結果"
@@ -254,11 +254,11 @@ func TestReembedCoversAttachmentsIntegration(t *testing.T) {
 	if err := s.Migrate(ctx, 4); err != nil {
 		t.Fatal(err)
 	}
-	model := fmt.Sprintf("reembed-att-%d", time.Now().UnixNano())
+	model := testdb.Unique(t, "reembed-att-")
 	svc := &Service{Store: s, Embedder: stubEmbedder{}, Log: slog.New(slog.DiscardHandler)}
 	actor := domain.Actor{Kind: "human", Name: "test"}
 
-	typ := domain.Type(fmt.Sprintf("svcre%d", time.Now().UnixNano()))
+	typ := domain.Type(testdb.Unique(t, "svcre"))
 	id := string(typ) + "/host"
 	if _, err := svc.Create(ctx, &domain.Knowledge{Type: typ, ID: id, Title: "host"}, actor); err != nil {
 		t.Fatal(err)

--- a/internal/service/context_integration_test.go
+++ b/internal/service/context_integration_test.go
@@ -10,11 +10,11 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/na0fu3y/ochakai/internal/domain"
 	"github.com/na0fu3y/ochakai/internal/httpauth"
 	"github.com/na0fu3y/ochakai/internal/store"
+	"github.com/na0fu3y/ochakai/internal/testdb"
 )
 
 // newIntegrationService dials the test database, skipping without
@@ -39,9 +39,11 @@ func newIntegrationService(t *testing.T, ctx context.Context) *Service {
 }
 
 // uid returns a run-unique slug token, so reruns against a shared test
-// database never collide on primary keys.
-func uid(prefix string) string {
-	return fmt.Sprintf("%s%d", prefix, time.Now().UnixNano())
+// database never collide on primary keys — and, since testdb owns it,
+// so the rows written under it go away when the test ends.
+func uid(t *testing.T, name string) string {
+	t.Helper()
+	return testdb.Unique(t, name)
 }
 
 // TestContextIntegration exercises the one-call context pack end to end:
@@ -53,7 +55,7 @@ func TestContextIntegration(t *testing.T) {
 	svc := newIntegrationService(t, ctx)
 	actor := domain.Actor{Kind: "human", Name: "test"}
 
-	id := uid("ctxit")
+	id := uid(t, "ctxit")
 	metricID, queryID, insightID, rejectedID := "metrics/"+id+"-revenue", "queries/"+id+"-monthly", "insights/"+id+"-reading", "insights/"+id+"-rejected"
 	entries := []*domain.Knowledge{
 		{Type: domain.TypeMetrics, ID: metricID, Title: id + "-revenue metric",
@@ -121,7 +123,7 @@ func TestSearchRecordsUsageIntegration(t *testing.T) {
 	svc := newIntegrationService(t, ctx)
 	actor := domain.Actor{Kind: "human", Name: "test"}
 
-	id := uid("usgit")
+	id := uid(t, "usgit")
 	if _, err := svc.Create(ctx, &domain.Knowledge{
 		Type: domain.TypeTerms, ID: id, Title: id + " term"}, actor); err != nil {
 		t.Fatal(err)
@@ -155,7 +157,7 @@ func TestDeleteIntegration(t *testing.T) {
 	svc := newIntegrationService(t, ctx)
 	actor := domain.Actor{Kind: "human", Name: "test"}
 
-	id := uid("delit")
+	id := uid(t, "delit")
 	if _, err := svc.Create(ctx, &domain.Knowledge{
 		Type: domain.TypeTerms, ID: id, Title: "to delete"}, actor); err != nil {
 		t.Fatal(err)
@@ -182,7 +184,7 @@ func TestContextBudgetIntegration(t *testing.T) {
 
 	// The shared test database carries other tests' entries, and fuzzy
 	// search does not respect test boundaries — assert over our own ids.
-	id := uid("budgetit")
+	id := uid(t, "budgetit")
 	mine := map[string]bool{}
 	for i := range 4 {
 		k := &domain.Knowledge{

--- a/internal/service/cursor_integration_test.go
+++ b/internal/service/cursor_integration_test.go
@@ -7,10 +7,10 @@ import (
 	"log/slog"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/na0fu3y/ochakai/internal/domain"
 	"github.com/na0fu3y/ochakai/internal/store"
+	"github.com/na0fu3y/ochakai/internal/testdb"
 )
 
 // A listing walked one page at a time must hand back exactly the listing
@@ -45,7 +45,7 @@ func TestListingsWalkToTheEndIntegration(t *testing.T) {
 	// The test database is shared with the other packages' integration
 	// tests, which leave entries behind: a tag only this run's entries
 	// carry is what keeps the walk over a set this test controls.
-	run := fmt.Sprintf("svcit-cursor-%d", time.Now().UnixNano())
+	run := testdb.Unique(t, "svcit-cursor-")
 	resource := "https://example.test/" + run
 	ids := make([]string, 6)
 	for i := range ids {

--- a/internal/service/service_integration_test.go
+++ b/internal/service/service_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/na0fu3y/ochakai/internal/embed"
 	"github.com/na0fu3y/ochakai/internal/okf"
 	"github.com/na0fu3y/ochakai/internal/store"
+	"github.com/na0fu3y/ochakai/internal/testdb"
 )
 
 // A document that is reformatted but says the same thing is a change to
@@ -40,7 +41,7 @@ func TestReformattingIsAChangeToTheFileOnlyIntegration(t *testing.T) {
 	svc := &Service{Store: s, Log: slog.New(slog.DiscardHandler)}
 	author := domain.Actor{Kind: domain.ActorHuman, Name: "author"}
 	editor := domain.Actor{Kind: domain.ActorHuman, Name: "editor"}
-	id := fmt.Sprintf("svcit-reformat-%d", time.Now().UnixNano())
+	id := testdb.Unique(t, "svcit-reformat-")
 
 	put := func(doc string, actor domain.Actor) (*domain.Knowledge, bool) {
 		t.Helper()
@@ -138,7 +139,7 @@ func TestUpdateNoOpIntegration(t *testing.T) {
 	actor := domain.Actor{Kind: domain.ActorHuman, Name: "test"}
 	// The ID is unique per run: entries stay live after the test, and the
 	// service layer has no hard delete to clean up with.
-	id := fmt.Sprintf("svcit-%d", time.Now().UnixNano())
+	id := testdb.Unique(t, "svcit-")
 
 	entry := func() *domain.Knowledge {
 		return &domain.Knowledge{
@@ -227,7 +228,7 @@ func TestUpdateIfMatchIntegration(t *testing.T) {
 	}
 	svc := &Service{Store: s, Log: slog.New(slog.DiscardHandler)}
 	actor := domain.Actor{Kind: domain.ActorHuman, Name: "test"}
-	id := fmt.Sprintf("svcit-ifmatch-%d", time.Now().UnixNano())
+	id := testdb.Unique(t, "svcit-ifmatch-")
 
 	mk := func(body string) *domain.Knowledge {
 		return &domain.Knowledge{Type: domain.TypeMetrics, ID: id, Title: "売上",
@@ -326,7 +327,7 @@ func TestRefuseIfCuratedIntegration(t *testing.T) {
 	}
 
 	t.Run("drafts stay writable", func(t *testing.T) {
-		id := "queries/" + uid("guard-draft")
+		id := "queries/" + uid(t, "guard-draft")
 		k, err := svc.Create(ctx, &domain.Knowledge{Type: domain.TypeMetrics, ID: id, Title: "draft"}, actor)
 		if err != nil {
 			t.Fatal(err)
@@ -353,7 +354,7 @@ func TestRefuseIfCuratedIntegration(t *testing.T) {
 	}
 	for _, tc := range rulings {
 		t.Run(string(tc.ruling)+" is refused", func(t *testing.T) {
-			id := "queries/" + uid("guard-"+string(tc.ruling))
+			id := "queries/" + uid(t, "guard-"+string(tc.ruling))
 			k, err := svc.Create(ctx, &domain.Knowledge{
 				Type: domain.TypeMetrics, ID: id, Title: string(tc.ruling),
 			}, actor)
@@ -395,7 +396,7 @@ func TestRefuseIfCuratedIntegration(t *testing.T) {
 	// entry, so without the guard an agent could delete it and recreate it
 	// as a draft, taking the reason for the rejection with it.
 	t.Run("a rejection cannot be laundered into a draft", func(t *testing.T) {
-		id := "queries/" + uid("guard-launder")
+		id := "queries/" + uid(t, "guard-launder")
 		k, err := svc.Create(ctx, &domain.Knowledge{
 			Type: domain.TypeMetrics, ID: id, Title: "rejected proposal",
 			StatusNote: "duplicate of an existing golden query",
@@ -432,7 +433,7 @@ func TestRefuseIfCuratedIntegration(t *testing.T) {
 		}
 		for _, tc := range rulings {
 			status, wantAdvice := tc.ruling, tombAdvice[tc.ruling]
-			id := "queries/" + uid("guard-tomb-"+string(status))
+			id := "queries/" + uid(t, "guard-tomb-"+string(status))
 			k, err := svc.Create(ctx, &domain.Knowledge{
 				Type: domain.TypeMetrics, ID: id, Title: "ruled on then deleted",
 			}, actor)
@@ -465,7 +466,7 @@ func TestRefuseIfCuratedIntegration(t *testing.T) {
 	// A draft tombstone is not a ruling: reviving an abandoned draft is
 	// what create-on-a-deleted-id is for.
 	t.Run("a draft tombstone stays revivable", func(t *testing.T) {
-		id := "queries/" + uid("guard-tomb-draft")
+		id := "queries/" + uid(t, "guard-tomb-draft")
 		if _, err := svc.Create(ctx, &domain.Knowledge{
 			Type: domain.TypeMetrics, ID: id, Title: "abandoned draft"}, actor); err != nil {
 			t.Fatal(err)
@@ -486,10 +487,10 @@ func TestRefuseIfCuratedIntegration(t *testing.T) {
 	// A free id is not a refusal, and neither is a live one: Create's own
 	// ErrAlreadyExists covers that case.
 	t.Run("free and live ids are untouched", func(t *testing.T) {
-		if err := svc.RefuseIfRevivingCurated(ctx, "queries/"+uid("guard-tomb-free")); err != nil {
+		if err := svc.RefuseIfRevivingCurated(ctx, "queries/"+uid(t, "guard-tomb-free")); err != nil {
 			t.Errorf("free id: %v", err)
 		}
-		id := "queries/" + uid("guard-tomb-live")
+		id := "queries/" + uid(t, "guard-tomb-live")
 		k, err := svc.Create(ctx, &domain.Knowledge{
 			Type: domain.TypeMetrics, ID: id, Title: "live"}, actor)
 		if err != nil {
@@ -523,7 +524,7 @@ func TestRefuseIfCuratedIntegration(t *testing.T) {
 		}{{"", func(*testing.T, *domain.Knowledge) {}, nil}}, rulings...)
 		for _, tc := range cases {
 			status, wantAdvice := tc.ruling, liveAdvice[tc.ruling]
-			id := "queries/" + uid("guard-live-"+string(status)+"x")
+			id := "queries/" + uid(t, "guard-live-"+string(status)+"x")
 			k, err := svc.Create(ctx, &domain.Knowledge{
 				Type: domain.TypeMetrics, ID: id, Title: "ruled on"}, actor)
 			if err != nil {
@@ -567,7 +568,7 @@ func TestReembedIntegration(t *testing.T) {
 		t.Errorf("without an embedder: got %v, want an UnsupportedError naming the setting", err)
 	}
 	svc.Embedder = embedder
-	id := "insights/" + uid("reembed")
+	id := "insights/" + uid(t, "reembed")
 	if _, err := svc.Create(ctx, &domain.Knowledge{
 		Type: domain.TypeInsights, ID: id, Title: "reembed me", Body: "text",
 	}, actor); err != nil {
@@ -636,7 +637,7 @@ func TestReembedIntegration(t *testing.T) {
 func TestReembedReportsWhatIsLeft(t *testing.T) {
 	ctx := context.Background()
 	actor := domain.Actor{Kind: "human", Name: "test"}
-	svc := newEmbeddingService(t, ctx, uid("m"))
+	svc := newEmbeddingService(t, ctx, uid(t, "m"))
 	model := svc.Embedder.Model()
 
 	// Entries written before a provider was configured: created with no
@@ -644,7 +645,7 @@ func TestReembedReportsWhatIsLeft(t *testing.T) {
 	// semantic search on an existing corpus leaves behind.
 	svc.Embedder = nil
 	for i := range 3 {
-		id := "insights/" + uid("missing")
+		id := "insights/" + uid(t, "missing")
 		if _, err := svc.Create(ctx, &domain.Knowledge{
 			Type: domain.TypeInsights, ID: id, Title: fmt.Sprintf("filler %d", i),
 		}, actor); err != nil {
@@ -793,7 +794,7 @@ func TestVerificationTimestampsSurviveTheRoundTripIntegration(t *testing.T) {
 			}},
 	} {
 		t.Run(tc.what, func(t *testing.T) {
-			id := uid("stampit")
+			id := uid(t, "stampit")
 			if _, err := svc.Create(ctx, &domain.Knowledge{
 				Type: domain.TypeTerms, ID: id, Title: id,
 			}, actor); err != nil {
@@ -837,7 +838,7 @@ func TestUpdatedByFollowsContentIntegration(t *testing.T) {
 	editor := domain.Actor{Kind: "human", Name: "tanaka"}
 	reviewer := domain.Actor{Kind: "human", Name: "na0"}
 
-	id := uid("generated-by")
+	id := uid(t, "generated-by")
 	k, err := svc.Create(ctx, &domain.Knowledge{
 		Type: domain.TypeTerms, ID: id, Title: id, Body: "First.",
 		StaleAfter: "2026-12-31",
@@ -909,7 +910,7 @@ func TestStaleAfterValidationIntegration(t *testing.T) {
 	svc := newIntegrationService(t, ctx)
 	actor := domain.Actor{Kind: "human", Name: "test"}
 	_, err := svc.Create(ctx, &domain.Knowledge{
-		Type: domain.TypeTerms, ID: uid("bad-stale"), Title: "x", StaleAfter: "30 days",
+		Type: domain.TypeTerms, ID: uid(t, "bad-stale"), Title: "x", StaleAfter: "30 days",
 	}, actor)
 	var invalid *InvalidInputError
 	if !errors.As(err, &invalid) {
@@ -947,7 +948,7 @@ func TestOKFFamilyValidationIntegration(t *testing.T) {
 			Type: domain.TypeTerms, Attrs: map[string]any{"sources": []any{}}},
 	} {
 		t.Run(name, func(t *testing.T) {
-			k.ID, k.Title = uid("okf-invalid"), "x"
+			k.ID, k.Title = uid(t, "okf-invalid"), "x"
 			var invalid *InvalidInputError
 			if _, err := svc.Create(ctx, k, actor); !errors.As(err, &invalid) {
 				t.Fatalf("create with %s: %v, want an invalid-input error", name, err)
@@ -958,14 +959,14 @@ func TestOKFFamilyValidationIntegration(t *testing.T) {
 	// The runtime requirement is scoped to the one type SPEC §10.2 puts it
 	// on; no other type gains a required field (design doc 0036 §5).
 	if _, err := svc.Create(ctx, &domain.Knowledge{
-		Type: domain.TypeTerms, ID: uid("no-runtime-ok"), Title: "x",
+		Type: domain.TypeTerms, ID: uid(t, "no-runtime-ok"), Title: "x",
 	}, actor); err != nil {
 		t.Fatalf("a Glossary Term must not need a runtime: %v", err)
 	}
 
 	// A full contract round-trips through the database intact, including
 	// the zero usage_count that means "counted, and never used".
-	id := uid("okf-full")
+	id := uid(t, "okf-full")
 	zero := 0
 	want := &domain.Knowledge{
 		Type: domain.TypeComputations, ID: id, Title: "x", Runtime: "bigquery",

--- a/internal/service/stats_integration_test.go
+++ b/internal/service/stats_integration_test.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 	"os"
 	"strings"
@@ -14,6 +13,7 @@ import (
 
 	"github.com/na0fu3y/ochakai/internal/config"
 	"github.com/na0fu3y/ochakai/internal/store"
+	"github.com/na0fu3y/ochakai/internal/testdb"
 )
 
 // A search that finds nothing is recorded as a question this base could
@@ -37,7 +37,7 @@ func TestSearchMissesAreRecordedIntegration(t *testing.T) {
 	svc := &Service{Store: s, Log: slog.New(slog.DiscardHandler)}
 	// Nothing in the base is like it — not even by trigram, which is
 	// what a shared test database makes easy to get wrong.
-	nonsense := fmt.Sprintf("qqzzxx%d", time.Now().UnixNano())
+	nonsense := testdb.Unique(t, "qqzzxx")
 	t.Cleanup(func() { deleteMisses(ctx, t, dbURL, nonsense) })
 
 	since := time.Now().Add(-time.Hour)

--- a/internal/store/blob_integration_test.go
+++ b/internal/store/blob_integration_test.go
@@ -3,13 +3,13 @@ package store
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/na0fu3y/ochakai/internal/domain"
+	"github.com/na0fu3y/ochakai/internal/testdb"
 )
 
 // GCS-only blob storage (design doc 0013): attachment bytes live only in
@@ -160,7 +160,7 @@ func TestIntegrationAttachRacingDeleteLoses(t *testing.T) {
 	s.UseBlobStore(newFakeBlobStore())
 	actor := domain.Actor{Kind: "human", Name: "test"}
 
-	id := fmt.Sprintf("it-attach-race-%d", time.Now().UnixNano())
+	id := testdb.Unique(t, "it-attach-race-")
 	defer func() {
 		_, _ = s.pool.Exec(ctx, `DELETE FROM attachment WHERE knowledge_id = $1`, id)
 		for _, table := range []string{"knowledge_revision", "object"} {

--- a/internal/store/migrate_integration_test.go
+++ b/internal/store/migrate_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/na0fu3y/ochakai/internal/domain"
+	"github.com/na0fu3y/ochakai/internal/testdb"
 )
 
 // TestMigrationLegacyData verifies the 0010 → 0011 migration chain
@@ -377,7 +378,7 @@ func TestMigrateConcurrent(t *testing.T) {
 	if _, err := admin.pool.Exec(ctx, `CREATE EXTENSION IF NOT EXISTS pg_trgm`); err != nil {
 		t.Fatal(err)
 	}
-	schema := fmt.Sprintf("migrate_race_%d", time.Now().UnixNano())
+	schema := testdb.Unique(t, "migrate_race_")
 	if _, err := admin.pool.Exec(ctx, `CREATE SCHEMA `+schema); err != nil {
 		t.Fatal(err)
 	}
@@ -656,7 +657,7 @@ func TestIntegrationEmbeddingDimChangeRebuilds(t *testing.T) {
 		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
 	}
 	ctx := context.Background()
-	s := scopedStore(ctx, t, fmt.Sprintf("embed_dim_%d", time.Now().UnixNano()))
+	s := scopedStore(ctx, t, testdb.Unique(t, "embed_dim_"))
 	// The vector tables are created outside the versioned migrations, and
 	// 0010/0011/0013 probe for them with an *unqualified* `to_regclass`,
 	// which walks the whole search path: with none in this schema they
@@ -1199,7 +1200,7 @@ func TestBackfillComposesStoredDocuments(t *testing.T) {
 		t.Fatal(err)
 	}
 	actor := domain.Actor{Kind: domain.ActorHuman, Name: "test"}
-	id := fmt.Sprintf("it-backfill-%d", time.Now().UnixNano())
+	id := testdb.Unique(t, "it-backfill-")
 	k := &domain.Knowledge{Type: domain.TypeInsights, ID: id, Title: "季節性",
 		Status: domain.StatusStable, Body: "12月は+40%。", CreatedBy: actor}
 	if err := s.Create(ctx, k, false); err != nil {

--- a/internal/store/objectpath_integration_test.go
+++ b/internal/store/objectpath_integration_test.go
@@ -3,13 +3,12 @@ package store
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/na0fu3y/ochakai/internal/domain"
+	"github.com/na0fu3y/ochakai/internal/testdb"
 )
 
 // One address space, two kinds of object (design doc 0046 §§3.1, 3.5),
@@ -46,7 +45,7 @@ func newObjectPathStore(t *testing.T) (*Store, context.Context, string) {
 	}
 	// A run-unique root keeps reruns and the other tests sharing this
 	// database out of the assertions, and lets the cleanup be a prefix.
-	root := fmt.Sprintf("it-op%d", time.Now().UnixNano())
+	root := testdb.Unique(t, "it-op")
 	t.Cleanup(func() {
 		for _, q := range []string{
 			`DELETE FROM object WHERE starts_with(path, $1)`,

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/na0fu3y/ochakai/internal/domain"
 	"github.com/na0fu3y/ochakai/internal/okf"
+	"github.com/na0fu3y/ochakai/internal/testdb"
 )
 
 // hitScore returns the score of id among hits, or -1 when it is absent.
@@ -160,7 +161,13 @@ func TestIntegration(t *testing.T) {
 		{"Metric", k.ID}, {"metric", k.ID}, {"METRIC", k.ID},
 		{"Data Contract", free.ID}, {"data contract", free.ID}, {"DATA CONTRACT", free.ID},
 	} {
-		hits, err := s.SearchLexical(ctx, "売上", Filter{Types: []domain.Type{tc.typ}}, 10)
+		// Scoped to the one entry each case is about. What is under
+		// test is whether the type filter matches it, and an unscoped
+		// search answers that only while the shared corpus is small
+		// enough for a bounded hit list to still contain it — a
+		// property of the database, not of the code (issue #278).
+		hits, err := s.SearchLexical(ctx, "売上",
+			Filter{Types: []domain.Type{tc.typ}, Prefixes: []string{tc.want}}, 10)
 		if err != nil {
 			t.Fatalf("SearchLexical(type=%q): %v", tc.typ, err)
 		}
@@ -1664,7 +1671,7 @@ func TestIntegrationLexicalSearchAnswersQuestions(t *testing.T) {
 	// the limit, failing recall on a corpus the test never planted. So
 	// every entry carries a run tag and every search is scoped to it,
 	// which is what the rest of this file does (see the 0037 feeds).
-	run := fmt.Sprintf("it-q-%d", time.Now().UnixNano())
+	run := testdb.Unique(t, "it-q-")
 	mine := Filter{Tags: []string{run}}
 
 	target, decoy := run+"/target", run+"/decoy"
@@ -2186,7 +2193,7 @@ func TestIntegrationCreateKeepsCuratedTombstones(t *testing.T) {
 		}},
 	} {
 		t.Run("guarded create refuses a "+string(tc.ruling)+" tombstone", func(t *testing.T) {
-			id := fmt.Sprintf("it-tomb-%s-%d", tc.ruling, time.Now().UnixNano())
+			id := testdb.Unique(t, "it-tomb-"+string(tc.ruling)+"-")
 			tombstone(t, id, tc.rule)
 			if err := s.Create(ctx, revive(id), true); !errors.Is(err, ErrCuratedTombstone) {
 				t.Fatalf("create = %v, want ErrCuratedTombstone", err)
@@ -2216,7 +2223,7 @@ func TestIntegrationCreateKeepsCuratedTombstones(t *testing.T) {
 	}
 
 	t.Run("guarded create still revives a draft tombstone", func(t *testing.T) {
-		id := fmt.Sprintf("it-tomb-draft-%d", time.Now().UnixNano())
+		id := testdb.Unique(t, "it-tomb-draft-")
 		tombstone(t, id, func(string) {})
 		if err := s.Create(ctx, revive(id), true); err != nil {
 			t.Fatalf("draft tombstone must stay revivable: %v", err)
@@ -2224,7 +2231,7 @@ func TestIntegrationCreateKeepsCuratedTombstones(t *testing.T) {
 	})
 
 	t.Run("guarded create over a live entry is still ErrAlreadyExists", func(t *testing.T) {
-		id := fmt.Sprintf("it-tomb-live-%d", time.Now().UnixNano())
+		id := testdb.Unique(t, "it-tomb-live-")
 		if err := s.Create(ctx, revive(id), false); err != nil {
 			t.Fatal(err)
 		}
@@ -2255,18 +2262,8 @@ func TestIntegrationMoveDoesNotClobberAConcurrentEdit(t *testing.T) {
 	}
 	actor := domain.Actor{Kind: "human", Name: "test"}
 
-	stamp := time.Now().UnixNano()
-	target := fmt.Sprintf("it-clobber-%d/metric", stamp)
-	moved := fmt.Sprintf("it-clobber-%d/renamed", stamp)
-	referrer := fmt.Sprintf("it-clobber-%d/insight", stamp)
-	cleanup := func() {
-		for _, table := range []string{"object", "knowledge_revision"} {
-			_, _ = s.pool.Exec(ctx, `DELETE FROM `+table+` WHERE id LIKE $1`,
-				fmt.Sprintf("it-clobber-%d%%", stamp))
-		}
-	}
-	cleanup()
-	defer cleanup()
+	run := testdb.Unique(t, "it-clobber-")
+	target, moved, referrer := run+"/metric", run+"/renamed", run+"/insight"
 
 	for _, k := range []*domain.Knowledge{
 		{Type: domain.TypeMetrics, ID: target, Title: "target", Status: domain.StatusDraft, CreatedBy: actor},
@@ -2363,7 +2360,7 @@ func TestStaleFeedAndSourceLookupIntegration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	run := fmt.Sprintf("it37-%d", time.Now().UnixNano())
+	run := testdb.Unique(t, "it37-")
 	mine := Filter{Tags: []string{run}}
 	actor := domain.Actor{Kind: "human", Name: "test"}
 	policy := "https://wiki.example/" + run + "/revenue-recognition"
@@ -2487,7 +2484,7 @@ func TestIntegrationMoveAndPurgeCarryTheLedgers(t *testing.T) {
 		t.Fatal(err)
 	}
 	actor := domain.Actor{Kind: domain.ActorHuman, Name: "test"}
-	from := fmt.Sprintf("it-ledger-move-%d", time.Now().UnixNano())
+	from := testdb.Unique(t, "it-ledger-move-")
 	to := from + "-moved"
 
 	if err := s.Create(ctx, &domain.Knowledge{
@@ -2546,7 +2543,7 @@ func TestIntegrationContentHashMovesOnlyWithContent(t *testing.T) {
 		t.Fatal(err)
 	}
 	actor := domain.Actor{Kind: domain.ActorHuman, Name: "test"}
-	id := fmt.Sprintf("it-hash-%d", time.Now().UnixNano())
+	id := testdb.Unique(t, "it-hash-")
 	k := &domain.Knowledge{Type: domain.TypeTerms, ID: id, Title: "first",
 		Status: domain.StatusDraft, Body: "One.", CreatedBy: actor}
 	if err := s.Create(ctx, k, false); err != nil {
@@ -2627,7 +2624,7 @@ func TestIntegrationStoredDocumentMatchesTheIndex(t *testing.T) {
 		t.Fatal(err)
 	}
 	actor := domain.Actor{Kind: domain.ActorHuman, Name: "test"}
-	id := fmt.Sprintf("it-storeddoc-%d", time.Now().UnixNano())
+	id := testdb.Unique(t, "it-storeddoc-")
 	count := 7
 	k := &domain.Knowledge{
 		Type: domain.TypeComputations, ID: id, Title: "月次売上", Description: "説明",
@@ -2694,7 +2691,7 @@ func TestIntegrationProducerKeysInsideObjectsSurviveStorage(t *testing.T) {
 		t.Fatal(err)
 	}
 	actor := domain.Actor{Kind: domain.ActorHuman, Name: "test"}
-	id := fmt.Sprintf("it-extra-%d", time.Now().UnixNano())
+	id := testdb.Unique(t, "it-extra-")
 	k := &domain.Knowledge{
 		Type: domain.TypeComputations, ID: id, Title: "extras", Runtime: "bigquery",
 		Status: domain.StatusDraft, CreatedBy: actor,
@@ -2762,7 +2759,7 @@ func TestIntegrationFrontmatterFilter(t *testing.T) {
 	if err := s.Migrate(ctx, 0); err != nil {
 		t.Fatal(err)
 	}
-	prefix := fmt.Sprintf("it-fm-%d", time.Now().UnixNano())
+	prefix := testdb.Unique(t, "it-fm-")
 	actor := domain.Actor{Kind: domain.ActorHuman, Name: "test"}
 
 	// Written as documents, because the index is derived from the
@@ -2870,7 +2867,7 @@ func TestIntegrationObjectIsKeyedByBundlePath(t *testing.T) {
 		t.Fatal(err)
 	}
 	actor := domain.Actor{Kind: domain.ActorHuman, Name: "t"}
-	id := fmt.Sprintf("it-path-%d/revenue", time.Now().UnixNano())
+	id := testdb.Unique(t, "it-path-") + "/revenue"
 	moved := id + "-moved"
 	defer func() {
 		for _, i := range []string{id, moved} {
@@ -2946,7 +2943,7 @@ func TestIntegrationFilesAreObjectsAttributedByPathOrBody(t *testing.T) {
 		t.Fatal(err)
 	}
 	actor := domain.Actor{Kind: domain.ActorHuman, Name: "t"}
-	base := fmt.Sprintf("it-files-%d", time.Now().UnixNano())
+	base := testdb.Unique(t, "it-files-")
 	id := base + "/revenue"
 	defer func() {
 		_, _ = s.pool.Exec(ctx, `DELETE FROM object WHERE path LIKE $1 || '%'`, base)
@@ -3178,7 +3175,7 @@ func TestIntegrationAFileReportsItsPath(t *testing.T) {
 	}
 	s.UseBlobStore(newFakeBlobStore())
 	actor := domain.Actor{Kind: domain.ActorHuman, Name: "t"}
-	base := fmt.Sprintf("it-path-%d", time.Now().UnixNano())
+	base := testdb.Unique(t, "it-path-")
 	id := base + "/revenue"
 	defer func() {
 		_, _ = s.pool.Exec(ctx, `DELETE FROM object WHERE path LIKE $1 || '%'`, base)
@@ -3246,7 +3243,7 @@ func TestIntegrationQueueCounts(t *testing.T) {
 
 	// Scoped by prefix, both because the test database is shared and
 	// because scoping is the only filter the counts take.
-	run := fmt.Sprintf("it49-%d", time.Now().UnixNano())
+	run := testdb.Unique(t, "it49-")
 	mine := Filter{Prefixes: []string{run}}
 	actor := domain.Actor{Kind: "human", Name: "test"}
 	mk := func(name string, status domain.Status, staleAfter string) string {

--- a/internal/testdb/testdb.go
+++ b/internal/testdb/testdb.go
@@ -1,0 +1,101 @@
+// Package testdb hands an integration test a namespace of its own in the
+// shared test database, and takes it back when the test ends.
+//
+// The database is shared on purpose: CI starts one container for the
+// whole run, and a developer keeps one up across sessions
+// (CONTRIBUTING). What that costs is that every test writes into the
+// same corpus, and a test that leaves its rows behind makes the corpus
+// grow without bound. That is not a tidiness problem. Ranking is
+// bounded — a search returns the top ten — so leftover entries push a
+// test's own entry out of its assertions, and the failure reads as a
+// search bug in whatever PR happens to cross the threshold (issue #278
+// found this the hard way, twice).
+//
+// So a test takes its namespace from Unique, and Unique is the only
+// place that knows how to give one back.
+package testdb
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// Unique returns name with a run-unique number appended, for a test to
+// build its ids and paths from, and registers the sweep that removes
+// every row carrying it.
+//
+// Call it before the store, service or server the test writes through:
+// cleanups run last-registered-first, so the sweep registered first runs
+// last — after the pool the test wrote with has closed, which is why it
+// opens a connection of its own.
+//
+// The name should say which test the rows belong to, so a sweep that
+// somehow does not run leaves rows that name their owner.
+func Unique(t *testing.T, name string) string {
+	t.Helper()
+	token := fmt.Sprintf("%s%d", name, time.Now().UnixNano())
+	t.Cleanup(func() { Sweep(t, token) })
+	return token
+}
+
+// Sweep removes every row whose object, ledger or measurement key
+// carries token anywhere in it. Exported for the few tests that write
+// under a name they did not get from Unique.
+//
+// Anywhere rather than at the front, because a test's token is as often
+// in the middle of an id as at the start: one run writes
+// "metrics/<token>-revenue" beside "insights/<token>-reading", and those
+// share no prefix. The token carries a nanosecond timestamp, so it
+// names one run of one test and nothing else.
+//
+// It runs outside the test's own transaction and connection on purpose:
+// by the time it runs the test's pool is usually closed, and a sweep
+// that needed the subject's machinery to work would not run for a test
+// that failed halfway through leaving rows behind.
+func Sweep(t *testing.T, token string) {
+	t.Helper()
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		return // the test skipped; there is nothing to sweep
+	}
+	// Outlives t.Context(), which is cancelled before cleanups run.
+	ctx := context.Background()
+	conn, err := pgx.Connect(ctx, dbURL)
+	if err != nil {
+		t.Errorf("testdb: sweeping %s: connect: %v", token, err)
+		return
+	}
+	defer func() { _ = conn.Close(ctx) }()
+	// Every table an entry or a file can leave a row in, keyed by
+	// whichever column holds the address. strpos rather than LIKE: an
+	// id may contain "_" and "%", which LIKE would read as wildcards.
+	for _, q := range []string{
+		`DELETE FROM object WHERE strpos(id, $1) > 0 OR strpos(path, $1) > 0`,
+		`DELETE FROM knowledge_revision WHERE strpos(id, $1) > 0 OR strpos(path, $1) > 0`,
+		`DELETE FROM knowledge_verification WHERE strpos(id, $1) > 0`,
+		`DELETE FROM knowledge_rejection WHERE strpos(id, $1) > 0`,
+		`DELETE FROM knowledge_purge WHERE strpos(id, $1) > 0`,
+		`DELETE FROM knowledge_usage WHERE strpos(knowledge_id, $1) > 0`,
+		`DELETE FROM knowledge_event WHERE strpos(knowledge_id, $1) > 0`,
+		`DELETE FROM attachment WHERE strpos(knowledge_id, $1) > 0`,
+	} {
+		if _, err := conn.Exec(ctx, q, token); err != nil {
+			t.Errorf("testdb: sweeping %s: %v", token, err)
+			return
+		}
+	}
+	// The embedding tables exist only where semantic search has been
+	// configured against this database, so a failure to find them is
+	// not a failure to clean up.
+	for _, q := range []string{
+		`DELETE FROM knowledge_embedding WHERE strpos(id, $1) > 0`,
+		`DELETE FROM attachment_embedding WHERE strpos(knowledge_id, $1) > 0`,
+	} {
+		_, _ = conn.Exec(ctx, q, token)
+	}
+}


### PR DESCRIPTION
Item 5 — the last of the five left open on #325. Test-only; nothing the program ships changes.

## What and why

The test database is shared: CI runs one container for a whole run, and by hand you keep one up across sessions. Every integration test wrote under a token it built itself —

```go
typ := fmt.Sprintf("restit%d", time.Now().UnixNano())
```

— which collides with nobody and is cleaned up by nobody. The corpus grew by about **75 entries a run**, and because ranking is bounded, from the **third run** a type filter stopped finding its own entry:

```
store_integration_test.go:172: type="Metric" must find "it-revenue", got 10 hits
```

The failure reads as a search bug in whatever change happens to be in the tree when the threshold is crossed. Issue #278 found it twice, and both times the fix was to the assertion that tipped, not to the thing filling the database.

**`internal/testdb.Unique` is the same token with the sweep attached.** It registers a cleanup that deletes every row carrying it — the object table and each ledger and measurement beside it. Registered before the store the test writes through, so it runs *after* that pool has closed, which is why it opens a connection of its own, and why it still runs for a test that failed halfway through.

The sweep matches the token **anywhere** in an address rather than at the front: a test's token is as often in the middle of an id as at the start, since one run writes `metrics/<token>-revenue` beside `insights/<token>-reading` and those share no prefix. The token carries a nanosecond timestamp, so it names one run of one test and nothing else.

### Two guards

- **`TestNoTestRollsItsOwnNamespace`** reads the tree for the shape this replaces. Nothing else would notice the next one: the hand-rolled version works perfectly, right up until the run that tips somebody else's assertion over. Two files are listed as allowed, where a unique number is not an address (an embedding model name, a search query nobody else asks).
- **`TestNothingShipsTestSupport`.** The environment-variable count reads `OCHAKAI_*` out of non-test source, and `internal/testdb` reads `OCHAKAI_TEST_DATABASE_URL` — so it was counted as a knob an operator sets, which it is not. The count now skips that package, and because a guard with a named exception is a place to hide something, the exception is checked rather than trusted (0035): the test fails if the program ever imports it, and also if no test does.

### And the assertion that kept tipping

Scoped to the entry it is about. What it tests is whether a type filter matches case-insensitively; an unscoped search answered that only while the corpus was small enough for a bounded hit list to still contain the entry — a property of the database, not of the code.

## Checks

- [x] `scripts/check` is clean — add `--db` when the change touches the store
- [x] Behavior changes come with tests

`scripts/check core` and `scripts/check lint` are clean against PostgreSQL 17 with pgvector. `scripts/check vuln` is not verifiable in this environment (the proxy refuses `vuln.go.dev`); CI runs it.

Six consecutive `go test ./...` against one database:

| run | objects | revisions |
|---|---|---|
| 1 | 38 | 67 |
| 2 | 38 | 67 |
| 3 | 38 | 67 |
| 4 | 38 | 67 |
| 5 | 38 | 67 |
| 6 | 38 | 67 |

Before this it grew every run and failed on the third. The 38 that remain are fixed ids (`it-revenue`, `it-contract`, …) that each run overwrites — they do not accumulate, and giving them run-unique names would cost the tests that assert on them by name.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and `internal/apiclient` say the same thing — untouched
- [x] The change lands on every surface it belongs on — none; this is test support
- [x] Widens a surface? No. `docs/surface.md` is unchanged and every count holds — including ENV, which is the one this could have moved and the reason for the second guard.

`CONTRIBUTING.md` gains the convention, next to the store-test setup it belongs with.

## Design docs

- [x] Alters an accepted decision? No — nothing a user can observe changes.
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xtrzd3JFhLg9S9WFqRUoJK)_