### PR TITLE
Fix stale CLI command names, actor spelling, and versions in the manual

### DIFF
--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -58,7 +58,7 @@ export IMAGE=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:$VERSION
 Pin a version rather than `:latest`, so a redeploy is a decision. Without
 the `gh` CLI, read the number off the
 [releases page](https://github.com/na0fu3y/ochakai/releases) and set it by
-hand — `export VERSION=0.14.0`.
+hand — `export VERSION=0.17.0`.
 
 (This guide assumes 0.9.0 or later; earlier releases are
 [retracted](https://go.dev/ref/mod#go-mod-file-retract) and unsupported —
@@ -197,7 +197,7 @@ How this works:
   authorization: whoever reaches it reads and writes.
 - **ochakai reads the Cloud-Run-verified caller identity for provenance**:
   people are recorded as `human:<email>`, service accounts as
-  `agent:<sa-email>`. Nothing to issue, rotate, or revoke.
+  `process:<sa-email>`. Nothing to issue, rotate, or revoke.
 - **Never make the service publicly invokable (`allUsers`)** — the
   identity headers ochakai reads are only trustworthy behind Cloud Run's
   IAM check. The single exception is a deployment that reads no identity
@@ -365,7 +365,8 @@ network is needed — `$OCHAKAI_URL` was exported when the service was
 deployed above:
 
 ```sh
-go run github.com/na0fu3y/ochakai/cmd/ochakai@latest create queries/monthly-revenue -f examples/golden-query.md
+curl -fsSL "https://raw.githubusercontent.com/na0fu3y/ochakai/v$VERSION/examples/golden-query.md" | \
+  go run github.com/na0fu3y/ochakai/cmd/ochakai@latest put queries/monthly-revenue
 ```
 
 Connect Claude Code — with the Cloud Run proxy running, no headers, no
@@ -403,7 +404,7 @@ is most of what ochakai sells, collapses.
 
 Let the application forward the identity of the person using it
 (design doc 0027). Both identities are recorded — `human:tanaka@…
-via agent:app-sa@…` — never just the forwarded one, so a write made
+via process:app-sa@…` — never just the forwarded one, so a write made
 through the application stays distinguishable from one the person made
 directly.
 
@@ -425,7 +426,7 @@ The application then sends the header with each request:
 X-Ochakai-On-Behalf-Of: human:tanaka@example.co.jp
 ```
 
-The kind (`human:` / `agent:`) is required and never guessed — the
+The kind (`human:` / `process:`) is required and never guessed — the
 application knows whether it is forwarding a person or another agent.
 
 Notes:

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -5,7 +5,7 @@ region     = "us-central1"
 
 # Pin a released version, not "latest", so a redeploy is a decision:
 # https://github.com/na0fu3y/ochakai/releases
-image_tag = "0.13.0"
+image_tag = "0.17.0"
 
 # Who can reach ochakai. This is the whole access-control surface — whoever
 # reaches it can read and write everything. Never allUsers.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -77,7 +77,7 @@ This is not authorization — a human on the same deployment can edit
 anything from REST, the CLI or the web UI. It is a surface rule: MCP has
 no way to carry the `If-Match` precondition that makes a safe replacement
 expressible (design docs 0015 §3.1, 0030). Reviving a curated concept's
-tombstone with `create` is refused on MCP for the same reason: it would
+tombstone with `put_concept` is refused on MCP for the same reason: it would
 put a fresh draft where a rejection's recorded reason used to be. On REST
 and the CLI that revival is allowed — those are the surfaces a human
 curates from.

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -66,20 +66,20 @@ response, use `budget` rather than a score floor.
 
 ## Writing concepts
 
-**409 on create.** A live concept already has that id — including a
-`rejected` one. Use `update`, or pick another id. Creating over a
-*soft-deleted* concept revives it, with its prior history intact; over MCP,
-reviving one that was verified, rejected or deprecated before deletion is
-refused instead, because it would put a fresh draft where a recorded
-ruling used to be. REST and the CLI allow that revival: they are the
-surfaces a human curates from.
+**409 on `put --only-if-new`.** A live concept already has that id —
+including a `rejected` one. Drop `--only-if-new`, or pick another id.
+Writing over a *soft-deleted* concept revives it, with its prior history
+intact; over MCP, reviving one that was verified, rejected or deprecated
+before deletion is refused instead, because it would put a fresh draft
+where a recorded ruling used to be. REST and the CLI allow that revival:
+they are the surfaces a human curates from.
 
-**404 on update.** `update` replaces a concept that exists; it does not
-create one.
+**404 on `put --if-match`.** `--if-match` replaces a concept that exists;
+it does not create one.
 
-**412 on update.** The `If-Match` you sent is not the concept's current
-`ETag` — somebody wrote in between. Re-read the concept, reapply your change
-and retry. Nothing was written.
+**412 on `put --if-match`.** The `If-Match` you sent is not the concept's
+current `ETag` — somebody wrote in between. Re-read the concept, reapply
+your change and retry. Nothing was written.
 
 **`invalid type "…"`.** A type is one line, no `/`, up to 128 bytes. Any
 value that fits is legal — the recommended vocabulary is a recommendation,


### PR DESCRIPTION
## Summary
- `create`/`update` were folded into `put` by 0056, but `deploy/cloudrun/README.md`, `docs/guides/troubleshooting.md`, and `docs/faq.md` still taught the removed command names — `cmd/ochakai/client.go:34` only registers `put`, so a reader following the guide hits `unknown command`.
- 0.15 renamed the `agent:` actor kind to `process:` (`internal/httpauth/httpauth.go:228`); `deploy/cloudrun/README.md` was the one page still teaching the rejected spelling, which the server answers with a 400.
- Repoints the two stale pinned versions (`0.13.0` tfvars example, `0.14.0` README hand-set fallback) at the current `0.17.0` release.
- The README's first `put` example used `-f examples/golden-query.md`, a path that only resolves after a `git clone` — but §5 never asks for one (only §5d's demo seeding does). Fetches the example over HTTP into stdin instead, so the guide stays clone-free through §5.

## Test plan
- [x] `scripts/check core` (gofmt, go vet, go test -race, build) passes
- [x] Verified `put`'s flags (`--only-if-new`, `--if-match`) and their REST status codes (409/404/412) against `cmd/ochakai/client.go` and `internal/restapi/restapi.go` before rewriting the troubleshooting entries
- [x] Verified `process:` is the accepted actor kind in `internal/httpauth/httpauth.go`
- [x] Verified `put_concept` is the MCP tool name in `internal/mcpserver/mcpserver.go`
- [x] Confirmed `0.17.0` is the current release tag

Fixes #363.

🤖 Generated with [Claude Code](https://claude.com/claude-code)