### PR TITLE
Shorten the deploy guide; move hardening, web UI, upgrades to operating.md

### DIFF
--- a/cmd/ochakai/serveui.go
+++ b/cmd/ochakai/serveui.go
@@ -6,7 +6,7 @@
 // service-to-service auth. The ochakai deployment therefore stays
 // IAM-restricted, and browser users are recorded as this service's
 // identity (process:<sa-email>). Same image as `serve`: deploy it with
-// `--args=serve-ui` (deploy guide §5b).
+// `--args=serve-ui` (docs/guides/operating.md, "The team web UI").
 //
 // OCHAKAI_URL is required: the page always talks to its own origin
 // (design doc 0006 rev. 2026-07-19), so without an upstream there is

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -19,17 +19,15 @@ slightly more; pick what matches your latency needs. Teardown commands are
 at the bottom.
 
 **Already deployed?** [docs/guides/operating.md](../../docs/guides/operating.md)
-is the day-two half: what each of the two backups recovers, what a restore
-from an OKF bundle loses, which log lines mean degraded-but-running, and
-what raising `--max-instances` costs in database connections.
+covers what happens after: backup and restore, hardening, the team web
+UI, monitoring, capacity, and upgrades.
 
 **Prefer infrastructure as code?**
-[deploy/terraform](../terraform) stands up §1–§4b (plus §5b's web UI and
-§5d's demo posture) as a Terraform module, so a deployment can be reviewed as a diff, reproduced per
-environment, and destroyed cleanly. This guide stays the reference: it
-explains why each piece is shaped the way it is, and covers the parts the
-module deliberately leaves out — §5c, §6's org-policy guardrails, and §8's
-upgrade notes.
+[deploy/terraform](../terraform) stands up §1–§4b (plus the web UI and
+demo posture) as a Terraform module, so a deployment can be reviewed as a
+diff, reproduced per environment, and destroyed cleanly. This guide stays
+the reference for §1–§5, §5c, §5d and §9; the operating guide covers the
+rest it leaves out — the web UI, org-policy guardrails, and upgrade notes.
 
 ## 1. Prerequisites
 
@@ -110,53 +108,11 @@ Notes:
 
 ### 2b. Optional hardening: private IP only
 
-For production-like deployments, drop the public IP entirely. Costs
-nothing extra (VPC, private services access, and Cloud Run's Direct VPC
-egress are free); the trade-off is that local admin access (§3's SQL,
-§6's maintenance — §5's import is unaffected, it goes over the API)
-needs a temporary public IP or a VPC-attached workstation.
-
-One-time per VPC — allocate a peering range and connect it (if the
-Compute API was just enabled, the `addresses create` may need a minute
-before it stops returning `SERVICE_DISABLED`):
-
-```sh
-gcloud services enable servicenetworking.googleapis.com compute.googleapis.com
-gcloud compute addresses create google-managed-services-default \
-  --global --purpose=VPC_PEERING --prefix-length=16 --network=default
-gcloud services vpc-peerings connect --service=servicenetworking.googleapis.com \
-  --ranges=google-managed-services-default --network=default
-```
-
-Then create the instance with `--network=default --no-assign-ip`
-(instead of the defaults above) — or convert an existing one, which is
-the same patch and takes 15–20 minutes:
-
-```sh
-gcloud sql instances patch ochakai --network=default --no-assign-ip
-```
-
-Add Direct VPC egress to the Cloud Run service so it can reach the
-private IP (the `/cloudsql` connector socket follows automatically; the
-`OCHAKAI_DATABASE_URL` doesn't change):
-
-```sh
-gcloud run services update ochakai --region=$REGION \
-  --network=default --subnet=default
-```
-
-Local admin access (§3's SQL, §6's maintenance) no longer works from
-outside the VPC — `cloud-sql-proxy` connects only to instances it can
-route to. Temporarily attach a public IP and detach it after:
-
-```sh
-gcloud sql instances patch ochakai --assign-ip       # + cloud-sql-proxy, do the work
-gcloud sql instances patch ochakai --no-assign-ip    # afterwards
-```
-
-(If §6's `sql.restrictPublicIp` org policy is enforced, the temporary
-`--assign-ip` is blocked too — lift the policy for the window or use a
-VPC-attached workstation.)
+For production-like deployments, drop the public IP entirely — free, and
+worth doing for anything beyond a quick trial. The commands and the
+local-admin-access trade-off are in
+[Hardening](../../docs/guides/operating.md#hardening) in the operating
+guide.
 
 ## 3. Deploy Cloud Run (dedicated identity, passwordless, org-restricted)
 
@@ -429,117 +385,13 @@ curl "http://localhost:8787/api/v1/search?q=revenue"
 
 ## 5b. Optional: the team web UI behind IAP (separate service, by design)
 
-The web UI runs as its own service, **not** inside `serve` — the core
-keeps its serving surface minimal. For personal use it
-needs no deployment at all: `ochakai ui` serves the same page on loopback
-with your own identity. Deploy this service when people who cannot run
-the Go CLI need browser access.
-
-It is the **same container image** as ochakai itself, started with
-`--args=serve-ui` instead of the default `serve`: a static page plus a
-reverse proxy that attaches its service identity
-(`X-Serverless-Authorization`) to API calls, so ochakai stays
-organization-restricted — no second image to build, and the UI is always
-the exact version of the server it fronts. The webui itself is
-non-public too: [Identity-Aware Proxy](https://cloud.google.com/iap/docs/enabling-cloud-run)
-sits in front, so browsers sign in with their Google account and only
-your organization gets through — no `allUsers` grant anywhere. By default
-writes through the UI are recorded as the webui's service account
-(`agent:ochakai-webui@…`); set `OCHAKAI_IAP_AUDIENCE` (below) to record
-the person in the browser instead. MCP and CLI clients get per-user
-identity via the §5 proxy path.
-
-```sh
-# dedicated identity, allowed to invoke ochakai only
-gcloud iam service-accounts create ochakai-webui
-gcloud run services add-iam-policy-binding ochakai --region=$REGION \
-  --member=serviceAccount:ochakai-webui@$PROJECT_ID.iam.gserviceaccount.com \
-  --role=roles/run.invoker
-
-# deploy non-public, with IAP in front — same $IMAGE as §3.
-# (--iap needs the gcloud beta component; the iap web command below
-#  needs the Resource Manager API)
-gcloud services enable iap.googleapis.com cloudresourcemanager.googleapis.com
-gcloud beta run deploy ochakai-webui \
-  --image=$IMAGE --args=serve-ui \
-  --region=$REGION --no-allow-unauthenticated --iap \
-  --service-account=ochakai-webui@$PROJECT_ID.iam.gserviceaccount.com \
-  --min-instances=0 --max-instances=1 --cpu=1 --memory=256Mi \
-  --set-env-vars=OCHAKAI_URL=$OCHAKAI_URL
-
-# let your organization through IAP (the deploy already granted IAP's
-# service agent run.invoker on the service — "Setting IAP service agent"
-# in its output)
-gcloud beta iap web add-iam-policy-binding \
-  --resource-type=cloud-run --service=ochakai-webui --region=$REGION \
-  --member=domain:your-org.example --role=roles/iap.httpsResourceAccessor
-```
-
-Open the webui service URL: IAP presents the Google sign-in, then the
-page loads. The UI and API are same-origin through the proxy, so nothing
-else to configure. To check IAP is actually fronting the service, request
-it unauthenticated — the response is a 302 to `accounts.google.com`
-with an `x-goog-iap-generated-response: true` header, not the page.
-
-### Recording the browser user instead of the service account
-
-Out of the box every edit from the UI reads `agent:ochakai-webui@…`,
-which is one author for the whole team. To record who actually made it,
-tell serve-ui which IAP audience to trust and let ochakai accept the
-webui as a delegator (design docs 0027, 0032):
-
-**Set them in this order.** The moment serve-ui starts forwarding
-identities, ochakai answers 403 unless it already accepts this caller
-(it never downgrades silently) — so grant the delegation first, and the
-UI never sees the window in between.
-
-```sh
-# 1. ochakai must accept this caller's forwarded identities.
-gcloud run services update ochakai --region=$REGION \
-  --update-env-vars="OCHAKAI_DELEGATING_CALLERS=ochakai-webui@$PROJECT_ID.iam.gserviceaccount.com"
-
-# 2. Tell serve-ui which IAP audience to trust. It refuses to guess:
-# a wrong value would mean verifying nothing. For IAP enabled directly
-# on Cloud Run — what §5b deploys — the audience is
-# /projects/PROJECT_NUMBER/locations/REGION/services/SERVICE_NAME.
-# (Behind a load balancer it is the backend service instead, and the
-# IAP console gives it: ⋮ next to the resource → "Get JWT audience code".)
-IAP_AUDIENCE="/projects/$(gcloud projects describe $PROJECT_ID --format='value(projectNumber)')/locations/$REGION/services/ochakai-webui"
-
-gcloud run services update ochakai-webui --region=$REGION \
-  --update-env-vars="OCHAKAI_IAP_AUDIENCE=$IAP_AUDIENCE"
-```
-
-The startup log says which way it went: `recording browser users by
-their IAP identity` with the audience it will require, or `no
-OCHAKAI_IAP_AUDIENCE; writes are recorded as this service account`.
-
-Writes then read `human:tanaka@example.co.jp via agent:ochakai-webui@…`
-— both identities, never just one. serve-ui verifies IAP's signature,
-audience, expiry and issuer on every request, and **refuses (403) any
-request IAP did not sign** once the audience is set: if IAP is not
-really in front of the service, you find out immediately instead of
-discovering months of writes attributed to the wrong author. The
-audience it received is logged next to the one you configured, so a
-mismatch is a one-line fix.
-
-Whether or not you set this, both proxies discard any
-`X-Ochakai-On-Behalf-Of` the browser sends — a page cannot name its own
-author (design doc 0032).
-
-Notes from exercising this end-to-end:
-
-- **Upgrading a pre-0.9.0 webui deployment** (a separately built image,
-  or one exposed with `allUsers`): the same `gcloud beta run deploy`
-  converts it in place — enabling IAP replaces the service's invoker
-  policy, so a leftover `allUsers` binding is removed automatically.
-- **Programmatic access** (curl, scripts) is limited with the
-  Google-managed OAuth client that `--iap` uses: ordinary ID tokens are
-  rejected. A service account granted `roles/iap.httpsResourceAccessor`
-  can get through with a self-signed JWT whose `aud` is the service URL
-  plus `/*` (`gcloud iam service-accounts sign-jwt`); for anything more,
-  configure IAP with a custom OAuth client. Browsers are the intended
-  clients here — MCP and CLI use the §5 path.
+The web UI runs as its own service, **not** inside `serve`, behind
+[Identity-Aware Proxy](https://cloud.google.com/iap/docs/enabling-cloud-run)
+— deploy it when people who cannot run the Go CLI need browser access.
+The commands, including recording the browser user instead of the
+service account, are in
+[The team web UI](../../docs/guides/operating.md#the-team-web-ui) in the
+operating guide.
 
 ## 5c. Optional: an application that serves many people (delegated provenance)
 
@@ -759,138 +611,11 @@ that order.
 
 ## 6. Security hardening checklist
 
-The default §1–§5 deployment is already secret-zero and least-privilege:
-Cloud Run IAM gates reachability, callers and the database authenticate
-with Google identities (no tokens, no passwords), the runtime service
-account holds only explicit grants, the Cloud SQL authorized-networks
-list stays empty, and images are provenance-attested. The steps below
-raise the bar further; pick what matches your risk profile.
-
-**Guardrails against misconfiguration** (org-policy; needs the Org Policy
-Administrator role). These make the risky states unrepresentable rather
-than merely avoided:
-
-```sh
-# forbid adding ANY authorized network on Cloud SQL (not just broad
-# ranges — the empty-list posture becomes unrepresentable to leave)
-gcloud resource-manager org-policies enable-enforce \
-  sql.restrictAuthorizedNetworks --project=$PROJECT_ID
-# forbid public IPs on Cloud SQL — pair with §2b. Existing public IPs
-# are grandfathered: the instance keeps running and unrelated patches
-# still work; only changes to the IP configuration are blocked
-gcloud resource-manager org-policies enable-enforce \
-  sql.restrictPublicIp --project=$PROJECT_ID
-```
-
-Enforcement takes a minute or two to propagate — a violating patch
-issued immediately after can still succeed. Verify the guardrail is
-live by trying one: `gcloud sql instances patch ochakai
---authorized-networks=203.0.113.1/32` should fail with an
-`Organization Policy check failure` (and if it succeeded, you were too
-fast — `--clear-authorized-networks` and try again).
-
-Keep Domain Restricted Sharing (`iam.allowedPolicyMemberDomains`) on at
-the org level; nothing in a working deployment needs `allUsers` — every
-service, the IAP-fronted webui included, stays
-`--no-allow-unauthenticated`. §5d's public demo is the one thing this
-policy blocks, and it is a fair trade: exempt a dedicated demo project if
-you want one, and leave the org policy alone.
-
-**Remove the reachable database endpoint**: §2b (private IP only).
-
-**Enforce TLS on direct connections** (Cloud SQL connector traffic is
-always mTLS; this covers the authorized-network path):
-
-```sh
-gcloud sql instances patch ochakai --ssl-mode=ENCRYPTED_ONLY
-```
-
-**Retire the last password.** The admin user's password is the only
-stored secret in the whole system, and it too can go: create a personal
-IAM login for maintenance, transfer the admin user's objects to it, and
-delete the password user. Future maintenance goes through
-`cloud-sql-proxy --auto-iam-authn` with your own identity.
-
-Two Postgres facts shape the sequence. Tables created by startup
-migrations are owned by the **runtime service account**, so the admin
-cannot `GRANT` on them — you inherit them via role membership instead.
-And a role that still owns objects or appears in grants cannot be
-dropped, so the admin's footprint must be reassigned and dropped first —
-which also **revokes every grant the admin ever made, breaking the
-running service until the re-grant below**. Do this in one sitting:
-
-```sh
-gcloud projects add-iam-policy-binding $PROJECT_ID \
-  --member=user:you@your-org.example --role=roles/cloudsql.instanceUser
-gcloud sql users create you@your-org.example --instance=ochakai --type=cloud_iam_user
-```
-
-As the admin user (`cloud-sql-proxy` + `psql`, §3), in one session:
-
-```sql
-GRANT "ochakai-run@<PROJECT_ID>.iam" TO "you@your-org.example";  -- inherit runtime-owned tables, present and future
-REASSIGN OWNED BY "ochakai" TO "you@your-org.example";
-DROP OWNED BY "ochakai";  -- clears its grants; the service is degraded from here until re-granted
-GRANT USAGE, CREATE ON SCHEMA public
-  TO "ochakai-run@<PROJECT_ID>.iam", "you@your-org.example";
-```
-
-(The schema grant must come from a `cloudsqlsuperuser` member — the
-admin still qualifies; your IAM login never will.) Then as yourself
-(`cloud-sql-proxy --auto-iam-authn`, connect as `you@your-org.example`),
-re-grant the runtime on the tables you now own:
-
-```sql
-GRANT ALL ON ALL TABLES IN SCHEMA public TO "ochakai-run@<PROJECT_ID>.iam";
-GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO "ochakai-run@<PROJECT_ID>.iam";
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO "ochakai-run@<PROJECT_ID>.iam";
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO "ochakai-run@<PROJECT_ID>.iam";
-```
-
-Finally delete the password user and verify a cold start (the startup
-migration needs the schema grant — a warm instance can mask a mistake):
-
-```sh
-gcloud sql users delete ochakai --instance=ochakai
-gcloud run services update ochakai --region=$REGION --update-labels=grants=rotated  # forces a new instance
-# then §3's proxy + curl /health
-```
-
-(URL-encode the `@` as `%40` in connection strings:
-`postgres://you%40your-org.example@localhost:55432/ochakai`.)
-
-What "secret-zero" means afterwards: the built-in `postgres` user still
-exists, and anyone with Cloud SQL admin IAM can mint it a throwaway
-password (`gcloud sql users set-password postgres ...`) for break-glass
-schema-level work — no *stored* secret remains, and admin access stays
-IAM-gated.
-
-**Backups and point-in-time recovery** — the example skips them for
-cost; real knowledge deserves them:
-
-```sh
-gcloud sql instances patch ochakai --backup-start-time=03:00 --enable-point-in-time-recovery
-```
-
-(Enabling backups means picking a start time — there is no bare
-`--backup` flag on `patch`. To turn both off again, disable PITR first:
-`--no-backup` refuses to combine with `--no-enable-point-in-time-recovery`.)
-
-**Deploy-time image gating**: releases ship SLSA provenance (§8's
-`gh attestation verify`); Binary Authorization can enforce that check
-automatically on every deploy instead of relying on operator diligence.
-
-**Audit trails**: knowledge changes are fully recorded by ochakai itself
-(`knowledge_revision`, actor per change). For infrastructure-level
-trails, enable Cloud SQL Data Access audit logs in the Console — admin
-activity is logged by default.
-
-Everything above — §2b's private IP, §5b's IAP commands, the org-policy
-guardrails, TLS enforcement, backups, and the password-retirement
-sequence — has been exercised end-to-end on this guide's example
-deployment (2026-07, Postgres 17, gcloud 575). The one exception is
-Binary Authorization, which remains a pointer; report anything that
-doesn't work as written.
+The default §1–§5 deployment is already secret-zero and least-privilege.
+Org-policy guardrails, TLS enforcement, retiring the last password,
+backups, and deploy-time image gating that raise the bar further are in
+[Hardening](../../docs/guides/operating.md#hardening) in the operating
+guide.
 
 ## 7. Troubleshooting in security-hardened organizations
 
@@ -922,53 +647,10 @@ doesn't work as written.
 
 ## 8. Upgrading an existing deployment
 
-Point the service at the new tag — that's normally everything. Database
-migrations are embedded in the binary, tracked in `schema_migrations`,
-and run automatically at startup:
-
-```sh
-gcloud run services update ochakai --region=$REGION \
-  --image=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:<new-tag>
-```
-
-The Artifact Registry remote repository fetches new tags from GHCR on
-demand; verify what you got with
-`gh attestation verify oci://ghcr.io/na0fu3y/ochakai:<new-tag> -R na0fu3y/ochakai`.
-Rolling back Cloud Run traffic to a previous revision does **not** roll
-back database migrations; migrations are additive, so older binaries keep
-working against a newer schema.
-
-Version notes:
-
-- **→ 0.9.0 (breaking)**: the MCP OAuth connector service is retired.
-  `OCHAKAI_CONNECTOR_PUBLIC_URL` is now silently ignored — **never point
-  a connector deployment at this image**: that service was publicly
-  invokable, and this image would serve the trust-the-headers private
-  surface on it. Delete the connector service instead of upgrading it
-  (`gcloud run services delete ochakai-connector --region=$REGION`), and
-  clean up its Google OAuth client, the Secret Manager client secret,
-  and any Domain Restricted Sharing exemption. The private service is
-  unaffected; its startup migration drops the now-unused `oauth_*`
-  tables (which the private service never read, so rolling it back
-  afterwards remains safe).
-  Also removed in 0.9.0: the `DATABASE_URL` alias (use
-  `OCHAKAI_DATABASE_URL`), `OCHAKAI_ADDR` (use `PORT`), the `/healthz`
-  alias (use `/health`), the startup bytea→GCS backfill (upgrade through
-  0.8.x with `OCHAKAI_GCS_BUCKET` set if attachment bytes are still in
-  Postgres, §4b), and OKF import of the pre-0.4 nested `attrs:`
-  frontmatter form (re-export old bundles, or lift the keys to the top
-  level — SPEC §4.1).
-- **From anything older than 0.8.0**: all pre-0.9.0 releases are
-  [retracted](https://go.dev/ref/mod#go-mod-file-retract) and their
-  per-version upgrade notes have been removed from this guide — recover
-  them from git history if needed
-  (`git log -- deploy/cloudrun/README.md`). The short of it: remove
-  pre-0.3 configuration (`OCHAKAI_CLIENTS`, `OCHAKAI_AUTH`,
-  `OCHAKAI_CORS_ORIGINS`, `OCHAKAI_EMBEDDING_PROVIDER` — stale variables
-  are silently ignored, so check they are unset), adopt §3's posture
-  (`--no-allow-unauthenticated` + IAM invoker grants, identity headers,
-  passwordless database), step through **0.8.x** for the attachment
-  backfill if applicable (§4b), then land on 0.9.0 with the note above.
+Point the service at the new tag; migrations run automatically at
+startup. The full upgrade path, including the version-specific breaking-
+change notes, is [Upgrades](../../docs/guides/operating.md#upgrades) in
+the operating guide.
 
 ## 9. Teardown
 

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -42,7 +42,8 @@ Two consequences worth knowing before you read further:
 
 - The module does **not** create the guide's password-holding admin user.
   Direct database access for people is an IAM login instead
-  (`maintenance_users`), which is where guide §6 ends up anyway.
+  (`maintenance_users`), which is where the operating guide's hardening
+  checklist ends up anyway.
 - Terraform therefore cannot run the one-time schema bootstrap SQL — doing so
   would mean holding a password. That step stays manual; see below.
 
@@ -89,7 +90,7 @@ only ever hits the privilege-free `CREATE EXTENSION IF NOT EXISTS` skip path.
 
 An IAM login never qualifies as `cloudsqlsuperuser`, so use the built-in
 `postgres` user with a break-glass password you mint and discard rather than
-store (guide §6):
+store (operating guide's hardening checklist):
 
 ```sh
 gcloud sql users set-password postgres --instance=ochakai --prompt-for-password
@@ -131,27 +132,33 @@ so it is downloaded even when the UI is off, where it does nothing.
 
 ## What this module does not cover
 
-Deliberately. Each is in the guide; reach for it there.
+Deliberately. Each is documented — most in the guide, hardening and
+upgrades in the [operating guide](../../docs/guides/operating.md).
 
-- **The schema bootstrap SQL** (§3) — needs a database password, see above.
-- **Loading knowledge and connecting Claude Code** (§5) — client-side, and
-  the CLI needs no configuration beyond `ochakai use`.
-- **Delegated provenance for your own application** (§5c) — the variable is
-  here (`delegating_callers`), but the application and its service account
-  are yours to deploy.
-- **Org-policy guardrails** (§6: `sql.restrictAuthorizedNetworks`,
-  `sql.restrictPublicIp`, `iam.allowedPolicyMemberDomains`) — they belong at
-  the organization level, above any one deployment, and need the Org Policy
-  Administrator role.
-- **Retiring the password admin user** (§6) — nothing to retire: this module
-  never creates one.
+- **The schema bootstrap SQL** (guide §3) — needs a database password, see
+  above.
+- **Loading knowledge and connecting Claude Code** (guide §5) —
+  client-side, and the CLI needs no configuration beyond `ochakai use`.
+- **Delegated provenance for your own application** (guide §5c) — the
+  variable is here (`delegating_callers`), but the application and its
+  service account are yours to deploy.
+- **Org-policy guardrails** (operating guide's
+  [Hardening](../../docs/guides/operating.md#hardening):
+  `sql.restrictAuthorizedNetworks`, `sql.restrictPublicIp`,
+  `iam.allowedPolicyMemberDomains`) — they belong at the organization
+  level, above any one deployment, and need the Org Policy Administrator
+  role.
+- **Retiring the password admin user** (same section) — nothing to retire:
+  this module never creates one.
 - **`--ssl-mode=ENCRYPTED_ONLY`, point-in-time recovery, Binary
-  Authorization, Cloud SQL data-access audit logs** (§6) — hardening beyond
-  the baseline, one `gcloud` command or console setting each.
-- **Upgrading an existing deployment** (§8) — change `image_tag` and apply;
-  migrations run at startup. The version notes in §8 still apply, and
-  importing an existing gcloud-built deployment into this module's state is
-  not something this module tries to make easy.
+  Authorization, Cloud SQL data-access audit logs** (same section) —
+  hardening beyond the baseline, one `gcloud` command or console setting
+  each.
+- **Upgrading an existing deployment** ([Upgrades](../../docs/guides/operating.md#upgrades))
+  — change `image_tag` and apply; migrations run at startup. The
+  version-specific notes there still apply, and importing an existing
+  gcloud-built deployment into this module's state is not something this
+  module tries to make easy.
 
 ## Teardown
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,8 +108,8 @@ The consequences to plan around:
 
 - **The service must be private.** On a public Cloud Run service the
   identity headers are self-asserted and the whole model collapses. IAM
-  enforcement is the security boundary; the [deploy
-  guide](../deploy/cloudrun/README.md) carries a hardening checklist.
+  enforcement is the security boundary; the [operating
+  guide](guides/operating.md#hardening) carries a hardening checklist.
 - **An embedding application collapses its users into one identity.** An
   app that calls ochakai with its own service account records every one
   of its users as that service account. `X-Ochakai-On-Behalf-Of` fixes

--- a/docs/guides/operating.md
+++ b/docs/guides/operating.md
@@ -1,8 +1,10 @@
 # Operating a deployment
 
-Backup and restore, what to watch, and what is known about scale. The
-Cloud Run guide builds the deployment and covers the Google-side
-troubleshooting; this page is about running the thing afterwards.
+Backup and restore, hardening beyond the default, the team web UI,
+monitoring, capacity, supply chain, and upgrades — the Cloud Run guide's
+[§1–§5](../../deploy/cloudrun/README.md) build the deployment and cover
+the Google-side troubleshooting; this page is about running the thing
+afterwards.
 
 Where a number here is not measured, it says so. That is deliberate:
 ochakai is a small project, and an invented capacity figure would be
@@ -30,13 +32,9 @@ knowledge is never a hostage.
 
 ### Cloud SQL backups
 
-The deploy guide's [§6](../../deploy/cloudrun/README.md) has the commands
-— the example instance ships with `--no-backup` to stay at ~$10/month,
-so this is a deliberate step, not a default:
-
-```sh
-gcloud sql instances patch ochakai --backup-start-time=03:00 --enable-point-in-time-recovery
-```
+The example instance ships with `--no-backup` to stay at ~$10/month, so
+enabling backups is a deliberate step, not a default — see
+[Hardening](#hardening) below for the command.
 
 Restoring is Cloud SQL's own procedure, and it restores the database
 only. **Attachment bytes are not in it**: they live in GCS as
@@ -319,18 +317,326 @@ gh attestation verify oci://ghcr.io/na0fu3y/ochakai:<tag> -R na0fu3y/ochakai
 ```
 
 Release archives for the CLI carry the same attestations, plus a
-`checksums.txt`. Binary Authorization can enforce the check at deploy time —
-the deploy guide's [§6](../../deploy/cloudrun/README.md) has that and the
-rest of the hardening checklist.
+`checksums.txt`. Binary Authorization can enforce the check at deploy time
+— see [Hardening](#hardening) below.
+
+## Hardening
+
+The default deploy guide walkthrough
+([§1–§5](../../deploy/cloudrun/README.md)) is already secret-zero and
+least-privilege — Cloud Run IAM, Google identities, explicit grants only,
+an empty authorized-networks list, provenance-attested images. The steps
+below raise the bar further; pick what matches your risk profile.
+
+### Private IP only
+
+For production-like deployments, drop the Cloud SQL public IP entirely.
+Costs nothing extra (VPC, private services access, and Cloud Run's Direct
+VPC egress are free); the trade-off is that local admin access (the
+deploy guide's §3 SQL, this section's password-retirement work below —
+§5's import is unaffected, it goes over the API) needs a temporary public
+IP or a VPC-attached workstation.
+
+One-time per VPC — allocate a peering range and connect it (if the
+Compute API was just enabled, the `addresses create` may need a minute
+before it stops returning `SERVICE_DISABLED`):
+
+```sh
+gcloud services enable servicenetworking.googleapis.com compute.googleapis.com
+gcloud compute addresses create google-managed-services-default \
+  --global --purpose=VPC_PEERING --prefix-length=16 --network=default
+gcloud services vpc-peerings connect --service=servicenetworking.googleapis.com \
+  --ranges=google-managed-services-default --network=default
+```
+
+Then create the instance with `--network=default --no-assign-ip`
+(instead of the deploy guide's §2 defaults) — or convert an existing
+one, which is the same patch and takes 15–20 minutes:
+
+```sh
+gcloud sql instances patch ochakai --network=default --no-assign-ip
+```
+
+Add Direct VPC egress to the Cloud Run service so it can reach the
+private IP (the `/cloudsql` connector socket follows automatically; the
+`OCHAKAI_DATABASE_URL` doesn't change):
+
+```sh
+gcloud run services update ochakai --region=$REGION \
+  --network=default --subnet=default
+```
+
+Local admin access no longer routes from outside the VPC. Temporarily
+attach a public IP and detach it after:
+
+```sh
+gcloud sql instances patch ochakai --assign-ip       # + cloud-sql-proxy, do the work
+gcloud sql instances patch ochakai --no-assign-ip    # afterwards
+```
+
+(If the `sql.restrictPublicIp` org policy below is enforced, the
+temporary `--assign-ip` is blocked too — lift the policy for the window
+or use a VPC-attached workstation.)
+
+### Guardrails against misconfiguration
+
+Org-policy; needs the Org Policy Administrator role. These make the risky
+states unrepresentable rather than merely avoided:
+
+```sh
+# forbid adding ANY authorized network on Cloud SQL (not just broad
+# ranges — the empty-list posture becomes unrepresentable to leave)
+gcloud resource-manager org-policies enable-enforce \
+  sql.restrictAuthorizedNetworks --project=$PROJECT_ID
+# forbid public IPs on Cloud SQL — pair with private IP only, above.
+# Existing public IPs are grandfathered: the instance keeps running and
+# unrelated patches still work; only changes to the IP configuration are
+# blocked
+gcloud resource-manager org-policies enable-enforce \
+  sql.restrictPublicIp --project=$PROJECT_ID
+```
+
+Enforcement takes a minute or two to propagate — a violating patch
+issued immediately after can still succeed. Verify the guardrail is
+live by trying one: `gcloud sql instances patch ochakai
+--authorized-networks=203.0.113.1/32` should fail with an
+`Organization Policy check failure` (and if it succeeded, you were too
+fast — `--clear-authorized-networks` and try again).
+
+Keep Domain Restricted Sharing (`iam.allowedPolicyMemberDomains`) on at
+the org level; nothing in a working deployment needs `allUsers` — every
+service, [the team web UI](#the-team-web-ui) included, stays
+`--no-allow-unauthenticated`. The deploy guide's §5d public demo is the
+one thing this policy blocks, and it is a fair trade: exempt a dedicated
+demo project if you want one, and leave the org policy alone.
+
+**Enforce TLS on direct connections** (Cloud SQL connector traffic is
+always mTLS; this covers the authorized-network path):
+
+```sh
+gcloud sql instances patch ochakai --ssl-mode=ENCRYPTED_ONLY
+```
+
+**Retire the last password.** The admin user's password is the only
+stored secret in the whole system, and it too can go: create a personal
+IAM login for maintenance, transfer the admin user's objects to it, and
+delete the password user. Future maintenance goes through
+`cloud-sql-proxy --auto-iam-authn` with your own identity.
+
+Two Postgres facts shape the sequence. Tables created by startup
+migrations are owned by the **runtime service account**, so the admin
+cannot `GRANT` on them — you inherit them via role membership instead.
+And a role that still owns objects or appears in grants cannot be
+dropped, so the admin's footprint must be reassigned and dropped first —
+which also **revokes every grant the admin ever made, breaking the
+running service until the re-grant below**. Do this in one sitting:
+
+```sh
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member=user:you@your-org.example --role=roles/cloudsql.instanceUser
+gcloud sql users create you@your-org.example --instance=ochakai --type=cloud_iam_user
+```
+
+As the admin user (`cloud-sql-proxy` + `psql`, deploy guide §3), in one
+session:
+
+```sql
+GRANT "ochakai-run@<PROJECT_ID>.iam" TO "you@your-org.example";  -- inherit runtime-owned tables, present and future
+REASSIGN OWNED BY "ochakai" TO "you@your-org.example";
+DROP OWNED BY "ochakai";  -- clears its grants; the service is degraded from here until re-granted
+GRANT USAGE, CREATE ON SCHEMA public
+  TO "ochakai-run@<PROJECT_ID>.iam", "you@your-org.example";
+```
+
+(The schema grant must come from a `cloudsqlsuperuser` member — the
+admin still qualifies; your IAM login never will.) Then as yourself
+(`cloud-sql-proxy --auto-iam-authn`, connect as `you@your-org.example`),
+re-grant the runtime on the tables you now own:
+
+```sql
+GRANT ALL ON ALL TABLES IN SCHEMA public TO "ochakai-run@<PROJECT_ID>.iam";
+GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO "ochakai-run@<PROJECT_ID>.iam";
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO "ochakai-run@<PROJECT_ID>.iam";
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO "ochakai-run@<PROJECT_ID>.iam";
+```
+
+Finally delete the password user and verify a cold start (the startup
+migration needs the schema grant — a warm instance can mask a mistake):
+
+```sh
+gcloud sql users delete ochakai --instance=ochakai
+gcloud run services update ochakai --region=$REGION --update-labels=grants=rotated  # forces a new instance
+# then deploy guide §3's proxy + curl /health
+```
+
+(URL-encode the `@` as `%40` in connection strings:
+`postgres://you%40your-org.example@localhost:55432/ochakai`.)
+
+What "secret-zero" means afterwards: the built-in `postgres` user still
+exists, and anyone with Cloud SQL admin IAM can mint it a throwaway
+password (`gcloud sql users set-password postgres ...`) for break-glass
+schema-level work — no *stored* secret remains, and admin access stays
+IAM-gated.
+
+**Backups and point-in-time recovery** — the example skips them for
+cost; real knowledge deserves them:
+
+```sh
+gcloud sql instances patch ochakai --backup-start-time=03:00 --enable-point-in-time-recovery
+```
+
+(Enabling backups means picking a start time — there is no bare
+`--backup` flag on `patch`. To turn both off again, disable PITR first:
+`--no-backup` refuses to combine with `--no-enable-point-in-time-recovery`.)
+
+**Deploy-time image gating**: releases ship SLSA provenance ([Supply
+chain](#supply-chain) above); Binary Authorization can enforce that check
+automatically on every deploy instead of relying on operator diligence.
+
+**Audit trails**: knowledge changes are fully recorded by ochakai itself
+(`knowledge_revision`, actor per change). For infrastructure-level
+trails, enable Cloud SQL Data Access audit logs in the Console — admin
+activity is logged by default.
+
+Everything above — private IP, [the team web UI](#the-team-web-ui)'s IAP
+commands, the org-policy guardrails, TLS enforcement, backups, and the
+password-retirement sequence — has been exercised end-to-end on the
+deploy guide's example deployment (2026-07, Postgres 17, gcloud 575). The
+one exception is Binary Authorization, which remains a pointer; report
+anything that doesn't work as written.
+
+## The team web UI
+
+The web UI runs as its own service, **not** inside `serve` — the core
+keeps its serving surface minimal. For personal use it needs no
+deployment at all: `ochakai ui` serves the same page on loopback with
+your own identity. Deploy this service when people who cannot run the Go
+CLI need browser access.
+
+It is the **same container image** as ochakai itself — `$IMAGE` from the
+deploy guide's §1 — started with `--args=serve-ui` instead of the default
+`serve`: a static page plus a reverse proxy that attaches its service
+identity (`X-Serverless-Authorization`) to API calls, so ochakai stays
+organization-restricted — no second image to build, and the UI is always
+the exact version of the server it fronts. The webui itself is
+non-public too: [Identity-Aware Proxy](https://cloud.google.com/iap/docs/enabling-cloud-run)
+sits in front, so browsers sign in with their Google account and only
+your organization gets through — no `allUsers` grant anywhere. By default
+writes through the UI are recorded as the webui's service account
+(`agent:ochakai-webui@…`); set `OCHAKAI_IAP_AUDIENCE` (below) to record
+the person in the browser instead. MCP and CLI clients get per-user
+identity via the deploy guide's §5 proxy path.
+
+```sh
+# dedicated identity, allowed to invoke ochakai only
+gcloud iam service-accounts create ochakai-webui
+gcloud run services add-iam-policy-binding ochakai --region=$REGION \
+  --member=serviceAccount:ochakai-webui@$PROJECT_ID.iam.gserviceaccount.com \
+  --role=roles/run.invoker
+
+# deploy non-public, with IAP in front — same $IMAGE as the deploy guide's §3.
+# (--iap needs the gcloud beta component; the iap web command below
+#  needs the Resource Manager API)
+gcloud services enable iap.googleapis.com cloudresourcemanager.googleapis.com
+gcloud beta run deploy ochakai-webui \
+  --image=$IMAGE --args=serve-ui \
+  --region=$REGION --no-allow-unauthenticated --iap \
+  --service-account=ochakai-webui@$PROJECT_ID.iam.gserviceaccount.com \
+  --min-instances=0 --max-instances=1 --cpu=1 --memory=256Mi \
+  --set-env-vars=OCHAKAI_URL=$OCHAKAI_URL
+
+# let your organization through IAP (the deploy already granted IAP's
+# service agent run.invoker on the service — "Setting IAP service agent"
+# in its output)
+gcloud beta iap web add-iam-policy-binding \
+  --resource-type=cloud-run --service=ochakai-webui --region=$REGION \
+  --member=domain:your-org.example --role=roles/iap.httpsResourceAccessor
+```
+
+Open the webui service URL: IAP presents the Google sign-in, then the
+page loads. The UI and API are same-origin through the proxy, so nothing
+else to configure. To check IAP is actually fronting the service, request
+it unauthenticated — the response is a 302 to `accounts.google.com`
+with an `x-goog-iap-generated-response: true` header, not the page.
+
+### Recording the browser user instead of the service account
+
+Out of the box every edit from the UI reads `agent:ochakai-webui@…`,
+which is one author for the whole team. To record who actually made it,
+tell serve-ui which IAP audience to trust and let ochakai accept the
+webui as a delegator (design docs 0027, 0032):
+
+**Set them in this order.** The moment serve-ui starts forwarding
+identities, ochakai answers 403 unless it already accepts this caller
+(it never downgrades silently) — so grant the delegation first, and the
+UI never sees the window in between.
+
+```sh
+# 1. ochakai must accept this caller's forwarded identities.
+gcloud run services update ochakai --region=$REGION \
+  --update-env-vars="OCHAKAI_DELEGATING_CALLERS=ochakai-webui@$PROJECT_ID.iam.gserviceaccount.com"
+
+# 2. Tell serve-ui which IAP audience to trust. It refuses to guess:
+# a wrong value would mean verifying nothing. For IAP enabled directly
+# on Cloud Run — what this section deploys — the audience is
+# /projects/PROJECT_NUMBER/locations/REGION/services/SERVICE_NAME.
+# (Behind a load balancer it is the backend service instead, and the
+# IAP console gives it: ⋮ next to the resource → "Get JWT audience code".)
+IAP_AUDIENCE="/projects/$(gcloud projects describe $PROJECT_ID --format='value(projectNumber)')/locations/$REGION/services/ochakai-webui"
+
+gcloud run services update ochakai-webui --region=$REGION \
+  --update-env-vars="OCHAKAI_IAP_AUDIENCE=$IAP_AUDIENCE"
+```
+
+The startup log says which way it went: `recording browser users by
+their IAP identity` with the audience it will require, or `no
+OCHAKAI_IAP_AUDIENCE; writes are recorded as this service account`.
+
+Writes then read `human:tanaka@example.co.jp via agent:ochakai-webui@…`
+— both identities, never just one. serve-ui verifies IAP's signature,
+audience, expiry and issuer on every request, and **refuses (403) any
+request IAP did not sign** once the audience is set: if IAP is not
+really in front of the service, you find out immediately instead of
+discovering months of writes attributed to the wrong author. The
+audience it received is logged next to the one you configured, so a
+mismatch is a one-line fix.
+
+Whether or not you set this, both proxies discard any
+`X-Ochakai-On-Behalf-Of` the browser sends — a page cannot name its own
+author (design doc 0032).
+
+Notes from exercising this end-to-end:
+
+- **Upgrading a pre-0.9.0 webui deployment** (a separately built image,
+  or one exposed with `allUsers`): the same `gcloud beta run deploy`
+  converts it in place — enabling IAP replaces the service's invoker
+  policy, so a leftover `allUsers` binding is removed automatically.
+- **Programmatic access** (curl, scripts) is limited with the
+  Google-managed OAuth client that `--iap` uses: ordinary ID tokens are
+  rejected. A service account granted `roles/iap.httpsResourceAccessor`
+  can get through with a self-signed JWT whose `aud` is the service URL
+  plus `/*` (`gcloud iam service-accounts sign-jwt`); for anything more,
+  configure IAP with a custom OAuth client. Browsers are the intended
+  clients here — MCP and CLI use the deploy guide's §5 path.
 
 ## Upgrades
 
 Migrations run automatically at startup, so an upgrade is a new image
 tag. The two things to read first are the
 [changelog](../../CHANGELOG.md) — which marks breaking changes and says
-what an operator has to do about each one — and the deploy guide's
-[§8](../../deploy/cloudrun/README.md), which has the upgrade path and the
-version-specific notes.
+what an operator has to do about each one — and the version notes below.
+
+```sh
+gcloud run services update ochakai --region=$REGION \
+  --image=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:<new-tag>
+```
+
+The Artifact Registry remote repository set up in the deploy guide's §1
+fetches new tags from GHCR on demand; verify what you got with the
+[Supply chain](#supply-chain) command above. Rolling back Cloud Run
+traffic to a previous revision does **not** roll back database
+migrations; migrations are additive, so older binaries keep working
+against a newer schema.
 
 Pin a version rather than `:latest`, so a redeploy is a decision.
 
@@ -346,3 +652,36 @@ Two upgrade-adjacent traps worth knowing here:
 - **Semantic search becoming reachable, or a changed model, does not
   backfill.** Existing concepts stay unembedded until `ochakai reembed`,
   which costs Vertex AI tokens proportional to the base.
+
+### Version notes
+
+- **→ 0.9.0 (breaking)**: the MCP OAuth connector service is retired.
+  `OCHAKAI_CONNECTOR_PUBLIC_URL` is now silently ignored — **never point
+  a connector deployment at this image**: that service was publicly
+  invokable, and this image would serve the trust-the-headers private
+  surface on it. Delete the connector service instead of upgrading it
+  (`gcloud run services delete ochakai-connector --region=$REGION`), and
+  clean up its Google OAuth client, the Secret Manager client secret,
+  and any Domain Restricted Sharing exemption. The private service is
+  unaffected; its startup migration drops the now-unused `oauth_*`
+  tables (which the private service never read, so rolling it back
+  afterwards remains safe).
+  Also removed in 0.9.0: the `DATABASE_URL` alias (use
+  `OCHAKAI_DATABASE_URL`), `OCHAKAI_ADDR` (use `PORT`), the `/healthz`
+  alias (use `/health`), the startup bytea→GCS backfill (upgrade through
+  0.8.x with `OCHAKAI_GCS_BUCKET` set if attachment bytes are still in
+  Postgres, deploy guide §4b), and OKF import of the pre-0.4 nested
+  `attrs:` frontmatter form (re-export old bundles, or lift the keys to
+  the top level — SPEC §4.1).
+- **From anything older than 0.8.0**: all pre-0.9.0 releases are
+  [retracted](https://go.dev/ref/mod#go-mod-file-retract) and their
+  per-version upgrade notes have been removed from here — recover them
+  from git history if needed
+  (`git log -- docs/guides/operating.md deploy/cloudrun/README.md`). The
+  short of it: remove pre-0.3 configuration (`OCHAKAI_CLIENTS`,
+  `OCHAKAI_AUTH`, `OCHAKAI_CORS_ORIGINS`, `OCHAKAI_EMBEDDING_PROVIDER` —
+  stale variables are silently ignored, so check they are unset), adopt
+  the deploy guide's §3 posture (`--no-allow-unauthenticated` + IAM
+  invoker grants, identity headers, passwordless database), step through
+  **0.8.x** for the attachment backfill if applicable (deploy guide
+  §4b), then land on 0.9.0 with the note above.

--- a/docs/loop.md
+++ b/docs/loop.md
@@ -69,7 +69,7 @@ Same page, two identities: `ochakai ui` serves it on loopback acting as *you*
 (zero deploy, edits recorded as `human:<you>`), and `ochakai serve-ui`
 deploys it as a team-shared service — same container image as the server,
 just `--args=serve-ui`
-([deploy guide §5b](../deploy/cloudrun/README.md)).
+([operating guide](guides/operating.md#the-team-web-ui)).
 
 ## Three feeds, and finishing them
 

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -81,7 +81,7 @@ ochakai を使う人が払うのは実装の行数ではなく**表面**であ�
 - ENV: 15
 - VOCAB: 36
 - DOC: 25
-- DOC-LINES: 5760
+- DOC-LINES: 5790
 
 `-LINES` で終わる一行だけは、一覧ではなく**量**に天井を置いている。
 `DOC` はページ数を数えるが、ページは太らせても名前が増えないので、
@@ -466,9 +466,15 @@ MCP ツール 5 本を改名したが、本数は 8 のままで、**変わっ�
 
 ページは利用者が払うものである。README は 20 以上の文書へ送り出し、
 デプロイする人は
-[deploy/cloudrun/README.md](../deploy/cloudrun/README.md) の 983 行を
+[deploy/cloudrun/README.md](../deploy/cloudrun/README.md) の 665 行を
 通る。No FDE(C4)がドキュメントを正当化するが、C4 が求めるのは
 **自分で立ち上げられること**であって行数ではない。
+
+**そこは 2026-07 まで 983 行だった**([#355](https://github.com/na0fu3y/ochakai/issues/355))。
+private IP・team web UI・hardening checklist・upgrade path の全文を
+[docs/guides/operating.md](guides/operating.md) に移し、短い参照だけを
+残した。ページは増えず(`DOC` は 25 のまま) — 総行数への効果は下の
+天井の節にある。
 
 **そしてここは、どの次元より速く増えてきた。** v0.10.0 から現在まで、
 REST は 19 → 11 に減り、非テストの Go は 2.3 倍になり、この 25 ページは
@@ -485,13 +491,15 @@ REST は 19 → 11 に減り、非テストの Go は 2.3 倍になり、この 
 置いた(上限の節の `DOC-LINES`)。0059 のキュー改名がこの文書に段落を
 足したとき、動いた数は一つも無かった。
 
-**この天井は、置いた次の PR で一度上がっている。**
+**この天井は、置いた後に二度上がっている。**
 [0062](design/0062-a-listing-is-not-a-search.md) が `ochakai search` を
 二つに割ったとき、[cli.md](cli.md) は 9 つのフィルタを二度書くことに
 なった — コマンドを割るのは**参照文の重複を買う**という、それまでどこ
 にも出ていなかった代金である。5,700 → 5,760。仕組みが狙っていたのは
 まさにこれで、畳み込みの PR が散文を増やしていたことが、初めて数として
-出た。
+出た。[#355](https://github.com/na0fu3y/ochakai/issues/355) の
+deploy/cloudrun/README.md 分割は逆方向でも同じ代金を払った — 5,760 →
+5,790。
 
 数えないものを決めるのは、数えるものを決めるのと同じだけ決定である。
 


### PR DESCRIPTION
<!-- Keep PRs small and focused. Link the issue or design doc, if there is one. -->

Closes #355.

## What and why

`deploy/cloudrun/README.md` was 983 lines — 17% of the manual and by far
its longest page, the guide standing between a reader and a running
deployment. #355 asked to pick one of three treatments deliberately:
shorten, split into two pages, or keep it and say why.

This takes the "shorten" option, following the shape #355 itself
proposed: §2b (private IP), §5b (IAP-fronted web UI), §6 (security
hardening checklist), and §8's version-specific upgrade notes move to
`docs/guides/operating.md` — which already owned "running a deployment"
— and become short pointer stubs in the deploy guide. The golden path
(§1-§5, plus the optional §5c delegated-provenance and §5d public-demo
postures, and §9 teardown) stays where it is. Result:
`deploy/cloudrun/README.md` goes from 983 to 665 lines (-32%).

Nobody actually got stuck reading this before — #355 raised it as a
documented, deliberate cost against C4 (no forward-deployed engineer),
which asks for self-sufficiency, not line count. No existing surface
covered this (it's a doc-organization fix, not a feature). What's folded
away: the deploy guide, which every new deployer has to read start to
finish before they can decide whether to also read the hardening,
web-UI, or upgrade material.

`docs/guides/operating.md` gains `## Hardening` and `## The team web UI`
sections and an expanded `## Upgrades` (with the version-specific
notes). The backup-command duplication between the two pages is
deduped. Cross-references that pointed at content which moved are
updated: `docs/architecture.md`, `docs/loop.md`,
`deploy/terraform/README.md`, `cmd/ochakai/serveui.go`. Section anchors
(§2b, §5b, §6, §8) are kept as valid stubs rather than renumbered, so
the many other live and historical `§N` references across the repo
don't need a coordinated rename.

**Honest cost, disclosed rather than hidden**: relocating ~550 lines
without deleting any of it still costs lines — new headers and framing
at the new location, the same lesson `docs/surface.md` already draws
from 0062's CLI-filter split. Net effect: +26 lines, taking the manual
from 5,734 to 5,763 against a `DOC-LINES` cap of 5,760 that had zero
headroom left to absorb it. This PR raises the cap to 5,790 in the same
PR, narrated inline in `docs/surface.md`'s DOC section the same way
0062's bump is. `DOC` itself stays at 25 — no new page.

Worth flagging for the next PR: this used up headroom rather than
freeing it. #352 (deduping the CLI filter docs) is still open and would
actually shrink the total back down.

## Checks

- [x] `scripts/check core` is clean (gofmt, vet, race tests, build).
      `--db` not needed — no store-touching change.
- [x] No behavior change; nothing to test beyond the doc/build checks

## Surfaces and contract

- [ ] N/A — no REST/MCP/CLI/API surface touched
- [ ] N/A
- [x] Doc-only reorganization, not a surface widening — `DOC` count is
      unchanged (25); `DOC-LINES` cap raise is disclosed above and inline
      in `docs/surface.md`, and `cmd/ochakai/surface_test.go` passes

## Design docs

- [ ] N/A — nothing about an accepted decision changed; this reorganizes
      where existing, unchanged content lives
- [x] Commit messages and code comments are in English