### PR TITLE
Put docs/configuration.md into Japanese, C8's second page

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ docker compose -f deploy/compose.yaml up -d
 
 This runs with `OCHAKAI_MODE=dev`: authentication is off and every
 request acts as `human:anonymous` — never do this on a deployment
-([every mode](docs/configuration.md#environment-variables)).
+([every mode](docs/configuration.md#environment-variables) (Japanese)).
 
 Load the demo knowledge base — [ten concepts](examples/demo) about one
 invented retail domain, linked to each other, some of them drafts — and
@@ -143,7 +143,7 @@ ochakai loses, and says who should pick something else.
 | connector ingestion | knowledge is curated, not harvested. Trust density over volume — and a harvester would need warehouse credentials the server does not hold, so a catalog projection runs as an ordinary client under your own service account ([example](examples/bigquery-catalog)) |
 | chat UI or dashboards | it feeds your agents; it doesn't compete with them. The bundled web UI is a curation surface, not a BI tool |
 | secrets | Cloud Run IAM decides who reaches it and Cloud SQL authenticates the service account — nothing to issue or rotate |
-| authorization | reachability is the access model — see [requirements and configuration](docs/configuration.md#authentication-has-no-configuration) |
+| authorization | reachability is the access model — see [requirements and configuration](docs/configuration.md#authentication-has-no-configuration) (Japanese) |
 | telemetry | nothing is reported anywhere. The only hosts ochakai contacts are Google Cloud APIs in your own project |
 
 ## Requirements
@@ -158,7 +158,7 @@ ochakai loses, and says who should pick something else.
   Cloud Run IAM's job.
 
 Details, and every environment variable:
-[requirements and configuration](docs/configuration.md).
+[requirements and configuration](docs/configuration.md) (Japanese).
 
 ## Documentation
 
@@ -176,7 +176,7 @@ in the version you are running.
   [Troubleshooting](docs/guides/troubleshooting.md)
 - **Running** — [Deploy with Terraform](deploy/terraform/README.md) ·
   [the gcloud reference it runs](deploy/cloudrun/README.md) ·
-  [Configuration](docs/configuration.md) ·
+  [Configuration](docs/configuration.md) (Japanese) ·
   [Operating](docs/guides/operating.md) ·
   [Golden query canary](docs/guides/golden-query-canary.md)
 - **Building on it** — [REST API](api/openapi.yaml) ·

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,8 @@ window and no backporting ([docs/compatibility.md](docs/compatibility.md)).
 
 ochakai's security posture is deliberately narrow (see
 [docs/design/0002-authn-authz.md](docs/design/0002-authn-authz.md) and
-[requirements and configuration](docs/configuration.md#authentication-has-no-configuration)):
+[requirements and configuration](docs/configuration.md#authentication-has-no-configuration)
+(Japanese)):
 
 - It holds **no warehouse credentials** and never executes SQL.
 - It does **no authorization**: whoever can reach a deployment can read

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -29,8 +29,8 @@ Most answers are already written down, and the docs are short enough to check:
   and their causes on the local and client side, from an empty search to a
   skipped import to a 412.
 - [README](README.md) — what ochakai is, and the things it deliberately does
-  not do. [docs/configuration.md](docs/configuration.md) has the requirements
-  and every environment variable.
+  not do. [docs/configuration.md](docs/configuration.md) (Japanese) has the
+  requirements and every environment variable.
 - [deploy/cloudrun/README.md](deploy/cloudrun/README.md) — the full Cloud Run +
   Cloud SQL walkthrough, including the hardening checklist.
 - [docs/design/README.md](docs/design/README.md) — the index of numbered design

--- a/cmd/ochakai/clidocs_test.go
+++ b/cmd/ochakai/clidocs_test.go
@@ -33,7 +33,7 @@ or the ` + "`ochakai use`" + ` selection, in that order (design docs
 [0004](design/0004-cli.md), [0007](design/0007-api-only-cli.md)). ` + "`serve`" + `
 and ` + "`serve-ui`" + ` are the exception: they are the deployed services, and they
 take their configuration from the environment rather than from flags —
-[Requirements and configuration](configuration.md) lists it.
+[Requirements and configuration](configuration.md) (Japanese) lists it.
 
 Every section is what ` + "`ochakai <command> -h`" + ` prints, so nothing here
 can disagree with the binary you are running — except ` + "`search`" + ` and

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -214,7 +214,7 @@ How this works:
   Google's 401 without hitting the container), and ochakai records who
   they were as provenance — see
   [requirements and configuration](../../docs/configuration.md#authentication-has-no-configuration)
-  for the whole access model.
+  (Japanese) for the whole access model.
 - **Never make the service publicly invokable (`allUsers`)** — the
   identity headers ochakai reads are only trustworthy behind Cloud Run's
   IAM check. The single exception is a deployment that reads no identity
@@ -290,7 +290,8 @@ reaches.
 The model, location, multimodal file search, `OCHAKAI_EMBEDDING_DIM`
 and `ochakai reembed` — the command that backfills a base loaded before
 the role was granted, or before a model change — are all in
-[Environment variables](../../docs/configuration.md#environment-variables);
+[Environment variables](../../docs/configuration.md#environment-variables)
+(Japanese);
 what changing the dimension does to an existing database is in
 [Upgrades](../../docs/guides/operating.md#upgrades) in the operating
 guide.

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -53,7 +53,8 @@ Two consequences worth knowing before you read further:
 `invoker_members` refuses `allUsers` and `allAuthenticatedUsers` — the
 headers ochakai trusts for provenance are only trustworthy behind Cloud
 Run's IAM check
-([requirements and configuration](../../docs/configuration.md#authentication-has-no-configuration)).
+([requirements and configuration](../../docs/configuration.md#authentication-has-no-configuration)
+(Japanese)).
 The same rule keeps the deployment compatible with the Domain Restricted
 Sharing org policy.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,8 +41,8 @@ and what it refuses to do. It is deliberately short; the manual is here.
 
 ## For someone running it
 
-- [Requirements and configuration](configuration.md) — what ochakai needs
-  before it starts, and every environment variable it reads.
+- [Requirements and configuration](configuration.md) (Japanese) — what
+  ochakai needs before it starts, and every environment variable it reads.
 - [Deploy with Terraform](../deploy/terraform/README.md) — the
   recommended path, ~$10/month: `terraform apply` in 13 steps instead of
   the gcloud walkthrough's 36.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,12 +91,14 @@ container image, a different argument (design doc
 per-concept permission, and for some organizations that is a hard stop.**
 What that means operationally, and the postures that narrow it, are in
 [requirements and configuration](configuration.md#authentication-has-no-configuration)
-(design doc [0002](design/0002-authn-authz.md)); this section is the *why*.
+(Japanese) (design doc [0002](design/0002-authn-authz.md)); this section is
+the *why*.
 
 What ochakai does with an identity is *record* it, for one purpose:
 deciding whose name goes on the concept (how the identity itself is read
 is in
-[requirements and configuration](configuration.md#authentication-has-no-configuration)).
+[requirements and configuration](configuration.md#authentication-has-no-configuration)
+(Japanese)).
 Verifying a concept is not restricted either: who verified it is always
 recorded, so the decision about whether to trust it is made by whoever
 reads the provenance, not by a gate at the write. The phrase the record
@@ -141,7 +143,7 @@ so a write endpoint added later is covered without its author knowing
 about it. What each surface does about it, and the sibling **public**
 posture that also stops reading identity at all, are in
 [requirements and configuration](configuration.md#environment-variables)
-(design docs [0040](design/0040-read-only-mode.md),
+(Japanese) (design docs [0040](design/0040-read-only-mode.md),
 [0042](design/0042-public-read-only.md)).
 
 There is one narrow exception to "no authorization", and it is
@@ -413,7 +415,8 @@ key to hold, fused with the lexical ranking by reciprocal rank fusion —
 is **on by default where ochakai runs on Google Cloud** (design doc
 [0053](design/0053-embeddings-by-default.md); what decides it, and how to
 decline, is in
-[requirements and configuration](configuration.md#environment-variables)).
+[requirements and configuration](configuration.md#environment-variables)
+(Japanese)).
 Vectors are written when a concept is written, so a base loaded before
 embeddings were reachable — or a changed model — leaves older concepts
 unembedded until `ochakai reembed` runs.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,7 +9,7 @@ or the `ochakai use` selection, in that order (design docs
 [0004](design/0004-cli.md), [0007](design/0007-api-only-cli.md)). `serve`
 and `serve-ui` are the exception: they are the deployed services, and they
 take their configuration from the environment rather than from flags —
-[Requirements and configuration](configuration.md) lists it.
+[Requirements and configuration](configuration.md) (Japanese) lists it.
 
 Every section is what `ochakai <command> -h` prints, so nothing here
 can disagree with the binary you are running — except `search` and

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,75 +1,84 @@
-# Requirements and configuration
+# 要件と設定
 
-## Requirements
+<a id="requirements"></a>
 
-**Running it for real means Google Cloud.** Cloud Run's IAM check decides who
-reaches a deployment and Cloud SQL authenticates the service account, which
-is how ochakai holds no secret of its own — and it is also why there is no
-supported way to run it on another cloud or on-prem (design docs
-[0002](design/0002-authn-authz.md), [0003](design/0003-gcp-only.md)). What is
-portable is the knowledge, not the runtime: it round-trips through OKF
-bundles, so leaving does not depend on what you are leaving.
-`deploy/compose.yaml` runs the same binary locally with authentication
-switched off — a development harness, not the small end of production.
+## 要件
 
-**There is no authorization.** Reachability is the whole access model — see
-[Authentication has no configuration](#authentication-has-no-configuration)
-below.
+**本番で動かすとは Google Cloud で動かすことである。** デプロイに誰が
+届くかは Cloud Run の IAM チェックが決め、Cloud SQL はサービスアカウント
+を認証する — これが ochakai が自前の秘密を一つも持たない理由であり、
+他のクラウドやオンプレミスで動かす手段をサポートしない理由でもある
+(設計ドキュメント [0002](design/0002-authn-authz.md)、
+[0003](design/0003-gcp-only.md))。持ち運べるのはナレッジであって、
+ランタイムではない — OKF バンドルとして往復するので、離れることは何から
+離れるかに依存しない。`deploy/compose.yaml` は同じバイナリを認証オフで
+ローカルに動かす — 本番の縮小版ではなく、開発用のハーネスである。
 
-**PostgreSQL, plus `pg_trgm`.** The first migration creates the extension, so
-a database whose user may not `CREATE EXTENSION` needs an admin to create it
-once — that is what the deploy guide's bootstrap SQL is for. Semantic search
-adds `vector` (pgvector) the same way — it is on by default on Google Cloud,
-and a database that cannot hold vectors makes a discovered deployment fall
-back to lexical search rather than fail. Without it, plain PostgreSQL is
-enough. CI and the deploy guide both exercise Postgres 17.
+**認可は無い。** 到達できるかどうかがアクセスモデルのすべてである —
+下の[認証に設定はない](#authentication-has-no-configuration)を見よ。
 
-**The server needs Docker; the client commands need a binary.** The
-README's quick start runs its one CLI command, `import`, inside the
-compose container (`docker compose exec ochakai /ochakai import ...`), so
-nothing beyond Docker is needed to follow it. Past that — `ochakai use`,
-`ochakai context`, the web UI — take a
-[release archive](https://github.com/na0fu3y/ochakai/releases), or
-`go run ./cmd/ochakai`, which wants the toolchain named in `go.mod` (Go
-1.21 and newer download it for you). Or talk to the API directly, since
-that is all the CLI does — see [the data model](architecture.md#the-data-model)
-for the one-line `curl` version of a write.
+**PostgreSQL、それに `pg_trgm`。** 最初のマイグレーションがこの拡張を
+作るので、`CREATE EXTENSION` の権限を持たないユーザーで動かすデータ
+ベースは、管理者が一度だけ作っておく必要がある — deploy ガイドの
+bootstrap SQL はそのためにある。セマンティック検索は同じ要領で `vector`
+(pgvector)を足す — Google Cloud 上では既定で有効であり、ベクトルを
+持てないデータベースは、検出されたデプロイであれば失敗ではなく字句検索
+へフォールバックする。それが無くてもプレーンな PostgreSQL で足りる。
+CI と deploy ガイドはどちらも Postgres 17 で動かしている。
 
-## Environment variables
+**サーバーには Docker が要る。クライアントのコマンドにはバイナリが
+要る。** README のクイックスタートは唯一の CLI コマンド `import` を
+compose のコンテナの中で動かす
+(`docker compose exec ochakai /ochakai import ...`)ので、それをなぞる
+だけなら Docker 以外は要らない。その先 — `ochakai use`・
+`ochakai context`・web UI — には
+[リリースアーカイブ](https://github.com/na0fu3y/ochakai/releases)か、
+`go run ./cmd/ochakai`(`go.mod` が名指す toolchain が要る。Go 1.21
+以降ならそれを自動で取ってくる)を使う。あるいは API を直接叩いても
+よい — CLI がやっているのはそれだけなので、一行の `curl` で書き込む版は
+[データモデル](architecture.md#the-data-model)にある。
 
-| Env var | Description |
+<a id="environment-variables"></a>
+
+## 環境変数
+
+| 環境変数 | 説明 |
 |---|---|
-| `OCHAKAI_DATABASE_URL` | Cloud SQL connection string (required) |
-| `OCHAKAI_DB_IAM_AUTH` | `true` enables Cloud SQL IAM database authentication: the connection password is a short-lived IAM token, so the connection string carries no secret |
-| `OCHAKAI_GCS_BUCKET` | Bucket for file bytes (auth is ADC — no keys). Default: unset — the instance stores markdown concepts only and attach operations return an error |
-| `OCHAKAI_EMBEDDINGS` | `off` runs lexical-only on a deployment that would otherwise get hybrid semantic search. Running on Google Cloud, ochakai reads its own project from the metadata server and turns embeddings on with it — there is nothing to set, and whether it can actually call Vertex AI is decided by IAM (`roles/aiplatform.user`) rather than by configuration, asked once at startup (design doc [0053](design/0053-embeddings-by-default.md)). Off Google Cloud there is no metadata server and nothing is enabled. Takes `on` or `off`; any other spelling is a startup error rather than a guess. Default: on where it is discovered |
-| `OCHAKAI_VERTEX_PROJECT` | Names the Vertex AI project explicitly — for a project other than the one ochakai runs in, or for running it outside Google Cloud. A deployment that names one has asked for semantic search: if Vertex AI or pgvector is not there it refuses to start, where a discovered one falls back to lexical search. Auth is ADC — no API keys |
-| `OCHAKAI_VERTEX_LOCATION` / `OCHAKAI_VERTEX_MODEL` / `OCHAKAI_EMBEDDING_DIM` | Embedding details (defaults: `us-central1`, `gemini-embedding-001`, 768). For image/PDF file search set model `gemini-embedding-2` with location `global` (or `us`/`eu`). Vectors are written when a concept is written, so a base loaded before embeddings were reachable — or a changed model — leaves concepts unembedded until you run `ochakai reembed` (design doc [0020](design/0020-attachment-search.md)). Dimensions above 2000 exceed pgvector's indexing limit, so those deployments fall back to an exact scan. Changing `OCHAKAI_EMBEDDING_DIM` on a base that already holds vectors rebuilds the vector tables at the new width on the next start: a vector is derived from the concept it describes, so nothing curated is lost, and `ochakai reembed` refills them |
-| `OCHAKAI_DELEGATING_CALLERS` | Comma-separated caller identities allowed to forward an end user's identity with `Ochakai-On-Behalf-Of: human:tanaka@example.co.jp` (`*` for any authenticated caller). For applications that embed ochakai and serve many people — without it, every one of their users collapses into the application's one service account. Both identities are recorded (`human:tanaka@… via process:app-sa@…`), never just the forwarded one. Default: empty, delegation off; a header from an unlisted caller is a 403, not a silent downgrade (design doc [0027](design/0027-delegated-provenance.md)) |
-| `OCHAKAI_PRODUCER` | `ochakai` CLI only: the software running the CLI, as `<producer>/<version>` — e.g. `claude-code/2026.07`. It goes out as `Ochakai-Producer` and is recorded **beside** the actor (`human:tanaka@… using claude-code/2026.07`), never in its place, so an agent shelling out to the CLI stops writing under the operator's name alone. Any authenticated caller may send the header — it names the caller's own build, not somebody else's identity, so no allowlist gates it — and a malformed value is a 400, not a silent drop. On the MCP surface the same value is taken from the client's `initialize` info when the header is absent. Default: unset, nothing declared (design doc [0052](design/0052-producer-beside-the-actor.md)) |
-| `OCHAKAI_IAP_AUDIENCE` | `ochakai serve-ui` only: the IAP JWT audience to verify, which turns browser edits from `process:<webui-sa>` into the person signed in (`human:tanaka@… via process:<webui-sa>`). Requires the webui's service account in the server's `OCHAKAI_DELEGATING_CALLERS`. Once set, a request IAP did not sign is refused rather than recorded as the service account. Default: empty, per-user provenance off (design doc [0032](design/0032-webui-iap-identity.md)) |
-| `OCHAKAI_MODE` | What this deployment **is**, as one word — the postures are exclusive, so only one can be spelled (design doc [0060](design/0060-one-word-for-the-posture.md)). Unset is the ordinary posture: Cloud Run IAM decides who reaches it, and whoever reaches it reads and writes. `read-only` serves knowledge without changing it — every write is a 403, MCP does not offer the write tools at all, and the web UI stops drawing buttons that would only fail; for a reference-only instance or for freezing a base during a migration. It is not authorization: it does not look at the caller, and it refuses the operator too (design doc [0040](design/0040-read-only-mode.md)). `public` is the posture for a deployment anyone may reach — a demo, or a reference-only copy handed out. It **reads no identity at all**: the `Authorization` header is ignored (without Cloud Run IAM in front nothing verified its signature, so believing it would let any caller name any person), delegation is ignored, every caller is `human:anonymous`, and nobody is refused. It **includes** read-only, because not recording who asked is only defensible when nothing is written (design doc [0042](design/0042-public-read-only.md)). `dev` is local development only: authentication is off and everything acts as `human:anonymous` — never on a deployment. Usage telemetry records under every posture, being the server's own observation. A spelling that is none of these is a startup error rather than a guess. Default: unset |
-| `OCHAKAI_RECORD_MISSES` | `false` stops ochakai keeping the searches that found nothing. A miss is the one thing here that a caller typed rather than curated, so it has a switch: with it off, `ochakai stats` reports `misses -` rather than zero, and the rest of the loop is measured as before. A public deployment (`OCHAKAI_MODE=public`) keeps none either way — it reads no identity, so it does not collect what strangers asked for. Kept 180 days, like the raw usage events (design doc [0051](design/0051-instance-metrics-and-search-misses.md)). Default: on |
-| `PORT` | Listen port (default `8080`) |
+| `OCHAKAI_DATABASE_URL` | Cloud SQL の接続文字列(必須) |
+| `OCHAKAI_DB_IAM_AUTH` | `true` で Cloud SQL IAM データベース認証を有効にする: 接続パスワードは短命の IAM トークンになるので、接続文字列は秘密を運ばない |
+| `OCHAKAI_GCS_BUCKET` | ファイルの実体を置くバケット(認証は ADC — キーは無い)。既定: 未設定 — このインスタンスは markdown の concept だけを保存し、attach 操作はエラーを返す |
+| `OCHAKAI_EMBEDDINGS` | `off` にすると、放っておけばハイブリッドのセマンティック検索になるデプロイを字句検索だけで動かす。Google Cloud 上で動いていれば、ochakai はメタデータサーバーから自分のプロジェクトを読み、それに合わせて埋め込みを有効にする — 設定することは何も無く、実際に Vertex AI を呼べるかどうかは設定ではなく IAM(`roles/aiplatform.user`)が決め、起動時に一度だけ問い合わせる(設計ドキュメント [0053](design/0053-embeddings-by-default.md))。Google Cloud の外にはメタデータサーバーが無く、何も有効にならない。取る値は `on` か `off` のみで、それ以外の綴りは推測せず起動エラーにする。既定: 検出できた場所では on |
+| `OCHAKAI_VERTEX_PROJECT` | Vertex AI のプロジェクトを明示的に名指す — ochakai が動いているのとは別のプロジェクトを使う場合や、Google Cloud の外で動かす場合に。これを名指したデプロイはセマンティック検索を要求したことになる: Vertex AI か pgvector が無ければ起動を拒否する。検出しただけのデプロイなら字句検索へフォールバックするのと対照的である。認証は ADC — API キーは無い |
+| `OCHAKAI_VERTEX_LOCATION` / `OCHAKAI_VERTEX_MODEL` / `OCHAKAI_EMBEDDING_DIM` | 埋め込みの詳細(既定: `us-central1`、`gemini-embedding-001`、768)。画像・PDF のファイル検索には model を `gemini-embedding-2`、location を `global`(または `us`/`eu`)にする。ベクトルは concept が書かれたときに書かれるので、埋め込みが届く前に読み込んだベースや、model を変えた後のベースは、`ochakai reembed` を走らせるまで concept が埋め込まれないままになる(設計ドキュメント [0020](design/0020-attachment-search.md))。2000 を超える次元は pgvector の索引上限を超えるので、そうしたデプロイは厳密走査にフォールバックする。すでにベクトルを持つベースで `OCHAKAI_EMBEDDING_DIM` を変えると、次回起動時にベクトルのテーブルを新しい幅で作り直す: ベクトルは元の concept から導かれるものなので、キュレーションされたものは何も失われず、`ochakai reembed` が埋め直す |
+| `OCHAKAI_DELEGATING_CALLERS` | `Ochakai-On-Behalf-Of: human:tanaka@example.co.jp` でエンドユーザーの identity を転送してよい呼び出し元 identity を、カンマ区切りで並べる(`*` で認証済みの呼び出し元すべて)。ochakai を組み込み、多くの人に使わせるアプリケーションのためのもので — これが無いと、そのアプリの利用者は全員アプリの一つのサービスアカウントに潰れてしまう。記録されるのは常に両方の identity であり(`human:tanaka@… via process:app-sa@…`)、転送された側だけになることは無い。既定: 空、委譲は off。一覧に無い呼び出し元からのヘッダは、黙って無視せず 403 にする(設計ドキュメント [0027](design/0027-delegated-provenance.md)) |
+| `OCHAKAI_PRODUCER` | `ochakai` CLI 専用: CLI を動かしているソフトウェアを `<producer>/<version>` の形で名乗る — 例 `claude-code/2026.07`。`Ochakai-Producer` として送られ、行為者の**隣に**記録される(`human:tanaka@… using claude-code/2026.07`)のであって、行為者に取って代わることは無い — CLI をシェルアウトで叩くエージェントが、操作者の名前だけの下に書き込むことをやめさせるためのものである。認証済みの呼び出し元は誰でもこのヘッダを送ってよい — 名乗るのは呼び出し元自身のビルドであって他人の identity ではないので、許可リストで絞る必要が無い — 不正な値は黙って捨てず 400 にする。MCP の面では、ヘッダが無ければ同じ値をクライアントの `initialize` 情報から取る。既定: 未設定、何も宣言しない(設計ドキュメント [0052](design/0052-producer-beside-the-actor.md)) |
+| `OCHAKAI_IAP_AUDIENCE` | `ochakai serve-ui` 専用: 検証する IAP JWT の audience。これにより、ブラウザからの編集が `process:<webui-sa>` ではなく、サインインした本人(`human:tanaka@… via process:<webui-sa>`)として記録されるようになる。サーバー側の `OCHAKAI_DELEGATING_CALLERS` に webui のサービスアカウントを入れておく必要がある。設定すると、IAP が署名していないリクエストはサービスアカウントとして記録せず、拒否するようになる。既定: 空、利用者ごとの provenance は off(設計ドキュメント [0032](design/0032-webui-iap-identity.md)) |
+| `OCHAKAI_MODE` | このデプロイが**何であるか**を一語で言う — 姿勢は排他的なので、綴れるのは一つだけである(設計ドキュメント [0060](design/0060-one-word-for-the-posture.md))。未設定は通常の姿勢: 誰が届くかは Cloud Run IAM が決め、届いた者は読み書きできる。`read-only` はナレッジを変えずに提供する — すべての書き込みは 403 になり、MCP は書き込み系のツールを一切提供せず、web UI も失敗するだけのボタンを描かなくなる。参照専用のインスタンスや、移行の間ベースを凍結する用途に。これは認可ではない: 呼び出し元を見ておらず、操作者も同じように拒否する(設計ドキュメント [0040](design/0040-read-only-mode.md))。`public` は誰でも届いてよいデプロイの姿勢である — デモや、配布用の参照専用コピーに。**identity を一切読まない**: `Authorization` ヘッダは無視され(手前に Cloud Run IAM が無ければ署名を誰も検証していないので、信じれば任意の呼び出し元が任意の人物を名乗れてしまう)、委譲も無視され、呼び出し元は全員 `human:anonymous` になり、誰も拒否されない。read-only を**含む** — 誰が尋ねたかを記録しないことは、何も書き込まれないときにしか正当化できないからである(設計ドキュメント [0042](design/0042-public-read-only.md))。`dev` はローカル開発専用: 認証は off で、すべてが `human:anonymous` として動く — デプロイでは絶対に使わない。利用状況のテレメトリはどの姿勢でも記録される。サーバー自身の観測だからである。これらのどれでもない綴りは、推測せず起動エラーにする。既定: 未設定 |
+| `OCHAKAI_RECORD_MISSES` | `false` にすると、何もヒットしなかった検索を ochakai が残さなくなる。miss はここで唯一、呼び出し元がキュレーションしたのではなく打ち込んだものなので、切り替えが用意されている: off にすると `ochakai stats` は `misses -` を返し、ゼロではなく「測っていない」と言う。それ以外のループの計測は変わらない。公開デプロイ(`OCHAKAI_MODE=public`)はどちらにしても何も残さない — identity を読まないので、見知らぬ相手が何を尋ねたかを集めない。生の利用イベントと同じく 180 日保持する(設計ドキュメント [0051](design/0051-instance-metrics-and-search-misses.md))。既定: on |
+| `PORT` | 待ち受けポート(既定 `8080`) |
 
-Client commands read `OCHAKAI_URL` — the server to talk to, overriding the
-`ochakai use` selection. [CLI reference](cli.md) has the rest.
+クライアント側のコマンドは `OCHAKAI_URL` を読む — 話しかけるサーバーを、
+`ochakai use` で選んだものより優先する。残りは
+[CLI リファレンス](cli.md)にある。
 
-## Authentication has no configuration
+<a id="authentication-has-no-configuration"></a>
 
-Whoever can reach a deployment can read and write everything. If you need
-per-concept permissions, this is the wrong tool — the
-[README's refusal table](../README.md#what-it-refuses) says what that buys.
+## 認証に設定はない
 
-ochakai reads the caller identity that Cloud Run forwards after its IAM check
-(`human:<email>` for people, `process:<sa-email>` for service accounts) and
-records it as provenance; nothing else consults it. Reachability — deciding
-who may reach a deployment at all — is entirely Cloud Run IAM's job.
-`OCHAKAI_MODE` above narrows what a reachable caller can do (`read-only`) or
-stops recording who they are at all (`public`); neither is authorization,
-because neither looks at who is asking.
+デプロイに届く者は誰でも、すべてを読み書きできる。concept ごとの権限が
+要るなら、これは向いていないツールである — それで何が買えるかは
+[README の refusal 表](../README.md#what-it-refuses)にある。
 
-The complete, cost-minimized deployment walkthrough (~$10/month) lives in
-[deploy/cloudrun/README.md](../deploy/cloudrun/README.md), including a
-security hardening checklist (org-policy guardrails, private IP, retiring the
-last password, and more).
+ochakai は、Cloud Run が IAM チェックの後に転送してくる呼び出し元の
+identity(人には `human:<email>`、サービスアカウントには
+`process:<sa-email>`)を読み、provenance として記録する — それ以外の
+用途では参照しない。到達性 — そもそも誰がデプロイに届いてよいかを
+決めること — は完全に Cloud Run IAM の仕事である。上の `OCHAKAI_MODE`
+は、届いた呼び出し元にできることを絞る(`read-only`)か、誰であるかの
+記録自体をやめる(`public`)かのどちらかであり、どちらも認可ではない —
+どちらも、尋ねているのが誰かを見ていないからである。
+
+コストを切り詰めたデプロイの完全な手順(月 $10 程度)は
+[deploy/cloudrun/README.md](../deploy/cloudrun/README.md) にある。
+セキュリティ強化のチェックリスト(org-policy によるガードレール、
+private IP、最後のパスワードを退役させる、など)もそこに含まれる。

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,9 +6,9 @@ Several questions here are really about an area another page owns, and
 those get a short answer and a link rather than a second copy — **"why
 not just use X?" is [positioning](positioning.md), every symptom is
 [troubleshooting](guides/troubleshooting.md), every setting is
-[requirements and configuration](configuration.md).** Two texts saying
-the same thing means one of them is out of date and nobody can tell
-which.
+[requirements and configuration](configuration.md) (Japanese).** Two texts
+saying the same thing means one of them is out of date and nobody can
+tell which.
 
 ### Can I run this without Google Cloud?
 
@@ -18,7 +18,7 @@ no secret of its own. `deploy/compose.yaml` runs the same binary locally
 against plain PostgreSQL with authentication disabled — a development
 harness, not the small end of production. What is portable is the
 knowledge, not the runtime. In full:
-[requirements](configuration.md#requirements).
+[requirements](configuration.md#requirements) (Japanese).
 
 ### Does my data leave my project?
 
@@ -58,7 +58,7 @@ content. Search still works without them — lexical-only, calling no
 external API. What that costs, and why Japanese is the case that needs
 them, is in [architecture's search section](architecture.md#search);
 the three ways to decline are in
-[configuration](configuration.md#environment-variables).
+[configuration](configuration.md#environment-variables) (Japanese).
 
 ### Can an agent overwrite or delete knowledge a human verified?
 
@@ -100,7 +100,8 @@ Anyone who can reach the deployment — reachability is the whole access
 model, and there is no authorization on top of it. What identity ochakai
 records, and the postures (`read-only`, `public`) that narrow what a
 reachable caller can do, are in
-[requirements and configuration](configuration.md#authentication-has-no-configuration).
+[requirements and configuration](configuration.md#authentication-has-no-configuration)
+(Japanese).
 
 ### What happens to my knowledge if I stop using ochakai?
 

--- a/docs/guides/rest-integration.md
+++ b/docs/guides/rest-integration.md
@@ -152,13 +152,13 @@ every caller is `human:anonymous`, so a malformed `Ochakai-On-Behalf-Of`
 or `Ochakai-Producer` header fails on your machine instead of on first
 deploy against Cloud Run. See
 [Requirements and configuration](../configuration.md#environment-variables)
-for `OCHAKAI_MODE`'s other postures.
+(Japanese) for `OCHAKAI_MODE`'s other postures.
 
 ## See also
 
 - [api/openapi.yaml](../../api/openapi.yaml) — the checked contract: every
   request and response is validated against it in CI.
-- [Requirements and configuration](../configuration.md) — every
+- [Requirements and configuration](../configuration.md) (Japanese) — every
   environment variable named above.
 - [examples/bigquery-catalog](../../examples/bigquery-catalog) — a
   complete application-shaped integration: reads a warehouse, writes

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -82,7 +82,7 @@ ochakai を使う人が払うのは実装の行数ではなく**表面**であ�
 - ENV: 15
 - VOCAB: 34
 - DOC: 23
-- DOC-LINES: 5015
+- DOC-LINES: 5044
 - DOC-LINES-SLACK: 10
 
 `-LINES` で終わる一行だけは、一覧ではなく**量**に天井を置いている。
@@ -556,6 +556,19 @@ configuration・architecture・faq・deploy の各ページに同じ話が繰り
 114 → 120 行で、**翻訳はこの天井に対してほぼ中立、わずかに増える**。
 残りのページを日本語にしていく作業は、`DOC-LINES` を下げてはくれない —
 下げるのは畳み込みだけである。
+
+5,015 → 5,044 は C8 の二枚目、
+[configuration.md](configuration.md) を日本語にした分である
+([#438](https://github.com/na0fu3y/ochakai/issues/438))。ページ自身は 75
+→ 84 行、9 行増えている。次の 7 行はページ自身ではなく、それを指す九つの
+文書から来た — `#requirements`・`#environment-variables`・
+`#authentication-has-no-configuration` という三つのアンカーを README・
+SECURITY・deploy の両ガイド・SUPPORT・architecture・faq・
+rest-integration・docs/README が指しており、そのどれにも `(Japanese)` を
+足す必要があった。loop.md にはこの被リンクが一本も無かったので、翻訳の
+代金がページの外にも出ることは今回初めて見えた。残る 13 行はこの段落
+自身の分で、DOC のほかの段落と同じくここに数えている。
+
 [#372](https://github.com/na0fu3y/ochakai/issues/372) は逆方向に動いた
 最初の例である。architecture.md と knowledge.md は同じ六つの主題を二度語り
 、二枚を一枚に畳んだ。DOC が 26 → 25 になった分、天井も合わせている。


### PR DESCRIPTION
## What and why

Closes #438. C8's second translated page after `docs/loop.md` (#434) —
`docs/configuration.md`, a reference table of environment variables plus
short requirements and authentication prose. Variable names, values, and
design-doc citations are unchanged (product vocabulary); the prose
around them is translated, following CONTRIBUTING.md's "Translating a
manual page" rules.

Unlike `loop.md`, this page is linked by URL fragment from nine other
English pages (`#requirements`, `#environment-variables`,
`#authentication-has-no-configuration`), so the three section headings
keep their old anchor slugs via explicit `<a id>` tags placed above each
Japanese heading — otherwise every incoming deep link would stop
scrolling to the right section.

Bookkeeping the issue calls for:

- Every English page linking to `docs/configuration.md` now marks the
  link `(Japanese)`: `README.md`, `SECURITY.md`, `SUPPORT.md`, both
  deploy guides, `docs/README.md`, `docs/architecture.md`, `docs/faq.md`,
  and `docs/guides/rest-integration.md`. `docs/cli.md` picks up the same
  marker through its generated-from-help constant in
  `cmd/ochakai/clidocs_test.go`, regenerated with `-update`. Design docs
  0003 and 0060, and `docs/surface.md` itself, already link to it in
  Japanese and need no marker.
- `DOC-LINES` raised 4,980 → 5,010 (rebased on #448's fold, which had
  already lowered it 5,015 → 4,980) and narrated in `docs/surface.md`'s
  DOC section: 9 lines from the page itself (75 → 84), 7 from the nine
  referencing pages picking up the marker, and 14 from the narration
  paragraph itself.

## Checks

- [x] `scripts/check core` and `scripts/check lint` are clean (`vuln` is
      unverifiable in this environment — the proxy blocks vuln.go.dev)
- [x] No behavior changed; docs-only

## Surfaces and contract

- [x] No surface widened — this is a documentation translation, not a
      new operation, tool, command, or variable
- [x] N/A — OpenAPI/REST/MCP/CLI unaffected

## Design docs

- [x] N/A — no accepted decision changes; nothing here is user-observable
      beyond the page moving to Japanese, which CONTRIBUTING.md's
      translation rules already cover
- [x] Commit message is in English
