### PR TITLE
Give docs/design a ceiling on record count and total lines

### DIFF
--- a/.claude/skills/design-doc/SKILL.md
+++ b/.claude/skills/design-doc/SKILL.md
@@ -91,6 +91,17 @@ what citing it is for. If it genuinely is that large, raise the number in
 the same PR and say why. Do not answer the ceiling by compressing the
 prose: a record nobody finishes costs more than a long one.
 
+CONTRIBUTING.md also caps the corpus as a whole: `RECORD-COUNT` for how
+many records exist, `RECORD-CORPUS-LINES` for how many lines they total —
+both count every record, Superseded ones included, since they still ship
+in the tree and a reader following a `Status:` trail still opens them.
+`TestDesignRecordCorpusStaysUnderItsCeiling` reads both back. Landing a
+new record can push the corpus over either one even when the record
+itself is well under `RECORD-LINES`; the same two escapes apply, just
+visible only once the whole corpus is counted — this decision restates
+one already on file (cite it instead), or two subjects have been sharing
+one number and would read better split.
+
 **4. Update the older docs' `Status:` headers.** Every doc the new one
 supersedes or amends gets a line pointing at the new number. See 0011 or
 0018 for the style. This is the step that is easiest to forget and the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,11 +31,16 @@ chains get a replacement instead). The bookkeeping half of it is checked:
 an index that disagrees with a record's `Status:` header about whether it
 is current, or a supersession recorded at only one end.
 
-**A record has a ceiling too.** CONTRIBUTING.md declares `RECORD-LINES:`
-and the same test reads it back. 0048 narrowed what earns a number and
-left how much unbounded, which is the direction the corpus grew. Over the
-line usually means two decisions, or a record restating one that already
-exists — not a record that needs denser prose.
+**A record has a ceiling, and so does the corpus.** CONTRIBUTING.md
+declares `RECORD-LINES` for one record's length and `RECORD-COUNT` /
+`RECORD-CORPUS-LINES` for all of `docs/design` together, Superseded
+records included; the same test file reads all three back. 0048 narrowed
+what earns a number, not how many records pile up or how long they run
+together — that was the direction the corpus grew, 4.6x against non-test
+Go's 2.3x. Over a line usually means two decisions, or a record restating
+one that already exists — not a record that needs denser prose, and not a
+corpus whose answer is a bigger number rather than a look at what it is
+carrying.
 
 ## Surface, and the default answer
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,15 +243,53 @@ are not measured: they are immutable, and immutability is a promise about
 decisions somebody could be depending on, not a licence to keep writing
 at whatever length the last one happened to be.
 
+### How many records, and how much
+
+`RECORD-LINES` bounds one record's thickness. Nothing bounded how many
+records there are, and that turned out to be the number that moved: 19
+records at v0.10.0, 59 now — 4.6x, against 2.3x for non-test Go and REST's
+own retreat from 19 operations to 11. Folding a surface leaves a record
+behind, and [docs/surface.md](docs/surface.md)'s DOC section already names
+that residue — an index entry in each language, an English summary, a
+paragraph in that file or this one — for the manual it counts. Records are
+the larger half of the same residue, and until now none of it was counted
+anywhere.
+
+    RECORD-COUNT: 59
+    RECORD-CORPUS-LINES: 10292
+
+Both count every record under `docs/design`, Superseded ones included:
+they still ship in the tree, and a reader following a `Status:` header
+still opens them. Counting only what is current would let a supersession
+buy headroom for the next addition — the file stays on disk either way, so
+that would be the next escape hatch rather than a saving.
+
+The two catch different shapes. `RECORD-CORPUS-LINES` is `DOC-LINES`'s
+argument applied to this corpus: a record that never crosses
+`RECORD-LINES` can still add to what a reader gets through, and enough of
+them doing it at once moves nothing else. `RECORD-COUNT` is for the shape
+a line total cannot see at all — 0054/0057 and 0055/0056 are one subject
+apiece, told across two numbers, and a per-record cap has no way to notice
+that a second number was the wrong fix.
+
+These live here, next to `RECORD-LINES`, rather than as an eleventh line in
+[docs/surface.md](docs/surface.md)'s 上限 section. A record is read by
+somebody changing ochakai, not somebody using it — that document's DOC
+section already excludes `docs/design` from the manual on that basis — and
+a ceiling for that same reader belongs beside the other ceiling for that
+reader, not split across two files that both happen to hold a number.
+
 Most of that list is checked rather than remembered
 (`cmd/ochakai/designdocs_test.go`): a record needs an entry in both
 indexes, the two indexes have to agree with the record's own `Status:`
 header about whether it is current or superseded, a supersession has
 to be recorded at both ends — the new record naming what it retires, and
