### PR TITLE
Clean up the five gaps the 17-PR batch left behind

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -86,7 +86,7 @@ body:
         The commands or requests you ran, in order. If the content of an entry
         matters, paste it as OKF markdown.
       placeholder: |
-        1. ochakai create metrics/revenue -f revenue.md
+        1. ochakai put metrics/revenue -f revenue.md
         2. ochakai search "revenue" --type Metric
     validations:
       required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,8 @@ last entry.
 - The committed `.mcp.json` pointed at the Cloud Run proxy's port
   (8787), so opening the repo in Claude Code after the quick start
   (port 8080) connected to nothing, with no error saying so. It now
-  matches the compose default; the Cloud Run guide says to repoint it
-  at the proxy instead of claiming that happens automatically.
+  matches the compose default; a Cloud Run deployment uses the bridge
+  or `ochakai ui` instead (docs/guides/mcp-clients.md), not this file.
 - The operating guide's web UI section still showed delegated writes as
   `agent:ochakai-webui@…`, the actor-kind spelling design doc
   [0043](docs/design/0043-document-first.md) §3.8 retired for `process:`
@@ -64,7 +64,24 @@ last entry.
   what `api/openapi.yaml` tells an operator to verify a backup by
   reading rather than by the status code, and this one read fine — valid
   gzip, valid tar, empty. A backup script pointed one path too deep
