### PR TITLE
Move a file's haystack into place before the files move (0.16.1)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Version
       description: Output of `ochakai version`, or the image tag you deployed.
-      placeholder: "0.16.0"
+      placeholder: "0.16.1"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,47 @@ last entry.
 
 ## [Unreleased]
 
+## [0.16.1] - 2026-07-30
+
+### Fixed
+
+- **Upgrading to 0.16.0 fails on any instance that holds a file**, and
+  fails in the worst place: migration `0029_files_become_objects.sql`
+  moves the attachment rows into `object`, where a file has no concept
+  id, but it did so *before* replacing the haystack trigger that 0016
+  put on the table. The old trigger computed `ochakai_search_text(NULL,
+  …)`, which is NULL, and the column is `NOT NULL` — so the first file
+  to move aborted the migration with
+
+  ```
+  migration 0029_files_become_objects.sql: ERROR: null value in column
+  "search_text" of relation "object" violates not-null constraint
+  ```
+
+  and the server exited. By then `0022`–`0028` had applied, so the
+  running 0.15.0 binary was looking for a `knowledge` table that had been
+  renamed out from under it and answered 500 to everything: **a failed
+  upgrade took the deployment down rather than leaving it where it
+  started.** An instance with no files migrated cleanly, which is why
+  nothing caught it — the statement order is only reachable when there is
+  a row to move.
+
+  The functions, the triggers and the two indexes are now established
+  before the rows move, which is the order the migration's own comments
+  describe. Nothing else about it changes: the same objects end up in the
+  same shape, so an instance that already applied `0029` successfully is
+  unaffected and re-runs nothing.
+
+  **If you hit this**: deploy 0.16.1 and start it. Migration `0029`
+  re-runs from the beginning — it never committed — and `0030`–`0033`
+  follow. There is nothing to undo by hand and no need to restore a
+  backup.
+
+  `TestMigrationFilesBecomeObjects` applies the migration to a base
+  seeded with two files, one at its entry's canonical `<id>/<name>` and
+  one an import placed elsewhere in the bundle, and checks the
+  attribution and the filename haystack that follow.
+
 ## [0.16.0] - 2026-07-30
 
 This release carries [0046](docs/design/0046-bundle-address-space.md)'s
@@ -1998,7 +2039,8 @@ worth naming: SQL injection in `compile_sql` through undeclared field
 pass-through, fixed in 0.8.0 — v0.7.0 and earlier are affected. Details
 are in git history.
 
