### PR TITLE
Name flags that exist in the instructions we ship

### DIFF
--- a/cmd/ochakai/main_test.go
+++ b/cmd/ochakai/main_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -88,6 +91,127 @@ func TestShippedInstructionsUseCurrentTypeVocabulary(t *testing.T) {
 		}
 		if !strings.Contains(s, "Attested Computation") {
 			t.Errorf("%s never names the Attested Computation type", f)
+		}
+	}
+}
+
+// shippedInvocation finds an invocation we ship — "ochakai search", the
+// command being any word — and its offset, so the flags after it are
+// attributed to it and not to the sentence before.
+var shippedInvocation = regexp.MustCompile(`ochakai ([a-z][a-z-]*)`)
+
+// shippedLongFlag matches a long flag written as a reader would type it.
+// The leading class keeps it off "---" in a frontmatter fence and off the
+// tail of a longer token.
+var shippedLongFlag = regexp.MustCompile(`(?:^|[^-\w])--([a-z][a-z0-9-]*)`)
+
+// shippedInstructionFiles is everything we hand somebody that tells them
+// how to invoke the CLI: the prose a person reads, the instructions an
+// agent is given, and the hooks that run unattended. docs/cli.md is
+// generated from the help, but the worked examples inside that help are
+// hand-written strings in client.go, so a stale flag reaches a reader
+// through it exactly as through the rest.
+func shippedInstructionFiles(t *testing.T) []string {
+	t.Helper()
+	var out []string
+	for _, glob := range []string{
+		"../../README.md", "../../CONTRIBUTING.md",
+		"../../docs/*.md", "../../docs/guides/*.md",
+		"../../deploy/*/README.md",
+		"../../examples/*.md", "../../examples/*/README.md",
+		"../../examples/claude-code/CLAUDE.md",
+		"../../examples/claude-code/hooks/*.sh",
+	} {
+		matches, err := filepath.Glob(glob)
+		if err != nil {
+			t.Fatalf("glob %s: %v", glob, err)
+		}
+		out = append(out, matches...)
+	}
+	if len(out) == 0 {
+		t.Fatal("no shipped instructions found: this check now guards nothing")
+	}
+	return out
+}
+
+// Guard: every flag we write beside a command is a flag that command
+// has. A reader cannot tell a typo from a feature, and an agent handed
+// one gets a usage error where it expected knowledge —
+// examples/claude-code/CLAUDE.md told agents to run `ochakai search
+// --verified true` for two releases after the flag became --trust, and
+// nothing failed. The type vocabulary and `put`'s id were already
+// pinned here; the flags were the third thing that could go stale in the
+// same file for the same reason.
+//
+// Flags are read from the commands themselves (commandLongFlags), so
+// this cannot be satisfied by keeping a second list up to date.
+func TestShippedInstructionsNameFlagsThatExist(t *testing.T) {
+	flags := commandLongFlags(t)
+	for _, path := range shippedInstructionFiles(t) {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		// A shell continuation carries one invocation across two lines;
+		// join them so the flags stay with their command.
+		text := strings.ReplaceAll(string(content), "\\\n", " ")
+		for _, line := range strings.Split(text, "\n") {
+			cmds := shippedInvocation.FindAllStringSubmatchIndex(line, -1)
+			if len(cmds) == 0 {
+				continue
+			}
+			for _, m := range shippedLongFlag.FindAllStringSubmatchIndex(line, -1) {
+				name := line[m[2]:m[3]]
+				// The nearest invocation to the left owns this flag.
+				cmd := ""
+				for _, c := range cmds {
+					if c[0] < m[2] {
+						cmd = line[c[2]:c[3]]
+					}
+				}
+				known, ok := flags[cmd]
+				if !ok {
+					continue // "ochakai serve", or prose that reads like one
+				}
+				if !slices.Contains(known, name) {
+					t.Errorf("%s tells the reader to run `ochakai %s --%s`, which has no such flag (it has: %s)",
+						path, cmd, name, strings.Join(known, ", "))
+				}
+			}
+		}
+	}
+}
+
+// Guard: what we hand somebody who is about to write a concept keeps
+// frontmatter flat. OKF SPEC §4.1 puts a producer's own key beside the
+// ones the spec defines, and ochakai exports them that way (design doc
+// 0043) — "attrs" is an internal field name that was never on the wire.
+// Two shipped files told agents to write `attrs.question`, which lands
+// as a key named attrs holding a map: valid YAML, and not the question
+// anyone can search for.
+//
+// The list is the authoring instructions alone, not every shipped file:
+// the deploy guide names the pre-0.4 nested form on purpose, in the
+// paragraph about importing a bundle written back then.
+func TestConceptAuthoringInstructionsKeepFrontmatterFlat(t *testing.T) {
+	for _, path := range []string{
+		"../../README.md",
+		"../../docs/knowledge.md",
+		"../../docs/guides/golden-query-canary.md",
+		"../../examples/README.md",
+		"../../examples/golden-query.md",
+		"../../examples/claude-code/CLAUDE.md",
+		"../../examples/claude-code/hooks/ochakai-write-back.sh",
+	} {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		for _, nested := range []string{"attrs.", "attrs:"} {
+			if strings.Contains(string(content), nested) {
+				t.Errorf("%s tells the reader to nest frontmatter under %q; "+
+					"a producer's key is written at the top level (OKF SPEC §4.1)", path, nested)
+			}
 		}
 	}
 }

--- a/examples/claude-code/CLAUDE.md
+++ b/examples/claude-code/CLAUDE.md
@@ -21,7 +21,7 @@ a metric), glossary terms, and table catalog entries. Search it before writing a
   concepts rank higher), expanded one hop through links so the insight
   explaining a metric arrives with it. Start here; use search/get below
   for precise lookups.
