### PR TITLE
Call the two kinds of object concept and file, on every part of MCP

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -65,8 +65,8 @@ paths:
         (report_outcome failed) are still unanswered, worst first, and each
         hit carries its usage totals — the re-verification feed. An entry
         drops out once it is verified after its last failure report
-        (POST /api/v1/verify/{id}), so a base that is kept up shows an
-        empty feed.
+        (POST /api/v1/review/{id} with ruling: verified), so a base that
+        is kept up shows an empty feed.
         With sort=stale_after it lists entries whose author declared a
         stale_after that has now passed, most overdue first — the feed for
         knowledge dated by whoever wrote it (design doc 0037 §2.1).
@@ -1137,7 +1137,7 @@ paths:
         fresh id: a live or soft-deleted entry there already owns that
         address and its history — free an id held by a deleted entry with
         DELETE ...?purge=true. Lives at its own top-level path for the
-        same reason /usage and /revisions do — a suffix after the
+        same reason /usage and /review do — a suffix after the
         hierarchical id could be confused with an ID segment.
       parameters:
         - $ref: "#/components/parameters/OnBehalfOf"
@@ -1972,7 +1972,8 @@ components:
         anything but unverified. Append-only and plural: re-checking an
         entry adds a row rather than replacing one, so the record answers
         "how often, and by whom" and not just "when last".
-        Written by POST /api/v1/verify/{id}, never from a payload.
+        Written by POST /api/v1/review/{id} with ruling: verified, never
+        from a payload.
       properties:
         by: { $ref: "#/components/schemas/Actor" }
         at: { type: string, format: date-time }
@@ -1981,8 +1982,8 @@ components:
       description: >
         This instance's ruling that an entry was not accepted — the memory
         that stops an agent re-proposing knowledge a human already turned
-        down. One live ruling per entry; POST /api/v1/reject/{id} records
-        it and DELETE lifts it.
+        down. One live ruling per entry; POST /api/v1/review/{id} records
+        it with ruling: rejected and lifts it with ruling: withdrawn.
         It is not a lifecycle value: a rejection is a judgment about the
         concept rather than a stage of it, and it could not round-trip as
         a status because export had to fold it onto deprecated, which
@@ -2173,14 +2174,16 @@ components:
           description: >
             Every recorded confirmation, oldest first. Absent means
             unverified, which is SPEC §5.3's own signal. Written by
-            POST /api/v1/verify/{id}: this is an instance ledger, and
+            POST /api/v1/review/{id} with ruling: verified: this is an
+            instance ledger, and
             import reads only whether a bundle's `verified` key was
             present (design docs 0009, 0043 §3.2).
         rejection:
           allOf: [{ $ref: "#/components/schemas/Rejection" }]
           description: >
             The live ruling, absent when there is none. Written by
-            POST /api/v1/reject/{id} and cleared by DELETE.
+            POST /api/v1/review/{id} with ruling: rejected, and cleared
+            by ruling: withdrawn.
     View:
       type: object
       description: >

