### PR TITLE
Keep every REST error response inside the documented JSON envelope

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -416,6 +416,7 @@ paths:
                   value:
                     error: cursor belongs to the usage listing; it cannot resume the failed one
         "403": { $ref: "#/components/responses/Forbidden" }
+        "500": { $ref: "#/components/responses/Error" }
   /api/v1/bundle/{path}:
     get:
       operationId: getBundleFile
@@ -731,6 +732,7 @@ paths:
                   error: { type: string }
               example:
                 error: no object at this path
+        "500": { $ref: "#/components/responses/Error" }
     put:
       operationId: putBundleFile
       summary: Write one object of the bundle
@@ -836,6 +838,7 @@ paths:
                   error: { type: string }
               example:
                 error: index.md is generated from the bundle, not stored in it (design doc 0046 §§3.7-3.8)
+        "500": { $ref: "#/components/responses/Error" }
     delete:
       operationId: deleteBundleFile
       summary: Delete one object of the bundle
@@ -887,6 +890,7 @@ paths:
                 type: object
                 properties:
                   error: { type: string }
+        "500": { $ref: "#/components/responses/Error" }
   /api/v1/context:
     get:
       operationId: getContext
@@ -1189,6 +1193,7 @@ paths:
                     truncated: 1
         "400": { $ref: "#/components/responses/Error" }
         "403": { $ref: "#/components/responses/Forbidden" }
+        "500": { $ref: "#/components/responses/Error" }
   /api/v1/move:
     post:
       operationId: moveKnowledge
@@ -1299,6 +1304,7 @@ paths:
         "403": { $ref: "#/components/responses/Forbidden" }
         "404": { $ref: "#/components/responses/Error" }
         "409": { $ref: "#/components/responses/Error" }
+        "500": { $ref: "#/components/responses/Error" }
   /api/v1/review/{id}:
     parameters:
       - name: id
@@ -1536,6 +1542,7 @@ paths:
                     error: 'a verification carries no note: "verified" says the concept is right as it stands, and anything to say about it belongs in the concept. Use ruling=rejected to record a reason'
         "403": { $ref: "#/components/responses/Forbidden" }
         "404": { $ref: "#/components/responses/Error" }
+        "500": { $ref: "#/components/responses/Error" }
   /api/v1/usage/{id}:
     parameters:
       - name: id
@@ -1575,6 +1582,7 @@ paths:
                     last_used_at: "2026-07-26T23:58:07.336114Z"
         "403": { $ref: "#/components/responses/Forbidden" }
         "404": { $ref: "#/components/responses/Error" }
+        "500": { $ref: "#/components/responses/Error" }
     post:
       operationId: reportOutcome
       summary: Report an outcome (worked/failed) for a knowledge concept
@@ -1641,6 +1649,7 @@ paths:
         "400": { $ref: "#/components/responses/Error" }
         "403": { $ref: "#/components/responses/Forbidden" }
         "404": { $ref: "#/components/responses/Error" }
+        "500": { $ref: "#/components/responses/Error" }
   /api/v1/stats:
     get:
       operationId: getStats
@@ -1748,6 +1757,7 @@ paths:
                           last_at: "2026-07-26T08:11:02.104233Z"
         "400": { $ref: "#/components/responses/Error" }
         "403": { $ref: "#/components/responses/Forbidden" }
+        "500": { $ref: "#/components/responses/Error" }
   /api/v1/reembed:
     post:
       operationId: reembedKnowledge
@@ -1842,6 +1852,7 @@ paths:
         "400": { $ref: "#/components/responses/Error" }
         "403": { $ref: "#/components/responses/Forbidden" }
         "501": { $ref: "#/components/responses/Error" }
+        "500": { $ref: "#/components/responses/Error" }
 components:
   headers:
     ETag:

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"sort"
@@ -784,7 +785,54 @@ func Handler(svc *service.Service) http.Handler {
 		writeJSON(w, http.StatusOK, res)
 	})
 
-	return announceReadOnly(svc, mux)
+	return announceReadOnly(svc, stdlibDefaultsAsJSON(mux))
+}
+
+// stdlibDefaultsAsJSON rewrites the two responses net/http's ServeMux
+// answers by itself — an unmatched path, and a path matched by another
+// method — into the same {"error": "..."} envelope every handler in this
+// file writes by hand, instead of the plain-text body http.Error puts on
+// the wire. Both travel through http.Error, which always sets
+// Content-Type to text/plain before the status is written; every
+// deliberate response here sets a JSON Content-Type first (writeJSON
+// runs before WriteHeader), so a still-text/plain Content-Type at a 404
+// or 405 can only be one of these two, never an application 404 like
+// store.ErrNotFound.
+func stdlibDefaultsAsJSON(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(&defaultEnvelopeWriter{ResponseWriter: w}, r)
+	})
+}
+
+type defaultEnvelopeWriter struct {
+	http.ResponseWriter
+	rewriting bool
+}
+
+func (w *defaultEnvelopeWriter) WriteHeader(status int) {
+	if (status != http.StatusNotFound && status != http.StatusMethodNotAllowed) ||
+		!strings.HasPrefix(w.Header().Get("Content-Type"), "text/plain") {
+		w.ResponseWriter.WriteHeader(status)
+		return
+	}
+	w.rewriting = true
+	msg := "not found"
+	if status == http.StatusMethodNotAllowed {
+		msg = "method not allowed"
+	}
+	body, _ := json.Marshal(map[string]string{"error": msg})
+	h := w.Header()
+	h.Set("Content-Type", "application/json; charset=utf-8")
+	h.Set("Content-Length", strconv.Itoa(len(body)))
+	w.ResponseWriter.WriteHeader(status)
+	_, _ = w.ResponseWriter.Write(body)
+}
+
+func (w *defaultEnvelopeWriter) Write(b []byte) (int, error) {
+	if w.rewriting {
+		return len(b), nil
+	}
+	return w.ResponseWriter.Write(b)
 }
 
 // announceReadOnly marks every REST response from a read-only deployment
