### PR TITLE
Give report_outcome a hook: Stop hook nudges outcome reporting

### DIFF
--- a/docs/loop.md
+++ b/docs/loop.md
@@ -41,11 +41,11 @@ letting the next agent trust it blind. Verifying it again empties the feed.
 If nothing comes back on the first prompt, the agent has not actually
 connected — `ochakai whoami` says which server it is talking to and as whom.
 
-To make the loop automatic rather than habitual, install the
-[Claude Code hooks](../examples/claude-code): a UserPromptSubmit hook injects
-relevant knowledge before the agent starts (recall), and a Stop hook asks it
-once per data session to save what it learned (write-back) — both without an
-LLM.
+To make the loop automatic rather than habitual, install the [Claude Code
+hooks](../examples/claude-code): a UserPromptSubmit hook injects relevant
+knowledge before the agent starts (recall), and a Stop hook asks it once per
+data session to save what it learned (write-back) and whether a recalled
+concept held up when acted on (`report_outcome`) — all without an LLM.
 
 ## The web UI: the human half
 

--- a/examples/claude-code/README.md
+++ b/examples/claude-code/README.md
@@ -9,14 +9,14 @@ Two layers, weakest to strongest:
 2. **[hooks/](hooks)** make the loop automatic. Hooks are executed by
    Claude Code itself, so they fire every time, no agent judgment
    involved — the same trick memory layers use, minus the LLM:
-   - `ochakai-recall.sh` (**UserPromptSubmit**) runs
-     `ochakai context "<prompt>"` and injects the resulting pack —
-     full concepts behind the top hits, links expanded — into the
-     context before the agent starts working. Automatic recall.
-   - `ochakai-write-back.sh` (**Stop**) interrupts the agent once per
-     data-work session, right before it stops, and asks it to save
-     reusable queries and metric insights (or explicitly decide there
-     is nothing worth saving). Automatic write-back prompting.
+   - `ochakai-recall.sh` (**UserPromptSubmit**) runs `ochakai context
+     "<prompt>"` and injects the resulting pack — full concepts behind the top
+     hits, links expanded — into the context before the agent starts working,
+     and records what it recalls for the Stop hook below. Automatic recall.
+   - `ochakai-write-back.sh` (**Stop**) interrupts the agent once per data-work
+     session, right before it stops, and asks it to save reusable queries and
+     metric insights (write-back), and whether a concept recall handed it held
+     up when acted on (`report_outcome`) — or decide neither applies.
 
 ## Install
 

--- a/examples/claude-code/hooks/ochakai-recall.sh
+++ b/examples/claude-code/hooks/ochakai-recall.sh
@@ -6,6 +6,11 @@
 # required. Whatever this script prints on stdout is added to the
 # context; printing nothing adds nothing.
 #
+# Also records which concepts were recalled this session (one ID per
+# line, appended to a per-session file under $TMPDIR) so ochakai-write-back.sh
+# can later ask, specifically, whether any of them held up when acted on —
+# report_outcome is a loop move too, and this is what gives it a hook.
+#
 # Requires: jq, and ochakai on PATH with a server selected
 # (`ochakai use <url>`). Tune with:
 #   OCHAKAI_RECALL_BUDGET     max injected bytes (default 4000)
@@ -14,7 +19,8 @@
 # block the user's prompt.
 set -eu
 
