### PR TITLE
Summarize what is current, point at what is not

### DIFF
--- a/.claude/skills/design-doc/SKILL.md
+++ b/.claude/skills/design-doc/SKILL.md
@@ -105,8 +105,12 @@ that table is what a reader is meant to reach the current state from
 
 **6. Summarize it in English.** `docs/design/README.en.md` needs an entry
 or `TestEnglishDesignIndexCoversEveryRecord` fails. A doc this one
-supersedes drops to a one-line pointer at its replacement — full
-summaries are only maintained for what is current (0048 §2.5).
+supersedes **drops to a one-line pointer at its replacement** — full
+summaries are only maintained for what is current (0048 §2.5), and
+`TestEnglishIndexSummarizesOnlyWhatIsCurrent` fails if the old summary is
+left standing. Cutting it is part of superseding, not tidying to do later:
+the summary of a replaced record describes the old world in the present
+tense and nobody rereads it.
 
 **7. Avoid amendment chains.** If this would be the *second* partial
 amendment stacked on the same doc, do not add another diff. Write a full

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,7 +201,8 @@ state per area, so when a design doc lands:
   update the area's row in the opening table.
 - Summarize it in `README.en.md`. A doc the new one supersedes drops to a
   one-line pointer at its replacement; full summaries are maintained only
-  for what is current.
+  for what is current, and a test holds it — cutting the old summary is
+  part of superseding, not tidying for later.
 - Avoid amendment chains. If the new decision would be the second
   partial amendment stacked on the same doc, don't add another diff:
   write it as a full replacement that states the area's whole current

