### PR TITLE
Close 0064 §2's body and bundle-mode gaps (issue #470 part A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,19 @@ last entry.
     silent no-op, which is what let a 0.16.1 server ignore `dry_run` and
     write anyway; this closes the same shape of hole for anything added
     to the wire from here on.
+  - An unrecognized JSON body key on `POST /api/v1/move`,
+    `POST /api/v1/review/{id}` and `POST /api/v1/usage/{id}` is now a 400
+    naming it too, closing the same hole for the body: `{"rulling":
+    "verified"}` used to be a 200 that did nothing recognizable, and
+    `"notes"` for `"note"` used to drop the note silently (issue
+    [#470](https://github.com/na0fu3y/ochakai/issues/470)).
+  - `GET /api/v1/bundle/{path}`'s `history`, `limit` and `files` query
+    parameters are now a 400 naming the mode when sent outside the mode
+    that reads them — `limit` outside `?history` and a directory's
+    `log.md`, `files` outside `Accept: application/gzip`, and `?history`
+    together with `Accept: application/gzip` (a different object, not a
+    representation choice, so no precedence rule decides it). All three
+    used to be silently ignored outside their mode (issue #470).
   - `X-Ochakai-On-Behalf-Of` and `X-Ochakai-Producer` lose their `X-`
     prefix — `Ochakai-On-Behalf-Of` and `Ochakai-Producer`, matching the
     five response headers, which never carried one. No dual-accept

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -293,7 +293,7 @@ state per area, so when a design doc lands:
 
 ### How long a record gets
 
-    RECORD-LINES: 222
+    RECORD-LINES: 253
     RECORD-CAP-FROM: 0063
 
 0048 narrowed *what* earns a number. It said nothing about *how much*,
@@ -404,8 +404,21 @@ add a posture beside it" differ by which noun a に governs, and a guess
 there fails by blocking a PR that did nothing wrong. That one stays a
 reviewer's job.
 
+222 → 253, 8,391 → 8,422: issue
+[#470](https://github.com/na0fu3y/ochakai/issues/470) found that §2's own
+decision — an unrecognized query parameter is a 400, naming it — had only
+half landed. A request body's unknown key was still a silent 200
+(`readJSON` never called `DisallowUnknownFields`), and
+`GET /api/v1/bundle/{path}` allowed `history`, `limit` and `files` for the
+whole address while reading each in only one or two of its modes, so a
+parameter sent to the wrong mode was ignored rather than refused — the
+same shape as the query-parameter gap 0064 already closed once. 0064 §2
+decides both, and §11 gains the two BREAKING bullets that follow from
+deciding them. 31 lines on the one record still unreleased enough to
+revise in place.
+
     RECORD-COUNT: 61
-    RECORD-CORPUS-LINES: 8391
+    RECORD-CORPUS-LINES: 8422
     RECORD-CORPUS-LINES-SLACK: 15
 
 Both `RECORD-COUNT` and `RECORD-CORPUS-LINES` count every record under

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -40,6 +40,12 @@ info:
     Every other operation has no such downstream check and rejects `fm.*`
     like any other unrecognized parameter.
 
+    **An unrecognized JSON body key is a 400, naming it** (design doc
+    0064), the same rule applied to the body: `POST /api/v1/move`,
+    `POST /api/v1/review/{id}` and `POST /api/v1/usage/{id}` reject a key
+    their schema does not declare, rather than decoding the request and
+    silently dropping it.
+
     **REST is frozen at `/api/v1`** (design doc 0064,
     docs/compatibility.md): this contract is the address list a client can
     hold onto, and the only thing that can still break it after this point
@@ -584,12 +590,20 @@ paths:
             §3.5). Presence is the whole of it — `?history` — and a
             value is ignored, the way `Accept` decides a representation
             without being asked a question. A directory's history is the
-            reserved `log.md` beside it.
+            reserved `log.md` beside it. Combined with
+            `Accept: application/gzip` it is a 400 rather than the
+            archive silently winning: the two address different objects
+            — this object's own history, not the archive's subtree
+            (design doc 0064 §2).
           schema: { type: string }
           allowEmptyValue: true
         - name: limit
           in: query
-          description: log.md and ?history only — maximum concepts (default and max 1000).
+          description: >
+            log.md and ?history only — maximum concepts (default and max
+            1000). Sent anywhere else on this address it is a 400 naming
+            the mode it belongs to, rather than a silently ignored value
+            (design doc 0064 §2).
           schema: { type: integer }
         - $ref: "#/components/parameters/IfNoneMatch"
         - name: files
@@ -599,7 +613,8 @@ paths:
             markdown without any file bytes. They live in GCS, so a
             periodic backup can copy them from there directly instead of
             pulling them through here. A value that is neither `true` nor
-            `false` is a 400.
+            `false` is a 400, and so is sending it without
+            `Accept: application/gzip` (design doc 0064 §2).
           schema: { type: boolean, default: true }
       responses:
         "200":
@@ -1329,6 +1344,7 @@ paths:
         - $ref: "#/components/parameters/Producer"
       requestBody:
         required: true
+        description: A key outside from/to is a 400 naming it (design doc 0064).
         content:
           application/json:
             schema:
@@ -1460,6 +1476,7 @@ paths:
         - $ref: "#/components/parameters/Producer"
       requestBody:
         required: true
+        description: A key outside ruling/note is a 400 naming it (design doc 0064).
         content:
           application/json:
             schema:
@@ -1729,6 +1746,7 @@ paths:
         - $ref: "#/components/parameters/Producer"
       requestBody:
         required: true
+        description: A key outside outcome/note is a 400 naming it (design doc 0064).
         content:
           application/json:
             schema:

--- a/docs/design/0064-rest-stops-at-api-v1.md
+++ b/docs/design/0064-rest-stops-at-api-v1.md
@@ -36,6 +36,31 @@ REST の 11 操作すべてで、宣言していないクエリキーは 400 に
 推測しているのはその名残)、凍結後に同じ形の事故が起きないための土台が
 これである。
 
+この決定はクエリパラメータでは閉じておらず、同じ形の穴が二つ残って
+いた(issue [#470](https://github.com/na0fu3y/ochakai/issues/470))。
+
+**リクエストボディの未知キー。** `readJSON`(`internal/restapi/restapi.go`)
+は `DisallowUnknownFields` を呼んでおらず、本文を読む三操作
+(`POST /api/v1/move`・`POST /api/v1/review/{id}`・
+`POST /api/v1/usage/{id}`)は宣言していないキーを黙って捨てて 200 を
+返していた。`{"rulling": "verified"}` は何もしない 200、`note` のつもり
+の `notes` は静かに消える書き込み — 本文版の `dry_run` false green で
+ある。**決定:** `dec.DisallowUnknownFields()` を呼び、JSON 値のあとに
+続く内容(`dec.More()`)も 400 にする。未知キーはクエリパラメータと
+同じ形で名指す。
+
+**バンドル GET のモード別パラメータ。**
+`GET /api/v1/bundle/{path}` は `history`・`limit`・`files` の三つを
+住所全体に許可していたが、実際に読むのはそれぞれ一部のモードだけ
+だった — `files` はアーカイブ分岐のみ、`limit` は `?history` と
+`log.md` のみ、`history` はアーカイブ分岐より後で見るため
+`Accept: application/gzip` と `?history` を同時に送ると `?history` が
+黙って無視されていた。**決定:** モードの外で送られたキーは、そのモード
+を名指す 400 にする。アーカイブと `?history` の重なりは、§4 が 6 通り
+の表現に優先順位を与えた理由(同じものの表現違いだから)がここには
+当てはまらない — `?history` はアーカイブとは別のオブジェクトなので、
+優先順位ではなく 400 にする。
+
 ## 3. ヘッダ接頭辞の統一
 
 `X-Ochakai-On-Behalf-Of` / `X-Ochakai-Producer`(リクエストヘッダ)を
@@ -209,6 +234,12 @@ Go の識別子も揃える(`domain.StatsEntries` → `StatsConcepts`、
   `X-` を外す。`On-Behalf-Of` は古い綴りのままだと 400 でなく黙って誤
   身元に書き込む。段階アップグレード中に限らない([Upgrades](../guides/operating.md#upgrades))。
 - 未知のクエリパラメータを送っていたら 400 になる。
+- `POST /api/v1/move`・`POST /api/v1/review/{id}`・
+  `POST /api/v1/usage/{id}` の本文に宣言外のキーを送っていたら 400 になる。
+- `GET /api/v1/bundle/{path}` で `history`・`limit`・`files` を、それを
+  読まないモードに送っていたら(`limit` を index.md や概念・ファイルの
+  住所に、`files` をアーカイブ以外に、`history` をアーカイブ
+  (`Accept: application/gzip`)と同時に、など)400 になる。
 - `attachments` という JSON キー・クエリパラメータ・MCP ツール名を
   読み書きしていたら `files` に読み替える。
 - `stats`・バンドル一覧・`context`(MCP `get_context` も)の JSON キー

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -289,10 +289,7 @@ func Handler(svc *service.Service) http.Handler {
 	// of them has (design doc 0046 §3.5).
 	mux.HandleFunc("GET /api/v1/bundle/{path...}", func(w http.ResponseWriter, r *http.Request) {
 		path := r.PathValue("path")
-		if err := rejectUnknownParams(r.URL.Query(), "history", "limit", "files"); err != nil {
-			writeError(w, err)
-			return
-		}
+		q := r.URL.Query()
 		// An archive is the bundle at a path: everything under it, as
 		// OKF, in the layout it lives at (design doc 0046 §3.5). The
 		// root is the whole knowledge base, which is what
@@ -300,6 +297,16 @@ func Handler(svc *service.Service) http.Handler {
 		// re-rooted — an export of metrics/ imports back to metrics/,
 		// because this is a copy of a subtree and not a move of one.
 		if wantsArchive(r) {
+			// history addresses a different object than the archive
+			// (the object's own log.md, not this subtree's), so
+			// combining them is a 400 rather than the archive silently
+			// winning — the six representations of §4 get a precedence
+			// order because they are representations of the same
+			// thing; this is not that (design doc 0064 §2 item 2).
+			if err := rejectOutOfModeParams(q, "with Accept: application/gzip", "files"); err != nil {
+				writeError(w, err)
+				return
+			}
 			// A reserved name is a file the bundle generates, not a
 			// directory in it, so there is no subtree at this address to
 			// archive — the same refusal the write face makes, for the
@@ -342,7 +349,11 @@ func Handler(svc *service.Service) http.Handler {
 		// same way: the ledger is keyed by path, so "what happened to
 		// this object" is one question with one answer whichever kind
 		// it is.
-		if r.URL.Query().Has("history") {
+		if q.Has("history") {
+			if err := rejectOutOfModeParams(q, "with ?history", "history", "limit"); err != nil {
+				writeError(w, err)
+				return
+			}
 			// Nothing ever happened to a file that is generated on
 			// demand, and "nothing ever happened here" (404) reads as a
 			// fact about the bundle rather than about the address. The
@@ -357,6 +368,10 @@ func Handler(svc *service.Service) http.Handler {
 		dir, base := splitReserved(path)
 		switch base {
 		case "index.md":
+			if err := rejectOutOfModeParams(q, "on index.md"); err != nil {
+				writeError(w, err)
+				return
+			}
 			if wantsJSON(r) {
 				res, err := svc.Browse(r.Context(), dir)
 				if err != nil {
@@ -373,7 +388,11 @@ func Handler(svc *service.Service) http.Handler {
 			}
 			writeMarkdown(w, doc)
 		case "log.md":
-			limit, err := queryInt(r.URL.Query(), "limit")
+			if err := rejectOutOfModeParams(q, "on log.md", "limit"); err != nil {
+				writeError(w, err)
+				return
+			}
+			limit, err := queryInt(q, "limit")
 			if err != nil {
 				writeError(w, err)
 				return
@@ -398,6 +417,10 @@ func Handler(svc *service.Service) http.Handler {
 			}
 			writeMarkdown(w, doc)
 		default:
+			if err := rejectOutOfModeParams(q, "on a concept or file's own address"); err != nil {
+				writeError(w, err)
+				return
+			}
 			// Every other path is an object of the bundle: a concept at
 			// its own path, or a file (design doc 0046 §3.5). A concept
 			// is answered by the concept surface's own writer, so one
@@ -1412,8 +1435,15 @@ func writeDocument(w http.ResponseWriter, status int, k *domain.Knowledge) {
 	_, _ = w.Write(doc)
 }
 
+// readJSON decodes the request body strictly: an unrecognized key is a 400
+// naming it, the same shape rejectUnknownParams gives an unrecognized query
+// key, and content trailing the JSON value is a 400 rather than silently
+// discarded. Before design doc 0064 §2 neither was checked — a body key a
+// server did not yet know was a 200 that dropped it, the same false-green
+// shape ?dry_run= had as a query parameter before this doc closed that one.
 func readJSON(w http.ResponseWriter, r *http.Request, v any) bool {
 	dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4<<20))
+	dec.DisallowUnknownFields()
 	if err := dec.Decode(v); err != nil {
 		// An oversized body is not malformed JSON, and calling it that
 		// sends the caller looking for a syntax error in a payload that
@@ -1424,7 +1454,15 @@ func readJSON(w http.ResponseWriter, r *http.Request, v any) bool {
 				map[string]string{"error": fmt.Sprintf("request body exceeds %d bytes", maxErr.Limit)})
 			return false
 		}
+		if field, ok := strings.CutPrefix(err.Error(), `json: unknown field "`); ok {
+			writeError(w, service.Invalidf("unknown field %q", strings.TrimSuffix(field, `"`)))
+			return false
+		}
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON: " + err.Error()})
+		return false
+	}
+	if dec.More() {
+		writeError(w, service.Invalidf("request body must be a single JSON value"))
 		return false
 	}
 	return true
@@ -1555,6 +1593,30 @@ func rejectUnknownParams(q url.Values, allowed ...string) error {
 		return service.Invalidf("unknown query parameter %q", key)
 	}
 	return nil
+}
+
+// bundleModeParams is history, limit and files: query keys the bundle GET
+// handler declares for the address as a whole, but each is read in only
+// some of its modes (archive, ?history, index.md, log.md, a concept or
+// file's own address). rejectOutOfModeParams is what makes that precise —
+// before design doc 0064 §2 item 2, a mode that did not read one of these
+// silently ignored it instead of saying so.
+var bundleModeParams = []string{"history", "limit", "files"}
+
+// rejectOutOfModeParams 400s a bundleModeParams key present outside the
+// mode that reads it, naming the mode — mode reads as "<key> is not
+// meaningful <mode>", so it must fit that sentence (e.g. "with
+// Accept: application/gzip", "on log.md"). allowed lists which of the
+// three this mode does read; any other unrecognized key falls through to
+// rejectUnknownParams's generic message.
+func rejectOutOfModeParams(q url.Values, mode string, allowed ...string) error {
+	for _, key := range bundleModeParams {
+		if !q.Has(key) || slices.Contains(allowed, key) {
+			continue
+		}
+		return service.Invalidf("%s is not meaningful %s", key, mode)
+	}
+	return rejectUnknownParams(q, allowed...)
 }
 
 // queryInt parses an optional numeric query parameter, rejecting a

--- a/internal/restapi/restapi_test.go
+++ b/internal/restapi/restapi_test.go
@@ -360,6 +360,42 @@ func TestBundleAddressesRefuseByPath(t *testing.T) {
 	}
 }
 
+// TestBundleParamsAreRejectedOutsideTheirMode pins design doc 0064 §2's
+// completion (issue #470): history, limit and files are declared for the
+// whole GET /api/v1/bundle/{path} address, but each is read in only some
+// of its modes. Sent to a mode that does not read it, each is now a 400
+// naming the mode, rather than a silently ignored value.
+func TestBundleParamsAreRejectedOutsideTheirMode(t *testing.T) {
+	h := Handler(&service.Service{})
+	cases := []struct {
+		name, url, accept string
+	}{
+		{"limit on index.md", "/api/v1/bundle/index.md?limit=5", ""},
+		{"limit on a concept", "/api/v1/bundle/metrics/revenue.md?limit=5", ""},
+		{"files on index.md", "/api/v1/bundle/index.md?files=false", ""},
+		{"files on log.md", "/api/v1/bundle/metrics/log.md?files=false", ""},
+		{"files on a concept", "/api/v1/bundle/metrics/revenue.md?files=false", "application/json"},
+		{"history with the archive", "/api/v1/bundle/metrics/revenue.md?history", "application/gzip"},
+		{"limit with the archive", "/api/v1/bundle/?limit=5", "application/gzip"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, c.url, nil)
+			if c.accept != "" {
+				req.Header.Set("Accept", c.accept)
+			}
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("GET %s = %d, want 400 (body: %s)", c.url, rec.Code, rec.Body)
+			}
+			if !strings.Contains(rec.Body.String(), "not meaningful") {
+				t.Errorf("body %q does not say the parameter is out of mode", rec.Body)
+			}
+		})
+	}
+}
+
 // TestAttachWithoutBlobStore pins the 501: on an instance without GCS
 // (design doc 0013), attaching fails before any validation or DB access
 // with the config hint.
@@ -402,6 +438,50 @@ func TestOversizedBodies(t *testing.T) {
 				t.Errorf("body %q does not mention %q", rec.Body, c.wantSubstr)
 			}
 		})
+	}
+}
+
+// TestUnknownBodyFieldsAreRejected pins design doc 0064 §2's completion
+// (issue #470): a JSON body key none of these three operations declare is
+// a 400 naming it, the same as an unrecognized query parameter, rather
+// than a 200 that silently dropped it — closing the body's version of the
+// hole that let ?dry_run= go unenforced.
+func TestUnknownBodyFieldsAreRejected(t *testing.T) {
+	h := Handler(&service.Service{})
+	cases := []struct {
+		name, method, url, body string
+	}{
+		{"move", http.MethodPost, "/api/v1/move", `{"from":"a","to":"b","force":true}`},
+		{"review", http.MethodPost, "/api/v1/review/metrics/revenue", `{"ruling":"verified","rulling":"verified"}`},
+		{"usage", http.MethodPost, "/api/v1/usage/metrics/revenue", `{"outcome":"worked","notes":"x"}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, httptest.NewRequest(c.method, c.url, strings.NewReader(c.body)))
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("%s %s = %d, want 400 (body: %s)", c.method, c.url, rec.Code, rec.Body)
+			}
+			if !strings.Contains(rec.Body.String(), "unknown field") {
+				t.Errorf("body %q does not name the unknown field", rec.Body)
+			}
+		})
+	}
+}
+
+// TestTrailingBodyContentIsRejected pins the other half of readJSON's
+// strictness: content after the JSON value is a 400, not silently
+// discarded.
+func TestTrailingBodyContentIsRejected(t *testing.T) {
+	h := Handler(&service.Service{})
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/v1/move",
+		strings.NewReader(`{"from":"a","to":"b"}{"from":"c","to":"d"}`)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("POST move with trailing content = %d, want 400 (body: %s)", rec.Code, rec.Body)
+	}
+	if !strings.Contains(rec.Body.String(), "single JSON value") {
+		t.Errorf("body %q does not say why", rec.Body)
 	}
 }
 


### PR DESCRIPTION
## Summary

This is Part A of issue #470's nine-item audit of what freezing REST at
`/api/v1` (design doc 0064) would make permanent. It closes items 1–2:
0064 §2's own decision — an unrecognized query parameter is a 400,
naming it — had only half landed.

- `readJSON` never called `DisallowUnknownFields`, so an unrecognized
  JSON body key on `POST /api/v1/move`, `POST /api/v1/review/{id}` and
  `POST /api/v1/usage/{id}` was a silent 200 that dropped it. Content
  trailing the JSON value was silently discarded too. Both are now a
  400 naming the problem.
- `GET /api/v1/bundle/{path}` allowed `history`, `limit` and `files`
  for the whole address but reads each in only some of its modes
  (`files` archive-only, `limit` only on `?history`/`log.md`), so a
  parameter sent outside its mode was silently ignored — including
  `?history` combined with `Accept: application/gzip`, where the
  archive silently won instead of the two being refused as different
  objects. Each is now a 400 naming the mode it belongs to.

Items 3–9 (the `attach`/`detach` vocabulary sweep, spec/code
reconciliation, etc.) are separate PRs per the issue's landing plan.

Revises design doc [0064](docs/design/0064-rest-stops-at-api-v1.md) §2
and §11 in place — it hasn't reached a release yet, so 0048 §2.3 says
to revise by replacing rather than stacking a new number.
`CONTRIBUTING.md`'s `RECORD-LINES` (222→253) and `RECORD-CORPUS-LINES`
(8391→8422) move to match, with a sentence saying why.

## Test plan

- [x] `scripts/check --db core` (gofmt, go vet, go test -race with a
      throwaway PostgreSQL, CGO_ENABLED=0 build) — all green
- [x] New tests: `TestUnknownBodyFieldsAreRejected`,
      `TestTrailingBodyContentIsRejected`,
      `TestBundleParamsAreRejectedOutsideTheirMode`
- [x] Existing contract tests (`TestUnknownQueryParamsMatchSpec`,
      `TestSpecParamsAreAccepted`, `TestOpenAPISpecIsValid`) still pass
- [x] `cmd/ochakai`'s design-doc bookkeeping tests
      (`TestDesignRecordsStayUnderTheirCeiling`,
      `TestDesignRecordCorpusStaysUnderItsCeiling`) pass with the
      revised line counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)