### PR TITLE
Derive the unknown-query-param check from the spec, and close a third fm. no-op

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -33,9 +33,12 @@ info:
     0064) — never a silent no-op. This is what makes it safe to add a
     parameter after the freeze: a client built against an older version
     of this contract finds out at the point of the call, rather than
-    having the parameter quietly ignored. The one exception is `fm.`,
-    whose keys are validated against the concept's own OKF frontmatter
-    (design doc 0047) rather than against a fixed name list.
+    having the parameter quietly ignored. The one exception is `fm.`, and
+    only on the operations that declare `fm.{key}` below (search,
+    context): there, its keys are validated against the concept's own OKF
+    frontmatter (design doc 0047) rather than against a fixed name list.
+    Every other operation has no such downstream check and rejects `fm.*`
+    like any other unrecognized parameter.
 
     **REST is frozen at `/api/v1`** (design doc 0064,
     docs/compatibility.md): this contract is the address list a client can

--- a/internal/restapi/openapi_test.go
+++ b/internal/restapi/openapi_test.go
@@ -13,6 +13,7 @@ package restapi
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -25,8 +26,10 @@ import (
 	"github.com/pb33f/libopenapi"
 	validator "github.com/pb33f/libopenapi-validator"
 	valerrors "github.com/pb33f/libopenapi-validator/errors"
+	yaml "go.yaml.in/yaml/v3"
 
 	"github.com/na0fu3y/ochakai/internal/domain"
+	"github.com/na0fu3y/ochakai/internal/service"
 )
 
 const specPath = "../../api/openapi.yaml"