-[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.16.0...HEAD
+[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.16.1...HEAD
+[0.16.1]: https://github.com/na0fu3y/ochakai/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/na0fu3y/ochakai/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/na0fu3y/ochakai/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/na0fu3y/ochakai/compare/v0.13.0...v0.14.0

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -31,7 +31,7 @@ info:
     Every interface is unstable while the major version is 0
     (docs/compatibility.md): a removal arrives in a minor release with a
     changelog entry, not after a deprecation window.
-  version: 0.16.0
+  version: 0.16.1
   license:
     name: MIT
 servers:

--- a/internal/store/migrate_integration_test.go
+++ b/internal/store/migrate_integration_test.go
@@ -1379,3 +1379,160 @@ func TestMigrationObjectPathKey(t *testing.T) {
 		t.Errorf("revisions under the path: got %d, want 2", revs)
 	}
 }
+
+// TestMigrationFilesBecomeObjects covers 0029 on the case that has files
+// in it (design doc 0046 §§3.3, 3.13). A base with no attachment rows
+// moves nothing, so the statement order inside the migration is only
+// exercised by one that has them: the rows arrive with a NULL id, and
+// 0016's trigger — which is still the one on the table when they land —
+// computes the haystack from that id and hands back NULL. The column is
+// NOT NULL, so the migration fails, and it fails after 0022-0028 have
+// applied: the old binary is then looking for a table that no longer
+// exists under that name. That is a failed upgrade taking the service
+// down, which is why this test seeds a file rather than trusting an
+// empty base.
+func TestMigrationFilesBecomeObjects(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(s.Close)
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck // rollback is the cleanup
+
+	for _, q := range []string{
+		`CREATE SCHEMA files_scratch`,
+		`SET LOCAL search_path TO files_scratch`,
+		// The post-0028 shape, reduced to what 0029 reads and writes.
+		`CREATE TABLE object (
+			path text NOT NULL PRIMARY KEY, id text, type text NOT NULL DEFAULT '',
+			title text NOT NULL DEFAULT '', description text NOT NULL DEFAULT '',
+			tags text[] NOT NULL DEFAULT '{}', body text NOT NULL DEFAULT '',
+			search_text text NOT NULL DEFAULT '',
+			created_by_kind text NOT NULL DEFAULT '', created_by_name text NOT NULL DEFAULT '',
+			updated_by_kind text NOT NULL DEFAULT '', updated_by_name text NOT NULL DEFAULT '',
+			created_at timestamptz NOT NULL DEFAULT now(),
+			updated_at timestamptz NOT NULL DEFAULT now(),
+			content_changed_at timestamptz NOT NULL DEFAULT now(),
+			deleted_at timestamptz)`,
+		`CREATE UNIQUE INDEX object_id ON object (id)`,
+		`CREATE TABLE attachment (
+			knowledge_id text NOT NULL, name text NOT NULL, sha256 text NOT NULL,
+			okf_path text NOT NULL DEFAULT '',
+			created_by_kind text NOT NULL, created_by_name text NOT NULL,
+			created_at timestamptz NOT NULL DEFAULT now(),
+			PRIMARY KEY (knowledge_id, name))`,
+		`CREATE TABLE blob (sha256 text PRIMARY KEY, media_type text NOT NULL, size bigint NOT NULL)`,
+		// 0016's haystack, which is what is on the table when the files
+		// land — the whole point of the ordering this test pins.
+		`CREATE OR REPLACE FUNCTION ochakai_search_text(
+			p_id text, p_title text, p_description text, p_tags text[], p_body text
+		 ) RETURNS text LANGUAGE sql STABLE AS $fn$
+			SELECT p_id || ' ' || p_title || ' ' || p_description || ' '
+				|| array_to_string(p_tags, ' ') || ' ' || p_body || ' '
+				|| COALESCE((SELECT string_agg(a.name, ' ')
+							   FROM attachment a WHERE a.knowledge_id = p_id), '')
+		 $fn$`,
+		`CREATE OR REPLACE FUNCTION ochakai_knowledge_search_text() RETURNS trigger
+		 LANGUAGE plpgsql AS $fn$
+		 BEGIN
+			NEW.search_text := ochakai_search_text(NEW.id, NEW.title, NEW.description, NEW.tags, NEW.body);
+			RETURN NEW;
+		 END $fn$`,
+		`CREATE TRIGGER knowledge_search_text BEFORE INSERT OR UPDATE ON object
+			FOR EACH ROW EXECUTE FUNCTION ochakai_knowledge_search_text()`,
+		`INSERT INTO object (path, id, title) VALUES
+			('metrics/revenue.md', 'metrics/revenue', '売上'),
+			('insights/q2.md', 'insights/q2', 'Q2')`,
+		`INSERT INTO blob (sha256, media_type, size) VALUES
+			('aaa', 'image/png', 11), ('bbb', 'application/pdf', 22)`,
+		// One file at the canonical <id>/<name>, one an import placed
+		// elsewhere in the bundle — the second is the attribution the
+		// files column has to carry, since its path does not say it.
+		`INSERT INTO attachment (knowledge_id, name, sha256, okf_path, created_by_kind, created_by_name) VALUES
+			('metrics/revenue', 'chart.png', 'aaa', '', 'human', 'na0'),
+			('insights/q2', 'deck.pdf', 'bbb', 'shared/deck.pdf', 'human', 'na0')`,
+	} {
+		if _, err := tx.Exec(ctx, q); err != nil {
+			t.Fatalf("scratch setup: %v\n%s", err, q)
+		}
+	}
+
+	sql, err := migrationFS.ReadFile("migrations/0029_files_become_objects.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec(ctx, string(sql)); err != nil {
+		t.Fatalf("apply 0029 to a base that has files: %v", err)
+	}
+
+	// Both files are objects now, at the path each lives at: the canonical
+	// one under its entry's namespace, the imported one where it arrived.
+	for _, tc := range []struct {
+		path, mediaType string
+		size            int64
+	}{
+		{"metrics/revenue/chart.png", "image/png", 11},
+		{"shared/deck.pdf", "application/pdf", 22},
+	} {
+		var id *string
+		var mediaType, searchText string
+		var size int64
+		if err := tx.QueryRow(ctx,
+			`SELECT id, media_type, size, search_text FROM object WHERE path = $1`,
+			tc.path).Scan(&id, &mediaType, &size, &searchText); err != nil {
+			t.Fatalf("%s: %v", tc.path, err)
+		}
+		if id != nil {
+			t.Errorf("%s has concept id %q: an id is the address of a concept", tc.path, *id)
+		}
+		if mediaType != tc.mediaType || size != tc.size {
+			t.Errorf("%s = %s/%d, want %s/%d", tc.path, mediaType, size, tc.mediaType, tc.size)
+		}
+		// A file is found by its path, not by a haystack.
+		if searchText != "" {
+			t.Errorf("%s search_text = %q, want empty", tc.path, searchText)
+		}
+	}
+
+	// Attribution: the canonical path says it, so nothing is written down;
+	// the imported one cannot, so the owning entry names it.
+	for _, tc := range []struct{ id, wantFiles string }{
+		{"metrics/revenue", `[]`},
+		{"insights/q2", `["shared/deck.pdf"]`},
+	} {
+		var files string
+		if err := tx.QueryRow(ctx,
+			`SELECT files::text FROM object WHERE id = $1`, tc.id).Scan(&files); err != nil {
+			t.Fatal(err)
+		}
+		if files != tc.wantFiles {
+			t.Errorf("%s files = %s, want %s", tc.id, files, tc.wantFiles)
+		}
+	}
+
+	// And the entries can still be found by their filenames (design doc
+	// 0020), now derived from the objects rather than the attachment rows.
+	for _, tc := range []struct{ id, want string }{
+		{"metrics/revenue", "chart.png"},
+		{"insights/q2", "deck.pdf"},
+	} {
+		var searchText string
+		if err := tx.QueryRow(ctx,
+			`SELECT search_text FROM object WHERE id = $1`, tc.id).Scan(&searchText); err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(searchText, tc.want) {
+			t.Errorf("%s search_text = %q, want it to carry %q", tc.id, searchText, tc.want)
+		}
+	}
+}

--- a/internal/store/migrations/0029_files_become_objects.sql
+++ b/internal/store/migrations/0029_files_become_objects.sql
@@ -37,44 +37,6 @@ ALTER TABLE object ADD COLUMN IF NOT EXISTS files      jsonb  NOT NULL DEFAULT '
 -- NULLs repeat and would refuse a second empty string.
 ALTER TABLE object ALTER COLUMN id DROP NOT NULL;
 
--- Where each file lands. Its own path when it has one and nothing is
--- there already, and the canonical <id>/<name> otherwise: an imported
--- bundle's file goes back where it came from (design doc 0046 §3.2, so
--- the bundle round-trips), while a collision moves the loser rather than
--- dropping it (§3.13 — losing one of two files is the worse answer).
-CREATE TEMP TABLE object_from_attachment ON COMMIT DROP AS
-SELECT a.knowledge_id, a.name, a.sha256, b.media_type, b.size,
-       a.created_by_kind, a.created_by_name, a.created_at,
-       CASE
-           WHEN a.okf_path <> ''
-            AND NOT EXISTS (SELECT 1 FROM object o WHERE o.path = a.okf_path)
-            AND (SELECT count(*) FROM attachment x WHERE x.okf_path = a.okf_path) = 1
-           THEN a.okf_path
-           ELSE a.knowledge_id || '/' || a.name
-       END AS path
-  FROM attachment a
-  JOIN blob b ON b.sha256 = a.sha256;
-
--- Attribution first, while the object table still says what was there
--- before this migration ran: every file whose path is not the entry's
--- own <id>/<name> is named by the entry it belonged to.
-UPDATE object o SET files = COALESCE((
-    SELECT jsonb_agg(DISTINCT m.path)
-      FROM object_from_attachment m
-     WHERE m.knowledge_id = o.id
-       AND m.path <> m.knowledge_id || '/' || m.name
-), '[]'::jsonb)
-WHERE EXISTS (SELECT 1 FROM object_from_attachment m WHERE m.knowledge_id = o.id);
-
-INSERT INTO object (path, type, title, body, blob_hash, size, media_type,
-                    created_by_kind, created_by_name, updated_by_kind, updated_by_name,
-                    created_at, updated_at, content_changed_at)
-SELECT m.path, '', '', '', m.sha256, m.size, m.media_type,
-       m.created_by_kind, m.created_by_name, m.created_by_kind, m.created_by_name,
-       m.created_at, m.created_at, m.created_at
-  FROM object_from_attachment m
-ON CONFLICT (path) DO NOTHING;
-
 -- Everything that reads entries reads them by their concept id, and a
 -- file has none: the partial index keeps those reads on an index that
 -- holds only concepts, so a bundle full of files costs them nothing.
