### PR TITLE
Close the guard holes the last review round left open

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -385,8 +385,19 @@ line in 0004 saying so — the one line 0004 gains points back at 0058, the
 sole deliberate exception to "not one line rewritten" this pass makes,
 since the record predates the check and cannot pass it any other way.
 
+8,378 → 8,383 is five more lines of the same kind. Reading the amendment
+by pattern hid two of them: 0062's header revises 0049 §3.4 and 0059's
+printed form in one clause, and the check read a header the way the file
+wraps rather than the way a sentence runs, so a line break inside 改訂す
+る hid one and the first match consumed the second. Both records now say
+so. The verb is still the only half read by pattern — 足す is not, because
+"add an entry to 0015 §3's list" and "take 0040's read-only as given and
+add a posture beside it" differ by which noun a に governs, and a guess
+there fails by blocking a PR that did nothing wrong. That one stays a
+reviewer's job.
+
     RECORD-COUNT: 61
-    RECORD-CORPUS-LINES: 8378
+    RECORD-CORPUS-LINES: 8383
     RECORD-CORPUS-LINES-SLACK: 15
 
 Both `RECORD-COUNT` and `RECORD-CORPUS-LINES` count every record under
@@ -436,9 +447,10 @@ reader, not split across two files that both happen to hold a number.
 Most of that list is checked rather than remembered
 (`cmd/ochakai/designdocs_test.go`): a record needs an entry in both
 indexes, the two indexes have to agree with the record's own `Status:`
-header about whether it is current or superseded, a supersession has
-to be recorded at both ends — the new record naming what it retires, and
-the retired one saying so — a new record has to fit under its own
+header about whether it is current or superseded, a supersession **or an
+amendment** has to be recorded at both ends — the new record naming what
+it retires or revises, and the older one saying so — a new record has to
+fit under its own
 ceiling, a Superseded one has to be a tombstone
 (`TestSupersededRecordsAreTombstones`), and the corpus as a whole has to
 fit under `RECORD-COUNT` and `RECORD-CORPUS-LINES`, with no more slack than

--- a/cmd/ochakai/designdocs_test.go
+++ b/cmd/ochakai/designdocs_test.go
@@ -46,19 +46,54 @@ var supersededByRe = regexp.MustCompile(`Superseded by \[(\d{4})\]`)
 // English is allowed (CONTRIBUTING.md), so both spellings count.
 var supersedesRe = regexp.MustCompile(`\[(\d{4})\]\([^)]*\)\s*を\s*\*{0,2}Superseded|[Ss]upersedes \[(\d{4})\]`)
 
-// amendsRe reads "amends 00YY" out of a record's own header — 00YY stays
-// current, but one of its sections is revised rather than the whole record
-// retired. Unlike Superseded, the verb the *older* record uses to record
-// this is not one fixed spelling: the corpus says it as 改名した, 訂正した,
-// or 現行ドキュメントは depending on what changed, so unlike supersededByRe
-// there is no single pattern to read it back with there. The verb the
-// *new* record uses when declaring the intent is consistently 改訂する
-// (design-doc skill's own template spells it this way), so that is the
-// half read here: a link immediately followed, before the next link or
-// sentence end, by that verb. TestSupersessionIsRecordedAtBothEnds below
-// checks the other end only for the link itself being present, not for
-// which of its several spellings acknowledges it.
-var amendsRe = regexp.MustCompile(`\[(\d{4})\]\([^)]*\)[^。\[]*(?:を|は)改訂する|[Aa]mends \[(\d{4})\]`)
+// An amendment leaves 00YY current and revises one of its sections rather
+// than retiring the whole record. Unlike Superseded, the verb the *older*
+// record uses to acknowledge one is not one fixed spelling — the corpus
+// says 改名した, 訂正した, or 現行ドキュメントは depending on what changed —
+// so only the *new* record's declaration can be read by pattern, and
+// TestSupersessionIsRecordedAtBothEnds checks the other end for the link
+// alone. The verb there is consistently 改訂する (the design-doc skill's
+// template spells it that way).
+//
+// What amendedNumbers deliberately does not read is 足す. "Add one entry
+// to 0015 §3's list" is an amendment and the corpus says it that way — but
+// so is "take 0040's read-only as given and add a posture beside it",
+// which is not one. Telling those apart is a question about which noun a
+// に governs, and a regexp that guesses at it fails in the direction that
+// costs most: a false positive blocks a PR that did nothing wrong. Those
+// stay a reviewer's job, and CONTRIBUTING.md says so.
+var amendsRe = regexp.MustCompile(`\[(\d{4})\]\([^)]*\)`)
+
+// amendedNumbers reads every record a header declares it amends. It scans
+// link by link rather than matching one pattern across the header, because
+// one clause routinely amends two records at once — 0062 revises both
+// 0049 §3.4 and 0059's printed form in a single sentence — and a match
+// that spanned from the first link to the verb would consume the second
+// link with it and report only one of them.
+//
+// Whitespace goes first so a line wrap inside the verb (改訂\nする, which
+// the corpus wraps that way) does not hide an amendment; Japanese does not
+// space its words, so removing it is lossless. A link counts when the verb
+// follows it before the sentence ends.
+func amendedNumbers(status string) []string {
+	squeezed := strings.Join(strings.Fields(status), "")
+	var out []string
+	for _, m := range amendsRe.FindAllStringSubmatchIndex(squeezed, -1) {
+		rest := squeezed[m[1]:]
+		if end := strings.Index(rest, "。"); end >= 0 {
+			rest = rest[:end]
+		}
+		if strings.Contains(rest, "を改訂する") || strings.Contains(rest, "は改訂する") {
+			out = append(out, squeezed[m[2]:m[3]])
+		}
+	}
+	for _, m := range amendsEnglishRe.FindAllStringSubmatch(squeezed, -1) {
+		out = append(out, m[1])
+	}
+	return out
+}
+
+var amendsEnglishRe = regexp.MustCompile(`[Aa]mends\[(\d{4})\]`)
 
 func designRecords(t *testing.T) []designRecord {
 	t.Helper()
@@ -215,7 +250,7 @@ func TestSupersessionIsRecordedAtBothEnds(t *testing.T) {
 					r.file, number)
 			}
 		}