--- a/cmd/ochakai/designdocs_test.go
+++ b/cmd/ochakai/designdocs_test.go
@@ -321,3 +321,51 @@ Japanese.`, r.file, lines, limit, contributing)
 		t.Fatalf("no record numbered %s or later: this check now guards nothing", firstCappedRecord)
 	}
 }
+
+// maxSupersededSummary is how many lines a superseded record earns in the
+// English index. Four, not one: the pointer is one sentence, but a long
+// title wraps and the bullet carries the link twice.
+const maxSupersededSummary = 5
+
+// README.en.md opens by saying that only current records are summarized in
+// full, and that a superseded one "keeps a one-line pointer to whatever
+// replaced it, which is enough to follow the trail and is all the
+// maintenance it earns" (design doc 0048 §2.5). It was not true of ten of
+// them: 0043 kept twenty-two lines describing a stored shape that no longer
+// exists, and the ten together held ninety-six lines of summary for
+// decisions nothing implements.
+//
+// A rule a file states about itself and does not keep is worse than no
+// rule, because a reader believes it. The prose of a superseded entry also
+// rots in a way nothing else notices — nobody rereads the summary of a
+// record that has been replaced, so it goes on describing the old world in
+// the present tense.
+func TestEnglishIndexSummarizesOnlyWhatIsCurrent(t *testing.T) {
+	checked := 0
+	for _, r := range designRecords(t) {
+		if !supersededByRe.MatchString(r.status) {
+			continue
+		}
+		entry := indexEntry(t, designEnglishIndex, r.file)
+		if entry == "" {
+			continue // TestEnglishDesignIndexCoversEveryRecord owns that failure
+		}
+		checked++
+		// The bullet runs to the blank line that separates it from the next.
+		lines := strings.Count(strings.SplitN(entry, "\n\n", 2)[0], "\n") + 1
+		if lines <= maxSupersededSummary {
+			continue
+		}
+		t.Errorf(`%s keeps a %d-line summary of %s in %s, which is superseded.
+
+The file says a superseded record keeps a pointer to what replaced it and
+nothing more (design doc 0048 §2.5), because that is enough to follow the
+trail and all the maintenance it earns. A full summary of a decision
+nothing implements is prose that describes the old world in the present
+tense, and nobody rereads it to notice.`,
+			designEnglishIndex, lines, r.number, r.file)
+	}
+	if checked == 0 {
+		t.Fatal("no superseded record has an English index entry: this check now guards nothing")
+	}
+}

--- a/docs/design/README.en.md
+++ b/docs/design/README.en.md
@@ -19,6 +19,12 @@ Only the records that are still current are summarized in full. A record
 that has been superseded keeps a one-line pointer to whatever replaced it,
 which is enough to follow the trail and is all the maintenance it earns
 (design record [0048](0048-decision-records-for-wire-contracts.md) §2.5).
+That rule now holds: `TestEnglishIndexSummarizesOnlyWhatIsCurrent` reads
+it back. It had not — ten superseded records carried ninety-six lines of
+summary between them, describing stored shapes and endpoints that no
+longer exist, in the present tense. Nobody rereads the summary of a record
+that has been replaced, which is exactly why it needed a check rather than
+a rule.
 
 For the shape of the system rather than the history of it, read
 [docs/architecture.md](../architecture.md) first.
@@ -304,26 +310,8 @@ For the shape of the system rather than the history of it, read
   nothing derives trust from.
 
 - **[0043 The document is the truth](0043-document-first.md)** —
-  *Superseded by 0046, which keeps its world-view, status vocabulary,
-  ledgers and actor spelling and replaces the stored shape, the wire, the
-  hash's subject, canonicalization, revisions and the surface list; §3.11's
-  web UI form sugar had already been withdrawn by 0044. Implemented across
-  later pull requests and not yet released.* Both storage and the wire become the
-  canonical OKF document itself (frontmatter + markdown); the database is
-  reduced to derived index columns and instance-local ledgers. Status
-  becomes OKF's three values verbatim; "a human confirmed this" is a row
-  in an append-only verification ledger (so verifications are plural and
-  re-verification is history, not an overwrite); rejection moves to its
-  own ledger and stops being a status; the ETag becomes a hash of the
-  canonical document; actors are spelled `human:` / `process:` per SPEC
-  §7. The mapping tables, the envelope-versus-`attrs` double floor, the
-  lossy `rejected` round trip, the demotion of foreign `stable` entries,
-  and `updated_at`'s triple duty all lose their subject.
-  *For a user:* a breaking release — knowledge is written as a document
-  (PUT), read as document + read-only projection + observed ledgers, the
-  status vocabulary changes, and one migration rewrites the stored shape
-  one way. Bundles gain multi-entry `verified` lists and `process:`
-  actors; nothing needs re-embedding.
+  *Superseded by [0046](0046-bundle-address-space.md), which keeps its
+  world-view, status vocabulary, ledgers and actor spelling.*
 
 - **[0041 Narrowing a search by address](0041-path-scoped-search.md)** —
   *Accepted.* Carries 0017's "the path is the address" through to search
@@ -358,18 +346,8 @@ For the shape of the system rather than the history of it, read
   stale feed — only editing the entry to re-declare a date does.
 
 - **[0036 OKF's schema is ochakai's schema](0036-okf-schema-first.md)** —
-  *Superseded by 0043, which the code keeps shipping until its
-  implementation lands. Shipped in 0.14.0; supersedes 0005 and 0016. Two
-  items in §5 were withdrawn and implemented by 0037, and §3.6's type list
-  was reworked by 0038.* One rule replaces
-  the whole area: keys the OKF v0.2 spec defines are first-class envelope
-  fields, and `attrs` keeps only producer extension keys. Seven fields move
-  up (`sources`, `usage_window`, `runtime`, `parameters`, `computation`,
-  `executor`, `attester`); trust becomes `generated` / `verified`.
-  Compatibility with past ochakai loses to compatibility with OKF.
-  *For a user:* those keys left `attrs` (migration 0020 moved them),
-  writing an `attrs` key that shadows an envelope key is a 400, and an
-  Attested Computation without `runtime` is rejected.
+  *Superseded by [0043](0043-document-first.md), then by
+  [0046](0046-bundle-address-space.md); supersedes 0005 and 0016.*
 
 - **0034 OKF v0.2 conformance** — *Withdrawn; the number is vacant.*
   Written as the v0.2 work and merged to `main`, but its criterion for
@@ -379,18 +357,12 @@ For the shape of the system rather than the history of it, read
   the document was withdrawn — the implementation shipped.
 
 - **[0005 OKF compatibility and knowledge
-  structure](0005-okf-compatibility.md)** — *Superseded by 0036.* The
-  starting point for bidirectional OKF compatibility: slash-separated
-  hierarchical ids, free-string types, unknown frontmatter preserved in
-  `attrs`, `index.md` / `log.md` reserved, and bundle import as a
-  client-side loop over endpoints that already exist rather than a new
-  server surface.
+  structure](0005-okf-compatibility.md)** — *Superseded by
+  [0036](0036-okf-schema-first.md).*
 
 - **[0016 Alignment with the knowledge-catalog reference
-  bundles](0016-knowledge-catalog-alignment.md)** — *Superseded by 0036;
-  its type vocabulary was already replaced by 0023.* Adopted the
-  conventions of Google's reference OKF bundles, including promoting
-  `resource` from `attrs` to an envelope field.
+  bundles](0016-knowledge-catalog-alignment.md)** — *Superseded by
+  [0036](0036-okf-schema-first.md); its type vocabulary by 0023.*
 
 - **[0017 The path is the address; the type is an
   attribute](0017-path-addressing.md)** — *Accepted; the id character set
@@ -424,12 +396,7 @@ For the shape of the system rather than the history of it, read
   *For a user:* clients must tolerate a missing `title` in responses.
 
 - **[0023 One type vocabulary, OKF's](0023-okf-type-vocabulary.md)** —
-  *Superseded by 0038.* Ends the double vocabulary of internal slugs and
-  OKF display names: the stored type is the OKF spelling itself, and a
-  type is any single line. Aliases were refused — no compatibility shims
-  while the major version is 0.
-  *For a user:* type values need quoting or URL-encoding, and are matched
-  case-insensitively.
+  *Superseded by [0038](0038-type-vocabulary-realignment.md).*
 
 - **[0038 Realigning the recommended
   vocabulary](0038-type-vocabulary-realignment.md)** — *Accepted; the
@@ -495,29 +462,16 @@ For the shape of the system rather than the history of it, read
 
 ## Attachments
 
-- **[0008 Image attachments](0008-image-attachments.md)** — *Superseded by
-  0046, which dissolves attachments into bundle objects; the "evidence, not
-  originals" framing and the `<id>/<name>` layout survive as the rule that
-  derives which entry a file belongs to.* An image is knowledge only together
-  with the text around it, so search and retrieval are per-entry and an
-  image is never a standalone result. Metadata first, bytes on demand. SVG
-  is refused because it can carry script into the web UI. 5 MiB per file,
-  20 files per entry.
+- **[0008 Image attachments](0008-image-attachments.md)** — *Superseded
+  by [0046](0046-bundle-address-space.md), which dissolves attachments
+  into bundle objects.*
 
 - **[0011 Moving attachment bytes to GCS](0011-gcs-attachment-storage.md)**
-  — *Superseded by 0046; only "the bytes live in GCS" survives.* Only the bytes move; attachment rows,
-  revisions and metadata stay in PostgreSQL. Signed URLs were refused —
-  the API keeps proxying bytes, so clients see no change.
+  — *Superseded by [0046](0046-bundle-address-space.md); only "the bytes
+  live in GCS" survives.*
 
 - **[0013 Any file type, GCS only](0013-attachment-files-gcs-only.md)** —
-  *Superseded by 0046; sniffing the media type and running markdown-only
-  without a bucket carry forward, while refusing SVG and HTML at write time
-  becomes a serving-side defence.* Widens attachments from
-  images to the intersection of what Claude reads and what Gemini embeds:
-  png, jpeg, webp, pdf, plain text. The media type is decided by sniffing
-  the bytes, never by what the client claims. HTML and SVG stay refused.
-  *For a user:* attachments need `OCHAKAI_GCS_BUCKET`; without it the
-  instance runs as a markdown-only knowledge base and attach returns 501.
+  *Superseded by [0046](0046-bundle-address-space.md).*
 
 - **[0020 Attachment search](0020-attachment-search.md)** — *Accepted; 0046
   rekeys it by bundle path.*
@@ -538,13 +492,9 @@ For the shape of the system rather than the history of it, read
   *For a user:* `ochakai ui` also proxies `/mcp`, so an MCP client can use
   `http://127.0.0.1:<port>/mcp` under your own identity.
 
