### PR TITLE
Test that each operation accepts every parameter it declares

### DIFF
--- a/internal/restapi/openapi_test.go
+++ b/internal/restapi/openapi_test.go
@@ -437,3 +437,61 @@ func TestUnknownQueryParamsMatchSpec(t *testing.T) {
 		}
 	}
 }
+
+// TestSpecParamsAreAccepted is TestUnknownQueryParamsMatchSpec's other
+// half, closing the gap issue #427 found: #409 asked that each operation
+// "accepts every parameter it declares and rejects every one it does
+// not", and the check above only ever tries the `allowed[name]` branch's
+// opposite. This tries that branch instead — every parameter an
+// operation's own allowlist declares, sent to that same operation, must
+// not come back a 400 naming it unknown. The mutation issue #427
+// describes — dropping trust and cursor off search's allowlist, and
+// trust and budget off context's — leaves TestUnknownQueryParamsMatchSpec
+// fully green, because removing a declared parameter only ever narrows
+// what that check tries; this is the half that would have caught it.
+//
+// It needs a real store: unlike the negative half, a parameter this test
+// sends is — by construction — one the handler is meant to act on, and
+// most of them read all the way through to Handler(&service.Service{})'s
+// nil Store, which panics (see readOnlyServer's comment on the same
+// hazard for writes). Skipped without OCHAKAI_TEST_DATABASE_URL, like
+// every other test that needs one.
+//
+// Not checkedServer, deliberately: this test sends "x" to parameters
+// api/openapi.yaml constrains with an enum (trust) or a stricter type
+// (limit), which the spec's own request validation would refuse before
+// the handler ever saw it. What this test is asking is whether the
+// handler's allowlist recognizes the parameter, not whether "x" is a
+// value the spec would accept — TestBadRequestValidation and its
+// neighbors already hold value validation to account. Matching on the
+// "unknown query parameter" text, the same way the negative half does,
+// is what lets an unrelated 400 — search or context with no q — pass
+// rather than forcing every operation's own required parameters into
+// this loop's URLs.
+func TestSpecParamsAreAccepted(t *testing.T) {
+	h := Handler(newIntegrationService(t))
+	declared := specQueryParams(t)
+
+	for _, op := range restOperations {
+		allowed, ok := declared[op.spec]
+		if !ok {
+			t.Fatalf("%s: openapi.yaml has no operation %q", op.name, op.spec)
+		}
+		for name := range allowed {
+			key := name
+			if name == "fm." {
+				key = "fm.owner"
+			}
+			t.Run(op.name+"/"+key, func(t *testing.T) {
+				url := op.url + "?" + key + "=x"
+				rec := httptest.NewRecorder()
+				h.ServeHTTP(rec, httptest.NewRequest(op.method, url, nil))
+				unknown := fmt.Sprintf("unknown query parameter %q", key)
+				if rec.Code == http.StatusBadRequest && strings.Contains(errMessage(t, rec), unknown) {
+					t.Errorf("%s %s = 400 %q — api/openapi.yaml declares %q on %s, so this should not "+
+						"be rejected as unknown", op.method, url, rec.Body, key, op.spec)
+				}
+			})
+		}
+	}
+}

--- a/internal/restapi/restapi_integration_test.go
+++ b/internal/restapi/restapi_integration_test.go
@@ -60,16 +60,15 @@ func lockLiveAttachments(t *testing.T) {
 	t.Cleanup(func() { _ = conn.Close(ctx) }) // closing the session releases the lock
 }
 
-// newIntegrationServer serves a real PostgreSQL through the REST handler,
-// skipping the test without OCHAKAI_TEST_DATABASE_URL. The store comes
-// back with it for the tests that swap in a blob fake.
+// newIntegrationService is a Service over a real, migrated PostgreSQL,
+// skipping the test without OCHAKAI_TEST_DATABASE_URL.
 //