--- a/cmd/ochakai/retired_test.go
+++ b/cmd/ochakai/retired_test.go
@@ -4,6 +4,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -187,4 +188,93 @@ func TestOneSpellingDecidesWhatIsReserved(t *testing.T) {
 	if !found {
 		t.Errorf("%s no longer spells the reserved names: this check now guards nothing", decides)
 	}
+}
+
+// An address the contract mentions but does not declare: everything
+// matching /api/v1/... in api/openapi.yaml, minus what its own `paths`
+// covers.
+var wireAddressRe = regexp.MustCompile(`/api/v1/[A-Za-z0-9_.{}/-]*`)
+
+// pastTense are the words that turn a retired address into history. A
+// removal cannot be explained without spelling what was removed, so the
+// signal cannot be the address — it has to be the tense around it.
+var pastTense = []string{"gone", "retired", "replaced", "used to", "was", "were", "old"}
+
+// Guard: the contract names no address it does not have, except to say
+// that address is gone.
+//
+// TestRetiredSpellingsAreNotTaught reads the tree for a list of literals
+// somebody has to remember to extend, and 0055's fold showed what that
+// costs: `POST /api/v1/verify/{id}` and `POST /api/v1/reject/{id}`
+// became one `POST /api/v1/review/{id}`, and four schema descriptions in
+// api/openapi.yaml went on saying a verification is "written by POST
+// /api/v1/verify/{id}" and a rejection is "cleared by DELETE". Every
+// counter in surface_test.go agreed the surface was 11 operations — the
+// endpoints were gone from `paths`, which is all those checks read —
+// while the prose beside them documented three addresses that answer
+// 404. It is the mistake issue #275 found in comments, one file over.
+//
+// Here nothing has to be remembered: `paths` is the list of addresses
+// that exist, so the list of addresses that do not is whatever else the
+// file says. The tense is what tells them apart — the four stale lines
+// were all in the present, and every note that records a removal was
+// already in the past.
+func TestContractNamesNoAddressItDoesNotHave(t *testing.T) {
+	spec := readWireSpec(t)
+	// A declared path matches by its static head: {path...} and {id...}
+	// are wildcards, and prose spells them filled in ("/api/v1/bundle/"
+	// is the root archive, "/api/v1/usage/queries/x" one entry's usage).
+	prefixes := make([]string, 0, 2*len(spec.Paths))
+	for path := range spec.Paths {
+		head, _, _ := strings.Cut(path, "{")
+		prefixes = append(prefixes, head, strings.TrimSuffix(head, "/"))
+	}
+	const contract = "../../api/openapi.yaml"
+	content, err := os.ReadFile(contract)
+	if err != nil {
+		t.Fatalf("read %s: %v", contract, err)
+	}
+	lines := strings.Split(string(content), "\n")
+	checked := 0
+	for i, line := range lines {
+		for _, mention := range wireAddressRe.FindAllString(line, -1) {
+			address := strings.TrimRight(mention, ".,;:)`")
+			if hasAnyPrefix(address, prefixes) {
+				continue
+			}
+			checked++
+			// A description wraps, so the sentence that says "gone" can
+			// sit a line or two above the address it is about.
+			if saysPast(lines[max(0, i-2) : i+1]) {
+				continue
+			}
+			t.Errorf("%s:%d names %s, which the contract does not declare — "+
+				"say it in the past tense if it is history, or fix the line\n\t%s",
+				contract, i+1, address, strings.TrimSpace(line))
+		}
+	}
+	if checked == 0 {
+		t.Log("the contract mentions no retired address: nothing to tell apart today")
+	}
+}
+
+func hasAnyPrefix(s string, prefixes []string) bool {
+	for _, p := range prefixes {
+		if strings.HasPrefix(s, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func saysPast(lines []string) bool {
+	for _, line := range lines {
+		lower := strings.ToLower(line)
+		for _, word := range pastTense {
+			if strings.Contains(lower, word) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -1,9 +1,10 @@
 // Package mcpserver exposes ochakai's MCP tools over streamable HTTP.
 // Tool names follow verb_object so they stay unambiguous next to other MCP
 // servers' tools (design doc §4). The REST API (internal/restapi) is a
-// superset of these tools: same operations plus bulk export/import and
-// the human-facing browse/revisions/backlinks endpoints (design doc
-// 0015 keeps those off MCP — agents use search/get_context; tool
+// superset of these tools: the same operations plus the archive of a
+// bundle path, the derived index.md and log.md, the reverse lookup
+// (search's links_to=), the human's ruling and file writes (design doc
+// 0015 §3.1 keeps those off MCP — agents use search/get_context; tool
 // schemas cost agent context, so the tool count is a budget).
 package mcpserver
 

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -702,7 +702,7 @@ func Handler(svc *service.Service) http.Handler {
 	// id is the address (design doc 0017), so the move carries revisions,
 	// usage, and attachments along and rewrites inbound references (link
 	// targets, attrs.model) so nothing breaks (design doc 0021). Its own
-	// top-level path for the same reason /usage and /revisions have one:
+	// top-level path for the same reason /usage and /review have one:
 	// a suffix after the hierarchical {id...} wildcard could be confused
 	// with an ID segment.
 	mux.HandleFunc("POST /api/v1/move", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## What and why

A review of the REST path space after 0046 §3.5 and 0055 found the wire
sound and three things behind it out of step: the contract's prose still
named endpoints 0055 had folded away, the MCP face still spoke the
vocabulary 0046 and 0054 replaced, and the address space had two rules
with no sentence deciding between them. Three commits, in that order.

### 1. The contract says what it has (no wire change)

0055 folded `POST /api/v1/verify/{id}`, `POST /api/v1/reject/{id}` and
`DELETE /api/v1/reject/{id}` into `POST /api/v1/review/{id}` and removed
them from `openapi.yaml`'s `paths`. Four schema descriptions went on
naming them as current writers. Every counter in `surface_test.go` agreed
the wire was 11 operations — `paths` is all they read — while the prose
beside them documented three addresses that answer 404. Two citations of
a retired sibling go with them: `/move` justified its top-level path by
"the same reason /usage and /revisions do" (in the contract and the
router), and the `mcpserver` package comment called REST a superset by
"bulk export/import and the human-facing browse/revisions/backlinks
endpoints" — none of which is an endpoint now.

`TestContractNamesNoAddressItDoesNotHave` is the new guard, and it needs
no list to maintain: the contract's own `paths` is what exists, so
whatever else the file spells is what does not, and the **tense** tells
them apart. A removal cannot be explained without spelling what was
removed, so the signal is the past tense around the address, not the
address. All four stale lines were in the present; every note recording a
removal was already in the past. Verified by reintroducing one and
watching it fail on the right line.

### 2. MCP speaks one vocabulary and one address (design doc 0054)

0054 renamed five tool names to OKF's `concept` and said, in §3.2, that
`get_attachment` was "a different question". It was the same question,
and 0046 §2.1 had already answered it: an object is a concept or a file,
"attachment" is the word from the model that fold dissolved, and the
tool's own description already said "one file of the bundle".

Names are not only tool names. The same two vocabularies were spelled in
three more places, all paid for in the currency that matters — the words
an agent has to hold:

```
get_attachment                    →  get_file
{"knowledge": …}  get/put_concept →  {"concept": …}
{"attachment": …} get_file        →  {"file": …}
report_outcome    target          →  id
resource template concept/{+id}   →  object/{+address}
```

`report_outcome`'s argument is the sharpest: `get_concept_usage` asks
about the same concept at the same address and calls it `id`.

**The URI is the other half.** `get_file` embeds a file under
`ochakai://<path>`; `resources/read` resolved every address as a concept
id, so that lookup could only miss — the server handed out an address it
refused itself. A URI is not optional in an embedded resource, so the
choice was never whether to mint one, only whether it works.
`resources/read` now resolves a concept first and a file otherwise, the
order `GET /api/v1/bundle/{path}` already uses: one address space, read
the same way from both faces. `index.md` and `log.md` stay unreadable
here — they are generated, and `ValidBundlePath` already said so.

**What did not move:** the tool count (8), every capability, and a
concept's `attachments` metadata — that is derived attribution (0046
§2.1), not "a file of the bundle", and one word meaning both was the
thing to fix. Tool descriptions keep "entry" and "knowledge base"; only
the compound "knowledge entry" changed, because that was one thing
spelled in two words. `domain.Knowledge` is internal and stays; only the
types that spell the wire follow it (`conceptOut`, `fileIn`/`fileOut`,
`parseObjectURI`).

**0054 is unreleased, so this replaces that record rather than taking
0056** (0048 §2.3), and the changelog entry it already had grows to cover
the rest. The retired tool names join `TestRetiredSpellingsAreNotTaught`.

### 3. Which of the two addresses an operation goes on (0046 §3.5)

`?history` is an instance's observation served at the object's own
address; `usage` and `review` are instance observations served at
top-level id-keyed paths. Both are right, and nothing said why — so the
next operation gets placed by whichever example its author read first.
The stated reason for the id faces did not decide it either: "a suffix
after the hierarchical `{id...}` would be indistinguishable from an ID
segment" is true of suffixes, and `?history` is a query parameter, which
that argument leaves free. It answers how to spell a face, not which side
it is on.

The rule that was already being followed:

> The bundle address carries the object and the representations OKF
> defines for it. The id-keyed top-level faces carry what this instance
> observed about a concept.

`?history` is on the object because it is SPEC §9's `log.md`, as
`index.md` and the archive are the bundle's own representations. `usage`
and `review` are not, because OKF represents neither and an observation
has no address in a bundle (0009). The rule predicts what is already
true: a file has no usage and no ruling, `move` renames a concept's id
rather than bytes, and a ledger write leaves the ETag alone because the
version belongs to the bytes.

No wire change. It is stated where each audience meets it — the
contract's intro for someone building on the API, 0046 §3.5 for someone
reading the decision, the router's comments beside the three faces that
raised the question — and the spelling it leaves behind is checkable, so
`TestPathVariablesSayWhichAddressSpaceAnOperationIsOn` holds it: `{path}`
under `/api/v1/bundle/`, `{id}` at a top-level name. A face that mixes
them is a face whose side nobody decided. The judgment stays in review;
what the test catches is skipping it. Also verified by a deliberate
break.

## Checks

- [x] `scripts/check --db` is clean: tests, `CGO_ENABLED=0` build and
      `golangci-lint` (0 issues), store tests against a throwaway
      PostgreSQL. `govulncheck` cannot run in this environment — the
      proxy answers `Forbidden` for vuln.go.dev — so CI is where that one
      is verified
- [x] Behavior changes come with tests.
      `TestIntegrationResourceReadsEitherKindOfObject` reads a concept by
      id and a file by path through `resources/read` — the second is the
      URI `get_file` hands out, which used to come back not-found. It was
      confirmed to run (and fail on a wrong expectation) rather than skip

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver` and
      `internal/apiclient` say the same thing; `internal/apiclient` and
      the CLI are untouched, because neither ever carried these names
- [x] The renames land on MCP only, and deliberately: REST and the CLI
      carry no `knowledge` (0046 §3.5 finished that), the Web UI is
      screen language, and `/api/v1/bundle/{path}` already resolves both
      kinds of object at one address — 0054 §3.6. The address rule is
      REST's own and changes no surface
- [x] Widens no surface. Tools stay at 8, no REST operation, CLI command
      or environment variable is added; `docs/surface.md`'s MCP section
      lists `get_file` where it listed `get_attachment` and no count
      moves

## Design docs

- [x] `docs/design/0054` is replaced in this PR and 0046 §3.5 gains the
      placement rule — both unreleased, so neither takes a new number
      (0048 §2.3). 0046's `Status:` header records both its own edit and
      that §3.14's tool table was restated; both indexes and
      `README.en.md` are updated. `designdocs_test.go` passes
- [x] Commit messages and code comments are in English