### PR TITLE
Make Terraform the front door for deploying ochakai

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ humans and agents together, and served to Claude Code and every other
 data agent over [MCP](https://modelcontextprotocol.io), REST, a CLI, and
 a bundled web UI. More at [ochak.ai](https://ochak.ai).
 
-One Go binary and Postgres: Cloud Run + Cloud SQL for
-[about $10/month](deploy/cloudrun/README.md), or Docker and nothing else
-locally.
+One Go binary and Postgres: [Terraform stands up Cloud Run + Cloud
+SQL](deploy/terraform/README.md) for about $10/month, or Docker and
+nothing else locally.
 
 [Quick start](#quick-start) · [Why ochakai](#why-ochakai) ·
 [Requirements](#requirements) · [All docs](docs/README.md) ·
@@ -167,7 +167,8 @@ in the version you are running.
   [Writing knowledge](docs/knowledge.md) · [CLI reference](docs/cli.md) ·
   [MCP clients](docs/guides/mcp-clients.md) ·
   [Troubleshooting](docs/guides/troubleshooting.md)
-- **Running** — [Deploy on Cloud Run](deploy/cloudrun/README.md) ·
+- **Running** — [Deploy with Terraform](deploy/terraform/README.md) ·
+  [the gcloud reference it runs](deploy/cloudrun/README.md) ·
   [Configuration](docs/configuration.md) ·
   [Operating](docs/guides/operating.md) ·
   [Golden query canary](docs/guides/golden-query-canary.md)

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -18,18 +18,28 @@ Cloud SQL dominates the bill. Regions in Asia (e.g. `asia-northeast1`) cost
 slightly more; pick what matches your latency needs. Teardown commands are
 at the bottom.
 
+**Recommended: stand this up with [deploy/terraform](../terraform)**,
+which turns §1–§4b (plus the web UI and demo posture) into a thirteen-step
+`terraform apply`, reviewable as a diff, reproducible per environment, and
+destroyed cleanly. This guide is what stays the reference — it explains
+why each resource is shaped the way it is, and is the path to use if you
+would rather run the commands by hand. It covers §1–§5, §5c, §5d and §9;
+the operating guide covers the rest it leaves out — the web UI,
+org-policy guardrails, and upgrade notes.
+
 **Already deployed?** [docs/guides/operating.md](../../docs/guides/operating.md)
 covers what happens after: backup and restore, hardening, the team web
 UI, monitoring, capacity, and upgrades.
 
-**Prefer infrastructure as code?**
-[deploy/terraform](../terraform) stands up §1–§4b (plus the web UI and
-demo posture) as a Terraform module, so a deployment can be reviewed as a
-diff, reproduced per environment, and destroyed cleanly. This guide stays
-the reference for §1–§5, §5c, §5d and §9; the operating guide covers the
-rest it leaves out — the web UI, org-policy guardrails, and upgrade notes.
-
 ## 1. Prerequisites
+
+Local tools this guide uses, beyond `gcloud` itself (authenticated —
+`gcloud auth login`): the [Go toolchain](https://go.dev/dl/) (`go run` /
+`go install`, §5), [`cloud-sql-proxy`](https://cloud.google.com/sql/docs/postgres/sql-proxy)
+and `psql` (§3's one-time database setup), `openssl` (§2's admin
+password), and optionally the [`gh` CLI](https://cli.github.com) (the
+version lookup just below — without it, read the version off the
+[releases page](https://github.com/na0fu3y/ochakai/releases) by hand).
 
 ```sh
 export PROJECT_ID=<your-project>
@@ -158,16 +168,6 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO "ochakai-run@<P
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO "ochakai-run@<PROJECT_ID>.iam";
 ```
 
-Note on ownership: the first deploy's startup migration creates the
-tables, owned by the **runtime service account** (imports go through the
-API, so nothing is ever created as the admin). For the admin user to
-work with those tables directly (maintenance, ad-hoc SQL), give it the
-runtime's role in the same session:
-
-```sql
-GRANT "ochakai-run@<PROJECT_ID>.iam" TO "ochakai";
-```
-
 Deploy privately with the dedicated identity and `OCHAKAI_DB_IAM_AUTH`
 (passwordless database), then allow your organization to invoke it:
 
@@ -187,6 +187,17 @@ gcloud run services add-iam-policy-binding ochakai --region=$REGION \
   --member=domain:your-org.example --role=roles/run.invoker
 
 export OCHAKAI_URL=$(gcloud run services describe ochakai --region=$REGION --format='value(status.url)')
+```
+
+**One more one-time step, now that the first deploy has run its startup
+migration:** the migration creates the tables, owned by the **runtime
+service account** (imports go through the API, so nothing is ever
+created as the admin). For the admin user to work with those tables
+directly (maintenance, ad-hoc SQL), give it the runtime's role —
+reconnect the same way as above, with `$DB_PASSWORD` from §2:
+
+```sql
+GRANT "ochakai-run@<PROJECT_ID>.iam" TO "ochakai";
 ```
 
 How this works:

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -4,11 +4,12 @@ The baseline of [deploy/cloudrun/README.md](../cloudrun/README.md) as code,
 so that a deployment can be reviewed as a diff, reproduced per environment,
 and torn down cleanly.
 
-**The gcloud guide remains the reference and the source of truth.** It
-explains why each piece is shaped the way it is, covers everything this
-module leaves out, and is the thing to read first. This module is a
-convenience for standing up what it describes — where the two disagree, the
-guide is right and this module has a bug.
+**This module is the recommended way to stand ochakai up** — thirteen
+steps below instead of the gcloud guide's thirty-six. The gcloud guide
+remains the reference and the source of truth: it explains why each piece
+is shaped the way it is and covers everything this module leaves out, but
+you do not need to read it to run `terraform apply`. Where the two
+disagree, the guide is right and this module has a bug.
 
 ## What it creates
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,9 +45,14 @@ and what it refuses to do. It is deliberately short; the manual is here.
 
 - [Requirements and configuration](configuration.md) — what ochakai needs
   before it starts, and every environment variable it reads.
-- [Deploy on Cloud Run](../deploy/cloudrun/README.md) — the complete
-  walkthrough, ~$10/month, including private IP, the IAP-fronted web UI,
-  a security hardening checklist, and the upgrade path.
+- [Deploy with Terraform](../deploy/terraform/README.md) — the
+  recommended path, ~$10/month: `terraform apply` in 13 steps instead of
+  the gcloud walkthrough's 36.
+- [Deploy on Cloud Run](../deploy/cloudrun/README.md) — the gcloud
+  walkthrough the module runs underneath. Read it instead of the module
+  when you want to run the commands by hand, or as the reference for
+  what each resource is and why: private IP, the IAP-fronted web UI, a
+  security hardening checklist, and the upgrade path.
 - [deploy/compose.yaml](../deploy/compose.yaml) — the local stack. Docker
   and nothing else; no Google account needed.
 - [Operating a deployment](guides/operating.md) — the two backups and what


### PR DESCRIPTION
Closes #367.

**The decision the issue asked for: yes, Terraform is the front door.** README.md and docs/README.md now name `deploy/terraform` first as the recommended path to stand ochakai up, with the gcloud walkthrough repositioned as the reference for what each resource is and why — the same shape #355 chose when it pulled hardening, web UI, and upgrade material out of the deploy guide into the operating guide. `deploy/cloudrun/README.md`'s own opening and `deploy/terraform/README.md`'s opening are updated to match, both stating the count the issue used to make the case: 13 Terraform steps vs. 36 gcloud steps.

**Also fixes the two literal defects the issue called out**, independent of the front-door decision:

- §1 Prerequisites never listed `cloud-sql-proxy`, `psql`, `openssl`, the Go toolchain, or `gh`, even though the walkthrough uses all five later. Added a short local-tools list at the top of §1.
- The admin `GRANT "ochakai-run@…" TO "ochakai"` was printed at the old `:168`, before `gcloud run deploy` at `:175` — even though the surrounding prose explains the grant is about tables that don't exist until the first deploy's migration creates them. Moved the note and the GRANT to right after the deploy command, where it now follows what it depends on.

Files touched: `README.md`, `docs/README.md`, `deploy/cloudrun/README.md`, `deploy/terraform/README.md` — the four the issue named.

No design doc: this is a documentation-navigation decision (which existing, already-shipped path is presented first), not a change to any wire shape, stored form, identity model, or new Google Cloud dependency per CLAUDE.md's numbering criteria.

`docs/surface.md`'s `DOC-LINES` cap (5790) is unaffected — the manual is now 5780 lines, still under, no cap change needed.

## Test plan

- [x] `scripts/check core` passes (gofmt, go vet, go test -race, build)
- [x] `TestUserDocsStayUnderTheirLineCap` passes at 5780/5790 lines
- [x] Manually re-read the reordered §3 in `deploy/cloudrun/README.md` end to end to confirm the GRANT now follows the deploy step it depends on

🤖 Generated with [Claude Code](https://claude.com/claude-code)