### PR TITLE
Answer "why not just X?" in one place, including a markdown vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ for what they still don't do:
   with trust in the spec's own keys. MIT-licensed and self-hosted per
   tenant: your knowledge is never a hostage.
 
+Each of those has an alternative you may already run — a catalog, a
+memory layer, a markdown vault with an MCP server.
+[Positioning](docs/positioning.md) takes them one at a time, says where
+ochakai loses, and says who should pick something else.
+
 ### What it refuses
 
 | ochakai has no… | because |
@@ -161,6 +166,7 @@ This README describes `main`; the [changelog](CHANGELOG.md) says what is
 in the version you are running.
 
 - **Evaluating** — [FAQ](docs/faq.md) ·
+  [Positioning](docs/positioning.md) ·
   [Architecture](docs/architecture.md) ·
   [Compatibility and support](docs/compatibility.md) ·
   [Roadmap](ROADMAP.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,8 +6,14 @@ and what it refuses to do. It is deliberately short; the manual is here.
 ## For someone evaluating ochakai
 
 - [FAQ](faq.md) — can it run outside Google Cloud, does anything leave
-  your project, how it differs from RAG and from a memory layer, what an
-  agent may do to verified knowledge, and what leaving looks like.
+  your project, how it differs from RAG, from a memory layer and from a
+  markdown vault, what an agent may do to verified knowledge, and what
+  leaving looks like.
+- [Positioning](positioning.md) — every "why not just use X?" in one
+  place: semantic layers, catalogs, memory layers, RAG, the verified-query
+  store inside an AI-analyst product, and a markdown vault with an MCP
+  server. Includes where ochakai loses, and who should pick something
+  else.
 - [Architecture](architecture.md) — how the pieces fit, what the data
   model is, and why there is no authorization layer. English summary of
   the decision records.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,7 +2,9 @@
 
 Answers that the README implies but never states in one place. When a
 question is really about a symptom, it is in
-[troubleshooting](guides/troubleshooting.md) instead.
+[troubleshooting](guides/troubleshooting.md) instead; when it is "why not
+just use X?", the three below are the short forms and
+[positioning](positioning.md) is the full landscape.
 
 ### Can I run this without Google Cloud?
 
@@ -54,6 +56,33 @@ unaudited: nobody reviews what got remembered, and a wrong memory persists
 quietly. ochakai is team-shared knowledge that passes through human
 review. They compose — preferences in your memory layer, verified data
 knowledge here.
+
+### How is it different from an Obsidian vault with an MCP server?
+
+By everything except the file format. Both store markdown with YAML
+frontmatter and take their relationships from links in the body, and an
+`ochakai export` bundle opens as a vault — so if what you want is to
+browse and edit your knowledge with a good editor, use one.
+
+What a vault has no notion of is a *ruling*. OKF's trust keys are
+ordinary YAML, so a vault can hold a `verified` entry naming a human —
+but there it is a line somebody typed, where here it is what the instance
+observed of an authenticated caller and is never read back from a
+document (design docs [0009](design/0009-provenance-portability.md),
+[0043](design/0043-document-first.md)). Nothing in a vault appends to
+that ledger, derives a trust tier from it, refuses an overwrite against
+it, or resurfaces an entry whose last confirmation has aged out.
+There is no review queue, no rejection that keeps its reason, no usage
+count, no outcome report — the [improvement loop](loop.md) has no
+analogue there at all. Nor is there an identity to record as provenance
+(a vault MCP server usually carries a local API key, and the writer is
+whoever's laptop it was), a precondition that stops two writers from
+clobbering each other, or reach beyond the one machine the vault sits on.
+
+A vault is where a person thinks. ochakai is where a team's verified data
+knowledge lives and is served to agents — including agents in CI and
+hosted ones that will never see your laptop. The long form, with the
+other five alternatives, is in [positioning](positioning.md).
 
 ### Do I need embeddings?
 

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -1,0 +1,209 @@
+# Positioning
+
+Every "why not just use X?" answered in one place. The honest answer is
+usually **"you can, and they compose"** — ochakai is one layer of a data
+agent's context, not a replacement for the warehouse, the catalog, the
+memory layer or your notes app. What it claims is a slot none of them
+fill: *knowledge a human verified, written by the agents that use it,
+served to every client over one contract.*
+
+This page is for somebody evaluating. What ochakai refuses is in the
+[README](../README.md#what-it-refuses) and the
+[roadmap](../ROADMAP.md#considered-and-deliberately-not-doing); why the
+surface stays small is [docs/surface.md](surface.md), whose **seven
+conditions** are the vocabulary used below.
+
+## The one line
+
+A semantic layer tells you revenue = `SUM(price)`. It does not tell you
+whether 100 is good or bad, that Q3 is always soft, that the `web` and
+`web_direct` channel codes were never two things, or that the query
+somebody sanctioned for this question is *that* one. ochakai holds that
+second half, keeps a human's ruling on each piece of it, and lets the
+agents that consume it write the next piece back.
+
+## The neighbors
+
+| Comparing against | It holds | It does not hold | Verdict |
+|---|---|---|---|
+| Warehouse-native semantic layers (dbt MCP, Cube, Lightdash, Snowflake Semantic Views, Databricks Metric Views) | Metric definitions, dimensions, compiled SQL | Interpretation, glossary, write-back, anything cross-warehouse | Compose |
+| Catalogs that became "context layers" (OpenMetadata, DataHub, Atlan) | Technical metadata, lineage, ownership, harvested at scale | The curated half as OSS — interpretation and the review loop tend to sit in the commercial tier | Compose, or replaces ochakai if you already run one |
+| Agent memory layers (mem0, Zep, Letta) | Per-user, per-agent memories, auto-extracted and auto-injected | Team ownership, human review, a record of *no* | Compose |
+| RAG over your documents | Passages from documents written for other reasons | A reviewed claim as the unit; provenance; direction of authorship | Compose |
+| Verified-query stores inside an AI-analyst product (Cortex Analyst's VQR, Genie) | Question + verified SQL, inside one vendor's chat | Any other client; an exit | Overlaps, and locks in |
+| **A markdown vault with an MCP server (Obsidian, Logseq, a git repo of notes)** | markdown + frontmatter, links, local ownership, agent-readable | Verification as a live state, the loop, multi-writer identity, reach beyond one machine | Compose — see below |
+
+### Warehouse-native semantic layers
+
+Closest on metric definitions, and by 2026 the warehouses hold them
+natively as schema objects. In a single-warehouse world that half is
+theirs and ochakai's `Metric` entries are redundant. What stays is
+everything that does not fit a semantic-model YAML: the baseline, the
+caveat, the threshold, the query somebody sanctioned, and knowledge that
+spans warehouses. ochakai stopped generating SQL deliberately
+([0028](design/0028-retire-compile-sql.md)) — what an agent needs is the
+verified query and the caveat around it.
+
+### Catalogs as context layers
+
+The nearest in intent, and the honest risk: an organization already
+running a catalog with an MCP server will reasonably find it sufficient.
+ochakai's structural differences are that interpretation knowledge and
+the review loop are the *open-source core* rather than the commercial
+tier, and that it is curated rather than harvested — no connectors, no
+ingestion, trust density over volume. It stands alone for a team with no
+catalog, or beside one as the verified layer for agents. A catalog
+projection is an ordinary client under your own service account
+([example](../examples/bigquery-catalog)), never a credential ochakai
+holds.
+
+### Agent memory layers
+
+*Memory layers remember what happened; ochakai curates what's true.*
+They extract with an LLM and inject unaudited: nobody reviews what got
+remembered, and a wrong memory persists quietly. In data analysis a
+wrong memory is a wrong decision, so the quality ceiling of unaudited
+recall is low. ochakai is team-shared knowledge behind a human's ruling,
+with rejections keeping their reason so agents stop re-proposing them.
+
+The lesson worth taking from them is not about memory quality but about
+ergonomics: their real strength is that the agent does not have to
+*decide* to remember. ochakai answers that with `get_context` and the
+Claude Code [hooks](../examples/claude-code) — recall and write-back as
+mechanism rather than habit, and still without an LLM.
+
+### RAG over your documents
+
+Answered in full in the [FAQ](faq.md#how-is-this-different-from-rag-over-our-documents).
+Short version: the unit is a reviewed claim, not a chunk, and the
+direction is reversed — a RAG index is built *from* documents, a
+knowledge base here is written *by the agents using it*.
+
+### Verified-query stores inside an AI-analyst product
+
+Every AI-analyst product has one, and each feeds only its own chat. The
+same knowledge in ochakai serves Claude Code, hosted MCP agents and CI
+jobs alike, and the whole base round-trips through OKF v0.2 bundles
+([0036](design/0036-okf-schema-first.md)) — plain markdown and YAML that
+lives in git. MIT and self-hosted per tenant: your knowledge is never a
+hostage.
+
+### A markdown vault with an MCP server
+
+The cheapest alternative, and in 2026 the most common one to have
+already: a vault of markdown notes with YAML frontmatter, links in the
+body, reachable from Claude Code over a community MCP server in about ten
+minutes with no infrastructure at all. Obsidian even reads frontmatter as
+typed properties and builds table, card, list and map views over them
+with Bases, while the data stays in the notes.
+
+The overlap is not superficial — it is the same physical form. An
+`ochakai export` bundle is a directory of markdown files with YAML
+frontmatter whose relationships are ordinary body links
+([0024](design/0024-links-from-body.md)), which is to say **it opens as a
+vault**. If what you want is to browse your knowledge base with a good
+editor and a graph view, that is the tool, and nothing here competes with
+it. (Whether every root-relative link in an export resolves in Obsidian's
+graph is untested.)
+
+What the vault does not have is everything that is not the file format:
+
+- **The unit.** A note is a document somebody wrote for their own
+  reasons. An ochakai entry is a claim carrying its lifecycle, its
+  `verified` ledger and its provenance in
+  [OKF](design/0036-okf-schema-first.md)'s own keys. Those keys are
+  ordinary YAML, so a vault can hold them — which is exactly where the
+  difference shows. In a vault, a `verified` entry naming a human is a
+  line somebody typed. Here it is what the instance observed of an
+  authenticated caller, and it is never read back from a document
+  ([0009](design/0009-provenance-portability.md),
+  [0043](design/0043-document-first.md)) — a file has no observer.
+  Nothing in a vault appends to that ledger, derives a trust tier from
+  it, refuses a write against it, or resurfaces an entry when its last
+  confirmation has aged out.
+- **The loop (C7).** There is no analogue at all — no review queue, no
+  memory of *no*, no usage counts, no verification-age feed, no outcome
+  reports from agents that acted on an entry and found it wrong
+  ([the loop](loop.md), [0025](design/0025-closing-the-loop.md)). This is
+  the sharpest difference, and it is the product.
+- **Direction.** A vault is written by a human for a human, with the
+  agent as a reader — or lately a writer, unaudited and unmeasured.
+  ochakai's bet is the opposite: the agent drafts breadth, a human
+  verifies the judgment-heavy core.
+- **Multiple writers.** A vault is a folder; its concurrency story is
+  file sync, and shared vaults produce conflicts. ochakai is a server
+  with ETag / `If-Match` optimistic locking
+  ([0030](design/0030-optimistic-locking.md)) and a surface rule that an
+  agent cannot overwrite what a human has ruled on
+  ([FAQ](faq.md#can-an-agent-overwrite-or-delete-knowledge-a-human-verified)).
+- **Identity, and no secret (C2).** A vault MCP server typically runs
+  behind a local REST API plugin with an API key in the client config —
+  exactly the token ochakai's design refuses
+  ([0002](design/0002-authn-authz.md),
+  [0003](design/0003-gcp-only.md)). And the caller has no identity to
+  record: "who wrote this" is whoever's laptop it was.
+- **Reach (C5, C6).** The vault is on one machine and so is its MCP
+  server. Hosted agents, CI jobs and a REST API you can embed in your own
+  web service are not there.
+- **Retrieval.** Hybrid search with embeddings on by default
+  ([0053](design/0053-embeddings-by-default.md)), path-scoped search,
+  attachment search over image and PDF content, and `get_context` — a
+  one-call read shaped for an agent's question rather than a human's
+  browse.
+- **Types.** A vault is type-agnostic, which is right for notes and
+  costly here: nothing tells an agent that this file is a verified golden
+  query and that one is a meeting note.
+
+So the composition is real and unusually literal. A vault is where a
+person thinks and writes; ochakai is where a team's verified data
+knowledge lives and is served to agents — and because the stored form is
+the same markdown, the export → Git → review → import loop can pass
+through a vault on the way.
+
+## Where ochakai loses
+
+Stated plainly, because an evaluation that only finds advantages is not
+an evaluation.
+
+- **Authoring experience.** Obsidian and its ecosystem are far better
+  places to write and to browse. The bundled web UI is a curation
+  surface by policy, not a writing environment or a BI tool
+  ([0015 §3.1](design/0015-surface-consistency.md)).
+- **Infrastructure.** A vault costs nothing to stand up. ochakai wants a
+  Google Cloud project and a Postgres — about $10/month, but not zero,
+  and not five minutes.
+- **Google Cloud only.** C2's secret-zero property is bought with Cloud
+  Run IAM and Cloud SQL IAM, and there is no supported way to run
+  production elsewhere ([0003](design/0003-gcp-only.md)). For many teams
+  that is disqualifying, and it is a decision rather than a gap.
+- **No authorization.** Whoever can reach a deployment can read and write
+  everything ([0002](design/0002-authn-authz.md)). If you need per-entry
+  permissions, this is the wrong tool.
+- **Scale.** Built for the size a *curated* base reaches — thousands of
+  entries, not millions, because every one passed a human.
+- **Ecosystem.** One maintainer, one binary, no plugins, no marketplace.
+
+## Choosing
+
+- Already run a catalog with an MCP server, and the questions your agents
+  miss are lineage and ownership → the catalog is enough.
+- One warehouse, and what is missing is metric definitions → the
+  warehouse's own semantic layer.
+- What is missing is the agent remembering *you* — preferences, ongoing
+  context → a memory layer.
+- One person, one machine, notes you write yourself → a vault, and an
+  MCP server over it.
+- **Several agents and people, and what is missing is knowledge somebody
+  checked** — which query is sanctioned, what the number means, what was
+  already tried and rejected — and you can run it on Google Cloud →
+  that is the slot this fills.
+
+## Where this research lives
+
+This page is the living answer and is expected to change as the
+alternatives do. The dated snapshots of the research behind it stay where
+they were taken, in
+[0001 §2](design/0001-architecture.md) — the 2026-07-16 note on catalogs
+turning into context layers and warehouse-native semantic layers, and the
+2026-07-17 note on memory layers. Those are decision records and are not
+rewritten; a landscape is not a decision, so it is tracked here instead.


### PR DESCRIPTION
<!-- Keep PRs small and focused. Link the issue or design doc, if there is one. -->

## What and why

The question that started this was narrow — *has anyone compared ochakai
against Obsidian?* The answer was no: `obsidian` appears nowhere in the
tree. Looking for where it *would* go turned up the wider problem.

The comparisons a reader needs are spread across four places and none of
them covers the cheapest alternative:

- `README.md` "Why ochakai" names five neighbours in passing
- `docs/faq.md` answers RAG and memory layers
- `ROADMAP.md` lists refusals
- the actual research sits in
  [0001 §2](docs/design/0001-architecture.md) as two dated notes in
  Japanese (2026-07-16 catalogs and warehouse-native semantic layers,
  2026-07-17 memory layers)

Somebody evaluating had to assemble that themselves.

**`docs/positioning.md`** is the assembly: six neighbours one at a time —
warehouse-native semantic layers, catalogs turned context layers, agent
memory layers, RAG, the verified-query store inside an AI-analyst
product, and a markdown vault with an MCP server — with what each holds,
what it does not, and whether it composes. Plus a *Where ochakai loses*
section and a list of who should pick something else, because an
evaluation that only finds advantages is not one. `README.md`, the FAQ
and `docs/README.md` point at it rather than repeating it.

The neighbour nobody had written down is **a markdown vault with an MCP
server** (Obsidian, Logseq, a git repo of notes), which by 2026 is the
lowest-friction thing a reader may already be running. The overlap is not
superficial — it is the same physical form: an export bundle is markdown
with YAML frontmatter whose relationships are body links
([0024](docs/design/0024-links-from-body.md)), so it opens as a vault,
and the page says so rather than pretending otherwise.

What a vault has no notion of is a *ruling*. OKF's trust keys are
ordinary YAML, so a vault can hold a `verified` entry naming a human —
but there it is a line somebody typed, where here it is what the instance
observed of an authenticated caller and is never read back from a
document ([0009](docs/design/0009-provenance-portability.md),
[0043](docs/design/0043-document-first.md)). A file has no observer. Nor
is there a review queue, a rejection that keeps its reason, usage counts,
outcome reports, a precondition against a second writer
([0030](docs/design/0030-optimistic-locking.md)), an identity to record,
or reach past the one machine the vault sits on. C7 has no analogue there
at all, which is the sharpest of the six comparisons.

**Rejected alternative: appending a third dated note to 0001 §2.** That
is where the previous two landed, so it was the precedent. But decision
records are not rewritten, and a landscape is not a decision — it changes
when the alternatives do, which is exactly the thing an immutable record
should not accumulate. The two existing notes stay as the snapshots they
were; the new page says where they are and takes over from here.

No surface changes, so `docs/surface.md` is untouched and the three
questions do not apply. Docs-only, so no changelog entry, matching how
the FAQ and the troubleshooting guide landed.

One thing the checks caught and this fixed before it shipped: the first
draft wrote `status: verified`, which is retired vocabulary.
`TestRetiredSpellingsAreNotTaught` failed on both new files. The current
model — lifecycle in `status`, confirmation in the `verified` ledger —
makes the argument sharper, not weaker, so the corrected text is what is
above.

## Checks

CI runs the same script; make it pass locally first (CONTRIBUTING.md has the
context, including the store integration test and the fuzz targets).

- [x] `scripts/check` is clean — add `--db` when the change touches the store

  `scripts/check core` and `scripts/check lint` both green (0 issues).
  Docs-only, so the store is untouched and `--db` adds nothing. This
  environment cannot reach `vuln.go.dev`, so `scripts/check vuln` is
  unverifiable here rather than failing — CI covers it.
- [x] Behavior changes come with tests — no behavior change. The prose is
      already under `TestRetiredSpellingsAreNotTaught`, which is what
      caught the vocabulary error above.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — untouched, no wire change
- [x] The change lands on every surface it belongs on — none. It is
      documentation
- [x] Widens a surface? No. No REST operation, MCP tool, CLI command or
      environment variable is added, so `docs/surface.md` is unchanged
      and the three questions do not apply. The new page does lean on
      that document: its seven conditions are the vocabulary the
      comparisons are argued in

## Design docs

- [x] Alters an accepted decision? It does not — no numbered doc here.
      The deliberate call is the inverse one described above: the
      landscape research is *not* appended to 0001, so no `Status:`
      header, index entry or English summary moves
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01RBmAPGgs5K4Pr6K8EeUi1p)_