### PR TITLE
Fix the first fifteen minutes: dev mode, Docker-only import, .mcp.json port

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "ochakai": {
       "type": "http",
-      "url": "http://localhost:8787/mcp"
+      "url": "http://localhost:8080/mcp"
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,23 @@ last entry.
 
 ## [Unreleased]
 
+### Fixed
+
+- The quick start's demo import needed the Go toolchain
+  (`go run ./cmd/ochakai import examples/demo`) despite the README
+  promising "Docker and nothing else locally", and there was no
+  Docker-only path: `deploy/compose.yaml` mounted no volume the import
+  could read from. It now mounts `examples/`, and the quick start runs
+  `docker compose exec ochakai /ochakai import /examples/demo` instead.
+- `OCHAKAI_MODE=dev` — what makes the compose stack usable with no
+  authentication — was undiscoverable outside a code comment and one
+  clause of the configuration reference. The quick start now names it.
+- The committed `.mcp.json` pointed at the Cloud Run proxy's port
+  (8787), so opening the repo in Claude Code after the quick start
+  (port 8080) connected to nothing, with no error saying so. It now
+  matches the compose default; the Cloud Run guide says to repoint it
+  at the proxy instead of claiming that happens automatically.
+
 ## [0.17.0] - 2026-07-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -30,16 +30,19 @@ to verify or reject them](docs/images/webui-review.png)
 
 ```sh
 git clone https://github.com/na0fu3y/ochakai && cd ochakai
-docker compose -f deploy/compose.yaml up
+docker compose -f deploy/compose.yaml up -d
 ```
+
+This runs with `OCHAKAI_MODE=dev`: authentication is off and every
+request acts as `human:anonymous` — never do this on a deployment
+([every mode](docs/configuration.md#environment-variables)).
 
 Load the demo knowledge base — [ten concepts](examples/demo) about one
 invented retail domain, linked to each other, some of them drafts — and
 search it. Everything goes through the API, so plain curl works too:
 
 ```sh
-export OCHAKAI_URL=http://localhost:8080
-go run ./cmd/ochakai import examples/demo
+docker compose -f deploy/compose.yaml exec ochakai /ochakai import /examples/demo
 curl 'http://localhost:8080/api/v1/search?q=revenue'
 ```
 

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -369,8 +369,9 @@ go run github.com/na0fu3y/ochakai/cmd/ochakai@latest create queries/monthly-reve
 ```
 
 Connect Claude Code — with the Cloud Run proxy running, no headers, no
-tokens (this repository's committed `.mcp.json` does the same
-automatically when you open the repo in Claude Code):
+tokens. The repository's committed `.mcp.json` defaults to the local
+compose port (8080); repoint its `url` at the proxy below, or add the
+server with `claude mcp add`:
 
 ```sh
 gcloud run services proxy ochakai --region=$REGION --port=8787 &

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -11,6 +11,9 @@ services:
     environment:
       OCHAKAI_DATABASE_URL: postgres://ochakai:ochakai@db:5432/ochakai?sslmode=disable
       OCHAKAI_MODE: dev # local only: all requests act as human:anonymous
+      OCHAKAI_URL: http://localhost:8080 # read by client commands only; lets `exec ochakai /ochakai import ...` work with no Go toolchain
+    volumes:
+      - ../examples:/examples:ro
     depends_on:
       db:
         condition: service_healthy

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,12 +25,16 @@ and a database that cannot hold vectors makes a discovered deployment fall
 back to lexical search rather than fail. Without it, plain PostgreSQL is
 enough. CI and the deploy guide both exercise Postgres 17.
 
-**The server needs Docker; the client commands need a binary.** The README's
-quick start runs the CLI with `go run`, which wants the toolchain named in
-`go.mod` — Go 1.21 and newer download it for you. To stay toolchain-free,
-take a [release archive](https://github.com/na0fu3y/ochakai/releases)
-instead, or talk to the API directly, since that is all the CLI does — see
-[Writing knowledge](knowledge.md) for the one-line `curl` version of a write.
+**The server needs Docker; the client commands need a binary.** The
+README's quick start runs its one CLI command, `import`, inside the
+compose container (`docker compose exec ochakai /ochakai import ...`), so
+nothing beyond Docker is needed to follow it. Past that — `ochakai use`,
+`ochakai context`, the web UI — take a
+[release archive](https://github.com/na0fu3y/ochakai/releases), or
+`go run ./cmd/ochakai`, which wants the toolchain named in `go.mod` (Go
+1.21 and newer download it for you). Or talk to the API directly, since
+that is all the CLI does — see [Writing knowledge](knowledge.md) for the
+one-line `curl` version of a write.
 
 ## Environment variables
 


### PR DESCRIPTION
## Summary

Fixes #368 — three small, compounding gaps in the first fifteen minutes with ochakai:

- The quick start's fourth line, `go run ./cmd/ochakai import examples/demo`, needed the Go toolchain despite the README promising "Docker and nothing else locally," and `deploy/compose.yaml` mounted no volume the import could read from, so there was no Docker-only path either. `deploy/compose.yaml` now mounts `examples/` read-only, and the quick start runs `docker compose exec ochakai /ochakai import /examples/demo` instead.
- `OCHAKAI_MODE=dev` — the mode that makes the compose stack usable with no authentication — was undiscoverable outside a code comment, `deploy/cloudrun/README.md` §5c, one clause of `docs/configuration.md`, `SECURITY.md`, and `docs/images/README.md`. The quick start now names it, with a link to the full reference.
- The committed `.mcp.json` pointed at the Cloud Run proxy's port (8787) while the quick start runs on 8080, so opening the repo in Claude Code after the quick start connected to nothing, with no error saying so. `.mcp.json` now defaults to the local compose port, and the Cloud Run guide says to repoint it at the proxy instead of claiming that happens automatically.

`docs/configuration.md` is updated to match: the quick start's one CLI command now runs inside the compose container, so nothing beyond Docker is needed to follow it; the Go toolchain / release archive note now applies to what comes after (`ochakai use`, `ochakai context`, the web UI).

## Test plan

- [x] `scripts/check core` (gofmt, go vet, go test -race, build) — passes
- [x] `go test ./cmd/ochakai/... -run 'TestSurface|TestUserDocsStayUnderTheirLineCap'` — passes (doc line count stays under the existing `DOC-LINES` cap, no new pages)
- [x] Manually verified the new quick-start import path: `docker compose -f deploy/compose.yaml up -d` then `docker compose -f deploy/compose.yaml exec ochakai /ochakai import /examples/demo --dry-run` correctly sees all 10 demo concepts through the new volume mount