-- **[0014 Folder browse](0014-folder-browse.md)** — *Superseded by 0046,
-  which makes browse the derived `index.md`; its parameters had been
-  revised by 0017 §4.7.* `GET /api/v1/browse` returns one
-  level of the id hierarchy at a time. A level is cut off at 1000 entries
-  and flagged rather than paginated. Browsing records no usage, since
-  walking a tree is not a demand signal. REST and web UI only — deliberately
-  not an MCP tool.
+- **[0014 Folder browse](0014-folder-browse.md)** — *Superseded by
+  [0046](0046-bundle-address-space.md), which makes browse the derived
+  `index.md`.*
 
 - **[0021 Move, and web UI refinements](0021-move-and-webui-refinements.md)**
   — *Accepted.* `POST /api/v1/move` rewrites an entry's id in one
@@ -871,10 +821,8 @@ For the shape of the system rather than the history of it, read
 ## The MCP OAuth connector, and what replaced it
 
 - **[0010 An MCP OAuth connector service](0010-mcp-oauth-connector.md)** —
-  *Superseded by 0012; kept as the starting point if it ever returns.* A
-  second, public Cloud Run service exposing only `/mcp` and the OAuth
-  endpoints, so hosted assistants could reach an otherwise private
-  deployment.
+  *Superseded by [0012](0012-retire-mcp-oauth-connector.md); kept as the
+  starting point if it ever returns.*
 
 - **[0012 Retiring the connector](0012-retire-mcp-oauth-connector.md)** —
   *Accepted.* Removed on cost, not on technique: no user materialized,


