### PR TITLE
Fix put --only-if-new blaming --if-match, and two more "entries" survivors

### DIFF
--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -1026,6 +1026,9 @@ func cmdPut(ctx context.Context, args []string) error {
 	if err != nil {
 		var apiErr *apiclient.APIError
 		if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusPreconditionFailed {
+			if *onlyIfNew {
+				return fmt.Errorf("conflict: ochakai://%s already exists — --only-if-new refuses to replace it; drop the flag to overwrite, or pick a different id", k.ID)
+			}
 			return fmt.Errorf("conflict: ochakai://%s changed since the version in --if-match — `ochakai get %s` again, redo the edit, and retry with the new content_hash", k.ID, k.ID)
 		}
 		return err

--- a/cmd/ochakai/client_test.go
+++ b/cmd/ochakai/client_test.go
@@ -415,6 +415,46 @@ func TestPutIfMatchSendsHeaderAndExplainsConflict(t *testing.T) {
 	}
 }
 
+// `ochakai put --only-if-new` sends If-None-Match "*", and a 412 comes
+// back blaming the id being taken, not a stale --if-match nobody passed
+// (issue #428).
+func TestPutOnlyIfNewExplainsConflictWithoutBlamingIfMatch(t *testing.T) {
+	var gotIfNoneMatch, gotIfMatch string
+	mux := http.NewServeMux()
+	mux.HandleFunc("PUT /api/v1/bundle/{path...}", func(w http.ResponseWriter, r *http.Request) {
+		gotIfNoneMatch = r.Header.Get("If-None-Match")
+		gotIfMatch = r.Header.Get("If-Match")
+		w.WriteHeader(http.StatusPreconditionFailed)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "knowledge already exists"})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	doc := filepath.Join(t.TempDir(), "revenue.md")
+	if err := os.WriteFile(doc, []byte("---\ntype: metric\ntitle: 売上\n---\n\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := cmdPut(context.Background(), []string{"metrics/revenue",
+		"-f", doc, "--only-if-new", "--url", srv.URL})
+	if gotIfNoneMatch != "*" {
+		t.Errorf("If-None-Match on the wire = %q, want \"*\"", gotIfNoneMatch)
+	}
+	if gotIfMatch != "" {
+		t.Errorf("If-Match on the wire = %q, want none — --if-match was never passed", gotIfMatch)
+	}
+	if err == nil {
+		t.Fatal("--only-if-new onto a taken id succeeded, want a conflict error")
+	}
+	if strings.Contains(err.Error(), "--if-match") {
+		t.Errorf("conflict error blames --if-match, which was never passed: %v", err)
+	}
+	for _, want := range []string{"conflict", "already exists", "--only-if-new"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("conflict error misses %q: %v", want, err)
+		}
+	}
+}
+
 // A verification's whole product is a timestamp and a name, and the only
 // way to read them back was a second call: verify printed one line and
 // dropped the concept the server had already returned. --json hands the

--- a/docs/guides/operating.md
+++ b/docs/guides/operating.md
@@ -145,7 +145,7 @@ confirm what a running instance actually has enabled:
 ```
 "ochakai listening" addr=:8080 version=… insecure_dev=false endpoints=[/mcp /api/v1 /health]
 "semantic search enabled" model=gemini-embedding-001 dim=768 project=… discovered=true
-"files disabled (no OCHAKAI_GCS_BUCKET); markdown entries only"
+"files disabled (no OCHAKAI_GCS_BUCKET); markdown concepts only"
 ```
 
 `discovered=true` means the project came from the metadata server rather

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -66,7 +66,7 @@ response, use `budget` rather than a score floor.
 
 ## Writing concepts
 
-**409 on `put --only-if-new`.** A live concept already has that id —
+**412 on `put --only-if-new`.** A live concept already has that id —
 including a `rejected` one. Drop `--only-if-new`, or pick another id.
 Writing over a *soft-deleted* concept revives it, with its prior history
 intact; over MCP, reviving one that was verified, rejected or deprecated

--- a/internal/service/attachment.go
+++ b/internal/service/attachment.go
@@ -134,7 +134,7 @@ func (s *Service) settleFile(p string, data []byte) (path, mediaType string, err
 	}
 	p = domain.Normalize(p)
 	if !s.Store.HasBlobStore() {
-		return "", "", Unsupportedf("files are not supported without GCS: this instance stores markdown entries only; set OCHAKAI_GCS_BUCKET (design doc 0013)")
+		return "", "", Unsupportedf("files are not supported without GCS: this instance stores markdown concepts only; set OCHAKAI_GCS_BUCKET (design doc 0013)")
 	}
 	if !domain.ValidBundlePath(p) {
 		return "", "", Invalidf("invalid bundle path %q (path segments separated by \"/\"; segments must not start with \".\", and index.md and log.md are generated rather than stored)", p)


### PR DESCRIPTION
## Summary
- `cmd/ochakai/client.go` — `ochakai put --only-if-new` treated any 412 from the server as a stale `--if-match`, even when `--if-match` was never passed. Since the freeze, `--only-if-new` sends `If-None-Match: *` and a live id also answers 412, so the CLI now branches on which conditional header it actually sent and reports the id being taken instead of an unfollowable `--if-match` message.
- `docs/guides/troubleshooting.md:69` — said 409 for a `put --only-if-new` conflict; it's 412 (`api/openapi.yaml`, pinned at `internal/restapi/restapi_integration_test.go`).
- `docs/guides/operating.md:148` — the sample startup log still showed `"...markdown entries only"`; the binary logs `"...markdown concepts only"` since #338.
- `internal/service/attachment.go:137` — the user-visible error for writing a file without GCS configured said "markdown entries only" while every other surface (`docs/architecture.md`, `docs/configuration.md`, `docs/guides/troubleshooting.md`) says "markdown concepts only".

## Test plan
- [x] Added `TestPutOnlyIfNewExplainsConflictWithoutBlamingIfMatch` covering the new 412 branch (asserts `If-None-Match: *` on the wire, no `If-Match` header, and the error doesn't mention `--if-match`)
- [x] `scripts/check --db`

Fixes #428