### PR TITLE
Close five bookkeeping gaps left by #400 and #407

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,11 +1,11 @@
 name: Feature request
-description: Propose something ochakai should do.
+description: Propose something `ochakai` should do.
 labels: ["enhancement"]
 body:
   - type: markdown
     attributes:
       value: |
-        ochakai stays small by refusing things — the README table and
+        `ochakai` stays small by refusing things — the README table and
         [docs/design/0015](https://github.com/na0fu3y/ochakai/blob/main/docs/design/0015-surface-consistency.md)
         list what is deliberately absent, and
         [ROADMAP.md](https://github.com/na0fu3y/ochakai/blob/main/ROADMAP.md)
@@ -27,7 +27,7 @@ body:
     id: proposal
     attributes:
       label: The proposal
-      description: What ochakai would do instead. Sketch the request and response, or the command, if you have one in mind.
+      description: What `ochakai` would do instead. Sketch the request and response, or the command, if you have one in mind.
     validations:
       required: true
 
@@ -69,7 +69,7 @@ body:
         out of scope rather than a matter of priority. Check both.
       options:
         - label: >-
-            No LLM inside, no SQL execution — ochakai stores and serves
+            No LLM inside, no SQL execution — `ochakai` stores and serves
             knowledge; interpretation and execution belong to the client agent
             (design doc 0001).
           required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,9 +129,18 @@ last entry.
     they named the wire concept: the `Attachment` OpenAPI schema and the
     JSON key on `View`, `SearchHit` and `ReembedResult`; the archive
     address's `?attachments=` query parameter (now `?files=`); the MCP
-    tool `get_attachment` (now `get_file`). `entries` is unaffected —
+    tool `get_attachment` (now `get_file`) and its result key
+    (`attachment` → `file`). `entries` is unaffected —
     design doc [0057](docs/design/0057-concept-is-the-word-a-reader-meets.md)
-    §3.2 already exempted it, and that stands.
+    §3.2 already exempted it, and that stands. The CLI followed past the
+    wire too: `ochakai export --no-attachments` is now `--no-files`.
+  - `ochakai import`'s summary line, and its `--dry-run` twin, traded
+    `%d attachments, %d files` for `%d attributed, %d loose`. Not a
+    rename of the line above — `attributed` counts files a concept's body
+    claims and `loose` counts files that belong to no concept, the same
+    two counts as before under words this PR had not taught anywhere
+    else. A script parsing the line by position still works; one
+    matching the old words breaks silently.
   - A failed `If-None-Match: *` (the id was already taken) is now 412,
     not 409 — RFC 9110's status for a failed precondition. 409 stays the
     answer for a conflict with no precondition behind it, such as `move`

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ in the version you are running.
   [Golden query canary](docs/guides/golden-query-canary.md)
 - **Building on it** — [REST API](api/openapi.yaml) ·
   [Examples](examples) · [All docs](docs/README.md)
-- **Deciding** — [The surface](docs/surface.md), the seven conditions
+- **Deciding** — [The surface](docs/surface.md), the eight conditions
   ochakai exists to satisfy and everything counted against them, and
   [docs/design](docs/design/README.md), the numbered decision records
   behind it (mostly Japanese, [summarized in

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,9 +14,9 @@ the last section is the load-bearing one: knowing what ochakai will not do is
 more useful than a list of what it might.
 
 What those refusals are measured against is written down in
-[docs/surface.md](docs/surface.md): seven conditions ochakai exists to satisfy,
+[docs/surface.md](docs/surface.md): eight conditions ochakai exists to satisfy,
 and every surface that serves them, counted. A request that serves none of the
-seven is one this project will decline — it is fairer to say so up front than
+eight is one this project will decline — it is fairer to say so up front than
 to leave it open.
 
 Priorities are open to input. Say what you need in

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -1594,11 +1594,6 @@ func isInvalid(err error) bool {
 	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusBadRequest
 }
 
-func isConflict(err error) bool {
-	var apiErr *apiclient.APIError
-	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusConflict
-}
-
 // readBundle loads an OKF bundle into a path→content map from a directory,
 // a tar.gz file, or stdin ("-", tar.gz).
 func readBundle(path string) (map[string][]byte, error) {

--- a/cmd/ochakai/surface_test.go
+++ b/cmd/ochakai/surface_test.go
@@ -945,18 +945,26 @@ var commandGuardExempt = map[string]bool{
 	"ROADMAP.md":  true,
 }
 
-// commandGuardExtra are files outside the manual that also teach a literal
-// "ochakai <command>" invocation and so need the same guard —
-// TestManualNamesNoCommandThatDoesNotExist did not reach them because
-// userDocs() is DOC-page prose only (.md, and .github/ skipped as a
-// dot-directory): issue #399 found bug_report.yml still showing the
-// retired `ochakai create` as the example every bug reporter copies.
-// These are scanned with commandWordsIn rather than commandWordIn: none of
-// them wrap prose in Markdown fences or backticks to isolate a span with,
-// so every field in every line is checked instead.
-var commandGuardExtra = []string{
-	".github/ISSUE_TEMPLATE/bug_report.yml",
-}
+// commandGuardExtraDir is the directory TestManualNamesNoCommandThatDoesNotExist
+// reads outside the Markdown manual: userDocs() is DOC-page prose only
+// (.md, and .github/ skipped as a dot-directory), so issue #399 found
+// bug_report.yml still showing the retired `ochakai create` as the
+// example every bug reporter copies. Issue #401's fix named that one
+// file (commandGuardExtra); issue #412 found the same directory's
+// feature_request.yml just as unwatched — its own dropdown option names
+// `ochakai ui` — so this reads every file the directory holds instead of
+// one chosen by hand, the way repoTextFiles (retired_test.go) walks a
+// directory rather than naming files in it.
+//
+// These are scanned with commandWordsIn rather than commandWordIn: an
+// issue form's dropdown options and placeholder text are read literally
+// by the GitHub UI, so wrapping the invocation in backticks or a fence to
+// isolate it — the way the Markdown manual does — would show the reporter
+// a stray backtick instead of the command. Every field in every line is
+// checked instead, and prose that merely mentions the product name
+// (`ochakai` in backticks) is worded to stay out of the way, the same
+// reason a URL segment or `./cmd/ochakai` already does not match.
+const commandGuardExtraDir = ".github/ISSUE_TEMPLATE"
 
 var inlineCodeSpanRe = regexp.MustCompile("`([^`]*)`")
 
@@ -985,11 +993,15 @@ var commandWordRe = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9-]*`)
 // an already-isolated span, this walks all fields so it also catches a
 // standalone "ochakai" appearing mid-sentence, while still passing over
 // "./cmd/ochakai" or "ochakai.example.com", where "ochakai" is never a
-// field by itself.
+// field by itself. A leading "(" is stripped first — an issue form's
+// dropdown option reads "Web UI (ochakai ui / serve-ui)", where
+// Fields() leaves the paren stuck to the word — so long as what remains
+// is exactly "ochakai" and not, say, "(ochakai.example.com)".
 func commandWordsIn(line string) []string {
 	fields := strings.Fields(line)
 	var words []string
 	for i, field := range fields[:max(0, len(fields)-1)] {
+		field = strings.TrimPrefix(field, "(")
 		if field != "ochakai" && field != "/ochakai" {
 			continue
 		}
@@ -1062,7 +1074,15 @@ func TestManualNamesNoCommandThatDoesNotExist(t *testing.T) {
 			}
 		}
 	}
-	for _, rel := range commandGuardExtra {
+	entries, err := os.ReadDir(filepath.Join("../..", commandGuardExtraDir))
+	if err != nil {
+		t.Fatalf("read %s: %v", commandGuardExtraDir, err)
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		rel := commandGuardExtraDir + "/" + e.Name()
 		content, err := os.ReadFile(filepath.Join("../..", rel))
 		if err != nil {
 			t.Fatalf("read %s: %v", rel, err)
@@ -1077,9 +1097,59 @@ func TestManualNamesNoCommandThatDoesNotExist(t *testing.T) {
 			}
 		}
 	}
+	for _, rel := range terraformOutputFiles(t) {
+		content, err := os.ReadFile(filepath.Join("../..", rel))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		for i, line := range strings.Split(string(content), "\n") {
+			m := terraformOchakaiValueRe.FindStringSubmatch(line)
+			if m == nil {
+				continue
+			}
+			checked++
+			if !valid[m[1]] {
+				t.Errorf("%s:%d names a command ochakai does not have: %q\n\t%s",
+					rel, i+1, m[1], strings.TrimSpace(line))
+			}
+		}
+	}
 	if checked == 0 {
 		t.Fatal("no command invocation found across the manual: this check now guards nothing")
 	}
+}
+
+// terraformOchakaiValueRe matches a Terraform output's `value` when it is
+// a literal string that opens with "ochakai <word>" — deploy/terraform/
+// outputs.tf's use_command tells the reader the next command to run, in a
+// string `terraform output` prints verbatim, so it cannot be fenced or
+// backtick-isolated the way the manual's invocations are without putting
+// stray backticks in what the operator copies and pastes. A description
+// string (prose about the output, not the output itself) is not this
+// shape, which is what keeps main.tf's and variables.tf's free-form
+// commentary about ochakai out of this check.
+var terraformOchakaiValueRe = regexp.MustCompile(`^\s*value\s*=\s*"ochakai ([A-Za-z][A-Za-z0-9-]*)`)
+
+// terraformOutputFiles lists the .tf files under deploy/terraform, the
+// only place a Terraform output's value has ever named a live ochakai
+// command — walked generically rather than naming outputs.tf, the same
+// reason commandGuardExtraDir reads a directory instead of one issue
+// form.
+func terraformOutputFiles(t *testing.T) []string {
+	t.Helper()
+	const dir = "deploy/terraform"
+	entries, err := os.ReadDir(filepath.Join("../..", dir))
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+	var out []string
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".tf" {
+			continue
+		}
+		out = append(out, dir+"/"+e.Name())
+	}
+	return out
 }
 
 // queueWordsToLearn is the queue keys that are words of their own. A

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -82,7 +82,7 @@ ochakai を使う人が払うのは実装の行数ではなく**表面**であ�
 - ENV: 15
 - VOCAB: 34
 - DOC: 23
-- DOC-LINES: 4948
+- DOC-LINES: 4984
 - DOC-LINES-SLACK: 10
 
 `-LINES` で終わる一行だけは、一覧ではなく**量**に天井を置いている。
@@ -184,6 +184,11 @@ ochakai を使う人が払うのは実装の行数ではなく**表面**であ�
 なる**からである。同じ PR で `Ochakai-Plan` も足しており、HEADER の
 天井も上がっている。
 
+19 のまま、PR [#407](https://github.com/na0fu3y/ochakai/issues/407)
+(design doc [0064](design/0064-rest-stops-at-api-v1.md)) が `attachments`
+を `files` に改めた。下の MCP の `get_attachment` → `get_file` と同じ
+改名で、**変わったのは利用者が知る語そのもの**である。
+
 - `budget`
 - `cursor`
 - `days`
@@ -219,6 +224,11 @@ ochakai を使う人が払うのは実装の行数ではなく**表面**であ�
 は片方しか読まなくなる — だから dry run では `Ochakai-Unchanged` を
 出さず、`Ochakai-Plan` が置き換える。
 
+10 のまま、同じ PR [#407](https://github.com/na0fu3y/ochakai/issues/407)
+が `Ochakai-On-Behalf-Of` / `Ochakai-Producer` から `X-` 接頭辞を落とし、
+他の八本と同じ綴りの型([0064](design/0064-rest-stops-at-api-v1.md))に
+した。
+
 - `Content-Disposition`
 - `ETag`
 - `If-Match`
@@ -245,6 +255,13 @@ ochakai を使う人が払うのは実装の行数ではなく**表面**であ�
 改名した — 知識の単位は OKF SPEC §2 の語で **concept** であり、文書が
 既にその語で書いていたのにツール名だけが `knowledge` を名乗っていた。
 能力も引数も応答も変わらない。
+
+8 本のまま、もう一度。PR [#407](https://github.com/na0fu3y/ochakai/issues/407)
+(design doc [0064](design/0064-rest-stops-at-api-v1.md)) が
+`get_attachment` を `get_file` に改めた — ワイヤの `attachments` が
+`files` になったのと同じ改名で、**変わったのは利用者が知る語そのもの**
+であって、能力も引数も応答も変わらない。応答の JSON キーも
+`attachment` から `file` に変わっている。
 
 ## CLI (26)
 
@@ -318,6 +335,10 @@ PARAM と同じく数えるのは**名前の異なり数**である。`--json` �
 
 `serve` / `serve-ui` のフラグは数えない。CLI の節が `serve` を数えないのと
 同じ理由で、バイナリの動かし方であって ochakai が知っていることではない。
+
+28 のまま、PR [#407](https://github.com/na0fu3y/ochakai/issues/407) が
+`ochakai export` の一本を `no-files` に改めた — PARAM の `attachments`
+→ `files` に揃えただけで、ワイヤの外で名前だけ遅れていた。
 
 - `budget`
 - `cursor`
@@ -501,7 +522,7 @@ REST は 19 → 11 に減り、非テストの Go は 2.3 倍になり、この 
 置いた(上限の節の `DOC-LINES`)。0059 のキュー改名がこの文書に段落を
 足したとき、動いた数は一つも無かった。
 
-**この天井は、置いた後に三度上がり、一度下がっている。**
+**この天井は、置いた後に四度上がり、一度下がっている。**
 [0062](design/0062-a-listing-is-not-a-search.md) が `ochakai search` を
 二つに割ったとき、[cli.md](cli.md) は 9 つのフィルタを二度書くことに
 なった — コマンドを割るのは**参照文の重複を買う**という、それまでどこ
@@ -517,7 +538,7 @@ deploy/cloudrun/README.md 分割は逆方向でも同じ代金を払った — �
 docs/guides/rest-integration.md を一枚足し、deploy/cloudrun/README.md
 の §5c(委譲された provenance の全文)をそこへの一段落に畳んだ。ページが
 増えたぶんは畳み込みで相殺されず、5,808 から 5,942 まで上げている —
-C6 が七つの条件の一つであり、これまで YAML のコメント一つに委ねられて
+C6 が八つの条件の一つであり、これまで YAML のコメント一つに委ねられて
 いたことが、その代金である。
 
 [#374](https://github.com/na0fu3y/ochakai/issues/374) は逆方向をもう一度
@@ -539,11 +560,26 @@ configuration・architecture・faq・deploy の各ページに同じ話が繰り
 いた。[CONTRIBUTING.md](../CONTRIBUTING.md) に移し、DOC は 24 → 23 に
 なった。
 
+**PR [#407](https://github.com/na0fu3y/ochakai/issues/407) は四つの
+綴りを書き換えた。** design doc [0064](design/0064-rest-stops-at-api-v1.md)
+の最後の破壊的変更が、PARAM の `attachments` を `files` に、HEADER の
+`Ochakai-On-Behalf-Of` / `Ochakai-Producer` から `X-` 接頭辞を落とし、
+MCP の `get_attachment` を `get_file` に、FLAG の `no-attachments` を
+`no-files` に改めた。[0054](design/0054-concept-is-the-okf-word.md) の
+ツール改名・[0059](design/0059-a-queue-is-named-by-its-listing.md) の
+キュー改名と同じ理由で——**変わったのは利用者が知る語そのもの**であって
+四つのどの一覧も本数は動かない——このページも同じだけの分量を払っている。
+4,930 → 4,938。
+
 **[#408](https://github.com/na0fu3y/ochakai/issues/408) はページを
 増やさず数行だけ足した。** REST の凍結を書いた直後の docs/README.md と
 docs/guides/rest-integration.md が、まだ「すべての面が不安定」と言って
 いた・凍結に触れていなかった箇所を直し、この段落自身もその天井を動かす
 分を数えている — 折り畳みではなく訂正なので、4,938 → 4,948。
+
+[#412](https://github.com/na0fu3y/ochakai/issues/412) も同じ形の訂正
+である。PARAM・HEADER・MCP・FLAG の四つの一覧に前回抜けていた説明を
+足し、この段落を含めてその分を数えている — 4,948 → 4,984。
 
 数えないものを決めるのは、数えるものを決めるのと同じだけ決定である。
 

--- a/internal/apiclient/apiclient.go
+++ b/internal/apiclient/apiclient.go
@@ -408,7 +408,7 @@ func (c *Client) Get(ctx context.Context, id string) (*domain.View, error) {
 // body's content_hash). The write then lands only if the entry still has
 // that version; a stale one is a 412 APIError and nothing is written. ""
 // means last write wins. onlyIfAbsent sends If-None-Match "*", which
-// makes an occupied id a 409 instead of a replacement.
+// makes an occupied id a 412 instead of a replacement.
 //
 // created reports which way it went; changed=false reports the server
 // wrote nothing because the document matched the stored content (the


### PR DESCRIPTION
## Summary

Closes #412. Five small, unrelated gaps grouped by the issue because none has an owner otherwise.

1. **"seven conditions" survived in three prose spots after #400 added C8.** `docs/surface.md:520` disagreed with its own `## 八つの条件` heading; `ROADMAP.md:17,19` and `README.md:184` still named the old count.

2. **The command-name guard (#401) named one file instead of reading a directory.** `commandGuardExtra` was `[]string{".github/ISSUE_TEMPLATE/bug_report.yml"}`, so `feature_request.yml`'s own `- Web UI (ochakai ui / serve-ui)` option went unwatched — verified before the fix by renaming it to `ochakai frobnicate` and seeing the guard stay green. `TestManualNamesNoCommandThatDoesNotExist` now reads every file `.github/ISSUE_TEMPLATE` holds (mirroring how `repoTextFiles` walks a directory rather than naming files in it), plus a small dedicated check for `deploy/terraform`'s Terraform-output invocation (`outputs.tf`'s `use_command`), which can't be backtick-isolated the way Markdown is without putting a stray backtick in what an operator copies and pastes.

   Fixing this also surfaced a latent gap in `commandWordsIn`: a paren-attached `"(ochakai"` (the exact shape both issue-template dropdown options use) was never matched by the field-equality check, so even the currently-guarded `bug_report.yml` never actually verified its own `(ochakai ui / serve-ui)` line. Fixed by stripping a leading `(` before the comparison.

3. **#407's CHANGELOG entry missed three user-visible breaks** in the `attachments`→`files` rename: the CLI's `--no-attachments`→`--no-files`, `import`'s summary-line vocabulary (`%d attachments, %d files` → `%d attributed, %d loose`), and the MCP result key (`attachment`→`file`).

4. **`docs/surface.md`'s own DOC-LINES history went silent for #407.** The ceiling moved (4,930 → 4,938) with no paragraph, unlike every prior raise, and the four renames (PARAM, HEADER, MCP, FLAG) landed as bare list edits with no narration, unlike 0054's and 0059's precedent for a count-stable rename. Added the missing paragraphs, corrected "risen three times" to "risen four times," and — following #408's precedent of narrating a correction rather than folding it in silently — counted this fix's own footprint too (4,948 → 4,984).

5. **Two stale comments.** `apiclient.go`'s `onlyIfAbsent` doc still said an occupied id becomes a 409 (the freeze made it 412), and `client.go`'s `isConflict` had no callers left.

## Test plan

- [x] `scripts/check core` (gofmt, go vet, go test -race, CGO_ENABLED=0 build)
- [x] `scripts/check --db core` (same, with real PostgreSQL for the store tests)
- [x] `scripts/check lint` (golangci-lint, 0 issues)
- [x] Verified the new guard catches the regression: renaming `ochakai ui` to `ochakai frobnicate` in `feature_request.yml` now fails `TestManualNamesNoCommandThatDoesNotExist`, as does the same rename in `deploy/terraform/outputs.tf`'s `use_command`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)