### PR DESCRIPTION
> **Stacked on #347**(base = `claude/a-record-has-a-ceiling`)。#345 → #346 → #347 の順でマージされれば自動で `main` に向き直ります。

## 誰が、何をしていて詰まったか

[README.en.md](docs/design/README.en.md) は冒頭でこう書いている:

> Only the records that are still current are summarized in full. A record that has been superseded keeps a one-line pointer to whatever replaced it, which is enough to follow the trail and is all the maintenance it earns (0048 §2.5).

**この規則は守られていなかった。** Superseded は 10 本、その要約が占めていたのは:

| 記録 | 行数 | 中身 |
|---|---|---|
| 0043 | 22 | 0046 が置き換えた保存形を、現在形で |
| 0036 | 14 | 0043 → 0046 で消えた envelope 規則 |
| 0013 | 10 | 0046 が溶かした添付の面 |
| 0008 | 9 | 同上 |
| 他 6 本 | 41 | |
| **合計** | **96** | ポインタなら 10 行で足りる |

**自分について書いた規則を守っていないファイルは、規則が無いより悪い** — 読む人は信じるからである。

そしてこの種の散文は、**誰も再読しない場所で腐る**。置き換えられた記録の要約を読み直す人はいないので、消えた世界を現在形で説明し続け、たどった人が間違えるまで気づかれない。規則ではなく検査が要る理由がこれである。

## 既存の面で回避できるか

できない。0048 §2.5 が既に規則として存在していて、それでもこうなった。0035 の「規約を信じるのではなく外から不変条件を読む」がそのまま当てはまる。

## 何が畳めるか

**畳むのが本体。** 899 → 840 行(−59)。表面は一つも動かない — `docs/design/**` は DOC の集計対象外(変える人の面)なので、DOC も DOC-LINES も動かない。

trail は失われていない。何が引き継がれたかは各記録自身の `Status:` ヘッダ(正典)と和索引が持っており、英語索引が三つ目の写しを持つ必要はない。

## 検査

`TestEnglishIndexSummarizesOnlyWhatIsCurrent` — Superseded な記録の英語エントリは 5 行以内(長いタイトルの折り返し + ポインタ)。上限を 2 に落として実際に落ちることを確認済み。

`design-doc` スキルの step 6 に「**古い要約を削るのは supersede の一部であって、あとで片付ける作業ではない**」と明記した。

## 設計ドキュメント

**取らない。** 0048 §2.5 が既に決めていることを実装しただけで、決定の変更ではない。

`scripts/check` 全緑(golangci-lint 0 issues)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)