### PR TITLE
Count the pages a reader has to get through

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,11 +35,14 @@ is current, or a supersession recorded at only one end.
 
 What ochakai costs the person using it is its **surface** — the endpoints
 they can call, the tool schemas that spend their agent's context, the
-commands they have to learn, the variables they have to set — not the
-code behind it. [docs/surface.md](docs/surface.md) counts all four in one
+commands they have to learn, the variables they have to set, the pages of
+the manual they have to read — not the code behind it.
+[docs/surface.md](docs/surface.md) counts all nine dimensions in one
 place, and `cmd/ochakai/surface_test.go` fails when the count and the
 build disagree, so an addition shows up as a heading moving from `(19)`
-to `(20)` instead of disappearing into a spec diff.
+to `(20)` instead of disappearing into a spec diff. **Prose is counted
+too**: the manual has a ceiling on its line count, so explaining a fold
+at length is a decision like any other.
 
 That document opens with the **seven conditions** ochakai exists to
 satisfy — the knowledge stays the user's, Google Cloud with no secrets,

--- a/cmd/ochakai/surface_test.go
+++ b/cmd/ochakai/surface_test.go
@@ -343,7 +343,16 @@ func TestOpenAPIComponentsAreReachable(t *testing.T) {
 
 // A cap line: "- REST: 14". Deliberately not the backticked shape an
 // item takes, so the ceiling section cannot be mistaken for a surface.
-var surfaceCapRe = regexp.MustCompile(`^- ([A-Z]+): (\d+)$`)
+//
+// A cap whose name ends in -LINES caps a measurement rather than a list:
+// "- DOC-LINES: 5800" is the reading volume of the section DOC counts.
+// Every other section is counted in names, because a name is learned once
+// however often it appears; reading is not paid that way.
+var surfaceCapRe = regexp.MustCompile(`^- ([A-Z-]+): (\d+)$`)
+
+// capMeasures is the suffix that marks a cap on an amount, and the
+// section whose amount it caps.
+const capMeasures = "-LINES"
 
 // The counters above are a thermometer: they say how big each surface is
 // and let it be any size at all, as long as the document agrees. This is
@@ -392,7 +401,8 @@ folded away in exchange.`, name, section.declared, limit, name)
 		}
 	}
 	for name := range caps {
-		if _, ok := sections[name]; !ok {
+		counted := strings.TrimSuffix(name, capMeasures)
+		if _, ok := sections[counted]; !ok {
 			t.Errorf("%s caps %s, which it does not count", surfaceDoc, name)
 		}
 	}
@@ -694,6 +704,128 @@ func TestSurfaceDocCountsVocabulary(t *testing.T) {
 	add("outcome", domain.Outcomes...)
 	add("queue", queueWordsToLearn(t)...)
 	compareSurface(t, "VOCAB", words)
+}
+
+// The eight sections above count what a caller can invoke, what a deployer
+// can set and what a curator has to know. None of them counts what
+// somebody reads before any of it means anything.
+//
+// docs/surface.md put the implementation's line count under "not counted"
+// and said why; the Web UI is there too, with its reason. Documentation
+// was on neither list — not excluded, but never recognized as surface,
+// though the README sends a reader to twenty-odd pages and the deploy
+// guide alone is longer than the CLI reference.
+//
+// It is the dimension that grew fastest. Between v0.10.0 and now the REST
+// contract went 19 → 11 while these pages passed 5,600 lines from 2,971: the
+// folding was real, and the prose explaining the folding outgrew what it
+// folded. Every other counter would have called that a pure win, which is
+// the same shape of blind spot PARAM, FLAG and VOCAB each closed.
+//
+// What counts as one of these pages is decided here rather than listed
+// twice: an exception nobody can see is a place to put a page.
+func TestSurfaceDocCountsUserDocs(t *testing.T) {
+	docs, _ := userDocs(t)
+	if len(docs) == 0 {
+		t.Fatal("no user-facing documents found: this check now guards nothing")
+	}
+	compareSurface(t, "DOC", docs)
+}
+
+// Counting pages leaves growing one free, and growing one is how the
+// manual actually grew: 0059 renamed two words and left paragraphs in four
+// files, moving no number anywhere. Names are counted everywhere else
+// because a name is learned once however often it appears — reading is not
+// paid that way, so this is the one place an amount has a ceiling.
+func TestUserDocsStayUnderTheirLineCap(t *testing.T) {
+	content, err := os.ReadFile(surfaceDoc)
+	if err != nil {
+		t.Fatalf("read %s: %v", surfaceDoc, err)
+	}
+	limit := 0
+	for _, line := range strings.Split(string(content), "\n") {
+		if m := surfaceCapRe.FindStringSubmatch(line); m != nil && m[1] == "DOC"+capMeasures {
+			if limit, err = strconv.Atoi(m[2]); err != nil {
+				t.Fatalf("%s: cap %q: %v", surfaceDoc, line, err)
+			}
+		}
+	}
+	if limit == 0 {
+		t.Fatalf("%s sets no DOC%s cap: this check now guards nothing", surfaceDoc, capMeasures)
+	}
+	_, lines := userDocs(t)
+	if lines > limit {
+		t.Errorf(`the manual is %d lines, over its cap of %d.
+
+What a reader has to get through is a cost like any other, and this is the
+only ceiling on an amount rather than on a list of names. Going past it is
+a decision: raise the cap in the same PR, having answered %s's three
+questions — or find the pages that say the same thing twice.`,
+			lines, limit, surfaceDoc)
+	}
+}
+
+// userDocs is the manual: every markdown page a reader is sent to in order
+// to evaluate, use or run ochakai, with the total number of lines in them.
+//
+// Four things are markdown and are not the manual, and each is left out
+// for a reason docs/surface.md states:
+//
+//   - docs/design — decision records, read by somebody changing ochakai.
+//     What earns a number is already narrowed by design doc 0048; the same
+//     thing is not tightened twice.
+//   - OKF documents — a file with frontmatter is knowledge, the thing
+//     ochakai stores, not prose about it. That is examples/demo and the
+//     bundle under examples/bigquery-catalog.
+//   - internal — fixtures.
+//   - CHANGELOG, CONTRIBUTING, CLAUDE.md, the code of conduct, and the
+//     dot-directories — a ledger read one entry at a time, and the surface
+//     somebody changing ochakai reads.
+func userDocs(t *testing.T) ([]string, int) {
+	t.Helper()
+	const root = "../.."
+	skipDirs := map[string]bool{
+		".git": true, "node_modules": true, "docs/design": true, "internal": true,
+	}
+	forChangers := map[string]bool{
+		"CHANGELOG.md": true, "CONTRIBUTING.md": true,
+		"CODE_OF_CONDUCT.md": true, "CLAUDE.md": true,
+	}
+	var docs []string
+	lines := 0
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		rel = filepath.ToSlash(rel)
+		if d.IsDir() {
+			if skipDirs[rel] || (strings.HasPrefix(d.Name(), ".") && rel != ".") {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if filepath.Ext(rel) != ".md" || forChangers[rel] {
+			return nil
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if strings.HasPrefix(string(content), "---\n") {
+			return nil // an OKF document: knowledge, not documentation
+		}
+		docs = append(docs, rel)
+		lines += strings.Count(string(content), "\n")
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	return docs, lines
 }
 
 // queueWordsToLearn is the queue keys that are words of their own. A

--- a/docs/README.md
+++ b/docs/README.md
@@ -79,11 +79,12 @@ and what it refuses to do. It is deliberately short; the manual is here.
   runs, and how design docs work.
 - [The surface](surface.md) — the seven conditions ochakai exists to
   satisfy, and every REST operation, query parameter, header, MCP tool,
-  CLI command, CLI flag, environment variable and word of vocabulary
-  counted in one place, with the three questions a change that adds one
-  has to answer. The default answer is no. A test reads all eight lists
-  back out of the build, so the count cannot drift and a feature cannot
-  arrive without the diff saying so.
+  CLI command, CLI flag, environment variable, word of vocabulary and page
+  of this manual counted in one place, with the three questions a change
+  that adds one has to answer. The default answer is no. A test reads all
+  nine lists back out of the build, so the count cannot drift and a
+  feature cannot arrive without the diff saying so — nor can the prose
+  explaining it, which is the ninth list and the fastest-growing one.
 - [docs/design](design) — the numbered, immutable decision records, and
   the [index](design/README.md) that says which ones still describe the
   current state. Mostly Japanese; authoritative where they and the English

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -7,12 +7,12 @@ ochakai を使う人が払うのは実装の行数ではなく**表面**であ�
 を先に決めている。
 
 数を出すだけでなく、上限も置く。**表面が増えたことを diff に出す**のが
-下の八つの節で、**増やすと決めたことを diff に出す**のが「上限」の節で
+下の九つの節で、**増やすと決めたことを diff に出す**のが「上限」の節で
 ある。エンドポイントを一本足す変更は
 [api/openapi.yaml](../api/openapi.yaml) の数十行の差分に埋もれるが、
 ここでは `## REST (14)` が `(15)` に変わる一行として出て、さらに上限の
 行を書き換えないと CI が通らない。
-`cmd/ochakai/surface_test.go` が八つの節を実物と突き合わせ、
+`cmd/ochakai/surface_test.go` が九つの節を実物と突き合わせ、
 食い違えば落ちる([0035](design/0035-verifiability.md):
 規約を信じるのではなく、外から不変条件を読む)。
 
@@ -80,6 +80,12 @@ ochakai を使う人が払うのは実装の行数ではなく**表面**であ�
 - FLAG: 29
 - ENV: 15
 - VOCAB: 36
+- DOC: 25
+- DOC-LINES: 5700
+
+`-LINES` で終わる一行だけは、一覧ではなく**量**に天井を置いている。
+`DOC` はページ数を数えるが、ページは太らせても名前が増えないので、
+そちらにも天井が要る(DOC の節)。
 
 **天井は一つのファイルの一行で、誰でも上げられる。それは弱点ではなく
 狙いである。** この仕組みが買っているのは、上の節と同じく、**黙って
@@ -427,6 +433,77 @@ MCP ツール 5 本を改名したが、本数は 8 のままで、**変わっ�
 - `type.Reference`
 - `type.Skill`
 
+## DOC (25)
+
+九つ目の次元は**読まされる文書**である。上の八つが数えているのは利用者が
+**使うもの** — 呼べる操作、渡す語、覚えるコマンド、設定する変数 — で
+あって、それを使えるようになるために**読むもの**は一つも数えていな
+かった。下の「数えていないもの」は実装の行数も Web UI も、数えない理由を
+書いて挙げている。ドキュメントはどちらの側にも無かった — 除外されていた
+のではなく、表面だと思われていなかった。
+
+ページは利用者が払うものである。README は 20 以上の文書へ送り出し、
+デプロイする人は
+[deploy/cloudrun/README.md](../deploy/cloudrun/README.md) の 983 行を
+通る。No FDE(C4)がドキュメントを正当化するが、C4 が求めるのは
+**自分で立ち上げられること**であって行数ではない。
+
+**そしてここは、どの次元より速く増えてきた。** v0.10.0 から現在まで、
+REST は 19 → 11 に減り、非テストの Go は 2.3 倍になり、この 25 ページは
+2,971 行から 5,600 行を超えた。畳み込みは本物だったが、**畳んだことの
+説明が、畳んだものより速く増えていた** — 表面を一つ減らす決定が、記録と
+二つの索引と英語要約とこの文書の段落を生む。数えていなければ、それは
+どの節にも出ない。これは PARAM・FLAG・VOCAB が塞いだのと同じ形の
+逃げ道である。
+
+**ここだけは量を数える。** 上の八つは名前を数え、`limit` を五箇所で
+使い回すのは無料だった — 覚えるのは一度きりだからである。読む労力は
+そう働かない。ページを一枚足すのは決定なので `DOC` に出るが、**既存の
+ページを太らせるのは名前を一つも増やさない**ので、総行数にも天井を
+置いた(上限の節の `DOC-LINES`)。0059 のキュー改名がこの文書に段落を
+足したとき、動いた数は一つも無かった。
+
+数えないものを決めるのは、数えるものを決めるのと同じだけ決定である。
+
+- **[docs/design](design) の記録。** 利用者ではなく、変えようとする人が
+  読む。何が番号を取るかは
+  [0048](design/0048-decision-records-for-wire-contracts.md) が既に
+  狭めており、同じものを二重に締めない。
+- **OKF ドキュメント。** `examples/demo` の 10 件も
+  `examples/bigquery-catalog/bundle` も、ochakai が**保存するもの**で
+  あって ochakai についての説明ではない。frontmatter を持つ md は
+  知識であり、ここでは数えない。
+- **CHANGELOG。** 過去の台帳で、読むのは一エントリである。通して読む
+  ものを数えるこの節に、追記だけで伸びるものを混ぜない。
+- **CONTRIBUTING・CLAUDE.md・行動規範・`.github`・`.claude`。**
+  変える人の面であって、使う人の面ではない。
+
+- `README.md`
+- `ROADMAP.md`
+- `SECURITY.md`
+- `SUPPORT.md`
+- `deploy/cloudrun/README.md`
+- `deploy/terraform/README.md`
+- `docs/README.md`
+- `docs/architecture.md`
+- `docs/cli.md`
+- `docs/compatibility.md`
+- `docs/configuration.md`
+- `docs/faq.md`
+- `docs/guides/golden-query-canary.md`
+- `docs/guides/mcp-clients.md`
+- `docs/guides/operating.md`
+- `docs/guides/troubleshooting.md`
+- `docs/images/README.md`
+- `docs/knowledge.md`
+- `docs/loop.md`
+- `docs/positioning.md`
+- `docs/surface.md`
+- `examples/README.md`
+- `examples/bigquery-catalog/README.md`
+- `examples/claude-code/CLAUDE.md`
+- `examples/claude-code/README.md`
+
 ## 数えていないもの
 
 - **Web UI。** 自分のアドレス空間を持たず、`/api/v1` の client として
@@ -450,6 +527,12 @@ CI は通る。この仕組みが買っているのは、それを**気づかな
 ない。VOCAB が塞いだのも一つで、「機構を畳んで語を増やせば得」という
 逃げ道である — `sort=` の 4 つのモードは `sort` 一語で 1 と数えられて
 いたが、いま `sort.*` として 4 語に数えられる。
+
+DOC が塞いだのはさらに一つで、これは他とは向きが違う —
+**「表面を畳んで、畳んだ説明を書けば得」**という逃げ道である。上の八つ
+だけを見ていると、面を一つ減らす PR は必ず勝ちに見える。その PR が記録と
+索引と要約と段落を残していくことは、どの数にも出なかった。減った面と
+増えた行が同じ表に並ぶのは、この節が足されて初めてである。
 
 FLAG が塞いだのはもう一つで、「REST を畳んで CLI に逃がせば得」という
 逃げ道である。[0046](design/0046-bundle-address-space.md) と


### PR DESCRIPTION
## 誰が、何をしていて詰まったか

シンプルさのレビューで、[docs/surface.md](docs/surface.md) の八次元だけを見ていると見えないものが出た。v0.10.0 → HEAD で:

| | v0.10.0 | HEAD |
|---|---|---|
| REST 操作 | 19 | 11 |
| 非テスト Go | 7,938 | 18,215 |
| **利用者が読む md** | **2,971** | **5,663** |

畳み込みは本物だった。だが**畳んだことの説明が、畳んだものより速く増えていた** — 0059(キュー名 2 語の改名)は記録 + 和索引 + 英索引 + surface.md の段落 + CHANGELOG に及び、**動いた数は一つも無い**。

surface.md の「数えていないもの」は Web UI と実装行数を理由付きで挙げているのに、ドキュメントはどちらの側にも無かった。除外されていたのではなく、表面だと思われていなかった。

## 既存の面で回避できるか

できない。これは**どの既存カウンタも構造的に見られない**次元である。八つは全て「機構」を数えており、機構を減らして散文を増やす PR は、どの数も動かさずに通る。PARAM・FLAG・VOCAB が塞いだのと同じ形の逃げ道で、向きだけが逆(面を**減らす** PR が無条件に勝ちに見える)。

## 何が畳めるか

**畳めない。表面が単調に増える。** 天井は 2 本増える(`DOC` / `DOC-LINES`)。

書ける理由: この節が数える対象は**この節自身を含む** — surface.md の 468 行は DOC に入っており、この PR が足した ~90 行もそこに乗って `DOC-LINES: 5700` の余白を 37 行に縮めている。増やしたぶんを自分で払う唯一の節である。

## 何を数え、何を数えないか

**DOC (25)** — 利用者が evaluate / use / run のために送り出される md。

数えない(理由は文書に、判定はテストに):
- `docs/design/**` — 変える人が読む。何が番号を取るかは 0048 が既に狭めており、二重に締めない
- **OKF ドキュメント** — frontmatter を持つ md は ochakai が*保存するもの*。`examples/demo` も `examples/bigquery-catalog/bundle` もこれ
- `internal/**` — fixture
- CHANGELOG(一エントリずつ読む台帳)、CONTRIBUTING / CLAUDE.md / 行動規範 / `.github` / `.claude`(変える人の面)

## ここだけ「量」を数える理由

上の八つが**名前の異なり数**を数えるのは、`limit` を 5 箇所で使い回しても覚えるのは一度きりだからである。読む労力はそう働かない。**ページを太らせるのは名前を一つも増やさない** — 実際に増えたのはその形だった。だから `DOC-LINES` が初の「量への天井」になる。

`-LINES` で終わる cap は一覧ではなく量に掛かる、と `surfaceCapRe` の仕様を一段だけ広げた(`[A-Z-]+`、`TestSurfaceStaysUnderItsCaps` は接尾辞を落として対応する節の存在を要求する)。

## 設計ドキュメント

**取らない。** surface.md 自身が「この文書は番号を取らない」(0048 §3: 以後プロセスについての決定は書かない)と定めており、これはその規則の下の運用。ワイヤも保存形も identity も動かない。

## 検査

- `TestSurfaceDocCountsUserDocs` — 節と実際のツリーを突き合わせる
- `TestUserDocsStayUnderTheirLineCap` — 総行数を天井と比べる(cap を 100 に落として実際に落ちることを確認済み: `the manual is 5663 lines, over its cap of 100`)

`scripts/check` 全緑(golangci-lint 0 issues)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)