### PR TITLE
Let the Terraform module stage a webui-first upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@ last entry.
   the web UI first, or both together, never the API alone while the web
   UI lags. See [Upgrades](docs/guides/operating.md#upgrades) (issue
   [#418](https://github.com/na0fu3y/ochakai/issues/418)).
+- **Security** — the Terraform module made that order impossible: the
+  webui's `OCHAKAI_URL` reads the server's `uri`, so a single
+  `terraform apply` bumping `image_tag` always settled the API first —
+  the one order #418 says never to use. `webui_image_tag` now lets an
+  operator stage the two: apply it ahead of `image_tag` to land the web
+  UI first, then apply again with `image_tag` caught up (issue
+  [#426](https://github.com/na0fu3y/ochakai/issues/426)).
 - The quick start's demo import needed the Go toolchain
   (`go run ./cmd/ochakai import examples/demo`) despite the README
   promising "Docker and nothing else locally", and there was no

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -156,10 +156,11 @@ upgrades in the [operating guide](../../docs/guides/operating.md).
   hardening beyond the baseline, one `gcloud` command or console setting
   each.
 - **Upgrading an existing deployment** ([Upgrades](../../docs/guides/operating.md#upgrades))
-  — change `image_tag` and apply; migrations run at startup. The
-  version-specific notes there still apply, and importing an existing
-  gcloud-built deployment into this module's state is not something this
-  module tries to make easy.
+  — change `image_tag` and apply (`webui_image_tag` first, for the one
+  upgrade that must reach the webui before the server); migrations run
+  at startup. The version-specific notes there still apply, and
+  importing an existing gcloud-built deployment into this module's
+  state is not something this module tries to make easy.
 
 ## Teardown
 

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -34,6 +34,10 @@ locals {
   # ghcr.io directly.
   image = "${var.region}-docker.pkg.dev/${var.project_id}/${var.artifact_registry_repository_id}/${var.image_repository}:${var.image_tag}"
 
+  # Same image, normally the same tag. var.webui_image_tag exists only to be
+  # set ahead of var.image_tag for a staged upgrade — see its description.
+  webui_image = "${var.region}-docker.pkg.dev/${var.project_id}/${var.artifact_registry_repository_id}/${var.image_repository}:${coalesce(var.webui_image_tag, var.image_tag)}"
+
   connection_name = google_sql_database_instance.ochakai.connection_name
 
   # The database principal for a service account is its email with the
@@ -497,8 +501,8 @@ resource "google_cloud_run_v2_service_iam_member" "webui_invokes_ochakai" {
 }
 
 # The same image as the server, started with serve-ui instead of the default
-# serve. There is no second image to build, and the UI is always the exact
-# version of the server it fronts.
+# serve. There is no second image to build, and by default (local.webui_image)
+# the UI is the exact version of the server it fronts.
 resource "google_cloud_run_v2_service" "webui" {
   count    = var.enable_webui ? 1 : 0
   provider = google-beta
@@ -523,7 +527,7 @@ resource "google_cloud_run_v2_service" "webui" {
     }
 
     containers {
-      image = local.image
+      image = local.webui_image
       args  = ["serve-ui"]
 
       resources {
@@ -544,11 +548,14 @@ resource "google_cloud_run_v2_service" "webui" {
     }
   }
 
-  # Ordering matters and Terraform gets it right for free here: the webui's
-  # OCHAKAI_URL reads the server's uri, so the server — carrying the
-  # delegation grant this UI depends on — is always settled first. The server
-  # answers 403 rather than downgrading silently, so the reverse order would
-  # leave a window where browser edits fail.
+  # Ordering matters and Terraform gets it right for free within one apply:
+  # the webui's OCHAKAI_URL reads the server's uri, so the server — carrying
+  # the delegation grant this UI depends on — is always settled first. That
+  # is also the wrong order for the one upgrade docs/guides/operating.md
+  # warns about (a header rename): the webui must land before or with the
+  # server, never after. var.webui_image_tag exists so that case can be
+  # driven as two applies — webui first, server second — without disturbing
+  # this resource's ordering within either one.
   depends_on = [google_project_service.this]
 }
 

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -284,12 +284,36 @@ variable "enable_webui" {
   description = <<-EOT
     Deploy `serve-ui` as a second Cloud Run service behind Identity-Aware
     Proxy, for people who need browser access and cannot run the Go CLI. It
-    is the same image as the server, so there is no second thing to build and
-    the UI is always the exact version of the server it fronts. Personal use
-    needs none of this: `ochakai ui` serves the same page on loopback.
+    is the same image as the server, so there is no second thing to build and,
+    by default (see `webui_image_tag`), the UI is always the exact version of
+    the server it fronts. Personal use needs none of this: `ochakai ui` serves
+    the same page on loopback.
   EOT
   type        = bool
   default     = false
+}
+
+variable "webui_image_tag" {
+  description = <<-EOT
+    Override the webui's image tag independently of `image_tag`. Defaults to
+    `image_tag`, so a plain tag bump upgrades both services together.
+
+    A single `terraform apply` always settles the server first regardless of
+    either tag, because the webui's `OCHAKAI_URL` reads the server's `uri`
+    (main.tf's webui resource). That is the wrong order for an upgrade that
+    renames the delegation header, per the operating guide's Upgrades
+    section: the webui must be upgraded before or together with the server,
+    never after. Set this variable ahead of `image_tag` and apply, then
+    apply again with `image_tag` caught up, to upgrade the webui first
+    without touching the server in between.
+  EOT
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.webui_image_tag != "latest"
+    error_message = "Pin a released version instead of \"latest\", so that a redeploy is a decision (deploy/cloudrun/README.md §1)."
+  }
 }
 
 variable "webui_iap_members" {

--- a/docs/design/0064-rest-stops-at-api-v1.md
+++ b/docs/design/0064-rest-stops-at-api-v1.md
@@ -204,8 +204,8 @@ Go の識別子も揃える(`domain.StatsEntries` → `StatsConcepts`、
 **BREAKING**。REST を組み込んでいるクライアントが直す必要があるもの:
 
 - `X-Ochakai-On-Behalf-Of` / `X-Ochakai-Producer` を送っているなら
-  `X-` を外す。`On-Behalf-Of` は API 先行だと 400 でなく黙って誤身元に
-  書き込む([Upgrades](../guides/operating.md#upgrades))。
+  `X-` を外す。`On-Behalf-Of` は古い綴りのままだと 400 でなく黙って誤
+  身元に書き込む。段階アップグレード中に限らない([Upgrades](../guides/operating.md#upgrades))。
 - 未知のクエリパラメータを送っていたら 400 になる。
 - `attachments` という JSON キー・クエリパラメータ・MCP ツール名を
   読み書きしていたら `files` に読み替える。

--- a/docs/guides/operating.md
+++ b/docs/guides/operating.md
@@ -815,7 +815,10 @@ Three upgrade-adjacent traps worth knowing here:
   strips the spelling its own build knows. An old web UI in front of an
   API that has already adopted 0064 forwards the current spelling
   untouched — silently misattributing a write, not a 400 (issue
-  [#418](https://github.com/na0fu3y/ochakai/issues/418)).
+  [#418](https://github.com/na0fu3y/ochakai/issues/418)). The Terraform
+  module always applies the API first; stage `webui_image_tag` ahead of
+  `image_tag` for this one (issue
+  [#426](https://github.com/na0fu3y/ochakai/issues/426)).
 - **Changing `OCHAKAI_EMBEDDING_DIM` on a database that already holds
   vectors rebuilds the vector tables at the new width**, because a vector
   is derived from the concept it describes and nothing curated is involved

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -82,7 +82,7 @@ ochakai を使う人が払うのは実装の行数ではなく**表面**であ�
 - ENV: 15
 - VOCAB: 34
 - DOC: 23
-- DOC-LINES: 4996
+- DOC-LINES: 5000
 - DOC-LINES-SLACK: 10
 
 `-LINES` で終わる一行だけは、一覧ではなく**量**に天井を置いている。


### PR DESCRIPTION
## Summary

Fixes #426. `main.tf`'s webui resource read `OCHAKAI_URL` off the server's `uri`, so a single `terraform apply` bumping `image_tag` always settled the API before the webui — the one order [Upgrades](docs/guides/operating.md#upgrades) says never to use for a delegation-header rename (issue #418). The module gave an operator no way around it, and its own comment claimed the forced order as a benefit while contradicting the guidance.

Chosen resolution, of the three the issue laid out: keep the implicit `OCHAKAI_URL` → server `uri` edge (it's what forces the server to already carry the delegation grant before the webui exists), and add `webui_image_tag` so an operator can split a tag bump into two applies — webui first, server second — to get the order the guidance wants. This is the option that costs the least (one variable, defaulting to `image_tag` so existing configs are unaffected) without trading away the property the module values.

- `deploy/terraform/variables.tf` — new `webui_image_tag` (optional, defaults to `image_tag`).
- `deploy/terraform/main.tf` — the webui container now takes `local.webui_image` (computed from the new tag) instead of `local.image`; both ordering comments updated to stop claiming the forced order is unconditionally correct.
- `deploy/terraform/README.md`, `docs/guides/operating.md` — the upgrade notes now say how to stage a Terraform upgrade.
- `docs/design/0064-rest-stops-at-api-v1.md` §11 — the misattribution note was conditioned on "API upgraded first"; corrected to the general form (any client that never renames the header hits the same silent misattribution, staggered upgrade or not), matching how the same fact is already stated in the CHANGELOG's `[Unreleased]` entry. 0064 hasn't shipped in a release yet, so this is a direct edit, not a new record.
- `docs/surface.md` — `DOC-LINES` raised 4996 → 5000 for the added prose in `operating.md`/`deploy/terraform/README.md` (the manual was sitting exactly at the prior cap with no headroom).
- `CHANGELOG.md` — `[Unreleased]` entry for the fix.

Three questions, since this widens the module's variable surface: who got stuck — the issue's author, hitting this on the very next Terraform upgrade past 0064's header rename, which hasn't released yet; does an existing surface already cover it — no, neither the module nor its docs offered a staged path; what folds away — nothing folds away, but the addition is inert by default (`webui_image_tag` unset behaves exactly as before) and the doc-line cost was paid for by raising `DOC-LINES` to the exact new total rather than leaving slack.

## Test plan

- [x] `terraform validate` / `terraform fmt -check -diff` in `deploy/terraform`
- [x] `scripts/check core` (gofmt, go vet, race tests, build)
- [x] `scripts/check lint` (golangci-lint)
- [x] `go test ./cmd/ochakai/... -run 'TestDesign|TestUserDocs|TestManual|TestEnglish'` — design-doc bookkeeping and surface-line-cap tests pass with the updated counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)