### PR TITLE
Give a decision record a ceiling

### DIFF
--- a/.claude/skills/design-doc/SKILL.md
+++ b/.claude/skills/design-doc/SKILL.md
@@ -82,6 +82,15 @@ Date: YYYY-MM-DD
 
 Use 0038 or 0015 as models for the header style.
 
+**Keep it under the ceiling.** CONTRIBUTING.md declares a `RECORD-LINES:`
+number and `TestDesignRecordsStayUnderTheirCeiling` reads it back; the
+median record is about 140 lines. Going over almost always means the
+decision is two decisions — split it and take two numbers — or that the
+record is restating something an earlier one already settled, which is
+what citing it is for. If it genuinely is that large, raise the number in
+the same PR and say why. Do not answer the ceiling by compressing the
+prose: a record nobody finishes costs more than a long one.
+
 **4. Update the older docs' `Status:` headers.** Every doc the new one
 supersedes or amends gets a line pointing at the new number. See 0011 or
 0018 for the style. This is the step that is easiest to forget and the
@@ -106,11 +115,12 @@ older docs **Superseded**.
 
 ## What the checks hold, and what they cannot
 
-`cmd/ochakai/designdocs_test.go` fails when steps 4-6 are half done: a
-record with no entry in either index, an index that still lists a
-superseded record as current (or retires one that is still standing), a
-supersession written at only one end. Run `go test ./cmd/ochakai/` before
-opening the PR and those come back as sentences, not review comments.
+`cmd/ochakai/designdocs_test.go` fails when steps 3-6 are half done: a
+record over the ceiling, a record with no entry in either index, an index
+that still lists a superseded record as current (or retires one that is
+still standing), a supersession written at only one end. Run
+`go test ./cmd/ochakai/` before opening the PR and those come back as
+sentences, not review comments.
 
 No test reads step 5's judgment — whether the opening table's row points
 at the doc somebody should actually read now — or whether the summary in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,12 @@ chains get a replacement instead). The bookkeeping half of it is checked:
 an index that disagrees with a record's `Status:` header about whether it
 is current, or a supersession recorded at only one end.
 
+**A record has a ceiling too.** CONTRIBUTING.md declares `RECORD-LINES:`
+and the same test reads it back. 0048 narrowed what earns a number and
+left how much unbounded, which is the direction the corpus grew. Over the
+line usually means two decisions, or a record restating one that already
+exists — not a record that needs denser prose.
+
 ## Surface, and the default answer
 
 What ochakai costs the person using it is its **surface** — the endpoints

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,15 +206,51 @@ state per area, so when a design doc lands:
   partial amendment stacked on the same doc, don't add another diff:
   write it as a full replacement that states the area's whole current
   picture and mark the older docs Superseded.
+- Keep it under the ceiling below. A record is prose somebody reads.
+
+### How long a record gets
+
+    RECORD-LINES: 220
+
+0048 narrowed *what* earns a number. It said nothing about *how much*,
+and the corpus grew accordingly: 58 records and about 10,400 lines, on
+top of a 25-page manual of 5,700. A decision that renames two words has
+cost 150 lines of record, an entry in each index and a paragraph in
+[docs/surface.md](docs/surface.md) — the explanation outgrowing the
+thing explained is the shape the numbers have been showing for several
+releases.
+
+So a record from 0063 on stays under that line, and
+`TestDesignRecordsStayUnderTheirCeiling` reads it back out of this file.
+The ceiling is the same bargain [docs/surface.md](docs/surface.md)
+strikes for the surface: it is one number in one file and anybody can
+raise it, in the same PR, having said why. What it buys is only that the
+raise cannot happen quietly.
+
+Going over usually means one of three things, in order of likelihood:
+
+1. **It is two decisions.** Split it and take two numbers. Two records a
+   reader can finish beat one they abandon.
+2. **It is restating what another record already decided.** Cite it
+   instead. The index exists so a record does not have to carry its
+   ancestors.
+3. **It really is that large** — 0046 rebuilt the address space in 601
+   lines and earned every one. Then raise the line above and say so.
+
+What the ceiling must not buy is denser prose. Records earlier than 0063
+are not measured: they are immutable, and immutability is a promise about
+decisions somebody could be depending on, not a licence to keep writing
+at whatever length the last one happened to be.
 
 Most of that list is checked rather than remembered
 (`cmd/ochakai/designdocs_test.go`): a record needs an entry in both
 indexes, the two indexes have to agree with the record's own `Status:`
-header about whether it is current or superseded, and a supersession has
+header about whether it is current or superseded, a supersession has
 to be recorded at both ends — the new record naming what it retires, and
-the retired one saying so. What no test can read is the judgment: whether
-the opening table's row still points at the doc somebody should actually
-read. That is where the attention goes.
+the retired one saying so — and a new record has to fit under the
+ceiling. What no test can read is the judgment: whether the opening
+table's row still points at the doc somebody should actually read. That
+is where the attention goes.
 
 Two decisions worth knowing before proposing features:
 

--- a/cmd/ochakai/designdocs_test.go
+++ b/cmd/ochakai/designdocs_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -255,4 +256,68 @@ func capturedNumbers(re *regexp.Regexp, s string) []string {
 		}
 	}
 	return numbers