@@ -89,7 +51,10 @@ CREATE INDEX IF NOT EXISTS object_files ON object USING gin (files);
 --
 -- A file row has no id, and 0016's trigger would compute NULL for it and
 -- fail the NOT NULL — a file is found by its path, not by a haystack, so
--- it gets an empty one and returns early.
+-- it gets an empty one and returns early. This has to be in place
+-- *before* the rows below move, or the first file inserted on a base
+-- that has any is the one that fails the migration and leaves the
+-- schema half-changed.
 CREATE OR REPLACE FUNCTION ochakai_knowledge_search_text() RETURNS trigger
 LANGUAGE plpgsql AS $$
 BEGIN
@@ -133,7 +98,9 @@ END $$;
 
 -- Two triggers rather than one: a DELETE trigger's WHEN condition may
 -- not mention NEW, so the condition is written against the row each
--- event actually has.
+-- event actually has. They are in place before the move as well, so the
+-- entries that own the arriving files have their haystacks recomputed by
+-- the same path a later write would take.
 DROP TRIGGER IF EXISTS object_file_search_text ON object;
 DROP TRIGGER IF EXISTS object_file_written ON object;
 DROP TRIGGER IF EXISTS object_file_removed ON object;
@@ -141,6 +108,44 @@ CREATE TRIGGER object_file_written AFTER INSERT OR UPDATE ON object
     FOR EACH ROW WHEN (NEW.id IS NULL) EXECUTE FUNCTION ochakai_file_search_text();
 CREATE TRIGGER object_file_removed AFTER DELETE ON object
     FOR EACH ROW WHEN (OLD.id IS NULL) EXECUTE FUNCTION ochakai_file_search_text();