@@ -293,5 +296,144 @@ func TestOpenAPITypeVocabularyMatchesDomain(t *testing.T) {
 		FindAllStringSubmatch(spec, -1) {
 		t.Errorf("an example still writes %q as a type. It is a free type and still works, "+
 			"but the spec is where people copy from (design doc 0038)", m[1])
+	}
+}
+
+// specHTTPMethods are the map keys a path item in api/openapi.yaml can
+// hold besides "parameters" (the path-level parameters shared by every
+// method under it).
+var specHTTPMethods = map[string]bool{"get": true, "put": true, "post": true, "delete": true, "patch": true}
+
+type specParam struct {
+	Name string `yaml:"name"`
+	In   string `yaml:"in"`
+}
+
+// specQueryParams reads api/openapi.yaml and returns, for every
+// "METHOD /path" operation, the query parameter names it declares — real
+// names, plus the sentinel "fm." standing for the `fm.{key}` family that
+// is this contract's one prefix exemption (see the spec's own prose
+// above TestOpenAPISpecIsValid's paths).
+//
+// This is the minimal reader TestUnknownQueryParamsMatchSpec needs, not
+// a second OpenAPI implementation: a $ref among components/parameters
+// resolves to a header on every one of them today (If-Match,
+// If-None-Match, Ochakai-On-Behalf-Of, Ochakai-Producer), so only
+// operations' own inline `parameters` are read — a query parameter added
+// later as a component would need this taught to resolve it, the same
+// way cmd/ochakai/surface_test.go's wireSpec does.
+func specQueryParams(t *testing.T) map[string]map[string]bool {
+	t.Helper()
+	raw, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", specPath, err)
+	}
+	var doc struct {
+		Paths map[string]map[string]yaml.Node `yaml:"paths"`
+	}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse %s: %v", specPath, err)
+	}
+	if len(doc.Paths) == 0 {
+		t.Fatal("no paths found in openapi.yaml: this check now guards nothing")
+	}
+	out := map[string]map[string]bool{}
+	for path, item := range doc.Paths {
+		var shared []specParam
+		if node, ok := item["parameters"]; ok {
+			if err := node.Decode(&shared); err != nil {
+				t.Fatalf("%s: parameters: %v", path, err)
+			}
+		}
+		for method, node := range item {
+			if !specHTTPMethods[method] {
+				continue
+			}
+			var op struct {
+				Parameters []specParam `yaml:"parameters"`
+			}
+			if err := node.Decode(&op); err != nil {
+				t.Fatalf("%s %s: %v", method, path, err)
+			}
+			names := map[string]bool{}
+			for _, p := range append(append([]specParam{}, shared...), op.Parameters...) {
+				switch {
+				case p.In != "query":
+					continue
+				case p.Name == "fm.{key}":
+					names["fm."] = true
+				default:
+					names[p.Name] = true
+				}
+			}
+			out[strings.ToUpper(method)+" "+path] = names
+		}
+	}
+	return out
+}
+
+// TestUnknownQueryParamsMatchSpec is issue #409's item 3: a hand-picked
+// list of examples cannot tell a per-operation allowlist from a shared or
+// globally-exempt one, because it never tries the one combination that
+// would fail — a parameter real on operation B, sent to operation A,
+// where A does not declare it. This builds that combination from
+// api/openapi.yaml itself, the way cmd/ochakai/surface_test.go's
+// readWireSpec builds the surface count, instead of by hand: every
+// parameter declared anywhere in the contract is tried against every
+// operation that does not declare it, and every one of those must be a
+// 400 naming it. Replacing any of restapi.go's per-operation allowlists
+// with a shared or wider one — the change #409 showed leaves a
+// hand-written five-case test green — fails this test on the first
+// parameter the merge widened.
+func TestUnknownQueryParamsMatchSpec(t *testing.T) {
+	h := Handler(&service.Service{})
+	declared := specQueryParams(t)
+
+	universe := map[string]bool{}
+	for _, names := range declared {
+		for name := range names {
+			universe[name] = true
+		}
+	}
+	if len(universe) == 0 {
+		t.Fatal("no query parameters found in openapi.yaml: this check now guards nothing")
+	}
+
+	for _, op := range restOperations {
+		allowed, ok := declared[op.spec]
+		if !ok {
+			t.Fatalf("%s: openapi.yaml has no operation %q", op.name, op.spec)
+		}
+		for name := range universe {
+			if allowed[name] {
+				continue
+			}
+			// dry_run is DELETE's one deliberate exception: PUT and
+			// DELETE share an allowlist (restapi.go) so DELETE can turn
+			// it into its own refusal ("a delete has no plan beside
+			// it") rather than "unknown query parameter" — pinned by
+			// TestRESTIntegrationDryRunAnswersWithoutWriting's DELETE
+			// ?dry_run=true case in restapi_integration_test.go.
+			// openapi.yaml correctly does not declare it there, since
+			// every value of it is refused; that is not the silent
+			// no-op this test guards against.
+			if op.name == "bundle delete" && name == "dry_run" {
+				continue
+			}
+			key := name
+			if name == "fm." {
+				key = "fm.owner"
+			}
+			t.Run(op.name+"/"+key, func(t *testing.T) {
+				url := op.url + "?" + key + "=x"
+				rec := httptest.NewRecorder()
+				h.ServeHTTP(rec, httptest.NewRequest(op.method, url, nil))
+				want := fmt.Sprintf("unknown query parameter %q", key)
+				if rec.Code != http.StatusBadRequest || !strings.Contains(errMessage(t, rec), want) {
+					t.Errorf("%s %s = %d %q, want 400 %q — api/openapi.yaml declares %q on another "+
+						"operation but not on %s", op.method, url, rec.Code, rec.Body, want, key, op.spec)
+				}
+			})
+		}
 	}
 }

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -1525,6 +1525,15 @@ func parseIfMatch(r *http.Request) *string {
 // no such downstream check, so fm.* left exempt there would be the same
 // silent no-op this function exists to close (issue #409).
 //
+// The literal key "fm." — an empty frontmatter key — is never accepted,
+// even where fm.* is exempt: it has "fm." as a prefix of itself, so the
+// exemption above would wave it through, and it is also the sentinel a
+// caller passes in allowed to grant that exemption, so a plain
+// slices.Contains(allowed, key) would wave it through a second way. Both
+// would hand it to frontmatterFilter, which drops it silently (name ==
+// "") — the third silent no-op issue #409 found, once the first two were
+// closed.
+//
 // This is what makes it safe to add a query parameter after the freeze —
 // an old server 400s a caller that sends one early, rather than silently
 // ignoring it the way ?dry_run= was ignored by a server that did not
@@ -1537,12 +1546,13 @@ func rejectUnknownParams(q url.Values, allowed ...string) error {
 	}
 	sort.Strings(keys)
 	for _, key := range keys {
-		if allowFM && strings.HasPrefix(key, "fm.") {
+		if name, ok := strings.CutPrefix(key, "fm."); allowFM && ok && name != "" {
 			continue
 		}
-		if !slices.Contains(allowed, key) {
-			return service.Invalidf("unknown query parameter %q", key)
+		if key != "fm." && slices.Contains(allowed, key) {
+			continue
 		}
+		return service.Invalidf("unknown query parameter %q", key)
 	}
 	return nil
 }

--- a/internal/restapi/restapi_test.go
+++ b/internal/restapi/restapi_test.go
@@ -155,36 +155,47 @@ func TestBadRequestValidation(t *testing.T) {
 	}
 }
 
+// restOperations pairs each of REST's eleven operations with a concrete
+// address that reaches it through Handler's router and the
+// api/openapi.yaml operation (method + path template) it implements.
+// Shared by every test below that needs to address all eleven, so there
+// is one list of URLs to keep in sync with the router rather than one
+// per test.
+var restOperations = []struct{ name, method, url, spec string }{
+	{"search", http.MethodGet, "/api/v1/search", "GET /api/v1/search"},
+	{"context", http.MethodGet, "/api/v1/context", "GET /api/v1/context"},
+	{"bundle get", http.MethodGet, "/api/v1/bundle/metrics/revenue.md", "GET /api/v1/bundle/{path}"},
+	{"bundle put", http.MethodPut, "/api/v1/bundle/metrics/revenue.md", "PUT /api/v1/bundle/{path}"},
+	{"bundle delete", http.MethodDelete, "/api/v1/bundle/metrics/revenue.md", "DELETE /api/v1/bundle/{path}"},
+	{"review", http.MethodPost, "/api/v1/review/metrics/revenue", "POST /api/v1/review/{id}"},
+	{"usage get", http.MethodGet, "/api/v1/usage/metrics/revenue", "GET /api/v1/usage/{id}"},
+	{"usage post", http.MethodPost, "/api/v1/usage/metrics/revenue", "POST /api/v1/usage/{id}"},
+	{"stats", http.MethodGet, "/api/v1/stats", "GET /api/v1/stats"},
+	{"move", http.MethodPost, "/api/v1/move", "POST /api/v1/move"},
+	{"reembed", http.MethodPost, "/api/v1/reembed", "POST /api/v1/reembed"},
+}
+
 // TestUnknownQueryParamsAreRejected pins design doc 0064's strict
 // allowlist: after the freeze, an unrecognized query parameter is a 400
 // naming it rather than a silent no-op — the asymmetry with an unknown
 // fm.* key (already checked against the concept's own vocabulary, see
 // TestBadRequestValidation) that made the dry_run false-green possible in
-// the first place. Covers every one of REST's 11 operations.
+// the first place. Covers every one of REST's 11 operations with a key
+// that appears in no allowlist at all; TestUnknownQueryParamsMatchSpec
+// below covers the sharper case, a key that is real on some operation and
+// not this one.
 func TestUnknownQueryParamsAreRejected(t *testing.T) {
 	h := Handler(&service.Service{})
-	cases := []struct{ name, method, url string }{
-		{"search", http.MethodGet, "/api/v1/search?q=x&typo=1"},
-		{"context", http.MethodGet, "/api/v1/context?q=x&typo=1"},
-		{"bundle get", http.MethodGet, "/api/v1/bundle/metrics/revenue.md?typo=1"},
-		{"bundle put", http.MethodPut, "/api/v1/bundle/metrics/revenue.md?typo=1"},
-		{"bundle delete", http.MethodDelete, "/api/v1/bundle/metrics/revenue.md?typo=1"},
-		{"review", http.MethodPost, "/api/v1/review/metrics/revenue?typo=1"},
-		{"usage get", http.MethodGet, "/api/v1/usage/metrics/revenue?typo=1"},
-		{"usage post", http.MethodPost, "/api/v1/usage/metrics/revenue?typo=1"},
-		{"stats", http.MethodGet, "/api/v1/stats?typo=1"},
-		{"move", http.MethodPost, "/api/v1/move?typo=1"},
-		{"reembed", http.MethodPost, "/api/v1/reembed?typo=1"},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
+	for _, op := range restOperations {
+		t.Run(op.name, func(t *testing.T) {
+			url := op.url + "?typo=1"
 			rec := httptest.NewRecorder()
-			h.ServeHTTP(rec, httptest.NewRequest(c.method, c.url, nil))
+			h.ServeHTTP(rec, httptest.NewRequest(op.method, url, nil))
 			if rec.Code != http.StatusBadRequest {
-				t.Fatalf("%s %s = %d, want 400 (body: %s)", c.method, c.url, rec.Code, rec.Body)
+				t.Fatalf("%s %s = %d, want 400 (body: %s)", op.method, url, rec.Code, rec.Body)
 			}
 			if !strings.Contains(rec.Body.String(), "typo") {
-				t.Errorf("%s %s body %q does not name the unknown parameter", c.method, c.url, rec.Body)
+				t.Errorf("%s %s body %q does not name the unknown parameter", op.method, url, rec.Body)
 			}
 		})
 	}
@@ -202,41 +213,43 @@ func TestFrontmatterParamsAreNotUnknown(t *testing.T) {
 	}
 }
 
-// TestUnknownQueryParamsArePerOperation pins the two silent no-ops issue
-// #409 found in the strict allowlist: a parameter declared in
-// api/openapi.yaml on one operation but accepted, and ignored, on
-// another. TestUnknownQueryParamsAreRejected already shows an
-// altogether-foreign key is rejected everywhere; this shows a key that
-// is real on *some* operation is still rejected on the ones that do not
-// declare it — the case a single shared or globally-exempt allowlist
-// cannot distinguish.
-func TestUnknownQueryParamsArePerOperation(t *testing.T) {
+// TestFrontmatterEmptyKeyIsRejected pins the third silent no-op issue
+// #409 found once the first two were closed: "fm." itself — an empty
+// frontmatter key — has "fm." as a prefix of itself, so the fm.*
+// exemption in rejectUnknownParams waved it through; it is also the
+// sentinel a caller passes in allowed to grant that exemption, so a
+// plain membership check waved it through a second way. Either path
+// handed it to frontmatterFilter, which drops a key of "" without
+// telling anyone — a client asking `?fm.=x` got a 200 that quietly
+// dropped the filter it asked for.
+func TestFrontmatterEmptyKeyIsRejected(t *testing.T) {
 	h := Handler(&service.Service{})
-	cases := []struct{ name, method, url string }{
-		// purge is DELETE's own parameter (api/openapi.yaml declares it
-		// there, not on PUT); before issue #409 the two verbs shared one
-		// allowlist and a PUT ?purge= passed it silently.
-		{"purge on PUT", http.MethodPut, "/api/v1/bundle/metrics/revenue.md?purge=true"},
-		// fm.* is real on search and context (frontmatterFilter); before
-		// issue #409 the exemption was unconditional, so it also passed
-		// on every operation that reads no Frontmatter filter at all.
-		{"fm. on stats", http.MethodGet, "/api/v1/stats?fm.owner=finance"},
-		{"fm. on move", http.MethodPost, "/api/v1/move?fm.owner=finance"},
-		{"fm. on reembed", http.MethodPost, "/api/v1/reembed?fm.owner=finance"},
-		{"fm. on bundle get", http.MethodGet, "/api/v1/bundle/metrics/revenue.md?fm.owner=finance"},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
+	for _, url := range []string{"/api/v1/search?q=x&fm.=x", "/api/v1/context?q=x&fm.=x"} {
+		t.Run(url, func(t *testing.T) {
 			rec := httptest.NewRecorder()
-			h.ServeHTTP(rec, httptest.NewRequest(c.method, c.url, nil))
+			h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, url, nil))
 			if rec.Code != http.StatusBadRequest {
-				t.Fatalf("%s %s = %d, want 400 (body: %s)", c.method, c.url, rec.Code, rec.Body)
+				t.Fatalf("GET %s = %d, want 400 (body: %s)", url, rec.Code, rec.Body)
 			}
-			if !strings.Contains(rec.Body.String(), "unknown query parameter") {
-				t.Errorf("%s %s body %q does not say the parameter is unknown", c.method, c.url, rec.Body)
+			if !strings.Contains(errMessage(t, rec), `unknown query parameter "fm."`) {
+				t.Errorf("GET %s body %q does not name fm. as unknown", url, rec.Body)
 			}
 		})
 	}
+}
+
+// errMessage decodes a writeError response's {"error": "..."} envelope,
+// so a check against its text is not defeated by JSON's own quoting: the
+// wire form of `unknown query parameter "fm."` is
+// `unknown query parameter \"fm.\"`, and a literal %q substring never
+// matches that escaped form.
+func errMessage(t *testing.T, rec *httptest.ResponseRecorder) string {
+	t.Helper()
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("body %q is not JSON: %v", rec.Body, err)
+	}
+	return body["error"]
 }
 
 // TestUnknownQueryParamNamedIsDeterministic pins that naming the


### PR DESCRIPTION
Closes #409.

#414 closed the first two silent no-ops the issue found (`purge` leaking onto PUT, `fm.*` exempted globally instead of per operation) but was reopened: item 3 — the check itself — was left as five hand-picked cases, and the reopening comment found a third no-op of the same shape.

## What was still open

**Item 3.** `TestUnknownQueryParamsArePerOperation` tried `purge` on PUT and `fm.owner` on four operations. Since none of the eleven per-operation allowlists shares a name with another's *foreign* parameter in those five spots, merging the nine non-bundle allowlists into one union — leaving PUT/DELETE and the `fm.` opt-in untouched — left `go test ./...` green while every parameter declared on any one of those nine leaked onto the other eight.

**A third no-op.** `?fm.=x` (an empty frontmatter key) passed `rejectUnknownParams` two different ways on `search`/`context` — the empty key has `"fm."` as a prefix of itself, and `"fm."` is also the sentinel a caller passes in `allowed` to grant the exemption, so a plain `slices.Contains` matched it too — and was then dropped silently by `frontmatterFilter` (`name == ""`).

## What this PR does

- **`rejectUnknownParams`** (`internal/restapi/restapi.go`) now requires a non-empty suffix after `fm.` before exempting it, and never treats the literal key `"fm."` as accepted via the sentinel.
- **`TestUnknownQueryParamsMatchSpec`** (`internal/restapi/openapi_test.go`) reads `api/openapi.yaml` itself — the way `cmd/ochakai/surface_test.go`'s `readWireSpec` already does for the surface count — and tries every query parameter declared anywhere in the contract against every operation that does not declare it, expecting a 400 naming it. I verified it against the exact regression the issue described: widening one operation's allowlist toward the others' union (e.g. `stats` gaining `tag`) fails this test on the first leaked parameter; the old hand-written test stayed green under the same change.
- **`TestFrontmatterEmptyKeyIsRejected`** pins the third no-op as a regression test.
- **`api/openapi.yaml`**'s prose corrected: it said the `fm.` exception was global; it is per operation (`search`, `context` only), which is what #414 actually shipped.

One deliberate exception the spec-derived test knows about: `dry_run` is accepted (and refused with its own message) on DELETE as well as PUT, even though `openapi.yaml` only declares it on PUT — every value of it on DELETE is refused, so it isn't the silent-acceptance case this test guards against, and it's already pinned by the integration suite's `DELETE ?dry_run=true` case.

## Test plan

- [x] `scripts/check --db` (full suite, including the Postgres-backed integration tests) — green
- [x] `scripts/check lint` — 0 issues
- [x] Manually reproduced the issue's described regression (merged one operation's allowlist toward the shared union) and confirmed `TestUnknownQueryParamsMatchSpec` fails while the old `TestUnknownQueryParamsArePerOperation` would not have