-		for _, number := range capturedNumbers(amendsRe, r.status) {
+		for _, number := range amendedNumbers(r.status) {
 			amended, ok := byNumber[number]
 			if !ok {
 				t.Errorf("docs/design/%s says it amends %s, which is not a record",

--- a/cmd/ochakai/surface_test.go
+++ b/cmd/ochakai/surface_test.go
@@ -1002,6 +1002,15 @@ func commandWordsIn(line string) []string {
 	var words []string
 	for i, field := range fields[:max(0, len(fields)-1)] {
 		field = strings.TrimPrefix(field, "(")
+		// Outside the Markdown manual the raw line is read, so a code
+		// span arrives with its backticks attached. A prose mention
+		// closes the span on the name — `ochakai` — while an invocation
+		// runs on into the command, `ochakai put`. Dropping only the
+		// opening backtick tells them apart: the first still carries its
+		// closing one and does not match, the second does. Without this
+		// a real invocation is exempt exactly where prose is, which is
+		// the inverse of the manual, where a span is the only thing read.
+		field = strings.TrimPrefix(field, "`")
 		if field != "ochakai" && field != "/ochakai" {
 			continue
 		}

--- a/docs/design/0049-queue-counts.md
+++ b/docs/design/0049-queue-counts.md
@@ -28,7 +28,9 @@ instance metric はこの応答に兄弟キーを足す形で入るべき」と�
 `reported_wrong` → `failed`、`past_expiry` → `stale_after`。キューは
 それを一覧する `sort` の名で呼ぶ(`drafts` は単一の sort ではないので
 据え置き)。数える集合・数え方・キューの本数はどれも本ドキュメントの
-ままである
+ままである。**§3.4 が各行に添える次のコマンド文字列は
+[0062](0062-a-listing-is-not-a-search.md) が改訂した** — `ochakai search
+--sort …` は `ochakai list …` になった。数える対象も終了コードも変わらない
 Date: 2026-07-28
 
 ## 1. 問題: 誰も見に行かなければ、キューは無いのと同じ

--- a/docs/design/0059-a-queue-is-named-by-its-listing.md
+++ b/docs/design/0059-a-queue-is-named-by-its-listing.md
@@ -6,7 +6,10 @@ Status: Accepted(2026-07-30)。**BREAKING。**
 [0049](0049-queue-counts.md) §3.3 が付けた名前を改訂する(数える集合も
 数え方も、キューの本数も変えない)。`drafts` は据え置く。
 [docs/surface.md](../surface.md) の VOCAB の数え方に 1 行足す —
-**sort の名を着たキューは第二の語ではない**ので 1 と数える
+**sort の名を着たキューは第二の語ではない**ので 1 と数える。
+**キュー名を印字する形は [0062](0062-a-listing-is-not-a-search.md) が
+改訂した** — 名前はそのままで、横に添えるコマンドが
+`ochakai search --sort …` から `ochakai list …` になった
 Date: 2026-07-30
 
 ## 1. 問題: 同じ一つのキューが、二つの名前を持っていた

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,7 +68,7 @@ type Config struct {
 
 	// GCSBucket names the bucket holding file bytes as GCS objects
 	// (blob/<sha256>, design doc 0013). Auth is ADC. When empty,
-	// files are unsupported — markdown entries only.
+	// files are unsupported — markdown concepts only.
 	GCSBucket string
 
 	// RecordMisses keeps the searches that found nothing, with the query

--- a/internal/restapi/openapi_test.go
+++ b/internal/restapi/openapi_test.go
@@ -372,6 +372,30 @@ func specQueryParams(t *testing.T) map[string]map[string]bool {
 	return out
 }
 
+// TestRESTOperationsCoverTheSpec keeps restOperations honest. Both halves
+// of the parameter check iterate that hand-written list rather than the
+// contract, and each looks its own spec key up — so an operation the
+// contract declares and the list omits is checked by neither, and both
+// tests go on passing while guarding one operation less. That is the
+// shape design doc 0064 §2 exists to prevent on the wire, applied to the
+// check itself: the freeze makes a twelfth operation a declared decision,
+// and this fails the moment one lands without a row here.
+func TestRESTOperationsCoverTheSpec(t *testing.T) {
+	covered := map[string]bool{}
+	for _, op := range restOperations {
+		covered[op.spec] = true
+	}
+	declared := specQueryParams(t)
+	if len(declared) == 0 {
+		t.Fatal("no operations found in openapi.yaml: this check now guards nothing")
+	}
+	for spec := range declared {
+		if !covered[spec] {
+			t.Errorf("api/openapi.yaml declares %s and restOperations does not name it, so the parameter checks skip that operation", spec)
+		}
+	}
+}
+
 // TestUnknownQueryParamsMatchSpec is issue #409's item 3: a hand-picked
 // list of examples cannot tell a per-operation allowlist from a shared or
 // globally-exempt one, because it never tries the one combination that

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -73,9 +73,9 @@ func NowStored() time.Time { return time.Now().UTC().Truncate(time.Microsecond) 
 
 type Store struct {
 	pool *pgxpool.Pool
-	// blobs holds attachment bytes (GCS, design doc 0013); metadata stays
-	// in PostgreSQL. When nil, attachments are unsupported — markdown
-	// entries only.
+	// blobs holds file bytes (GCS, design doc 0013); metadata stays
+	// in PostgreSQL. When nil, files are unsupported — markdown concepts
+	// only.
 	blobs blob.Store
 	// lastEventPrune throttles knowledge_event pruning (unix seconds).
 	lastEventPrune atomic.Int64


### PR DESCRIPTION
Four guards were passing while guarding less than they read as, and the corpus check could not see two amendments that were recorded at one end only. Found while verifying #429, #430 and #432; none of those PRs is wrong, each just stopped one step short of the thing it was checking.

## `restOperations` was never checked against the contract

`internal/restapi/restapi_test.go`'s `restOperations` is a hand-written list of REST's eleven operations, and **both** halves of the parameter check iterate it rather than `api/openapi.yaml` — `TestUnknownQueryParamsMatchSpec` and `TestSpecParamsAreAccepted`. An operation the contract declares and the list omits is checked by neither, and both go on passing. The freeze makes a twelfth operation a declared decision (0064 §2), so the list has to be provably complete.

`TestRESTOperationsCoverTheSpec` reads the spec back against the list. Dropping `reembed` from `restOperations` now fails with `api/openapi.yaml declares POST /api/v1/reembed and restOperations does not name it, so the parameter checks skip that operation`.

## The amends check read a wrap, not a sentence — and two records were one-ended

`amendsRe` matched one pattern across the raw header. Two things hid behind that, both in `0062`:

- its header wraps `改訂` and `する` across a line break, so the verb never matched;
- one clause amends **two** records (`0049` §3.4 and `0059`'s printed form), and a match spanning from the first link to the verb consumed the second link with it.

`amendedNumbers` squeezes the header's whitespace — Japanese does not space its words, so that is lossless — and scans link by link instead. `0049` and `0059` now carry the back-link, both stating exactly what moved (the command string beside each queue, `ochakai search --sort …` → `ochakai list …`); neither record's body changed.

`足す` stays deliberately unread. "Add an entry to 0015 §3's list" is an amendment and the corpus says it that way — but so is "take 0040's read-only as given and add a posture beside it", which is not one. They differ by which noun a `に` governs, and a regexp that guesses fails by blocking a PR that did nothing wrong. I tried it: it flagged `0042 → 0040` falsely. That one stays a reviewer's job, and the comment and CONTRIBUTING.md now say so.

## Backticks exempted an invocation exactly where prose is exempt

`commandWordsIn` gets raw lines outside the Markdown manual, so a code span arrives with its backticks attached and never matched `ochakai`. That is the inverse of the manual, where a span is the only thing read — and it is load-bearing, since the generic walk from #416 forced prose mentions to be backticked to avoid false positives.

Dropping only the *opening* backtick tells the two apart: `` `ochakai` `` still carries its closing one and stays exempt, `` `ochakai put` `` matches. Verified both ways.

## Two Go comments still said "markdown entries only"

`internal/config/config.go` and `internal/store/store.go`, the phrase whose user-facing copies moved to "concepts" in #430.

## Accounting

`RECORD-CORPUS-LINES` 8,378 → 8,383 for the two back-links, narrated in CONTRIBUTING.md — whose list of what `designdocs_test.go` covers was also still saying supersession only, now stale twice over.

No production behaviour changes: the diff is tests, comments, two `Status:` headers and CONTRIBUTING.md. `scripts/check core` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)