### PR TITLE
Make the reembed cursor opaque, versioned and base64url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,19 @@ last entry.
 
 ## [Unreleased]
 
+### Fixed
+
+- **BREAKING** — `POST /api/v1/reembed`'s `cursor` is now opaque, versioned
+  and base64url-encoded, the same shape a listing's `cursor` has had since
+  design doc [0050](docs/design/0050-listings-page-rankings-do-not.md). It
+  used to be the last concept id and attachment name joined with a raw NUL
+  byte and handed back unencoded — a hazard through proxies and WAFs, not
+  URL-safe on its own, and published as an example in `api/openapi.yaml`
+  right after the same paragraph called it opaque. A cursor from a pass
+  running when this deploys is invalid after the upgrade; a reembed pass
+  is minutes long and restartable, so resuming means starting the pass
+  over, not losing work.
+
 ## [0.17.0] - 2026-07-31
 
 ### Added

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1830,7 +1830,7 @@ paths:
                     attachments: 0
                     failed: 0
                     missing: 613
-                    cursor: "metrics/revenue\u0000"
+                    cursor: "MQByZWVtYmVkAG1ldHJpY3MvcmV2ZW51ZQAA"
                 done:
                   summary: The last pass
                   description: Nothing is missing, so no cursor comes back.

--- a/internal/service/embed.go
+++ b/internal/service/embed.go
@@ -6,6 +6,7 @@ package service
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"strings"
@@ -103,7 +104,10 @@ func (s *Service) Reembed(ctx context.Context, cursor string, limit int) (*Reemb
 	if limit <= 0 || limit > maxReembedPass {
 		limit = defaultReembedPass
 	}
-	entryCursor, attachCursor := splitReembedCursor(cursor)
+	entryCursor, attachID, attachName, err := decodeReembedCursor(cursor)
+	if err != nil {
+		return nil, err
+	}
 	ids, err := s.Store.ListUnembedded(ctx, s.Embedder.Model(), entryCursor, limit)
 	if err != nil {
 		return nil, err
@@ -138,7 +142,7 @@ func (s *Service) Reembed(ctx context.Context, cursor string, limit int) (*Reemb
 	// first and attachments fill the rest of the pass, so a corpus with
 	// both makes progress on both.
 	if rest := limit - len(ids); rest > 0 {
-		attachCursor, err = s.reembedAttachments(ctx, res, attachCursor, rest)
+		attachID, attachName, err = s.reembedAttachments(ctx, res, attachID, attachName, rest)
 		if err != nil {
 			return nil, err
 		}
@@ -160,19 +164,18 @@ func (s *Service) Reembed(ctx context.Context, cursor string, limit int) (*Reemb
 	}
 	res.Missing = missing + attMissing
 	if res.Missing > 0 {
-		res.Cursor = joinReembedCursor(entryCursor, attachCursor)
+		res.Cursor = encodeReembedCursor(entryCursor, attachID, attachName)
 	}
 	return res, nil
 }
 
 // reembedAttachments re-embeds up to limit attachments, returning the
-// cursor to resume from. Failures are counted like concept failures: a
+// position to resume from. Failures are counted like concept failures: a
 // file the provider rejects must not strand the rest.
-func (s *Service) reembedAttachments(ctx context.Context, res *ReembedResult, cursor string, limit int) (string, error) {
-	afterID, afterName := splitReembedCursor(cursor)
+func (s *Service) reembedAttachments(ctx context.Context, res *ReembedResult, afterID, afterName string, limit int) (string, string, error) {
 	pending, err := s.Store.ListUnembeddedAttachments(ctx, s.Embedder.Model(), afterID, afterName, limit)
 	if err != nil {
-		return cursor, err
+		return afterID, afterName, err
 	}
 	for _, a := range pending {
 		att, data, err := s.Store.GetAttachment(ctx, a.KnowledgeID, a.Name)
@@ -193,7 +196,7 @@ func (s *Service) reembedAttachments(ctx context.Context, res *ReembedResult, cu
 		}
 		afterID, afterName = a.KnowledgeID, a.Name
 	}
-	return joinReembedCursor(afterID, afterName), nil
+	return afterID, afterName, nil
 }
 
 // attachmentVectorCount reports whether a current-model vector exists,
@@ -207,20 +210,44 @@ func (s *Service) attachmentVectorCount(ctx context.Context, id, name string) in
 	return n
 }
 
-// The reembed cursor carries two positions — concepts and attachments —
-// in one opaque string, so the wire stays a single token the CLI can
-// hand back unchanged. "\x00" cannot occur in an id (design doc 0017)
-// or an attachment name.
-func joinReembedCursor(a, b string) string {
-	if a == "" && b == "" {
+// reembedCursorTag marks a cursor as belonging to the reembed pass rather
+// than to a listing (internal/service/cursor.go) — both share cursorVersion
+// as their first field, so without a second discriminator a listing cursor
+// with one ordering key and a reembed cursor decode to the same field
+// count and one would silently be accepted as the other.
+const reembedCursorTag = "reembed"
+
+// The reembed cursor carries three positions — the last concept id and
+// the last attachment's (concept id, name) — packed and base64url-encoded
+// the same way encodeCursor packs a listing position: a version prefix so
+// a later change of shape is a 400 with a sentence, and an opaque token
+// rather than raw ids so the wire survives proxies and WAFs that balk at
+// a NUL byte and needs no client-side encoding to round-trip. "\x00"
+// cannot occur in an id (design doc 0017) or an attachment name.
+func encodeReembedCursor(entryID, attachID, attachName string) string {
+	if entryID == "" && attachID == "" && attachName == "" {
 		return ""
 	}
-	return a + "\x00" + b
+	raw := strings.Join([]string{cursorVersion, reembedCursorTag, entryID, attachID, attachName}, "\x00")
+	return base64.RawURLEncoding.EncodeToString([]byte(raw))
 }
 
-func splitReembedCursor(c string) (string, string) {
-	a, b, _ := strings.Cut(c, "\x00")
-	return a, b
+// decodeReembedCursor reads a cursor back, refusing anything this server
+// did not hand out — including a cursor from a listing's own cursor
+// space, which carries a different tag in the same position.
+func decodeReembedCursor(c string) (entryID, attachID, attachName string, err error) {
+	if c == "" {
+		return "", "", "", nil
+	}
+	raw, decErr := base64.RawURLEncoding.DecodeString(c)
+	if decErr != nil {
+		return "", "", "", malformedCursor()
+	}
+	parts := strings.Split(string(raw), "\x00")
+	if len(parts) != 5 || parts[0] != cursorVersion || parts[1] != reembedCursorTag {
+		return "", "", "", malformedCursor()
+	}
+	return parts[2], parts[3], parts[4], nil
 }
 
 // embedDocument embeds text, halving it and retrying while the model says

--- a/internal/service/embed_test.go
+++ b/internal/service/embed_test.go
@@ -1,0 +1,63 @@
+package service
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// A reembed cursor is opaque like a listing cursor (issue #366): it must
+// round-trip its three positions, refuse anything not base64url, and
+// refuse a listing's own cursor rather than silently misreading it as a
+// reembed position.
+func TestReembedCursorRoundTrip(t *testing.T) {
+	for _, tc := range []struct {
+		name                          string
+		entryID, attachID, attachName string
+	}{
+		{name: "concepts only", entryID: "metrics/revenue", attachID: "", attachName: ""},
+		{name: "concepts and attachments", entryID: "metrics/revenue", attachID: "insights/q3", attachName: "report.pdf"},
+		// A NUL cannot occur in either field (design doc 0017), but the
+		// separator character itself and other punctuation must survive.
+		{name: "punctuation", entryID: "a/b?c+d", attachID: "x/y", attachName: "name with spaces.txt"},
+	} {
+		enc := encodeReembedCursor(tc.entryID, tc.attachID, tc.attachName)
+		gotEntry, gotAttachID, gotAttachName, err := decodeReembedCursor(enc)
+		if err != nil {
+			t.Fatalf("%s: %v", tc.name, err)
+		}
+		if gotEntry != tc.entryID || gotAttachID != tc.attachID || gotAttachName != tc.attachName {
+			t.Errorf("%s: got (%q, %q, %q), want (%q, %q, %q)",
+				tc.name, gotEntry, gotAttachID, gotAttachName, tc.entryID, tc.attachID, tc.attachName)
+		}
+	}
+}
+
+// The empty cursor is the first pass, not a malformed one — Reembed with
+// no cursor argument must decode cleanly.
+func TestReembedCursorEmpty(t *testing.T) {
+	entry, attachID, attachName, err := decodeReembedCursor("")
+	if err != nil || entry != "" || attachID != "" || attachName != "" {
+		t.Errorf("empty cursor: got (%q, %q, %q, %v), want the first pass", entry, attachID, attachName, err)
+	}
+}
+
+func TestReembedCursorRefusals(t *testing.T) {
+	var inputErr *InvalidInputError
+	listingCursor := encodeCursor("usage", []*string{ptr("74"), ptr("2026-07-14T02:33:41Z")}, "insights/seasonality")
+
+	for _, tc := range []struct {
+		name, cursor string
+	}{
+		{name: "not base64", cursor: "not a cursor!"},
+		{name: "a listing's own cursor", cursor: listingCursor},
+		{name: "wrong field count", cursor: encodeRaw("1", "reembed", "metrics/revenue")},
+		{name: "another version", cursor: encodeRaw("9", "reembed", "metrics/revenue", "", "")},
+		{name: "missing the reembed tag", cursor: encodeRaw("1", "metrics/revenue", "", "")},
+	} {
+		_, _, _, err := decodeReembedCursor(tc.cursor)
+		if !errors.As(err, &inputErr) || !strings.Contains(err.Error(), "not one this server handed out") {
+			t.Errorf("%s: got %v, want an InvalidInputError saying the cursor is not one this server handed out", tc.name, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #366.

- `reembed`'s cursor used to be the last concept id and attachment name joined with a raw NUL byte and handed back unencoded — a hazard through proxies and WAFs, not URL-safe on its own, and published as an `openapi.yaml` example six lines after telling the caller the cursor is opaque.
- `internal/service/embed.go`'s `joinReembedCursor`/`splitReembedCursor` are replaced with `encodeReembedCursor`/`decodeReembedCursor`, which reuse `cursorVersion` and `malformedCursor` from `internal/service/cursor.go` and base64url-encode the packed fields, the same shape search/listing cursors have had since design doc 0050.
- Added a `"reembed"` tag as a second field so a listing's own cursor (or any other malformed input) is refused with the same "not one this server handed out" error, rather than silently misread.
- Updated the `api/openapi.yaml` example to a real opaque token.
- Added a changelog entry under `Unreleased` marked **BREAKING**: an in-flight reembed cursor is invalidated by the upgrade, which is acceptable since a pass is minutes long and restartable.

## Test plan

- [x] `scripts/check --db core` (gofmt, go vet, `go test -race` including the Postgres-backed integration tests, `CGO_ENABLED=0 go build`)
- [x] `scripts/check lint` (golangci-lint, 0 issues)
- [x] New unit tests `TestReembedCursorRoundTrip`, `TestReembedCursorEmpty`, `TestReembedCursorRefusals` in `internal/service/embed_test.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)