+}
+
+// The four checks above read a record against the index. None of them reads
+// how much of it there is.
+//
+// 0048 narrowed what earns a number and said nothing about how much a number
+// costs, so the corpus grew in the one direction nothing measured: 58 records
+// and roughly 10,400 lines beside a 25-page manual of 5,700. The record for
+// renaming two queue keys runs to 150 lines and leaves an entry in each index
+// behind it. Explaining a fold has been outgrowing the fold for several
+// releases, and docs/surface.md's DOC section now says so in numbers.
+//
+// The ceiling lives in CONTRIBUTING.md rather than here, for the same reason
+// docs/surface.md keeps the surface caps in prose: raising it should be a
+// line in a diff whose subject is the agreement, not a constant in a test.
+const (
+	contributing = "../../CONTRIBUTING.md"
+	// firstCappedRecord is where the rule starts. Everything before it is
+	// immutable — a ceiling cannot reach back, and a record that could be
+	// edited to fit was never a decision somebody could depend on. 0062 is
+	// the exception that is not one: it has not reached a release, and
+	// CONTRIBUTING.md already says an unreleased record is revised by
+	// replacing it, so nobody can be depending on its length either. It also
+	// keeps this check from guarding nothing on the day it lands.
+	firstCappedRecord = "0062"
+)
+
+var recordCeilingRe = regexp.MustCompile(`(?m)^\s*RECORD-LINES: (\d+)$`)
+
+func TestDesignRecordsStayUnderTheirCeiling(t *testing.T) {
+	content, err := os.ReadFile(contributing)
+	if err != nil {
+		t.Fatalf("read %s: %v", contributing, err)
+	}
+	m := recordCeilingRe.FindStringSubmatch(string(content))
+	if m == nil {
+		t.Fatalf("%s declares no RECORD-LINES ceiling: this check now guards nothing", contributing)
+	}
+	limit, err := strconv.Atoi(m[1])
+	if err != nil {
+		t.Fatalf("%s: RECORD-LINES %q: %v", contributing, m[1], err)
+	}
+	capped := 0
+	for _, r := range designRecords(t) {
+		if r.number < firstCappedRecord {
+			continue
+		}
+		capped++
+		lines := strings.Count(r.body, "\n")
+		if lines <= limit {
+			continue
+		}
+		t.Errorf(`%s is %d lines, over the %d in %s.
+
+A record is prose somebody reads, and going over usually means the decision
+is two decisions — split it and take two numbers. If it is restating what an
+earlier record already settled, cite that record instead. If it really is
+that large, raise the ceiling in this PR and say why: the number is there so
+the raise cannot happen quietly, not to be worked around by writing denser
+Japanese.`, r.file, lines, limit, contributing)
+	}
+	if capped == 0 {
+		t.Fatalf("no record numbered %s or later: this check now guards nothing", firstCappedRecord)
+	}
 }


### PR DESCRIPTION
> **Stacked on #346**(base = `claude/list-is-not-search`)。#345 → #346 の順にマージされれば自動で `main` に向き直ります。

## 誰が、何をしていて詰まったか

[0048](docs/design/0048-decision-records-for-wire-contracts.md) は **何が**番号を取るかを狭めた。**どれだけ書くか**は定めていない。伸びたのは、誰も測っていなかったそちらだった。

| | |
|---|---|
| 設計記録 | 58 本 / 約 10,400 行 |
| 利用者が読む manual | 25 ページ / 5,700 行(#345 で数え始めた) |
| 記録の行数 | median **137**、p75 208、直近 12 本は 131〜307 |

具体例: [0059](docs/design/0059-a-queue-is-named-by-its-listing.md) は **キュー名 2 語の改名**に 150 行の記録 + 和索引 + 英索引 + surface.md の段落。**畳んだものより、畳んだことの説明のほうが大きい。**

## 既存の面で回避できるか

できない。0048 は入口(何が番号を取るか)しか絞っておらず、通ったあとの量に効く仕組みが無い。レビューで都度言うのは、まさに 0035 が「規約を信じるな、外から不変条件を読め」と言っている形である。

## 何が畳めるか

畳めるものは無い(これは表面ではなくプロセスの天井)。ただし**表面は一つも増えない** — CONTRIBUTING.md は DOC の集計対象外(変える人の面)なので、DOC も DOC-LINES も動かない。

## 天井 = 220 行

```
RECORD-LINES: 220
```

- median 137、直近 12 本のうち 10 本が下
- 引っかかっていたのは 0051(307)・0056(218)・0052(216)の 3 本 — どれも「議論すればよい」水準で、禁止ではない
- 天井は CONTRIBUTING.md の一行。`docs/surface.md` の cap と同じ取引で、**誰でも上げられるが、黙っては上げられない**

失敗メッセージは、超えたときの意味を可能性の高い順に言う:

1. **二つの決定である** → 分けて番号を二つ取る
2. **既存の記録の言い直しである** → 引用する
3. **本当にその大きさである**(0046 は 601 行で妥当だった)→ 同じ PR で天井を上げて理由を書く

**やってはいけないのは 4 つ目 —「日本語を圧縮する」。** 読み切れない記録は長い記録より高い、とメッセージにもスキルにも書いた。

## 適用範囲

**0062 以降。** それ以前は immutable なので天井は遡れない。0062 だけ例外に見えるが例外ではない — 未リリースの記録は CONTRIBUTING.md が既に「差し替えで改訂する」と定めており、誰も長さに依存していない。おまけに、**着地日に何も守らないチェック**にならずに済む(この repo の他のガードと同じく、空振りは `Fatal` にした)。

## 検査

`TestDesignRecordsStayUnderTheirCeiling` — CONTRIBUTING.md から数値を読み戻す。天井を 100 に落として実際に落ちることを確認済み:

```
0062-a-listing-is-not-a-search.md is 164 lines, over the 100 in ../../CONTRIBUTING.md.
```

## 設計ドキュメント

**取らない。** 0048 §3 が「以後、プロセスについての決定は書かない」と定めている。ワイヤも保存形も identity も動かない。代わりに CONTRIBUTING.md・`design-doc` スキル・CLAUDE.md の 3 箇所に載せた。

`scripts/check` 全緑(golangci-lint 0 issues)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)