### PR TITLE
Say what shipped, at the release the fold finished in (0.16.0)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Version
       description: Output of `ochakai version`, or the image tag you deployed.
-      placeholder: "0.15.0"
+      placeholder: "0.16.0"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,41 @@ last entry.
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-07-30
+
+This release carries [0046](docs/design/0046-bundle-address-space.md)'s
+fold from end to end, and the fold moved some things more than once
+before it settled. **Entries below are in landing order, newest first,
+so where an early one names a spelling a later one changed, the later
+one is what shipped.** The whole of what moved between `0.15.0` and here:
+
+```
+REST
+  GET|PUT|DELETE /api/v1/knowledge/{id}          →  the same three on /api/v1/bundle/{id}.md
+  GET|PUT|DELETE /api/v1/attachments/{id}/{name} →  the same three on /api/v1/bundle/{path}
+  GET    /api/v1/knowledge?q=…                   →  GET  /api/v1/search?q=…
+  GET    /api/v1/backlinks/{id}                  →  GET  /api/v1/search?links_to={id}
+  GET    /api/v1/export                          →  GET  /api/v1/bundle/ + Accept: application/gzip
+  GET    /api/v1/bundle/{id}/log.md as JSON      →  GET  /api/v1/bundle/{id}.md?history
+  POST   /api/v1/verify/{id}                     →  POST /api/v1/review/{id} {"ruling":"verified"}
+  POST   /api/v1/reject/{id}                     →  POST /api/v1/review/{id} {"ruling":"rejected"}
+  DELETE /api/v1/reject/{id}                     →  POST /api/v1/review/{id} {"ruling":"withdrawn"}
+
+MCP
+  search_knowledge     →  search_concepts        create_knowledge  ┐
+  get_knowledge        →  get_concept            update_knowledge  ┴→  put_concept
+  delete_knowledge     →  delete_concept
+  get_knowledge_usage  →  get_concept_usage
+
+CLI
+  ochakai create  ┐
+  ochakai update  ┴→  ochakai put [--only-if-new]
+```
+
+REST goes from 19 operations to 11, MCP stays at 8 tools, the CLI goes
+from 28 commands to 27 ([docs/surface.md](docs/surface.md)). Nothing
+that could be asked before cannot be asked now.
+
 ### Added
 
 - **BREAKING** — the three faces a human rules from become one,
@@ -47,23 +82,44 @@ last entry.
   value or trust derivation moves. Clients calling REST directly rewrite
   three calls, each a one-liner.
 
-- **BREAKING** — `GET /api/v1/queues` is gone; its three numbers are the
-  `queues` key of `GET /api/v1/stats`, which they already were (design
-  doc [0049 §3.1](docs/design/0049-queue-counts.md), revised before
-  release). The endpoint returned what the stats response already
-  carried, under the same key and from the same query; the only thing it
-  could do that stats could not was scope the counts to a subtree.
+- **Something to tell you the review queue is not empty** (design doc
+  [0049](docs/design/0049-queue-counts.md)). **`ochakai queues`** counts
+  the three feeds a curator empties — drafts waiting to be published or
+  turned down, entries whose failure reports are unanswered, entries past
+  the expiry their author declared — instead of listing them. The three
+  numbers are the `queues` key of `GET /api/v1/stats`; they get no
+  address of their own, because that address would return what the stats
+  response already carries, under the same key and from the same query
+  (§3.1, revised before release).
 