+
+-- Where each file lands. Its own path when it has one and nothing is
+-- there already, and the canonical <id>/<name> otherwise: an imported
+-- bundle's file goes back where it came from (design doc 0046 §3.2, so
+-- the bundle round-trips), while a collision moves the loser rather than
+-- dropping it (§3.13 — losing one of two files is the worse answer).
+CREATE TEMP TABLE object_from_attachment ON COMMIT DROP AS
+SELECT a.knowledge_id, a.name, a.sha256, b.media_type, b.size,
+       a.created_by_kind, a.created_by_name, a.created_at,
+       CASE
+           WHEN a.okf_path <> ''
+            AND NOT EXISTS (SELECT 1 FROM object o WHERE o.path = a.okf_path)
+            AND (SELECT count(*) FROM attachment x WHERE x.okf_path = a.okf_path) = 1
+           THEN a.okf_path
+           ELSE a.knowledge_id || '/' || a.name
+       END AS path
+  FROM attachment a
+  JOIN blob b ON b.sha256 = a.sha256;
+
+-- Attribution first, while the object table still says what was there
+-- before this migration ran: every file whose path is not the entry's
+-- own <id>/<name> is named by the entry it belonged to.
+UPDATE object o SET files = COALESCE((
+    SELECT jsonb_agg(DISTINCT m.path)
+      FROM object_from_attachment m
+     WHERE m.knowledge_id = o.id
+       AND m.path <> m.knowledge_id || '/' || m.name
+), '[]'::jsonb)
+WHERE EXISTS (SELECT 1 FROM object_from_attachment m WHERE m.knowledge_id = o.id);
+
+INSERT INTO object (path, type, title, body, blob_hash, size, media_type,
+                    created_by_kind, created_by_name, updated_by_kind, updated_by_name,
+                    created_at, updated_at, content_changed_at)
+SELECT m.path, '', '', '', m.sha256, m.size, m.media_type,
+       m.created_by_kind, m.created_by_name, m.created_by_kind, m.created_by_name,
+       m.created_at, m.created_at, m.created_at
+  FROM object_from_attachment m
+ON CONFLICT (path) DO NOTHING;
 
 -- The old attachment trigger has nothing left to fire on: nothing writes
 -- the attachment table now. It goes with the table, a release from now.


