### PR TITLE
Refuse an archive of a concept's or a file's own address (409)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,21 @@ last entry.
 
 ## [Unreleased]
 
+### Fixed
+
+- **BREAKING** — `Accept: application/gzip` on a concept's or a file's
+  own bundle path answers 409 instead of an empty, valid `tar.gz` with a
+  200 on it. Dots are legal inside a path segment, so an object's own
+  address — `metrics/revenue.md` as much as a reserved name — normalized
+  as a legal prefix nothing lives under, and the archive of nothing that
+  produced was the same defect fixed one release ago for `index.md` and
+  `log.md` (design doc 0046 §3.5): the refusal covered the two reserved
+  names and not every other object. It matters because the archive is
+  what `api/openapi.yaml` tells an operator to verify a backup by
+  reading rather than by the status code, and this one read fine — valid
+  gzip, valid tar, empty. A backup script pointed one path too deep
+  succeeded forever.
+
 ## [0.17.0] - 2026-07-31
 
 ### Added

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -450,6 +450,11 @@ paths:
         the thing it returns (design doc 0046 §3.5). Your knowledge is
         yours.
 
+        A path is a subtree or it is not: a concept's or a file's own
+        address — `metrics/revenue.md` as much as a reserved name — is
+        409, not an empty archive with a 200 on it, because nothing lives
+        under an object's own address (design doc 0046 §3.5).
+
         Paths inside the archive are not re-rooted: an archive of
         `metrics/` carries `metrics/revenue.md` and imports back to where
         it came from, because this is a copy of a subtree rather than a
@@ -698,14 +703,22 @@ paths:
                 error: "files are not supported without GCS: set OCHAKAI_GCS_BUCKET (design doc 0013)"
         "409":
           description: >
-            A reserved name was read as something other than the file it
-            is: as an archive (`Accept: application/gzip`), or as an
-            object's own `?history`. Both read the path as a thing the
-            bundle stores — a directory to walk, an object with events —
-            and a generated file is neither (design doc 0046 §§3.7-3.8).
-            The same refusal PUT and DELETE make at these two names, for
-            the same reason. Reading the file itself is a 200: that is
-            what generating it is for.
+            The path was read as a thing it is not. A reserved name was
+            read as something other than the file it is: as an archive
+            (`Accept: application/gzip`), or as an object's own
+            `?history`. Both read the path as a thing the bundle stores —
+            a directory to walk, an object with events — and a generated
+            file is neither (design doc 0046 §§3.7-3.8). The same refusal
+            PUT and DELETE make at these two names, for the same reason.
+            Reading the file itself is a 200: that is what generating it
+            is for.
+
+            The same status answers `Accept: application/gzip` on a
+            concept's or a file's own address: dots are legal inside a
+            path segment, so an object's address — `metrics/revenue.md`
+            as much as a reserved name — normalizes as a legal, empty
+            subtree unless it is refused here. Reading the object itself
+            is still a 200; only reading it as an archive is refused.
           headers:
             Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
           content:

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -302,6 +302,20 @@ func Handler(svc *service.Service) http.Handler {
 				writeError(w, err)
 				return
 			}
+			// A concept or a file is an object at its own address, not a
+			// directory: NormalizePrefix accepts it — dots are legal
+			// inside a segment, so "metrics/revenue.md" is a legal prefix
+			// — and nothing lives beneath an object's own address, so the
+			// same empty-archive-with-a-200 the reserved names got fixed
+			// above is still open here for every other object.
+			refused, err := refuseObjectAsArchive(w, r, svc, scope)
+			if err != nil {
+				writeError(w, err)
+				return
+			}
+			if refused {
+				return
+			}
 			writeBundleArchive(w, r, svc, scope)
 			return
 		}
@@ -998,6 +1012,43 @@ func refuseReserved(w http.ResponseWriter, path, because string) bool {
 			base, because),
 	})
 	return true
+}
+
+// refuseObjectAsArchive answers 409 when path names one object — a
+// concept at its own <id>.md or a file at its own path — rather than a
+// directory nothing lives under, and reports whether it did. It goes
+// straight to the store rather than through svc.Get: this is a check of
+// whether the address is a subtree, not a read of the object living
+// there, and must not count as a fetch or fault on missing attachments.
+func refuseObjectAsArchive(w http.ResponseWriter, r *http.Request, svc *service.Service, path string) (bool, error) {
+	if path == "" {
+		return false, nil // the root is the whole bundle, never an object's own address
+	}
+	isObject := false
+	if id, ok := strings.CutSuffix(path, ".md"); ok {
+		switch _, err := svc.Store.Get(r.Context(), id); {
+		case err == nil:
+			isObject = true
+		case !errors.Is(err, store.ErrNotFound):
+			return false, err
+		}
+	}
+	if !isObject {
+		switch _, err := svc.Store.GetFileMeta(r.Context(), path); {
+		case err == nil:
+			isObject = true
+		case !errors.Is(err, store.ErrNotFound):
+			return false, err
+		}
+	}
+	if !isObject {
+		return false, nil
+	}
+	writeJSON(w, http.StatusConflict, map[string]string{
+		"error": fmt.Sprintf(
+			"%s is an object, not a directory (design doc 0046 §3.5); there is no subtree here to archive, ask the directory it sits in", path),
+	})
+	return true, nil
 }
 
 // splitReserved cuts a bundle path into the directory it names and its

