### PR TITLE
restapi: scope purge and fm. exemption per operation

### DIFF
--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -235,7 +235,7 @@ func Handler(svc *service.Service) http.Handler {
 		q := r.URL.Query()
 		if err := rejectUnknownParams(q,
 			"limit", "rejected", "type", "status", "tag", "source", "links_to",
-			"prefix", "trust", "q", "sort", "cursor"); err != nil {
+			"prefix", "trust", "q", "sort", "cursor", "fm."); err != nil {
 			writeError(w, err)
 			return
 		}
@@ -486,9 +486,21 @@ func Handler(svc *service.Service) http.Handler {
 	// Ochakai-Plan. It is a query parameter and not a header because a
 	// header a proxy drops turns a dry run into a write.
 	for _, m := range []string{"PUT", "DELETE"} {
+		// purge is DELETE's own parameter (api/openapi.yaml declares it
+		// there and not on PUT): a PUT that carries it is a caller who
+		// meant the two-step delete-then-purge and sent it to the wrong
+		// verb, and that deserves the 400 rejectUnknownParams gives every
+		// other misdirected parameter — not the silent no-op it was
+		// before (issue #409). dry_run stays allowed on both: DELETE's
+		// own handling below turns it into a more specific refusal than
+		// "unknown query parameter" would.
+		allowed := []string{"dry_run"}
+		if m == "DELETE" {
+			allowed = append(allowed, "purge")
+		}
 		mux.HandleFunc(m+" /api/v1/bundle/{path...}", func(w http.ResponseWriter, r *http.Request) {
 			path := r.PathValue("path")
-			if err := rejectUnknownParams(r.URL.Query(), "dry_run", "purge"); err != nil {
+			if err := rejectUnknownParams(r.URL.Query(), allowed...); err != nil {
 				writeError(w, err)
 				return
 			}
@@ -625,7 +637,7 @@ func Handler(svc *service.Service) http.Handler {
 	mux.HandleFunc("GET /api/v1/context", func(w http.ResponseWriter, r *http.Request) {
 		q := r.URL.Query()
 		if err := rejectUnknownParams(q,
-			"q", "type", "status", "tag", "prefix", "trust", "limit", "budget"); err != nil {
+			"q", "type", "status", "tag", "prefix", "trust", "limit", "budget", "fm."); err != nil {
 			writeError(w, err)
 			return
 		}
@@ -1499,19 +1511,33 @@ func parseIfMatch(r *http.Request) *string {
 	return &v
 }
 
-// rejectUnknownParams 400s on the first query key outside allowed,
-// naming it. Before design doc 0064 an unrecognized key was a silent
-// no-op on every endpoint but one — an unrecognized fm.* key already
-// 400s downstream, once the service checks it against the concept's own
-// vocabulary (checkedFilter), which is why frontmatterFilter's keys are
-// exempt here rather than enumerated: they are validated by content, not
-// by a fixed list. This is what makes it safe to add a query parameter
-// after the freeze — an old server 400s a caller that sends one early,
-// rather than silently ignoring it the way ?dry_run= was ignored by a
-// server that did not know it yet.
+// rejectUnknownParams 400s on the lowest unknown query key, naming it —
+// sorted rather than range order, so which key gets named does not
+// depend on Go's randomized map iteration. Before design doc 0064 an
+// unrecognized key was a silent no-op on every endpoint but one.
+//
+// fm.* is exempt only for a caller that passes "fm." among allowed: an
+// unrecognized fm.* key already 400s downstream, once the service checks
+// it against the concept's own vocabulary (checkedFilter), which is why
+// frontmatterFilter's keys are validated by content there rather than
+// enumerated here — but only on the two operations that read a
+// Frontmatter filter at all (search, context). Every other operation has
+// no such downstream check, so fm.* left exempt there would be the same
+// silent no-op this function exists to close (issue #409).
+//
+// This is what makes it safe to add a query parameter after the freeze —
+// an old server 400s a caller that sends one early, rather than silently
+// ignoring it the way ?dry_run= was ignored by a server that did not
+// know it yet.
 func rejectUnknownParams(q url.Values, allowed ...string) error {
+	allowFM := slices.Contains(allowed, "fm.")
+	keys := make([]string, 0, len(q))
 	for key := range q {
-		if strings.HasPrefix(key, "fm.") {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if allowFM && strings.HasPrefix(key, "fm.") {
 			continue
 		}
 		if !slices.Contains(allowed, key) {

--- a/internal/restapi/restapi_test.go
+++ b/internal/restapi/restapi_test.go
@@ -202,6 +202,60 @@ func TestFrontmatterParamsAreNotUnknown(t *testing.T) {
 	}
 }
 
+// TestUnknownQueryParamsArePerOperation pins the two silent no-ops issue
+// #409 found in the strict allowlist: a parameter declared in
+// api/openapi.yaml on one operation but accepted, and ignored, on
+// another. TestUnknownQueryParamsAreRejected already shows an
+// altogether-foreign key is rejected everywhere; this shows a key that
+// is real on *some* operation is still rejected on the ones that do not
+// declare it — the case a single shared or globally-exempt allowlist
+// cannot distinguish.
+func TestUnknownQueryParamsArePerOperation(t *testing.T) {
+	h := Handler(&service.Service{})
+	cases := []struct{ name, method, url string }{
+		// purge is DELETE's own parameter (api/openapi.yaml declares it
+		// there, not on PUT); before issue #409 the two verbs shared one
+		// allowlist and a PUT ?purge= passed it silently.
+		{"purge on PUT", http.MethodPut, "/api/v1/bundle/metrics/revenue.md?purge=true"},
+		// fm.* is real on search and context (frontmatterFilter); before
+		// issue #409 the exemption was unconditional, so it also passed
+		// on every operation that reads no Frontmatter filter at all.
+		{"fm. on stats", http.MethodGet, "/api/v1/stats?fm.owner=finance"},
+		{"fm. on move", http.MethodPost, "/api/v1/move?fm.owner=finance"},
+		{"fm. on reembed", http.MethodPost, "/api/v1/reembed?fm.owner=finance"},
+		{"fm. on bundle get", http.MethodGet, "/api/v1/bundle/metrics/revenue.md?fm.owner=finance"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, httptest.NewRequest(c.method, c.url, nil))
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("%s %s = %d, want 400 (body: %s)", c.method, c.url, rec.Code, rec.Body)
+			}
+			if !strings.Contains(rec.Body.String(), "unknown query parameter") {
+				t.Errorf("%s %s body %q does not say the parameter is unknown", c.method, c.url, rec.Body)
+			}
+		})
+	}
+}
+
+// TestUnknownQueryParamNamedIsDeterministic pins that naming the
+// offending key in a 400 does not depend on Go's randomized map
+// iteration: with two unknown keys, the same one is named every time.
+func TestUnknownQueryParamNamedIsDeterministic(t *testing.T) {
+	h := Handler(&service.Service{})
+	for i := 0; i < 20; i++ {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/v1/stats?zzz=1&aaa=1", nil))
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("run %d: = %d, want 400 (body: %s)", i, rec.Code, rec.Body)
+		}
+		if !strings.Contains(rec.Body.String(), "aaa") {
+			t.Errorf("run %d: body %q does not name the lexicographically first unknown key", i, rec.Body)
+		}
+	}
+}
+
 // TestReviewRefusesRulingsItCannotRecord pins the two ways a ruling is
 // refused before any store access (design doc 0055 §§3.2-3.3): a value
 // outside the vocabulary, and a note where nothing can carry one.


### PR DESCRIPTION
Fixes #409

`rejectUnknownParams` had two silent no-ops inside the mechanism design doc 0064 built to eliminate exactly this class of bug:

1. **`purge` accepted, and ignored, on PUT.** PUT and DELETE `/api/v1/bundle/{path...}` shared one allowlist (`dry_run`, `purge`), but `api/openapi.yaml` declares `purge` on DELETE only. `PUT ...?purge=true` passed the allowlist and did nothing. The loop now builds a per-method allowed list — PUT gets `dry_run` only, DELETE keeps both (its own handling already turns a stray `dry_run` into a more specific refusal than a generic "unknown query parameter" would, so that path is untouched).

2. **`fm.*` exempt globally instead of per-operation.** The exemption fired for every operation regardless of whether it read a Frontmatter filter — `GET /api/v1/stats?fm.owner=x`, `POST /api/v1/move?fm.owner=x`, etc. all passed, even though only `search` and `context` (the two operations that build a `store.Filter.Frontmatter`) validate `fm.*` downstream. `rejectUnknownParams` now only exempts `fm.*` for a caller that opts in by including the literal `"fm."` in its allowed list — `search` and `context` do; the other 9 operations don't.

Also fixed the minor nondeterminism the issue flagged: which key gets named in the 400 no longer depends on Go's randomized map iteration (keys are sorted before the check).

## Test plan
- [x] `scripts/check --db` (gofmt, vet, race tests incl. store integration tests against real PostgreSQL, build) — all green
- [x] `scripts/check lint` — 0 issues
- [x] New tests: `TestUnknownQueryParamsArePerOperation` (PUT `?purge=`, `fm.*` on stats/move/reembed/bundle-get all now 400) and `TestUnknownQueryParamNamedIsDeterministic`
- [x] Existing `TestUnknownQueryParamsAreRejected`, `TestFrontmatterParamsAreNotUnknown`, and the integration test covering `DELETE ?dry_run=true` and `DELETE ?purge=true` still pass unchanged

No design doc change: 0064 already states the intended rule (per-operation 400 on undeclared keys); this closes the gap between that rule and the implementation rather than changing the decision. (docs/design's corpus line ceiling has zero slack left, which also argued against a wording tweak there.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)