### PR TITLE
Fix two remaining "entries" mentions after the concepts rename

### DIFF
--- a/docs/guides/operating.md
+++ b/docs/guides/operating.md
@@ -247,7 +247,7 @@ it with `>>` and a date:
 
 ```console
 $ ochakai stats --days 7
-entries	128
+concepts	128
 draft	31
 stable	92
 …

--- a/internal/service/browse.go
+++ b/internal/service/browse.go
@@ -123,7 +123,7 @@ func (s *Service) IndexDocument(ctx context.Context, prefix string) ([]byte, err
 		// silently is a listing that misdescribes the directory
 		// (design doc 0014's decision, now visible to whoever reads
 		// the file rather than only to whoever read the JSON).
-		notes = append(notes, fmt.Sprintf("_This listing was cut off at %d entries._", store.MaxBrowseEntries))
+		notes = append(notes, fmt.Sprintf("_This listing was cut off at %d concepts._", store.MaxBrowseEntries))
 	}
 	return okf.IndexDocument(dir, []okf.IndexSection{
 		{Lines: dirs}, {Lines: concepts}, {Heading: okf.FileSection, Lines: files},


### PR DESCRIPTION
## Summary
- `docs/guides/operating.md:250` — the `ochakai stats --days 7` sample transcript still showed `entries	128`; the binary now prints `concepts`.
- `internal/service/browse.go:126` — the served `index.md` truncation note said "entries" while lines 95-97 of the same function already say "concepts", and #417 already renamed the identical web UI notes to "concepts".

Both are prose, not JSON keys, which is why #417's rename missed them.

Fixes #421

## Test plan
- [x] `scripts/check core` passes