-- `ochakai search "<question or keyword>" [--type Metric|'Attested Computation'|Skill|Playbook|Insight|Policy|'Glossary Term'|'BigQuery Dataset'|'BigQuery Table'|'API Endpoint'|Reference] [--verified true]`
+- `ochakai search "<question or keyword>" [--type Metric|'Attested Computation'|Skill|Playbook|Insight|Policy|'Glossary Term'|'BigQuery Dataset'|'BigQuery Table'|'API Endpoint'|Reference] [--trust human-reviewed]`
   — one hit per line: score, uri, status, title. Trust verified concepts;
   judge `draft` concepts by their provenance (`--json` shows `created_by`).
 - `ochakai get <id>` — full concept as markdown (YAML frontmatter +
@@ -55,5 +55,7 @@ related knowledge.
 
 When a query you wrote turns out to be correct and useful,
 save it: `type: Attested Computation` with `runtime` (where the SQL runs),
-the SQL in a `# Computation` fence in the body, and `attrs.question` (the
-natural-language question). A human can promote it to `verified` later.
+the SQL in a `# Computation` fence in the body, and a top-level
+`question` key (the natural-language question) — OKF frontmatter is flat,
+so a key of your own goes beside the ones the spec defines, never nested
+under one. A human confirms it later with `ochakai verify`.

--- a/examples/claude-code/hooks/ochakai-write-back.sh
+++ b/examples/claude-code/hooks/ochakai-write-back.sh
@@ -28,5 +28,5 @@ grep -qiE 'SELECT|ochakai|bigquery|warehouse' "$transcript" || exit 0
 
 jq -n '{
   decision: "block",
-  reason: "Before finishing: this session did data work. If a query you wrote proved correct and reusable, or you learned how to read a metric (a baseline, a seasonality, a caveat), write it back to ochakai — search first (including --rejected) to avoid re-proposing, then `ochakai put <path>` (type \"Attested Computation\" with runtime, the SQL in a # Computation fence, and attrs.question; or type \"Insight\"). If nothing durable was learned, finish now without creating anything — do not invent knowledge."
+  reason: "Before finishing: this session did data work. If a query you wrote proved correct and reusable, or you learned how to read a metric (a baseline, a seasonality, a caveat), write it back to ochakai — search first (including --rejected) to avoid re-proposing, then `ochakai put <path>` (type \"Attested Computation\" with runtime, the SQL in a # Computation fence, and a top-level question key; or type \"Insight\"). If nothing durable was learned, finish now without creating anything — do not invent knowledge."
 }'


### PR DESCRIPTION
`examples/claude-code/CLAUDE.md` is the file [the README](../blob/main/README.md#connect-an-agent) tells people to copy into their own project's CLAUDE.md, so it is what every agent using ochakai reads. Two things in it are wrong:

- **`ochakai search ... [--verified true]`** — no such flag. The trust filter has been `--trust` since it gained three tiers (`unverified` / `machine-confirmed` / `human-reviewed`). An agent following it gets a usage error where it expected knowledge.
- **`attrs.question`** — an internal Go field name that was never on the wire. This is the worse of the two, because it *succeeds*: it is valid YAML, so the write lands a key named `attrs` holding a map, and the question nobody can search for is discovered later or never. The same string is in the write-back hook's blocking prompt.

Both are residue from renames that landed correctly everywhere except here.

## Who got stuck

Any agent following our own instructions, on the first search it filtered by trust and the first attested computation it wrote back. `--verified` fails loudly; `attrs.question` fails silently and leaves a malformed concept in the base.

## Why a test, not just two lines

The file was already pinned against two kinds of drift — `ochakai put` must name an id ([0017](../blob/main/docs/design/0017-path-addressing.md)), types must be spelled the way [0023](../blob/main/docs/design/0023-okf-type-vocabulary.md)/[0038](../blob/main/docs/design/0038-type-vocabulary-realignment.md) spell them. Both guards exist because this file went stale the same way before. **Flags were the third thing that could go stale, and the only one nothing read.**

- `TestShippedInstructionsNameFlagsThatExist` — every long flag written beside an `ochakai <command>` invocation in anything we ship must exist on that command. Flags come from `commandLongFlags`, which runs each command with `-h` and reads its `FlagSet` (already built for the completion scripts), so this cannot be satisfied by keeping a second list up to date. Covers the README, `docs/`, `docs/guides/`, the deploy guides, `examples/`, the hooks, and `docs/cli.md` — whose worked examples are hand-written strings in `client.go`.
- `TestConceptAuthoringInstructionsKeepFrontmatterFlat` — the narrower set that tells somebody how to author a concept may not nest under `attrs`. The deploy guide names the pre-0.4 nested form on purpose, in the paragraph about importing a bundle written back then, so it is not in this list.

Both guards were verified to fail on the pre-fix content.

## Surfaces

No surface changes. REST / MCP / CLI / Web UI are all untouched, and `docs/surface.md` needs no edit.

## Design doc

None. [0048 §2.1](../blob/main/docs/design/0048-decision-records-for-wire-contracts.md) wants a number for a decision a user can observe; this is the shipped docs catching up with decisions already recorded — `--trust` in [0043](../blob/main/docs/design/0043-document-first.md)'s split of status from verification, flat frontmatter in OKF SPEC §4.1.

## Checks

`scripts/check core` passes.

---

First of a five-PR stack from a simplicity review. The next four are stacked on this one: removing filters nobody uses, aligning the queue names with the sorts that list them, folding the three posture variables into one, and counting CLI flags in `docs/surface.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)