-prompt=$(jq -r '.prompt // empty' 2>/dev/null) || exit 0
+input=$(cat)
+prompt=$(printf '%s' "$input" | jq -r '.prompt // empty' 2>/dev/null) || exit 0
 [ -z "$prompt" ] && exit 0
 case $prompt in
 /*) exit 0 ;; # slash commands are not data questions
@@ -22,5 +28,14 @@ esac
 
 pack=$(ochakai context "$prompt" --budget "${OCHAKAI_RECALL_BUDGET:-4000}" 2>/dev/null) || exit 0
 [ -z "$pack" ] && exit 0
+
+session=$(printf '%s' "$input" | jq -r '.session_id // empty' 2>/dev/null) || session=""
+if [ -n "$session" ]; then
+	# Only concepts rendered in full ("## ochakai://…" headings) count as
+	# recalled — the "Also relevant" one-liners are pointers, not knowledge
+	# the agent was actually handed.
+	{ printf '%s\n' "$pack" | grep -o '^## ochakai://[^ ]*' | sed 's/^## //' \
+		>>"${TMPDIR:-/tmp}/ochakai-recalled-$session"; } 2>/dev/null || true
+fi
 
 printf 'Team knowledge from ochakai relevant to this request (trust verified concepts; judge drafts by created_by):\n\n%s\n' "$pack"

--- a/examples/claude-code/hooks/ochakai-write-back.sh
+++ b/examples/claude-code/hooks/ochakai-write-back.sh
@@ -1,11 +1,21 @@
 #!/bin/sh
 # ochakai-write-back: Stop hook for Claude Code.
 #
-# The write-back half of the loop. When the agent finishes a session that
-# looks like data work, ask it once — before it stops — whether anything
-# it learned belongs in the team knowledge base. CLAUDE.md alone relies
-# on the agent remembering the habit; this hook makes the question
-# unskippable, exactly once per session.
+# Two of the loop's write-side moves, both nudged once per session, before
+# the agent stops:
+#
+# - write-back: whether anything the agent learned belongs in the team
+#   knowledge base.
+# - report_outcome: whether any concept ochakai-recall.sh handed this
+#   session (recorded to a per-session file under $TMPDIR) held up when
+#   acted on. `failed` reports are what moves a verified concept into the
+#   re-verification feed (design doc 0025) — without them that feed stays
+#   at zero regardless of how stale the knowledge actually is.
+#
+# CLAUDE.md alone relies on the agent remembering both habits; this hook
+# makes the question unskippable. Neither move is something the hook can
+# judge for itself (no LLM here, per 0001) — it can only ask, using the
+# structural fact of which concepts this session actually read.
 #
 # Requires: jq. Failures are silent: never block the agent from stopping.
 set -eu
@@ -26,7 +36,16 @@ marker="${TMPDIR:-/tmp}/ochakai-write-back-$session"
 grep -qiE 'SELECT|ochakai|bigquery|warehouse' "$transcript" || exit 0
 : >"$marker"
 
-jq -n '{
+recalled_file="${TMPDIR:-/tmp}/ochakai-recalled-$session"
+recalled=""
+[ -r "$recalled_file" ] && recalled=$(sort -u "$recalled_file" 2>/dev/null | head -20 | tr '\n' ' ')
+
+outcome_reason=""
+if [ -n "$recalled" ]; then
+	outcome_reason="This session was handed these ochakai concepts: $recalled — if you acted on one (ran its SQL, followed its definition), report whether the result held up: \`ochakai report <id> worked\` or \`ochakai report <id> failed --note \"what went wrong\"\`. Skip any you only read but never acted on. Always report failed when a verified concept led you to a wrong number. "
+fi
+
+jq -n --arg outcome "$outcome_reason" '{
   decision: "block",
-  reason: "Before finishing: this session did data work. If a query you wrote proved correct and reusable, or you learned how to read a metric (a baseline, a seasonality, a caveat), write it back to ochakai — search first (including --rejected) to avoid re-proposing, then `ochakai put <path>` (type \"Attested Computation\" with runtime, the SQL in a # Computation fence, and a top-level question key; or type \"Insight\"). If nothing durable was learned, finish now without creating anything — do not invent knowledge."
+  reason: ($outcome + "Before finishing: this session did data work. If a query you wrote proved correct and reusable, or you learned how to read a metric (a baseline, a seasonality, a caveat), write it back to ochakai — search first (including --rejected) to avoid re-proposing, then `ochakai put <path>` (type \"Attested Computation\" with runtime, the SQL in a # Computation fence, and a top-level question key; or type \"Insight\"). If nothing durable was learned, finish now without creating anything — do not invent knowledge.")
 }'


### PR DESCRIPTION
## Summary
- `report_outcome` was the third loop move (recall / write-back / report_outcome) but the only one with no hook backing it — it existed solely as prose in `examples/claude-code/CLAUDE.md`, so `sort=failed` (the evidence-based re-verification feed, design doc 0025) stays at zero regardless of how stale the knowledge actually is.
- `ochakai-recall.sh` now records which concepts it fully recalled this session into a per-session file under `$TMPDIR`.
- `ochakai-write-back.sh` reads that file on Stop and folds a `report_outcome` nudge into its existing unskippable question, naming the concepts the session was actually handed rather than asking in the abstract.
- Neither hook judges whether a concept was actually wrong — that stays the agent's call, per 0001's no-LLM-inside constraint — but the asking is no longer optional, matching the pattern the issue itself suggested (narrow the Stop-hook question to concepts the session actually read, since the recall hook already knows which those are).
- `docs/loop.md` and `examples/claude-code/README.md` updated to describe the hook accurately; no new design doc needed since this is an example integration, not a change to ochakai's own wire surface.

Fixes #378.

## Test plan
- [x] `sh -n` on both hook scripts
- [x] Simulated a full recall → write-back run with a fake `ochakai` CLI and fake stdin JSON, confirmed the recorded concept IDs (only fully-rendered ones, not "Also relevant" pointers) surface correctly in the Stop hook's block reason
- [x] Confirmed backward compatibility: sessions with no recalled concepts get the original write-back-only prompt
- [x] `scripts/check core` (all Go tests, including the guard tests over these example files and the docs line-count cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)