### PR TITLE
Prepare release v0.17.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Version
       description: Output of `ochakai version`, or the image tag you deployed.
-      placeholder: "0.16.1"
+      placeholder: "0.17.0"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ last entry.
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-07-31
+
 ### Added
 
 - **BREAKING** — a listing is not a search, so it is not the same command
@@ -2315,7 +2317,8 @@ worth naming: SQL injection in `compile_sql` through undeclared field
 pass-through, fixed in 0.8.0 — v0.7.0 and earlier are affected. Details
 are in git history.
 
-[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.16.1...HEAD
+[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.17.0...HEAD
+[0.17.0]: https://github.com/na0fu3y/ochakai/compare/v0.16.1...v0.17.0
 [0.16.1]: https://github.com/na0fu3y/ochakai/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/na0fu3y/ochakai/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/na0fu3y/ochakai/compare/v0.14.0...v0.15.0

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -31,7 +31,7 @@ info:
     Every interface is unstable while the major version is 0
     (docs/compatibility.md): a removal arrives in a minor release with a
     changelog entry, not after a deprecation window.
-  version: 0.16.1
+  version: 0.17.0
   license:
     name: MIT
 servers:


### PR DESCRIPTION
## Summary

- Move the `CHANGELOG.md` `[Unreleased]` entries under `[0.17.0] - 2026-07-31`, add a fresh empty `Unreleased` section, and add the compare link.
- Bump `api/openapi.yaml`'s `info.version` to `0.17.0`.
- Bump the version placeholder in `.github/ISSUE_TEMPLATE/bug_report.yml` to `0.17.0`.

Minor bump (not patch): the unreleased section carries several **BREAKING** entries accumulated since v0.16.1 (`list`/`search` split, `OCHAKAI_MODE`, queue renames, dropped `min_score`/MCP `fm`, CLI command folds, `concept` renamed everywhere, dry-run rework, and the type-vocabulary trim).

## Test plan

- [x] `scripts/check`