### PR TITLE
README: state one primary interface per agent shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,17 +68,10 @@ command carries its flags and worked examples in `ochakai <command> -h`;
 [docs/cli.md](docs/cli.md) is that same text rendered, for reading before
 you install anything.
 
-Agents without a shell (Claude Desktop, hosted agents) connect over MCP,
-which remains the primary interface. Claude Code can use it too:
-
-```sh
-claude mcp add --transport http ochakai http://localhost:8080/mcp
-```
-
-Against Cloud Run, and for clients that only speak stdio, `ochakai
-mcp-stdio` is the bridge — it forwards each message and resolves your
-identity, so the client itself holds no credentials. Which form each
-client wants, and the eight tools it will see:
+Agents without a shell — Claude Desktop, hosted agents — connect over
+MCP instead, and it's the primary interface for that case. Which form
+each client wants (a URL, or the `ochakai mcp-stdio` bridge against
+Cloud Run), and the eight tools it will see:
 [connecting an MCP client](docs/guides/mcp-clients.md).
 
 Then copy [examples/claude-code/CLAUDE.md](examples/claude-code/CLAUDE.md)


### PR DESCRIPTION
## Summary
- The "Connect an agent" section recommended the CLI for shell-bearing agents, then called MCP "the primary interface" three paragraphs later without qualification — leaving a first-time reader to pick among four routes in (CLI, MCP over HTTP, the `mcp-stdio` bridge, `ochakai ui`) before they had a reason to.
- `examples/claude-code` (CLAUDE.md and hooks) is entirely CLI-based and never touches MCP, so the blanket "MCP remains the primary interface" claim no longer matched what the project recommends for Claude Code.
- State it once instead: CLI for anything with a shell, MCP for anything without one. Per-client detail (URL vs. bridge, which tools) already lives in [docs/guides/mcp-clients.md](docs/guides/mcp-clients.md) — the README now points there once instead of duplicating the `claude mcp add --transport http` snippet and the mcp-stdio explanation inline.
- `docs/guides/mcp-clients.md` needed no changes — it already had everything the README used to duplicate.

Fixes #354.

## Test plan
- [x] `scripts/check core` (docs-only change, no code touched)
- [x] Manual read-through of the new "Connect an agent" section for coherence

🤖 Generated with [Claude Code](https://claude.com/claude-code)