### PR DESCRIPTION
`v0.16.0` cannot be upgraded to by any instance that holds a file, and it fails in the worst place.

Migration `0029_files_become_objects.sql` moves the attachment rows into `object`, where a file has no concept id — but it did so *before* replacing the haystack trigger 0016 put on the table. The old trigger computes `ochakai_search_text(NULL, …)`, which is NULL, against a `NOT NULL` column:

```
migration 0029_files_become_objects.sql: ERROR: null value in column "search_text"
of relation "object" violates not-null constraint (SQLSTATE 23502)
```

The server exits — after `0022`–`0028` have applied. The running 0.15.0 binary is then looking for a `knowledge` table that has been renamed out from under it and answers 500 to everything. **A failed upgrade takes the deployment down rather than leaving it where it started.** Hit on ochakai-example this evening.

An instance with no files migrates cleanly, which is why nothing caught it: the statement order is only reachable when there is a row to move.

## The change

The functions, the triggers and the two indexes are established before the rows move — the order the migration's own comments describe ("this has to be in place before the rows below move"). No DDL is added or removed and no data is shaped differently, so an instance that already applied `0029` successfully is unaffected and re-runs nothing.

Editing `0029` in place rather than adding `0034` is what the bug requires: `0029` has to *succeed*, and a later migration is never reached.

## Recovery, for anyone who hit it

Deploy 0.16.1 and start it. `0029` re-runs from the beginning — it never committed — and `0030`–`0033` follow. Nothing to undo by hand, no backup to restore.

## Test

`TestMigrationFilesBecomeObjects` applies the migration to a base seeded with two files, one at its entry's canonical `<id>/<name>` and one an import placed elsewhere in the bundle, and checks the attribution and the filename haystack that follow. Verified to fail with the old ordering and pass with the new one.

`scripts/check --db` is green.

## Surface

No surface change: no endpoint, tool, command or variable moves, so no design doc (CLAUDE.md — an internal change that leaves the outside unchanged belongs in the PR description). The version bump to 0.16.1 is in the same three files `TestReleaseVersionsAgree` pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)