@@ -1219,6 +1267,15 @@ func writeError(w http.ResponseWriter, err error) {
 		status = http.StatusBadRequest
 	case errors.As(err, &unsupportedErr):
 		status = http.StatusNotImplemented
+	}
+	if status == http.StatusInternalServerError {
+		// Every status above is a message a caller is meant to read; this
+		// one is whatever the store or a driver said, which can carry SQL
+		// text or a connection string. Logged for an operator instead of
+		// put on the wire.
+		slog.Default().Error("unhandled REST error", "error", err)
+		writeJSON(w, status, map[string]string{"error": "internal error"})
+		return
 	}
 	writeJSON(w, status, map[string]string{"error": err.Error()})
 }

--- a/internal/restapi/restapi_test.go
+++ b/internal/restapi/restapi_test.go
@@ -2,6 +2,7 @@ package restapi
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -36,6 +37,62 @@ func TestWriteErrorStatuses(t *testing.T) {
 			writeError(rec, c.err)
 			if rec.Code != c.want {
 				t.Errorf("writeError(%v) = %d, want %d", c.err, rec.Code, c.want)
+			}
+		})
+	}
+}
+
+// TestWriteErrorHidesInternalDetailsOn500 pins the one status whose
+// message a caller does not get verbatim: everything else above is text
+// the service deliberately wrote for a caller to read, but an unmapped
+// error can be a driver or SQL message, and a 500 must not put that on
+// the wire (issue #365).
+func TestWriteErrorHidesInternalDetailsOn500(t *testing.T) {
+	rec := httptest.NewRecorder()
+	writeError(rec, errors.New("pq: password authentication failed for user \"ochakai\" at 10.0.0.5:5432"))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("body %q is not JSON: %v", rec.Body, err)
+	}
+	if strings.Contains(body["error"], "10.0.0.5") || strings.Contains(body["error"], "password") {
+		t.Errorf(`error = %q, leaks the underlying error`, body["error"])
+	}
+}
+
+// TestUnmatchedRoutesAnswerJSON pins the other half of the same envelope
+// promise: a path nothing serves and a path served under a different
+// method both used to fall through to net/http's own plain-text 404/405
+// instead of the {"error": "..."} shape every other response here uses
+// (issue #365).
+func TestUnmatchedRoutesAnswerJSON(t *testing.T) {
+	h := Handler(&service.Service{})
+	cases := []struct {
+		name, method, url string
+		want              int
+		wantErr           string
+	}{
+		{"unknown path", http.MethodGet, "/api/v1/nope", http.StatusNotFound, "not found"},
+		{"wrong method", http.MethodPost, "/api/v1/search", http.StatusMethodNotAllowed, "method not allowed"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, httptest.NewRequest(c.method, c.url, nil))
+			if rec.Code != c.want {
+				t.Fatalf("%s %s = %d, want %d (body: %s)", c.method, c.url, rec.Code, c.want, rec.Body)
+			}
+			if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+				t.Errorf("Content-Type = %q, want application/json", ct)
+			}
+			var body map[string]string
+			if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+				t.Fatalf("body %q is not JSON: %v", rec.Body, err)
+			}
+			if body["error"] != c.wantErr {
+				t.Errorf("error = %q, want %q", body["error"], c.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Fixes #365 — two error paths escaped the documented `{"error": "<sentence>"}` envelope, and a 500 put internal error text on the wire.

- **No 404/405 handler was registered.** `http.NewServeMux` answers an unmatched path or a path hit with the wrong method by itself, before any handler in this package runs — `GET /api/v1/nope` and `POST /api/v1/search` got Go's own `text/plain` bodies. `Handler` now wraps the mux with `stdlibDefaultsAsJSON`, which rewrites those two stdlib-generated responses into the same JSON envelope every other response uses. It distinguishes them from a deliberate application 404 (`store.ErrNotFound`, etc.) by Content-Type: every handler-written response sets `application/json` before calling `WriteHeader`, so a response still carrying `text/plain` at a 404/405 can only be net/http's own `NotFoundHandler`/method-mismatch handler.
- **A 500 put the store's own text on the wire.** `writeError`'s fallback for any error none of the known cases classify wrote `err.Error()` verbatim — a driver or SQL message could reach the caller. That case now logs the real error via `slog` and answers with a generic `"internal error"` instead. Every other status `writeError` maps to is a message the service deliberately wrote for a caller to read, so only the unmapped/500 case changes.
- **500 was undeclared in `api/openapi.yaml`.** Added `"500": { $ref: "#/components/responses/Error" }` to all eleven operations, reusing the existing generic `Error` response — so the contract test can (going forward) fail a 500 body that doesn't match the envelope, the same way it already does for 400/403/404/etc.

Whether the envelope should also carry a machine-readable `code` is out of scope here, per the issue.

## Test plan

- [x] `scripts/check core` (gofmt, go vet, go test -race, build)
- [x] `scripts/check lint` (golangci-lint, 0 issues)
- [x] New tests: `TestUnmatchedRoutesAnswerJSON` (unmatched path, wrong method both answer JSON) and `TestWriteErrorHidesInternalDetailsOn500` (a driver-style message is not echoed back)
- [x] Existing `TestOpenAPISpecIsValid` and `TestOpenAPISchemasMatchGoTypes` still pass against the updated spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)