--- a/internal/restapi/restapi_integration_test.go
+++ b/internal/restapi/restapi_integration_test.go
@@ -2326,6 +2326,84 @@ func TestRESTIntegrationReservedNamesAreNotObjects(t *testing.T) {
 	}
 }
 
+// A concept and a file are objects at their own address, not a
+// directory — dots are legal inside a segment, so their address
+// normalizes as a legal prefix nothing lives under. The archive face
+// used to hand back an empty, valid tar.gz with a 200 on it (issue
+// #364), which reads as "nothing lives under this path" rather than as
+// "this is not a directory" — the same defect
+// TestRESTIntegrationReservedNamesAreNotObjects covers for the two
+// generated names, still open for every other object.
+func TestRESTIntegrationAnObjectIsNotAnArchivableDirectory(t *testing.T) {
+	lockLiveAttachments(t)
+	srv, s := newIntegrationServer(t)
+	s.UseBlobStore(memBlobStore{})
+
+	typ := testdb.Unique(t, "restobjarchive")
+	id := typ + "/revenue"
+	resp := putDoc(t, srv.URL, id, docFrom(t, map[string]any{
+		"type": typ, "id": id, "title": "Revenue"}), true)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create status = %d", resp.StatusCode)
+	}
+
+	loose := typ + "/seed.csv"
+	req, err := http.NewRequest(http.MethodPut, srv.URL+"/api/v1/bundle/"+loose,
+		bytes.NewReader([]byte("a,b\n1,2\n")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	putResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	putResp.Body.Close()
+	if putResp.StatusCode != http.StatusOK {
+		t.Fatalf("writing the file = %d", putResp.StatusCode)
+	}
+
+	for _, path := range []string{id + ".md", loose} {
+		resp, err := getArchive(t, srv.URL+"/api/v1/bundle/"+path, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusConflict {
+			t.Errorf("archive at %s = %d, want 409 (it is an object, not a directory)", path, resp.StatusCode)
+		}
+	}
+
+	// The directory both objects sit in is a real subtree, and archiving
+	// it still works, carrying both.
+	resp, err = getArchive(t, srv.URL+"/api/v1/bundle/"+typ, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("archive status = %d", resp.StatusCode)
+	}
+	gz, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := map[string]bool{}
+	for tr := tar.NewReader(gz); ; {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		found[hdr.Name] = true
+	}
+	if !found[id+".md"] || !found[loose] {
+		t.Errorf("archive of the real directory = %v, want both %s and %s", found, id+".md", loose)
+	}
+}
+
 // storedDocument reads a concept's stored bytes back, so a test can say
 // what a dry run did not write.
 func storedDocument(t *testing.T, base, id string) string {


### PR DESCRIPTION
## Summary
- `GET /api/v1/bundle/{path}` with `Accept: application/gzip` streamed a well-formed, empty `tar.gz` with a 200 when `{path}` named a concept or a file rather than a directory — dots are legal inside a path segment, so `service.NormalizePrefix` accepted an object's own address (e.g. `metrics/revenue.md`) as a legal, empty prefix.
- This is the same defect fixed one release ago for the two OKF-reserved names (`index.md`, `log.md`); that fix closed the gap for generated files only.
- `refuseObjectAsArchive` now checks the normalized scope against the store directly (concept via `Store.Get`, file via `Store.GetFileMeta` — not through `svc.Get`, so the check doesn't count as a fetch or fault on missing attachments) and answers 409 before `writeBundleArchive` runs, mirroring the existing `refuseReserved` pattern.
- Updated `api/openapi.yaml`'s archive description and 409 response to document the new case, and added a `CHANGELOG.md` entry under `[Unreleased]` (marked **BREAKING** since the response code changes from 200 to 409).

## Test plan
- [x] `scripts/check --db` (gofmt, go vet, go test -race incl. store-backed integration tests, build, lint, govulncheck) — all pass
- [x] New integration test `TestRESTIntegrationAnObjectIsNotAnArchivableDirectory`: archiving a concept's `<id>.md` address and a file's own address both answer 409; archiving the real parent directory still returns 200 and carries both objects
- [x] Existing `TestRESTIntegrationReservedNamesAreNotObjects` and `TestBooleanQueryParamsRejectUnreadableValues` (the nil-store unit test) still pass

Fixes #364.

🤖 Generated with [Claude Code](https://claude.com/claude-code)