### PR TITLE
Drop the literal backticks from feature_request.yml's description

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: Feature request
-description: Propose something `ochakai` should do.
+description: Propose a feature for ochakai.
 labels: ["enhancement"]
 body:
   - type: markdown


### PR DESCRIPTION
## Summary

Issue #420 named three guard holes. Two were already fixed and merged:

- **#429** — `retired_test.go` skipping `docs/design` wholesale (including its
  two non-immutable indexes), and `designdocs_test.go`'s
  `TestSupersessionIsRecordedAtBothEnds` checking supersession but not
  amendment.
- **#433** — a follow-up that fixed `commandWordsIn` treating a backticked
  invocation in `.github/ISSUE_TEMPLATE/*.yml` as exempt, the inverse of the
  Markdown manual's convention.

Neither PR used a GitHub closing keyword, so #420 stayed open despite being
substantively resolved.

One loose end from #420 was never picked up: item 3 flagged
`feature_request.yml:2`'s top-level `description:` field carrying backticks
around `` `ochakai` ``. GitHub renders that field as plain text in the issue
template chooser, so every reporter sees literal backticks — `bug_report.yml`'s
equivalent field has none.

## Change

Reworded the description to drop the backticks, ending the sentence on
"ochakai" so `TestManualNamesNoCommandThatDoesNotExist` doesn't read the
following word as an invented subcommand (verified: the naive backtick-strip
`Propose something ochakai should do.` fails the guard with `names a command
ochakai does not have: "should"`, which is exactly the false-positive #433's
docs explain the backtick convention exists to avoid).

Closes #420.

## Test plan

- [x] `scripts/check core` — all green
- [x] `go test ./cmd/ochakai/... -run TestManualNamesNoCommandThatDoesNotExist -v` passes with the reworded description

🤖 Generated with [Claude Code](https://claude.com/claude-code)