### PR TITLE
Make Claude Code's connect path consistent across docs

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "ochakai": {
       "type": "http",
-      "url": "http://localhost:8787/mcp"
+      "url": "http://localhost:8080/mcp"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -63,7 +63,11 @@ ochakai verify metrics/revenue      # promotes a draft; re-affirms a verified co
 ochakai ui                          # web UI at http://127.0.0.1:8098, acting as you
 ```
 
-Auth is `gcloud login` / ADC — there are no tokens to configure. Every
+Auth is `gcloud auth login` — there are no tokens to configure. (A
+service account's ADC works too; your own `gcloud auth
+application-default login` does not, because Cloud Run needs an
+audience-bound ID token that only those two can mint — [why, and what to
+run instead](docs/guides/mcp-clients.md#what-the-bridge-needs).) Every
 command carries its flags and worked examples in `ochakai <command> -h`;
 [docs/cli.md](docs/cli.md) is that same text rendered, for reading before
 you install anything.

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -368,18 +368,27 @@ deployed above:
 go run github.com/na0fu3y/ochakai/cmd/ochakai@latest create queries/monthly-revenue -f examples/golden-query.md
 ```
 
-Connect Claude Code — with the Cloud Run proxy running, no headers, no
-tokens (this repository's committed `.mcp.json` does the same
-automatically when you open the repo in Claude Code):
+Point Claude Code — or any agent with a shell — at the same URL; the CLI
+run above already proved it resolves tokens with no proxy needed. This is
+the recommended way in, per the README's
+[Connect an agent](../../README.md#connect-an-agent):
+
+```sh
+go install github.com/na0fu3y/ochakai/cmd/ochakai@latest
+ochakai use $OCHAKAI_URL
+```
+
+If you want MCP tools inside Claude Code instead, the bridge needs no
+proxy either — `claude mcp add ochakai -- ochakai mcp-stdio` (needs
+`gcloud auth login` and `ochakai` on `PATH`; see [connecting an MCP
+client](../../docs/guides/mcp-clients.md#what-the-bridge-needs)).
+
+Smoke test over REST through the [Cloud Run
+proxy](https://cloud.google.com/sdk/gcloud/reference/run/services/proxy),
+same as §3 (direct `curl` is blocked by IAM):
 
 ```sh
 gcloud run services proxy ochakai --region=$REGION --port=8787 &
-claude mcp add --transport http ochakai http://localhost:8787/mcp
-```
-
-Smoke test over REST (through the proxy, also tokenless):
-
-```sh
 curl "http://localhost:8787/api/v1/search?q=revenue"
 ```
 

--- a/docs/guides/mcp-clients.md
+++ b/docs/guides/mcp-clients.md
@@ -21,7 +21,7 @@ bridge** — which has prerequisites of its own, listed
 
 | Client | Local `docker compose` | Cloud Run | Config lives in |
 |---|---|---|---|
-| [Claude Code](#claude-code) | URL | bridge | `.mcp.json`, or `claude mcp add` |
+| [Claude Code](#claude-code)* | URL | bridge | `.mcp.json`, or `claude mcp add` |
 | [Claude Desktop](#claude-desktop) | bridge | bridge | `claude_desktop_config.json` |
 | [Cursor](#cursor) | URL | bridge | `~/.cursor/mcp.json` or `.cursor/mcp.json` |
 | [VS Code](#vs-code) | URL | bridge | `.vscode/mcp.json` |
@@ -33,6 +33,10 @@ bridge** — which has prerequisites of its own, listed
 
 The local URL below is `http://localhost:8080/mcp`, which is what
 `deploy/compose.yaml` gives you.
+
+\* Claude Code is the one exception to this table: it also has a shell,
+and the [recommended path there is the CLI](#claude-code), not MCP at
+all.
 
 Claude Code and the bridge are what this project exercises. The rest is
 transcribed from each client's own documentation as of July 2026 and
@@ -88,6 +92,10 @@ is present on a machine by default:
 - **`gcloud auth login` having happened**, as a principal holding
   `roles/run.invoker` on the service.
 
+The CLI resolves the same token the same way when you point it straight
+at a Cloud Run URL (`ochakai use https://your-service.run.app`) — this
+list is really what reaching Cloud Run needs, bridge or not.
+
 "The client is configured with no credentials" is a claim about the
 config file, not about the machine. The credential exists; it lives in
 your gcloud session instead of in JSON, which is what keeps it out of
@@ -103,13 +111,21 @@ token at all.
 
 ## Claude Code
 
+**Recommended: the CLI, not MCP.** Claude Code has a shell, so the CLI's
+tool schemas cost the agent no context — `--help` is read on demand —
+and against Cloud Run it needs no proxy or bridge process, because it
+resolves the ID token itself. See the README's
+[Connect an agent](../../README.md#connect-an-agent).
+
+### If you want MCP tools instead
+
 Against a local server:
 
 ```sh
 claude mcp add --transport http ochakai http://localhost:8080/mcp
 ```
 
-Against Cloud Run:
+Against Cloud Run, the bridge:
 
 ```sh
 claude mcp add ochakai -- ochakai mcp-stdio
@@ -117,13 +133,9 @@ claude mcp add ochakai -- ochakai mcp-stdio
 
 `-s user` puts it in your user config instead of the project's; the
 default scope is local to the project directory. `-s project` writes
-`.mcp.json`, which is the committed form — this repository has one, and
-opening it in Claude Code connects automatically.
-
-Claude Code also has a shell, which is the other way in and often the
-better one: the CLI's tool schemas cost the agent no context, because
-`--help` is read on demand. See the README's
-[Connect an agent](../../README.md#connect-an-agent).
+`.mcp.json`, which is the committed form — this repository's own
+`.mcp.json` targets its local `docker compose` server and connects
+automatically once that's running.
 
 ## Claude Desktop
 
@@ -309,8 +321,10 @@ and exposes `/mcp` alongside the web UI, bound to loopback:
 ochakai ui        # http://127.0.0.1:8098/mcp
 ```
 
-`gcloud run services proxy` is the third way, and it is the one the
-deploy guide's [§5](../../deploy/cloudrun/README.md) documents.
+`gcloud run services proxy` is the third way — a plain HTTP tunnel with
+no MCP-specific behavior. The deploy guide uses it for verifying a
+deployment over `curl` ([§3](../../deploy/cloudrun/README.md)), not for
+connecting a client; prefer the bridge or `ochakai ui` above for that.
 
 ## Clients that cannot reach your deployment
 


### PR DESCRIPTION
Fixes #370.

Three files gave three different answers for how a Claude Code user reaches ochakai:

- `README.md` recommends the CLI for Claude Code.
- `docs/guides/mcp-clients.md` documented Claude Code's MCP config first, only mentioning the CLI as an aside afterward.
- `deploy/cloudrun/README.md` §5 told Cloud Run users to open a `gcloud run services proxy` and add an MCP URL — a third path, distinct from both the CLI and the `ochakai mcp-stdio` bridge that `mcp-clients.md` recommends for Cloud Run.
- The committed `.mcp.json` quietly assumed the proxy (port 8787), which doesn't even match this project's own local `docker compose` default (8080) — so opening the repo in Claude Code during local development didn't actually auto-connect.

There was also a quieter trap: README's "Auth is `gcloud login` / ADC" reads as if either is sufficient, but a personal `gcloud auth application-default login` cannot mint the audience-bound ID token Cloud Run wants — only `gcloud auth login` or a service account's ADC can. A reader who sets up ADC alone and skips the login hits "the server has no tools" with nothing explaining why.

## Changes

- **README.md** — reworded the auth line to say what actually works, and links to the explanation in `mcp-clients.md`.
- **docs/guides/mcp-clients.md** — the Claude Code section now leads with "recommended: the CLI, not MCP," and the URL/bridge configs move under "if you want MCP tools instead." Noted that the CLI resolves Cloud Run identity the same way the bridge does, not just the bridge. Updated the "URL that works against Cloud Run" section's reference to the deploy guide, since §5 no longer documents the proxy as an MCP connection method.
- **deploy/cloudrun/README.md §5** — Claude Code now points at the CLI first (matching the README), with the bridge as a secondary MCP option; the `gcloud run services proxy` example stays only for the REST smoke test, consistent with how §3 already uses it.
- **.mcp.json** — points at `localhost:8080` (the `docker compose` default) instead of `localhost:8787` (a Cloud Run proxy port nothing in local dev runs), so opening this repo in Claude Code actually connects during local development.

One recommended path per client scenario now; the other transports are demoted to short "when you need this instead" notes, per 0015 §3.1 (MCP's default is no, CLI is the completeness surface).

## Test plan

- [x] `scripts/check core` passes
- [x] Manually re-read all four changed files for cross-reference consistency (line numbers, anchors, §5/§3 references)

🤖 Generated with [Claude Code](https://claude.com/claude-code)