-  succeeded forever.
+  succeeded forever. This covers an object's own address; a prefix that
+  matches no object at all — the same typo one segment shallower —
+  still answers 200 with an empty archive, indistinguishable from a
+  directory that is legitimately empty. That is a deliberate scope
+  limit, not an oversight.
+
+- **BREAKING** — a REST error response used to leave the documented
+  `{"error": "..."}` envelope in two ways. A request net/http's own
+  routing turned away before a handler ran — an unmatched path, or a
+  path matched by a different method — answered plain text instead of
+  JSON (404 `not found`, 405 `method not allowed`; issue #365). And a
+  500 echoed whatever the store or a driver said, which could carry SQL
+  text or a connection string. Both now stay inside the envelope: 404
+  and 405 are JSON, and a 500 is logged for an operator and answered as
+  `{"error": "internal error"}`. A caller parsing a 500 body for a
+  driver message now finds `internal error` and needs the server log
+  for detail. `api/openapi.yaml` declares 405 alongside the 500 already
+  on all eleven operations.
 
 ## [0.17.0] - 2026-07-31
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -426,6 +426,7 @@ paths:
                   value:
                     error: cursor belongs to the usage listing; it cannot resume the failed one
         "403": { $ref: "#/components/responses/Forbidden" }
+        "405": { $ref: "#/components/responses/Error" }
         "500": { $ref: "#/components/responses/Error" }
   /api/v1/bundle/{path}:
     get:
@@ -755,6 +756,7 @@ paths:
                   error: { type: string }
               example:
                 error: no object at this path
+        "405": { $ref: "#/components/responses/Error" }
         "500": { $ref: "#/components/responses/Error" }
     put:
       operationId: putBundleFile
@@ -861,6 +863,7 @@ paths:
                   error: { type: string }
               example:
                 error: index.md is generated from the bundle, not stored in it (design doc 0046 §§3.7-3.8)
+        "405": { $ref: "#/components/responses/Error" }
         "500": { $ref: "#/components/responses/Error" }
     delete:
       operationId: deleteBundleFile
@@ -913,6 +916,7 @@ paths:
                 type: object
                 properties:
                   error: { type: string }
+        "405": { $ref: "#/components/responses/Error" }
         "500": { $ref: "#/components/responses/Error" }
   /api/v1/context:
     get:
@@ -1216,6 +1220,7 @@ paths:
                     truncated: 1
         "400": { $ref: "#/components/responses/Error" }
         "403": { $ref: "#/components/responses/Forbidden" }
+        "405": { $ref: "#/components/responses/Error" }
         "500": { $ref: "#/components/responses/Error" }
   /api/v1/move:
     post:
@@ -1327,6 +1332,7 @@ paths:
         "403": { $ref: "#/components/responses/Forbidden" }
         "404": { $ref: "#/components/responses/Error" }
         "409": { $ref: "#/components/responses/Error" }
+        "405": { $ref: "#/components/responses/Error" }
         "500": { $ref: "#/components/responses/Error" }
   /api/v1/review/{id}:
     parameters:
@@ -1565,6 +1571,7 @@ paths:
                     error: 'a verification carries no note: "verified" says the concept is right as it stands, and anything to say about it belongs in the concept. Use ruling=rejected to record a reason'
         "403": { $ref: "#/components/responses/Forbidden" }
         "404": { $ref: "#/components/responses/Error" }
+        "405": { $ref: "#/components/responses/Error" }
         "500": { $ref: "#/components/responses/Error" }
   /api/v1/usage/{id}:
     parameters:
@@ -1605,6 +1612,7 @@ paths:
                     last_used_at: "2026-07-26T23:58:07.336114Z"
         "403": { $ref: "#/components/responses/Forbidden" }
         "404": { $ref: "#/components/responses/Error" }
+        "405": { $ref: "#/components/responses/Error" }
         "500": { $ref: "#/components/responses/Error" }
     post:
       operationId: reportOutcome
@@ -1672,6 +1680,7 @@ paths:
         "400": { $ref: "#/components/responses/Error" }
         "403": { $ref: "#/components/responses/Forbidden" }
         "404": { $ref: "#/components/responses/Error" }
+        "405": { $ref: "#/components/responses/Error" }
         "500": { $ref: "#/components/responses/Error" }
   /api/v1/stats:
     get:
@@ -1780,6 +1789,7 @@ paths:
                           last_at: "2026-07-26T08:11:02.104233Z"
         "400": { $ref: "#/components/responses/Error" }
         "403": { $ref: "#/components/responses/Forbidden" }
+        "405": { $ref: "#/components/responses/Error" }
         "500": { $ref: "#/components/responses/Error" }
   /api/v1/reembed:
     post:
@@ -1875,6 +1885,7 @@ paths:
         "400": { $ref: "#/components/responses/Error" }
         "403": { $ref: "#/components/responses/Forbidden" }
         "501": { $ref: "#/components/responses/Error" }
+        "405": { $ref: "#/components/responses/Error" }
         "500": { $ref: "#/components/responses/Error" }
 components:
   securitySchemes:

--- a/cmd/ochakai/conflictmarkers_test.go
+++ b/cmd/ochakai/conflictmarkers_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// conflictMarkerSkipExt are the extensions this guard does not read as
+// text — content nothing checks for well-formedness because it is not
+// meant to be read as prose or source, so a marker-shaped byte run inside
+// it says nothing about an unresolved merge.
+var conflictMarkerSkipExt = map[string]bool{
+	".png": true, ".jpg": true, ".jpeg": true, ".gif": true, ".ico": true,
+	".pdf": true, ".zip": true, ".gz": true, ".tar": true,
+	".woff": true, ".woff2": true, ".ttf": true,
+}
+
+// conflictMarkers are the lines a merge leaves behind when a conflict is
+// not resolved — the three-way form and the plain form both, since either
+// can be left by an editor depending on merge.conflictstyle.
+var conflictMarkers = []string{"<<<<<<< ", "=======", ">>>>>>> ", "||||||| "}
+
+// TestNoUnresolvedConflictMarkers reads every tracked text file for a
+// conflict marker a merge left behind unresolved.
+//
+// #393 merged with `<<<<<<<`, `=======` and `>>>>>>>` sitting inside
+// docs/surface.md, and nothing here noticed: TestSurfaceDocCountsUserDocs
+// checks that file's *numbers*, not whether it is well-formed prose, so a
+// conflict marker between two of them was invisible to CI. #392 rebased
+// over the markers without seeing them; a later PR cleaned them up by
+// hand. This reads the whole tree instead of one file, because the same
+// gap exists everywhere else a merge can land one.
+func TestNoUnresolvedConflictMarkers(t *testing.T) {
+	const root = "../.."
+	skipDirs := map[string]bool{".git": true, "node_modules": true}
+	checked := 0
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		rel = filepath.ToSlash(rel)
+		if d.IsDir() {
+			if skipDirs[rel] {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if conflictMarkerSkipExt[filepath.Ext(rel)] || strings.Contains(rel, "/testdata/fuzz/") {
+			return nil
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		checked++
+		for i, line := range strings.Split(string(content), "\n") {
+			for _, marker := range conflictMarkers {
+				if strings.HasPrefix(line, marker) {
+					t.Errorf("%s:%d carries an unresolved conflict marker\n\t%s",
+						rel, i+1, strings.TrimSpace(line))
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	if checked == 0 {
+		t.Fatal("no files walked: this check now guards nothing")
+	}
+}

--- a/cmd/ochakai/retired_test.go
+++ b/cmd/ochakai/retired_test.go
@@ -127,6 +127,7 @@ func repoTextFiles(t *testing.T) []string {
 	text := map[string]bool{
 		".go": true, ".md": true, ".yaml": true, ".yml": true, ".json": true,
 		".html": true, ".css": true, ".js": true, ".sh": true, ".sql": true,
+		".tf": true,
 	}
 	var out []string
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
@@ -138,7 +139,10 @@ func repoTextFiles(t *testing.T) []string {
 			return relErr
 		}
 		if d.IsDir() {
-			if skipDirs[rel] || strings.HasPrefix(d.Name(), ".") && rel != "." {
+			// .github holds prose a reader follows too — issue templates,
+			// most namely — so it is not skipped as a dot-directory the
+			// way .git and other tooling directories are.
+			if skipDirs[rel] || strings.HasPrefix(d.Name(), ".") && rel != "." && rel != ".github" {
 				return fs.SkipDir
 			}
 			return nil

--- a/cmd/ochakai/surface_test.go
+++ b/cmd/ochakai/surface_test.go
@@ -945,6 +945,19 @@ var commandGuardExempt = map[string]bool{
 	"ROADMAP.md":  true,
 }
 
+// commandGuardExtra are files outside the manual that also teach a literal
+// "ochakai <command>" invocation and so need the same guard —
+// TestManualNamesNoCommandThatDoesNotExist did not reach them because
+// userDocs() is DOC-page prose only (.md, and .github/ skipped as a
+// dot-directory): issue #399 found bug_report.yml still showing the
+// retired `ochakai create` as the example every bug reporter copies.
+// These are scanned with commandWordsIn rather than commandWordIn: none of
+// them wrap prose in Markdown fences or backticks to isolate a span with,
+// so every field in every line is checked instead.
+var commandGuardExtra = []string{
+	".github/ISSUE_TEMPLATE/bug_report.yml",
+}
+
 var inlineCodeSpanRe = regexp.MustCompile("`([^`]*)`")
 
 // commandWordIn reads "ochakai <word>" out of an already-isolated code
@@ -966,6 +979,26 @@ func commandWordIn(span string) (string, bool) {
 }
 
 var commandWordRe = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9-]*`)
+
+// commandWordsIn finds every "ochakai <word>" in a line where "ochakai" is
+// its own field — unlike commandWordIn, which requires "ochakai" to open
+// an already-isolated span, this walks all fields so it also catches a
+// standalone "ochakai" appearing mid-sentence, while still passing over
+// "./cmd/ochakai" or "ochakai.example.com", where "ochakai" is never a
+// field by itself.
+func commandWordsIn(line string) []string {
+	fields := strings.Fields(line)
+	var words []string
+	for i, field := range fields[:max(0, len(fields)-1)] {
+		if field != "ochakai" && field != "/ochakai" {
+			continue
+		}
+		if word := commandWordRe.FindString(fields[i+1]); word != "" {
+			words = append(words, word)
+		}
+	}
+	return words
+}
 
 // TestManualNamesNoCommandThatDoesNotExist reads every DOC page for
 // "ochakai <word>" and fails on any word that is not a command the binary
@@ -1025,6 +1058,21 @@ func TestManualNamesNoCommandThatDoesNotExist(t *testing.T) {
 				if !valid[word] {
 					t.Errorf("%s:%d names a command ochakai does not have: %q\n\t%s",
 						rel, i+1, word, strings.TrimSpace(span))
+				}
+			}
+		}
+	}
+	for _, rel := range commandGuardExtra {
+		content, err := os.ReadFile(filepath.Join("../..", rel))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		for i, line := range strings.Split(string(content), "\n") {
+			for _, word := range commandWordsIn(line) {
+				checked++
+				if !valid[word] {
+					t.Errorf("%s:%d names a command ochakai does not have: %q\n\t%s",
+						rel, i+1, word, strings.TrimSpace(line))
 				}
 			}
 		}

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -351,10 +351,7 @@ ochakai use $OCHAKAI_URL
 If you want MCP tools inside Claude Code instead, the bridge needs no
 proxy either — `claude mcp add ochakai -- ochakai mcp-stdio` (needs
 `gcloud auth login` and `ochakai` on `PATH`; see [connecting an MCP
-client](../../docs/guides/mcp-clients.md#what-the-bridge-needs)). The
-repository's committed `.mcp.json` defaults to the local compose port
-(8080); if using this repo's config file against a Cloud Run deployment,
-repoint its `url` at the proxy below.
+client](../../docs/guides/mcp-clients.md#what-the-bridge-needs)).
 
 Smoke test over REST through the [Cloud Run
 proxy](https://cloud.google.com/sdk/gcloud/reference/run/services/proxy),

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -306,7 +306,7 @@ variable "webui_iap_members" {
 variable "webui_records_browser_user" {
   description = <<-EOT
     Record the person signed in to the browser as the author of their edits
-    (`human:tanaka@… via agent:<webui-sa>`) instead of the webui's own service
+    (`human:tanaka@… via process:<webui-sa>`) instead of the webui's own service
     account. Sets OCHAKAI_IAP_AUDIENCE on the webui and adds the webui's
     service account to the server's delegating callers (design docs 0027,
     0032). Once set, serve-ui refuses any request IAP did not sign, so a

--- a/docs/design/0029-usage-recording-off-the-read-path.md
+++ b/docs/design/0029-usage-recording-off-the-read-path.md
@@ -1,6 +1,6 @@
 # ochakai 設計ドキュメント 0029: 利用測定を読み取りパスから外す
 
-Status: Accepted(2026-07-26)。[0049](0049-instance-metrics-and-search-misses.md)
+Status: Accepted(2026-07-26)。[0051](0051-instance-metrics-and-search-misses.md)
 が同じバッファ・同じフラッシュ・同じ 180 日の刈り取りを、エントリに紐づかない
 事実(ヒット 0 の検索)にも広げた — 決定そのものは変わらない
 Date: 2026-07-26

--- a/docs/design/0040-read-only-mode.md
+++ b/docs/design/0040-read-only-mode.md
@@ -4,7 +4,7 @@ Status: Accepted(2026-07-27)。[0002](0002-authn-authz.md) の「認可を持た
 を維持したまま、デプロイ全体を読み取り専用にできるようにする。0002 を改訂は
 しない — §2.1 でその理由を述べる。[0015](0015-surface-consistency.md) の
 面一貫性に従い 4 面すべてに現れる。§2.2 の「利用測定は凍結の外」は
-[0049](0049-instance-metrics-and-search-misses.md) の検索ミスにもそのまま
+[0051](0051-instance-metrics-and-search-misses.md) の検索ミスにもそのまま
 及ぶ(§3.4)。**綴りは [0060](0060-one-word-for-the-posture.md) が改訂
 した** — `OCHAKAI_READ_ONLY=true` は `OCHAKAI_MODE=read-only` になった。
 この記録が決めたこと(何を拒否するか、認可ではないこと、4 面すべてに

--- a/docs/design/0042-public-read-only.md
+++ b/docs/design/0042-public-read-only.md
@@ -3,7 +3,7 @@
 Status: Accepted(2026-07-27)。[0040](0040-read-only-mode.md) の read-only を
 前提に、**identity を一切読まない**姿勢を足す。[0002](0002-authn-authz.md) の
 「到達制御は Cloud Run IAM の仕事」は変えない — §2.1 で、この姿勢が
-その外側にあることを述べる。[0049](0049-instance-metrics-and-search-misses.md)
+その外側にあることを述べる。[0051](0051-instance-metrics-and-search-misses.md)
 §3.4 が、この姿勢の帰結を 1 つ足した — identity を読まないデプロイは、
 呼び出し元が打ったクエリ文字列も残さない。**綴りは
 [0060](0060-one-word-for-the-posture.md) が改訂した** —

--- a/docs/design/0058-filters-nobody-arrived-through.md
+++ b/docs/design/0058-filters-nobody-arrived-through.md
@@ -8,7 +8,7 @@ frontmatter フィルタ `fm.` を **MCP の 2 ツールから降ろす**
 MCP も載せないに改訂する)— REST と CLI には残るので能力は落ちない。
 [0015](0015-surface-consistency.md) §3 の「載せないもの」に 1 件足す。
 [0051](0051-instance-metrics-and-search-misses.md) §3.1 がスコアの床を
-採らなかった理由を、そのままこちらにも適用する
+採らなかった理由を、そのままこちらにも適用する。**§1.1 の `knowledge.md` は architecture.md に畳まれた** — [architecture.md](../architecture.md#search) に読み替える
 Date: 2026-07-30
 
 ## 1. 問題: 面に載っているが、誰も通っていない

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -1068,6 +1068,14 @@ func refuseReserved(w http.ResponseWriter, path, because string) bool {
 // straight to the store rather than through svc.Get: this is a check of
 // whether the address is a subtree, not a read of the object living
 // there, and must not count as a fetch or fault on missing attachments.
+//
+// A prefix that is not an object's own address but still matches
+// nothing — a typo one level too deep, as much as a directory that is
+// legitimately empty — is deliberately not refused here: the two are
+// indistinguishable from the store's side, and treating "matches
+// nothing" as an error would refuse every empty subtree along with
+// every typo. Only an object's own address is a defect this endpoint
+// can tell apart from a real, empty directory (issue #399).
 func refuseObjectAsArchive(w http.ResponseWriter, r *http.Request, svc *service.Service, path string) (bool, error) {
 	if path == "" {
 		return false, nil // the root is the whole bundle, never an object's own address
@@ -1254,8 +1262,7 @@ func planOf(created, changed bool) string {
 func writeView(w http.ResponseWriter, status int, k *domain.Knowledge) {
 	v, err := okf.ViewOf(k)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError,
-			map[string]string{"error": "render document: " + err.Error()})
+		writeError(w, fmt.Errorf("render document: %w", err))
 		return
 	}
 	writeJSON(w, status, v)
@@ -1271,8 +1278,7 @@ func writeView(w http.ResponseWriter, status int, k *domain.Knowledge) {
 func writeDocument(w http.ResponseWriter, status int, k *domain.Knowledge) {
 	doc, err := okf.Document(k)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError,
-			map[string]string{"error": "render document: " + err.Error()})
+		writeError(w, fmt.Errorf("render document: %w", err))
 		return
 	}
 	w.Header().Set("Content-Type", documentMediaType)


### PR DESCRIPTION
## Summary

Closes #399. Five small, unrelated defects the 17-PR batch (#381-#397) left behind — each fell in a gap between two PRs, and three fell in a gap the new guards from #395 did not reach.

1. **A reopened contradiction (#370's regression).** `deploy/cloudrun/README.md` told a reader to repoint the committed `.mcp.json` at the Cloud Run proxy; `docs/guides/mcp-clients.md` says to prefer the bridge or `ochakai ui` instead. Removed the deploy guide's sentence — `mcp-clients.md` now owns that story per #394's rule.

2. **A dangling link into a page that no longer exists.** `docs/design/0058`'s Status header now notes its `knowledge.md` link points into `docs/architecture.md` (folded there by #393) — a note rather than a silent edit, since design records are immutable. Also fixed three pre-existing dangling links (`0029`, `0040`, `0042`) that still pointed at the pre-renumbering `0049-instance-metrics-and-search-misses.md`; that content is `0051` now, after a pre-release renumbering (0048 §2.3) reused `0049` for a different record.

3. **Two retired-spelling teaching spots outside guard reach.** `.github/ISSUE_TEMPLATE/bug_report.yml`'s worked example still showed the retired `ochakai create`; `deploy/terraform/variables.tf`'s description still showed the retired `via agent:`. Fixed both, and extended the guards that missed them: `TestManualNamesNoCommandThatDoesNotExist` now also reads `commandGuardExtra` files outside the Markdown manual, and `retired_test.go`'s file walk no longer skips `.github/` and now includes `.tf`.

4. **A missing CHANGELOG entry for #384.** Added an `[Unreleased]` `Fixed`/**BREAKING** entry for the 404/405 JSON envelope and the 500 that stopped echoing the underlying error, matching the standard #383 and #385 already applied.

5. **Two loose ends inside otherwise-correct PRs.**
   - `writeView` and `writeDocument` now scrub render failures through `writeError` instead of writing `"render document: " + err.Error()` onto the wire.
   - `api/openapi.yaml` declares 405 alongside the 500 already on all eleven operations.
   - `refuseObjectAsArchive`'s doc comment now states, rather than leaves silent, that a prefix matching no object at all (a typo one segment shallower than an object's own address) still answers 200 with an empty archive — a deliberate scope limit, not an oversight. Noted in the CHANGELOG entry for #385 too.

Also added `TestNoUnresolvedConflictMarkers` (the issue's "not outstanding, recorded because it should not recur" item) — it reads every tracked text file for an unresolved git conflict marker, the mistake #393 made in `docs/surface.md` that nothing caught because only that file's numbers were checked, not its well-formedness.

## Test plan

- [x] `scripts/check core` (gofmt, go vet, go test -race, CGO_ENABLED=0 build) — all green
- [x] `TestRetiredSpellingsAreNotTaught`, `TestManualNamesNoCommandThatDoesNotExist`, `TestOneSpellingDecidesWhatIsReserved`, `TestContractNamesNoAddressItDoesNotHave` — pass, and the two new-file cases are now actually exercised
- [x] `TestNoUnresolvedConflictMarkers` — pass
- [x] `TestDesignRecordsStayUnderTheirCeiling`, `TestDesignRecordCorpusStaysUnderItsCeiling` — pass (the 0058 amendment is written as one dense line to stay under the corpus ceiling, which had no slack left)
- [x] `TestOpenAPISpecIsValid`, `TestOpenAPISchemasMatchGoTypes`, full `internal/restapi` suite — pass with the new 405 declarations
- [ ] `scripts/check --db` (store integration tests) not run locally — no store code changed in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)