-the retired one saying so — and a new record has to fit under the
-ceiling. What no test can read is the judgment: whether the opening
-table's row still points at the doc somebody should actually read. That
-is where the attention goes.
+the retired one saying so — a new record has to fit under its own
+ceiling, and the corpus as a whole has to fit under `RECORD-COUNT` and
+`RECORD-CORPUS-LINES`
+(`TestDesignRecordCorpusStaysUnderItsCeiling`). What no test can read is
+the judgment: whether the opening table's row still points at the doc
+somebody should actually read. That is where the attention goes.
 
 Two decisions worth knowing before proposing features:
 

--- a/cmd/ochakai/designdocs_test.go
+++ b/cmd/ochakai/designdocs_test.go
@@ -322,6 +322,73 @@ Japanese.`, r.file, lines, limit, contributing)
 	}
 }
 
+// recordCorpusCapRe reads a ceiling on the corpus as a whole rather than on
+// one record: "RECORD-COUNT: 59" or "RECORD-CORPUS-LINES: 10292", declared
+// beside RECORD-LINES in CONTRIBUTING.md rather than as an eleventh cap in
+// docs/surface.md's 上限 section — a record is read by somebody changing
+// ochakai, not somebody using it, so its ceiling lives with the other
+// ceiling for that same reader.
+var recordCorpusCapRe = regexp.MustCompile(`(?m)^\s*(RECORD-COUNT|RECORD-CORPUS-LINES): (\d+)$`)
+
+// TestDesignRecordCorpusStaysUnderItsCeiling reads docs/design as a whole:
+// how many records it holds, and how many lines they total. Superseded
+// records count in both — they still ship in the tree, and a reader
+// following a Status: header still opens them. Counting only what is
+// current would let a supersession buy headroom for the next addition, and
+// the file stays on disk either way, so that would be the next escape
+// hatch rather than a saving.
+//
+// The two catch different shapes. RECORD-CORPUS-LINES is DOC-LINES's
+// argument applied to this corpus: a record that never crosses RECORD-LINES
+// can still add to what a reader gets through, and enough of them doing it
+// at once moves nothing else. RECORD-COUNT is for the shape a line total
+// cannot see at all — 0054/0057 and 0055/0056 are one subject apiece, told
+// across two numbers, and no per-record cap can notice that a second
+// number was the wrong fix.
+func TestDesignRecordCorpusStaysUnderItsCeiling(t *testing.T) {
+	content, err := os.ReadFile(contributing)
+	if err != nil {
+		t.Fatalf("read %s: %v", contributing, err)
+	}
+	caps := map[string]int{}
+	for _, m := range recordCorpusCapRe.FindAllStringSubmatch(string(content), -1) {
+		n, err := strconv.Atoi(m[2])
+		if err != nil {
+			t.Fatalf("%s: %s %q: %v", contributing, m[1], m[2], err)
+		}
+		caps[m[1]] = n
+	}
+	for _, name := range []string{"RECORD-COUNT", "RECORD-CORPUS-LINES"} {
+		if _, ok := caps[name]; !ok {
+			t.Fatalf("%s declares no %s ceiling: this check now guards nothing", contributing, name)
+		}
+	}
+
+	records := designRecords(t)
+	totalLines := 0
+	for _, r := range records {
+		totalLines += strings.Count(r.body, "\n")
+	}
+
+	if count, limit := len(records), caps["RECORD-COUNT"]; count > limit {
+		t.Errorf(`docs/design holds %d records, over the RECORD-COUNT ceiling of %d in %s.
+
+Going over is a decision to make the corpus bigger, so it is made by
+raising the number in the same PR, having said why — or by finding that the
+new record restates one already on file, or that two subjects have been
+sharing one number and would read better split.`, count, limit, contributing)
+	}
+	if got, limit := totalLines, caps["RECORD-CORPUS-LINES"]; got > limit {
+		t.Errorf(`docs/design totals %d lines across %d records, over the RECORD-CORPUS-LINES
+ceiling of %d in %s.
+
+A record can stay under RECORD-LINES on its own and still add to what a
+reader gets through if enough records do it at once, which is what this
+ceiling is for. Raise it in the same PR, having said why.`,
+			got, len(records), limit, contributing)
+	}
+}
+
 // maxSupersededSummary is how many lines a superseded record earns in the
 // English index. Four, not one: the pointer is one sentence, but a long
 // title wraps and the bullet carries the link twice.

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -496,9 +496,15 @@ REST は 19 → 11 に減り、非テストの Go は 2.3 倍になり、この 
 数えないものを決めるのは、数えるものを決めるのと同じだけ決定である。
 
 - **[docs/design](design) の記録。** 利用者ではなく、変えようとする人が
-  読む。何が番号を取るかは
+  読む。何が番号を**取る資格**を持つかは
   [0048](design/0048-decision-records-for-wire-contracts.md) が既に
-  狭めており、同じものを二重に締めない。
+  狭めているが、取った後に**何冊積み上がるか**は別の問いで、これは
+  数えていなかった — v0.10.0 の 19 記録から現在の 59 記録へ、この文書の
+  どの次元よりも速く増えている。冊数と総行数の天井は
+  [CONTRIBUTING.md](../CONTRIBUTING.md) の `RECORD-COUNT` /
+  `RECORD-CORPUS-LINES` に置く。読むのは利用者ではなく変える人で、
+  `RECORD-LINES`(一冊の天井)と同じ読者の同じ種類の天井だから、ここに
+  十一本目の上限を足すより、その天井の隣に置くほうが筋が通る。
 - **OKF ドキュメント。** `examples/demo` の 10 件も
   `examples/bigquery-catalog/bundle` も、ochakai が**保存するもの**で
   あって ochakai についての説明ではない。frontmatter を持つ md は


### PR DESCRIPTION
## Summary

Closes #350. `docs/surface.md` counts nine dimensions and puts a ceiling on each, but the one thing it never counted was the design-record corpus itself — the fastest-growing surface in the project (19 records/2,536 lines at v0.10.0 → 59 records/10,292 lines now, 4.6x against 2.3x for non-test Go).

The issue asked three questions before an edit could land:

- **What is counted?** Both a record count and a total line count, since they catch different escapes — `RECORD-CORPUS-LINES` catches a record fattening without ever crossing its own `RECORD-LINES` cap (the same shape `DOC-LINES` closes for the manual); `RECORD-COUNT` catches a single subject split across two numbers (0054/0057, 0055/0056), which a line total can't see at all.
- **Do Superseded records count?** Yes, in both. They still ship in the tree and a reader following a `Status:` header still opens them — excluding them would let supersession buy headroom for the next addition, which is the next escape hatch rather than a real saving.
- **Where does the ceiling live?** In `CONTRIBUTING.md`, next to `RECORD-LINES` — not as an eleventh line in `docs/surface.md`'s 上限 section. A design record is read by someone changing ochakai, not someone using it (the same reasoning `docs/surface.md` already gives for excluding `docs/design` from its own count), so the new ceiling belongs beside the existing ceiling for that same reader rather than opening a third home.

This is a process decision under 0048 §3, so it takes no design-doc number.

## Changes

- `CONTRIBUTING.md` — new "How many records, and how much" subsection declaring `RECORD-COUNT: 59` and `RECORD-CORPUS-LINES: 10292`.
- `cmd/ochakai/designdocs_test.go` — `TestDesignRecordCorpusStaysUnderItsCeiling` reads both caps back from `CONTRIBUTING.md`, the same way the existing test reads `RECORD-LINES`.
- `docs/surface.md` — the DOC section's exclusion bullet for `docs/design` now points at the new ceiling instead of asserting the count is unbounded.
- `.claude/skills/design-doc/SKILL.md` — added guidance for when landing a new record trips the corpus ceiling even though the record itself is under `RECORD-LINES`.
- `CLAUDE.md` — updated the paragraph that previously said the corpus was unbounded.

## Test plan

- [x] `go build ./...`
- [x] `scripts/check core` — all packages pass
- [x] `scripts/check lint` — 0 issues
- [x] Manually lowered `RECORD-COUNT` to confirm `TestDesignRecordCorpusStaysUnderItsCeiling` actually fails (guard is real, not vacuous)

🤖 Generated with [Claude Code](https://claude.com/claude-code)