-  So **`prefix` moved to `GET /api/v1/stats`** — and got wider there.
-  Every number keyed by an entry now honors it (`entries`, `queues`,
-  `review`, `outcomes`), where before a team on a shared deployment could
-  count its own review queue but not its own knowledge. `misses` is never
-  scoped and cannot be: a search that found nothing found it nowhere, so
-  there is no id to scope by (design doc
+  The queues were emptiable already; nothing said they were not empty,
+  and a review queue going quiet looked exactly like one with nothing in
+  it. Each printed line carries the command that lists that queue, and
+  `ochakai queues --exit-code` exits **2** while any of them is
+  non-empty, so a scheduled CI job goes red on work nobody picked up —
+  1 stays "the command failed", so an unreachable server cannot be read
+  as "nothing to do". The web UI shows the same counts on its Review
+  tab. [docs/guides/operating.md](docs/guides/operating.md) has the cron
+  recipe.
+
+  Scoping the counts to a subtree is what the endpoint of its own would
+  have been for, so **`prefix` landed on `GET /api/v1/stats`** instead —
+  and got wider there. Every number keyed by an entry honors it
+  (`entries`, `queues`, `review`, `outcomes`), where a team on a shared
+  deployment would otherwise have been able to count its own review queue
+  but not its own knowledge. `misses` is never scoped and cannot be: a
+  search that found nothing found it nowhere, so there is no id to scope
+  by (design doc
   [0051 §3.7](docs/design/0051-instance-metrics-and-search-misses.md)).
+  `ochakai stats` takes `--prefix`.
 
-  **`ochakai queues` is unchanged**, including `--exit-code`; it reads
-  the stats face now. `ochakai stats` gains `--prefix`.
+  ochakai delivers nothing itself: no mail, no chat, no webhooks, no
+  address book, and no scheduler inside the server. The verification-age
+  feed is deliberately uncounted — it ranks every verified entry, so its
+  size is the size of the knowledge base and nobody can drive it to
+  zero. MCP gets no tool for it: an agent's ends of the loop are
+  drafting and reporting outcomes, both of which lengthen a queue rather
+  than read it.
 
 - **BREAKING** — the five MCP tools carrying `knowledge` are renamed to
   OKF's word for the unit of knowledge, `concept` (design doc
@@ -135,9 +191,9 @@ last entry.
   GET /api/v1/export?attachments=false   →  GET /api/v1/bundle/?attachments=false + the same header
   ```
 
-  **This completes §3.5's fold: REST is 14 operations, from 19.** The
-  address space is the bundle, and what is not an object of it — a
-  ranking, a judgment, a measurement — is addressed outside it.
+  **This completes §3.5's fold.** The address space is the bundle, and
+  what is not an object of it — a ranking, a judgment, a measurement —
+  is addressed outside it.
 
   The archive gains a scope it did not have: **any path is a subtree**.
   `GET /api/v1/bundle/metrics/` with the header archives `metrics/` and
@@ -185,8 +241,6 @@ last entry.
   already gets it inside `get_context`, which follows it when packing
   companions (design docs 0015 §3.1, 0046 §3.14).
 
-  The REST surface goes from 16 operations to 15 (docs/surface.md).
-
 - **BREAKING** — `GET|PUT|DELETE /api/v1/knowledge/{id}` is retired, and
   `GET /api/v1/knowledge` is now `GET /api/v1/search` (design doc
   [0046](docs/design/0046-bundle-address-space.md) §3.5). A concept is
@@ -216,10 +270,7 @@ last entry.
   collection nor addressable as one.
 
   The CLI, the MCP tools and the web UI are unchanged — they speak this
-  for you. A direct REST caller edits the URL. The REST surface goes from
-  19 operations to 16 (docs/surface.md); `/api/v1/backlinks/{id}` and
-  `/api/v1/export`, which §3.5 also folds, keep working until their
-  successors exist.
+  for you. A direct REST caller edits the URL.
 
 - **Which agent, at which build, wrote this** (design doc
   [0052](docs/design/0052-producer-beside-the-actor.md)). An actor now
@@ -271,32 +322,6 @@ last entry.
   Every file an entry shows carries its `path`, so a client that reads
   an entry has the address of each of its files without composing one.
 
-- **Something to tell you the review queue is not empty** (design doc
-  [0049](docs/design/0049-queue-counts.md)). `GET /api/v1/queues` and
-  `ochakai queues` count the three feeds a curator empties — drafts
-  waiting to be published or turned down, entries whose failure reports
-  are unanswered, entries past the expiry their author declared —
-  instead of listing them. `--prefix` scopes the counts to a subtree, and nothing else
-  filters them: which entries is the feed's question.
-
-  The queues were emptiable already; nothing said they were not empty,
-  and a review queue going quiet looked exactly like one with nothing in
-  it. Each printed line carries the command that lists that queue, and
-  `ochakai queues --exit-code` exits **2** while any of them is
-  non-empty, so a scheduled CI job goes red on work nobody picked up —
-  1 stays "the command failed", so an unreachable server cannot be read
-  as "nothing to do". The web UI shows the same counts on its Review
-  tab. [docs/guides/operating.md](docs/guides/operating.md) has the cron
-  recipe.
-
-  ochakai delivers nothing itself: no mail, no chat, no webhooks, no
-  address book, and no scheduler inside the server. The verification-age
-  feed is deliberately uncounted — it ranks every verified entry, so its
-  size is the size of the knowledge base and nobody can drive it to
-  zero. MCP does not get the endpoint: an agent's ends of the loop are
-  drafting and reporting outcomes, both of which lengthen a queue rather
-  than read it.
-
 - **BREAKING** — a file reports the path it lives at. `okf_path` is gone
   from the wire and from the attach call; `Attachment` carries `path`
   instead (design doc
@@ -317,8 +342,9 @@ last entry.
   something else.
 
 - **BREAKING** — the MCP write face is one tool. `create_knowledge` and
-  `update_knowledge` are `put_knowledge`: it creates when the id is free
-  and replaces when it is taken (design doc
+  `update_knowledge` are one `put_concept` (spelled `put_knowledge` until
+  0054 renamed the five, above): it creates when the id is free and
+  replaces when it is taken (design doc
   [0046](docs/design/0046-bundle-address-space.md) §3.14).
 
   The two tools asked the agent a question the document does not answer.
@@ -337,7 +363,7 @@ last entry.
   (issue #272), and the surface is eight tools.
 - **A listing walks past the limit** (design doc
   [0050](docs/design/0050-listings-page-rankings-do-not.md)). Every
-  listing mode of `GET /api/v1/knowledge` — the four `sort` feeds and the
+  listing mode of `GET /api/v1/search` — the four `sort` feeds and the
   `source` lookup — answers with a `cursor` when more entries follow, and
   takes it back as `?cursor=` to continue. The feeds are ledgers a
   reviewer works through, and one that stopped at 1000 with no way
@@ -360,11 +386,11 @@ last entry.
   end of the listing; an exact count over a filtered feed costs a second
   scan of it, and a cursor is a position rather than a snapshot — the
   feeds are live, so an entry that moves while you walk may be missed or
-  seen twice. Counting the three review queues is `GET /api/v1/queues`
-  above, on an address of its own: count once, or walk — they are
-  different questions.
+  seen twice. Counting the three review queues is the `queues` key of
+  `GET /api/v1/stats`, above: count once, or walk — they are different
+  questions.
 
-  On the surfaces: MCP's `search_knowledge` takes and returns `cursor`;
+  On the surfaces: MCP's `search_concepts` takes and returns `cursor`;
   `ochakai search --cursor` resumes a listing and prints the way on to
   stderr, leaving stdout one hit per line (the command does not walk the
   pages for you — `--limit` is your bound); and the web UI's review queue
@@ -423,9 +449,9 @@ last entry.
   `GET /api/v1/stats?days=30` answers the question nothing answered
   before: entries by lifecycle and by trust tier, how many were created
   and verified in the window, what callers reported, and the most-asked
-  questions that came back empty. It carries the three queue depths of
-  `/api/v1/queues` beside them, from that endpoint's own query — the
-  place 0049 §3.1 kept for exactly this. It is computed on demand — no
+  questions that came back empty. It carries the three queue depths
+  beside them, under `queues` — the place 0049 §3.1 kept for exactly
+  this, and the only address they have. It is computed on demand — no
   rollup table, no scheduler — and a window longer than the 180-day
   retention is a 400 rather than a quietly short answer.
 
@@ -920,32 +946,21 @@ last entry.
   nothing would query. Refilling them stays `ochakai reembed`, because
   that spends money; until it runs, search answers lexically.
 
-- **The published contract says which address to build on.** While
-  [0046](docs/design/0046-bundle-address-space.md) §3.5's fold is in
-  flight, three addresses answer for the same object, and
-  `api/openapi.yaml` did not say which one survives it.
-  `/api/v1/bundle/{path}` does. The operations it replaces —
-  `GET|PUT|DELETE /api/v1/knowledge/{id}` and
-  `GET|PUT|DELETE /api/v1/attachments/{path}` — are now marked
-  `deprecated`, each naming the bundle call that answers the same
-  question. Nothing is removed and no behaviour changes: a removal
-  arrives in a minor release with a changelog entry, as
-  [the compatibility policy](docs/compatibility.md) says, not after a
-  deprecation window.
-
-  `/api/v1/knowledge` (the list), `/api/v1/backlinks/{id}` and
-  `/api/v1/export` are retired by the same section but carry no mark:
-  their successors are not built yet, so they are still the only way to
-  ask what they answer. The document says so rather than leaving a
-  reader to find out.
-
-  Two things that read as holes are closed with it. The `501` on
-  `PUT /api/v1/bundle/{path}` now says what it is — writing a file needs
-  GCS (design doc 0013), and a concept is unaffected — rather than
+- **The published contract closes two holes it had been carrying.** The
+  `501` on `PUT /api/v1/bundle/{path}` says what it is — writing a file
+  needs GCS (design doc 0013), and a concept is unaffected — rather than
   standing unexplained where a "not built yet" placeholder used to be.
-  And `/api/v1/export`'s recipe for writing your own importer no longer
-  sends the reader to a `POST /api/v1/knowledge` that does not exist:
-  it is one PUT per bundle member, at the path it arrived at.
+  And the recipe for writing your own importer no longer sends the
+  reader to a `POST` that never existed: it is one PUT per bundle
+  member, at the path it arrived at.
+
+  While [0046](docs/design/0046-bundle-address-space.md) §3.5's fold ran,
+  the spec marked the second spellings `deprecated` so a reader knew
+  which address survives. The fold finished inside this release, so the
+  marks went with the addresses: what `api/openapi.yaml` declares is what
+  answers, and there is no deprecation window here — a removal arrives in
+  a minor release with a changelog entry, as
+  [the compatibility policy](docs/compatibility.md) says.
 
 - **A file is an object in the bundle** (design doc
   [0046](docs/design/0046-bundle-address-space.md) §§3.3, 3.13). Migration
@@ -960,14 +975,13 @@ last entry.
   every write, the way its links have been since 0024, and the two halves
   of the derivation are one predicate every read goes through.
 
-  Nothing on the wire moves: a file is still fetched, attached and
-  detached by `(entry, filename)`, and `okf_path` still reports a file
-  that lives somewhere other than the canonical `<id>/<name>` — derived
-  now from the path rather than stored beside it. Two behaviours follow
-  from the derivation rather than from a column, and both are what the
-  design asks for: moving an entry carries the files under its namespace
-  with it, and attaching a file at a path the entry's body says nothing
-  about stores it at `<id>/<name>` instead of orphaning it.
+  The wire caught up with it later in this release — a file is read and
+  written at its own bundle path, and `path` replaced `okf_path`
+  (above). Two behaviours follow from the derivation rather than from a
+  column, and both are what the design asks for: moving an entry carries
+  the files under its namespace with it, and attaching a file at a path
+  the entry's body says nothing about stores it at `<id>/<name>` instead
+  of orphaning it.
 
   Operators: `attachment` and `attachment_embedding` keep their rows —
   the read paths move in this release and the tables go in a later one,
@@ -1984,7 +1998,8 @@ worth naming: SQL injection in `compile_sql` through undeclared field
 pass-through, fixed in 0.8.0 — v0.7.0 and earlier are affected. Details
 are in git history.
 
-[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.15.0...HEAD
+[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.16.0...HEAD
+[0.16.0]: https://github.com/na0fu3y/ochakai/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/na0fu3y/ochakai/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/na0fu3y/ochakai/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/na0fu3y/ochakai/compare/v0.12.1...v0.13.0

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,9 +34,13 @@ if the proposal is concrete.
   0.15.0 extended the same habit to the documentation: the CLI reference is
   generated from the commands' own help and the shell completions are read
   from their FlagSets, so both fail CI rather than drifting quietly. Prose the
-  checks do not reach is where the drift now shows up — the OpenAPI examples
-  still teach the vocabulary 0038 retired, because the guard reads the `Type:`
-  schema block and never the examples (issue #222).
+  checks do not reach is where the drift shows up, so the habit reached the
+  prose too: the vocabulary guard reads the whole OpenAPI document rather than
+  only its `Type:` schema block (issue #222), a guard fails a tree that teaches
+  a retired spelling (issue #275), and another fails a contract that names an
+  address its own `paths` does not declare. Each of those was written after a
+  release review found the drift by hand, which is where the next one will
+  come from as well.
 - **Make the project legible to somebody who has not read it.** An audit of
   what a newcomer can learn from this repository found the writing good and
   the way in poor. Most of what it raised has landed: the quick start loads a
@@ -50,8 +54,10 @@ if the proposal is concrete.
   [troubleshooting](docs/guides/troubleshooting.md) and an
   [operating guide](docs/guides/operating.md). What is left is
   [open as issues](https://github.com/na0fu3y/ochakai/issues) rather than a
-  paragraph here: the compatibility policy the wire surfaces actually follow
-  is still unwritten (issue #215), and the two ways in that are missing for
+  paragraph here. The compatibility policy the wire surfaces actually follow
+  has since been written down
+  ([docs/compatibility.md](docs/compatibility.md), issue #215); what is left is
+  the two ways in that are missing for
   somebody with no shell or no map — an installable bundle for desktop MCP
   clients (issue #213) and a guided `ochakai tutorial` (issue #212, which
   needs a design doc before code, and may be the first command whose purpose

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -31,7 +31,7 @@ info:
     Every interface is unstable while the major version is 0
     (docs/compatibility.md): a removal arrives in a minor release with a
     changelog entry, not after a deprecation window.
-  version: 0.15.0
+  version: 0.16.0
   license:
     name: MIT
 servers:
@@ -52,7 +52,7 @@ paths:
       description: >
         Rejected entries are excluded unless rejected=true is passed (so
         agents can check for already-rejected proposals). Whether an entry
-        was confirmed is asked with verified, independently of the status
+        was confirmed is asked with trust, independently of the status
         filter — status is the lifecycle value alone (design doc 0043
         §§3.2-3.3).
         With sort=verified_at the endpoint lists entries by verification age

--- a/docs/README.md
+++ b/docs/README.md
@@ -72,11 +72,12 @@ and what it refuses to do. It is deliberately short; the manual is here.
 - [CONTRIBUTING.md](../CONTRIBUTING.md) — local setup, the exact checks CI
   runs, and how design docs work.
 - [The surface](surface.md) — the seven conditions ochakai exists to
-  satisfy, and every REST operation, MCP tool, CLI command and environment
-  variable counted in one place, with the three questions a change that
-  adds one has to answer. The default answer is no. A test reads the four
-  lists back out of the build, so the count cannot drift and a feature
-  cannot arrive without the diff saying so.
+  satisfy, and every REST operation, query parameter, header, MCP tool,
+  CLI command and environment variable counted in one place, with the
+  three questions a change that adds one has to answer. The default
+  answer is no. A test reads the six lists back out of the build, so the
+  count cannot drift and a feature cannot arrive without the diff saying
+  so.
 - [docs/design](design) — the numbered, immutable decision records, and
   the [index](design/README.md) that says which ones still describe the
   current state. Mostly Japanese; authoritative where they and the English

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -16,16 +16,18 @@ Everything a client can touch:
 
 - **REST** — paths, request and response shapes, status codes. `0.13.0`
   moved the knowledge out of `/context`'s `hits`; `0.14.0` moved seven
-  keys out of `attrs` into envelope fields. Right now several addresses
-  answer for the same object while
-  [0046](design/0046-bundle-address-space.md) §3.5's fold is in flight:
-  **build on `/api/v1/bundle/{path}`**, which is the one that survives
-  it. The addresses it replaces are marked `deprecated` in
-  [api/openapi.yaml](../api/openapi.yaml) and name their successor;
-  where no successor is serving yet, the operation says so and carries
-  no such mark.
+  keys out of `attrs` into envelope fields. The largest move so far is
+  [0046](design/0046-bundle-address-space.md) §3.5's fold, which left an
+  object with one address: **build on `/api/v1/bundle/{path}`**. The
+  second spellings it replaced — `/api/v1/knowledge/{id}`,
+  `/api/v1/attachments/{id}/{name}`, `/api/v1/backlinks/{id}`,
+  `/api/v1/export` — were removed rather than deprecated, which is what
+  the paragraph above means by "no deprecation window".
+  [api/openapi.yaml](../api/openapi.yaml) is the list of addresses that
+  exist; a changelog entry names the successor of each one that went.
 - **MCP** — tool names, arguments, and which tools exist at all.
-  `compile_sql` existed until `0.13.0` and does not now.
+  `compile_sql` existed until `0.13.0` and does not now, and the five
+  tools that said `knowledge` say `concept`.
 - **The CLI** — commands, flags, and the shape of what they print.
 - **The stored data** — migrations run automatically at server start, and
   they are one-way. There is no downgrade path.

--- a/internal/okf/attachment.go
+++ b/internal/okf/attachment.go
@@ -47,7 +47,7 @@ func AttachmentPath(id string, att *domain.Attachment) string {
 type BundleAttachment struct {
 	ID   string
 	Name string // filename (last segment of Path)
-	Path string // bundle path, preserved as okf_path for round-trips
+	Path string // bundle path — the file's address, kept so it round-trips
 	Data []byte
 }
 

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -1302,14 +1302,3 @@ func serveDefensively(w http.ResponseWriter, mediaType, name string) {
 	w.Header().Set("Content-Disposition",
 		disposition+`; filename="`+strings.ReplaceAll(name, `"`, `\"`)+`"`)
 }
-
-// splitAttachmentPath cuts "{id...}/{name}" at the final slash: attachment
-// names are single segments, so the last segment is always the filename
-// and the rest is the (possibly hierarchical) entry ID.
-func splitAttachmentPath(p string) (id, name string, ok bool) {
-	i := strings.LastIndex(p, "/")
-	if i <= 0 || i == len(p)-1 {
-		return "", "", false
-	}
-	return p[:i], p[i+1:], true
-}

--- a/internal/store/attachment.go
+++ b/internal/store/attachment.go
@@ -30,10 +30,9 @@ import (
 // the metric's diagram is that the metric's document shows it.
 //
 // The two halves are one SQL predicate, attributedTo, which every read
-// here goes through. The name a surface calls a file by is the last
-// segment of its path, and okf_path is that path when it is not the
-// canonical <id>/<name> — both derived on the way out, so the wire is
-// unchanged while the storage underneath it is a bundle.
+// here goes through. The path is what the wire carries, and the name a
+// surface calls a file by is its last segment — derived on the way out,
+// the way a concept keeps its id beside its path.
 
 // attributedTo is the predicate joining file objects f to the entry row
 // k: living directly under the entry's namespace (no further slash), or
@@ -50,8 +49,7 @@ const attributedTo = `f.id IS NULL AND f.deleted_at IS NULL
 	     OR k.files ? f.path)`
 
 // fileCols is one file object as an attachment is read: the path is what
-// the name and okf_path are derived from, so it is selected rather than
-// either of them.
+// the name is derived from, so it is selected rather than the name.
 const fileCols = `f.path, f.media_type, f.size, f.blob_hash,
 	f.created_by_kind, f.created_by_name, f.created_at`
 


### PR DESCRIPTION
## What and why

A pre-release read of the whole tree. **No broken behaviour was found** —
`scripts/check --db core lint` is clean, and the store integration tests ran
against a live PostgreSQL. What the read did find is eight places where the
prose fell behind the code, all of them the drift issue #275 named: nothing
changes behaviour, which is exactly why every other check let them through.

This PR fixes those and doubles as the release-prep PR for **0.16.0** (there
are BREAKING entries, so the minor bumps).

**The wire contract.** `GET /api/v1/search`'s description said whether an
entry was confirmed is "asked with `verified`" — a parameter that has not
existed since `trust` replaced it (0046 §§3.9-3.10). The endpoint declares
`trust` fifteen lines below the sentence. `TestContractNamesNoAddressItDoesNotHave`
reads the *addresses* a contract names but does not declare; this is the same
mistake one dimension over, in parameters.

**The code.** `splitAttachmentPath` in `internal/restapi` outlived its only
caller, the retired `/api/v1/attachments/{id}/{name}` handler. `unused` is not
among the enabled linters (`.golangci.yml` takes `staticcheck` without it), so
nothing said so. Three comments still described `okf_path` as something the
wire carries — 0046 §3.3 replaced it with the path itself.

**The docs a reader lands on.** `docs/compatibility.md` — the page
`docs/README.md` tells people to read before building on ochakai — said §3.5's
fold is "in flight", that several addresses answer for the same object, and
that the replaced ones "are marked `deprecated` in api/openapi.yaml". The fold
finished, the addresses are gone, and no operation in the spec carries the
mark. `ROADMAP.md` said the compatibility policy was still unwritten (#215)
and that the OpenAPI examples still teach the vocabulary 0038 retired (#222);
both landed in this cycle, the second recorded in this very changelog.
`docs/README.md` said a test reads "the four lists" back out of the build, and
`surface.md` has counted six since PARAM and HEADER joined.

**The changelog, which was the largest of them.** Its unreleased section was a
development log rather than release notes. Within one section it announced and
then retracted `GET /api/v1/queues`, `put_knowledge`, `?okf_path=` and the
`deprecated` marks, and reported the REST surface at 19 → 16 → 15 → 14
operations — none of which any release has, because what ships is 11. An
operator upgrading from 0.15.0 would have read about an endpoint and a tool
that never existed for them. The entries that retract each other are merged,
the spellings that never shipped are corrected, and the section now opens with
the whole of what moved between 0.15.0 and here as one table, plus a line
saying entries below are in landing order so the later spelling wins.

Nothing here widens a surface, so the three questions do not apply; the counts
in `docs/surface.md` are untouched and still agree with the build.

**One thing for you to decide:** the release heading is dated `2026-07-30`
(JST). The skill says the tag date — adjust it if this merges on a different
day.

## Checks

- [x] `scripts/check` is clean — add `--db` when the change touches the store

  `scripts/check --db core lint` → exit 0. Store tests ran against
  PostgreSQL 16.13 (this environment's own cluster), not the
  `pgvector/pgvector:pg17` CI uses — CI is the check that matters for that
  one. `scripts/check vuln` could not run here: the proxy refuses
  `vuln.go.dev`, which is a network fact rather than a finding.
- [x] Behavior changes come with tests

  No behaviour changes. Removing dead code, prose, and a version bump —
  `TestReleaseVersionsAgree` is the check that covers the last of those and
  now exercises 0.16.0 across all three files.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing

  The spec change is one word of description (`verified` → `trust`) bringing
  it back in line with what the three already implement. Verified by hand:
  the spec's declared paths and parameters match `restapi.go`'s routes
  (8 paths, 11 operations) and `surface.md`'s counts exactly.
- [x] The change lands on every surface it belongs on

  Not applicable — no capability moves.
- [x] Widens a surface?

  No. `docs/surface.md` is unchanged and its test still passes.

## Design docs

- [x] Alters an accepted decision?

  It does not. Every fix brings prose back to a decision already recorded —
  0046 §3.3 (`okf_path`), §3.5 (the fold), §§3.9-3.10 (`trust`), 0049 §3.1
  (the queue counts' address), 0054 (the tool names). No numbered doc is
  needed, and none of the `Status:` headers move.

  Two things the checked half cannot see, read by hand and found true: the
  index's opening table still points at the doc to read now for each area,
  and `README.en.md` covers 0055.
- [x] Commit messages and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxUGAnkxtH4BNYbwhZZXcw

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxUGAnkxtH4BNYbwhZZXcw)_