-// Like checkedServer's close, the pool's is registered rather than
-// deferred, and registered here so that it is the last cleanup to run:
-// the rows a test wrote are removed over HTTP (removeEntries), and a
-// deferred Close would take the pool out from under those requests —
-// leaving the rows behind in a database the next run reuses (issue #278).
-func newIntegrationServer(t *testing.T) (*httptest.Server, *store.Store) {
+// The pool's cleanup is registered rather than deferred, and registered
+// here so that it is the last cleanup to run: the rows a test wrote are
+// removed over HTTP (removeEntries), and a deferred Close would take the
+// pool out from under those requests — leaving the rows behind in a
+// database the next run reuses (issue #278).
+func newIntegrationService(t *testing.T) *service.Service {
 	t.Helper()
 	ctx := context.Background() // outlives t.Context()'s pre-Cleanup cancel
 	s, err := store.New(ctx, testDatabaseURL(t), false)
@@ -80,8 +79,16 @@ func newIntegrationServer(t *testing.T) (*httptest.Server, *store.Store) {
 	if err := s.Migrate(ctx, 0); err != nil {
 		t.Fatal(err)
 	}
-	svc := &service.Service{Store: s, Log: slog.New(slog.NewTextHandler(os.Stderr, nil))}
-	return checkedServer(t, Handler(svc)), s
+	return &service.Service{Store: s, Log: slog.New(slog.NewTextHandler(os.Stderr, nil))}
+}
+
+// newIntegrationServer serves a real PostgreSQL through the REST handler,
+// checked against api/openapi.yaml on every request and response. The
+// store comes back with it for the tests that swap in a blob fake.
+func newIntegrationServer(t *testing.T) (*httptest.Server, *store.Store) {
+	t.Helper()
+	svc := newIntegrationService(t)
+	return checkedServer(t, Handler(svc)), svc.Store
 }
 
 // removeEntries frees the ids a test wrote once it ends, so that a


### PR DESCRIPTION
## Summary

Closes #427.

`TestUnknownQueryParamsMatchSpec` (#425) tested only the negative half of issue #409's assertion — that a parameter an operation does not declare is rejected as unknown. It never tried the other half: that a parameter an operation *does* declare is accepted. Dropping a declared parameter from an operation's own allowlist (`trust`/`cursor` off `search`, `trust`/`budget` off `context`) left `go test ./...` fully green, since removing an allowed name only narrows what that check tries against it — the mutation issue #427 describes. That's a frozen-contract break: a 400 on a parameter `api/openapi.yaml` declares, which breaks an existing client rather than merely admitting a new one.

`TestSpecParamsAreAccepted` closes the gap: same declared-parameter map from `api/openapi.yaml`, same per-operation loop, taking the `allowed` branch instead of skipping it, asserting the response is not a 400 naming the parameter unknown.

It needs a real store, unlike the negative half: a parameter that's genuinely declared reads through to the store once accepted, and `Handler(&service.Service{})`'s nil `Store` panics on that (the same hazard `readOnlyServer`'s comment already calls out for writes). `newIntegrationServer`'s setup is split so `newIntegrationService` can be reused without the `checkedServer` wrapping — this test deliberately sends loose values (`trust=x`) that `checkedServer`'s spec validation would reject as bad enum values before the handler ever saw them, since what's under test here is the handler's own allowlist, not value validation.

## Test plan

- [x] `go build ./...`, `go vet ./...`
- [x] Verified the new test is skipped without `OCHAKAI_TEST_DATABASE_URL`, like the rest of the integration suite
- [x] Ran with a real PostgreSQL and confirmed it reproduces the four failures from the issue (`search/cursor`, `search/trust`, `context/trust`, `context/budget`) against the exact mutation described, while `TestUnknownQueryParamsMatchSpec` and `TestUnknownQueryParamsAreRejected` stay green
- [x] `scripts/check` and `scripts/check --db core` both pass on the unmutated tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)