### PR TITLE
Make the REST freeze a machine-checked invariant

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,6 +17,10 @@ context, including the store integration test and the fuzz targets).
       integration test, which is what puts it under the OpenAPI contract check
 - [ ] The change lands on every surface it belongs on — REST / MCP / CLI /
       Web UI — and what it stays off is deliberate (design doc 0015)
+- [ ] `api/openapi.frozen.txt` is untouched. REST is frozen at `/api/v1`
+      (design doc 0064), and `cmd/ochakai/frozenwire_test.go` fails on any
+      wire change; regenerating that file is a decision, and §11 leaves a
+      security defect as the only reason — say which one, here
 - [ ] Widens a surface — a REST operation, an MCP tool, a CLI command, an
       environment variable? `docs/surface.md` is updated
       (`cmd/ochakai/surface_test.go` says so), the description names which of

--- a/api/openapi.frozen.txt
+++ b/api/openapi.frozen.txt
@@ -1,0 +1,444 @@
+# The frozen REST wire, read out of api/openapi.yaml by
+# cmd/ochakai/frozenwire_test.go. Generated — do not edit by hand:
+#
+#	go test ./cmd/ochakai -run TestFrozenWireHasNotMoved -update
+#
+# One line per thing a client can observe. Prose (description, summary,
+# example, examples) is left out on purpose: documentation stays free to
+# improve after the freeze. Moving any line below is a change to a contract
+# design doc 0064 froze at /api/v1, and §11 says the only reason left is a
+# security defect.
+
+DELETE /api/v1/bundle/{path}
+DELETE /api/v1/bundle/{path} header If-Match ref=IfMatch
+DELETE /api/v1/bundle/{path} header Ochakai-On-Behalf-Of ref=OnBehalfOf
+DELETE /api/v1/bundle/{path} header Ochakai-Producer ref=Producer
+DELETE /api/v1/bundle/{path} query purge required=false type=boolean
+DELETE /api/v1/bundle/{path} response 204
+DELETE /api/v1/bundle/{path} response 204 header Ochakai-Read-Only ref=ReadOnly
+DELETE /api/v1/bundle/{path} response 400 ref=Error
+DELETE /api/v1/bundle/{path} response 403 ref=Forbidden
+DELETE /api/v1/bundle/{path} response 404
+DELETE /api/v1/bundle/{path} response 404 content application/json type=object
+DELETE /api/v1/bundle/{path} response 404 content application/json.error required=false type=string
+DELETE /api/v1/bundle/{path} response 404 header Ochakai-Read-Only ref=ReadOnly
+DELETE /api/v1/bundle/{path} response 405 ref=Error
+DELETE /api/v1/bundle/{path} response 409
+DELETE /api/v1/bundle/{path} response 409 content application/json type=object
+DELETE /api/v1/bundle/{path} response 409 content application/json.error required=false type=string
+DELETE /api/v1/bundle/{path} response 409 header Ochakai-Read-Only ref=ReadOnly
+DELETE /api/v1/bundle/{path} response 412
+DELETE /api/v1/bundle/{path} response 412 content application/json type=object
+DELETE /api/v1/bundle/{path} response 412 content application/json.error required=false type=string
+DELETE /api/v1/bundle/{path} response 500 ref=Error
+GET /api/v1/bundle/{path}
+GET /api/v1/bundle/{path} header If-None-Match ref=IfNoneMatch
+GET /api/v1/bundle/{path} path path required=true type=string
+GET /api/v1/bundle/{path} query files required=false type=boolean
+GET /api/v1/bundle/{path} query history required=false type=string
+GET /api/v1/bundle/{path} query limit required=false type=integer
+GET /api/v1/bundle/{path} response 200
+GET /api/v1/bundle/{path} response 200 content */* type=string
+GET /api/v1/bundle/{path} response 200 content application/gzip type=string
+GET /api/v1/bundle/{path} response 200 content application/json
+GET /api/v1/bundle/{path} response 200 content application/json/anyOf/0 ref=View
+GET /api/v1/bundle/{path} response 200 content application/json/anyOf/1 ref=BundleListing
+GET /api/v1/bundle/{path} response 200 content application/json/anyOf/2 ref=BundleLog
+GET /api/v1/bundle/{path} response 200 content application/json/anyOf/3 ref=ObjectHistory
+GET /api/v1/bundle/{path} response 200 content application/json/anyOf/4 ref=File
+GET /api/v1/bundle/{path} response 200 content text/markdown type=string
+GET /api/v1/bundle/{path} response 200 header Content-Disposition
+GET /api/v1/bundle/{path} response 200 header ETag ref=ETag
+GET /api/v1/bundle/{path} response 200 header Ochakai-Read-Only ref=ReadOnly
+GET /api/v1/bundle/{path} response 304
+GET /api/v1/bundle/{path} response 304 header Ochakai-Read-Only ref=ReadOnly
+GET /api/v1/bundle/{path} response 400 ref=Error
+GET /api/v1/bundle/{path} response 403 ref=Forbidden
+GET /api/v1/bundle/{path} response 404
+GET /api/v1/bundle/{path} response 404 content application/json type=object
+GET /api/v1/bundle/{path} response 404 content application/json.error required=false type=string
+GET /api/v1/bundle/{path} response 404 header Ochakai-Read-Only ref=ReadOnly
+GET /api/v1/bundle/{path} response 405 ref=Error
+GET /api/v1/bundle/{path} response 409
+GET /api/v1/bundle/{path} response 409 content application/json type=object
+GET /api/v1/bundle/{path} response 409 content application/json.error required=false type=string
+GET /api/v1/bundle/{path} response 409 header Ochakai-Read-Only ref=ReadOnly
+GET /api/v1/bundle/{path} response 500 ref=Error
+GET /api/v1/bundle/{path} response 501
+GET /api/v1/bundle/{path} response 501 content application/json type=object
+GET /api/v1/bundle/{path} response 501 content application/json.error required=false type=string
+GET /api/v1/bundle/{path} response 501 header Ochakai-Read-Only ref=ReadOnly
+GET /api/v1/context
+GET /api/v1/context query budget required=false type=integer
+GET /api/v1/context query fm.{key} required=false type=string
+GET /api/v1/context query limit required=false type=integer
+GET /api/v1/context query prefix required=false type=array
+GET /api/v1/context query prefix[] type=string
+GET /api/v1/context query q required=true type=string
+GET /api/v1/context query status required=false type=array
+GET /api/v1/context query status[] ref=Status
+GET /api/v1/context query tag required=false type=array
+GET /api/v1/context query tag[] type=string
+GET /api/v1/context query trust required=false type=array
+GET /api/v1/context query trust[] ref=Trust
+GET /api/v1/context query type required=false type=array
+GET /api/v1/context query type[] ref=Type
+GET /api/v1/context response 200
+GET /api/v1/context response 200 content application/json type=object
+GET /api/v1/context response 200 content application/json.concepts required=false type=array
+GET /api/v1/context response 200 content application/json.concepts[] ref=View
+GET /api/v1/context response 200 content application/json.hits required=false type=array
+GET /api/v1/context response 200 content application/json.hits[] ref=ContextRank
+GET /api/v1/context response 200 content application/json.outline required=false type=array
+GET /api/v1/context response 200 content application/json.outline[] ref=ContextOutline
+GET /api/v1/context response 200 header Ochakai-Read-Only ref=ReadOnly
+GET /api/v1/context response 400 ref=Error
+GET /api/v1/context response 403 ref=Forbidden
+GET /api/v1/context response 405 ref=Error
+GET /api/v1/context response 500 ref=Error
+GET /api/v1/search
+GET /api/v1/search query cursor required=false type=string
+GET /api/v1/search query fm.{key} required=false type=string
+GET /api/v1/search query limit required=false type=integer
+GET /api/v1/search query links_to required=false type=string
+GET /api/v1/search query prefix required=false type=array
+GET /api/v1/search query prefix[] type=string
+GET /api/v1/search query q required=false type=string
+GET /api/v1/search query rejected required=false type=boolean
+GET /api/v1/search query sort required=false type=string enum=["verified_at" "usage" "failed" "stale_after"]
+GET /api/v1/search query source required=false type=string
+GET /api/v1/search query status required=false type=array
+GET /api/v1/search query status[] ref=Status
+GET /api/v1/search query tag required=false type=array
+GET /api/v1/search query tag[] type=string
+GET /api/v1/search query trust required=false type=array
+GET /api/v1/search query trust[] ref=Trust
+GET /api/v1/search query type required=false type=array
+GET /api/v1/search query type[] ref=Type
+GET /api/v1/search response 200
+GET /api/v1/search response 200 content application/json type=object
+GET /api/v1/search response 200 content application/json.cursor required=false type=string
+GET /api/v1/search response 200 content application/json.hits required=false type=array
+GET /api/v1/search response 200 content application/json.hits[] ref=SearchHit
+GET /api/v1/search response 200 header Ochakai-Read-Only ref=ReadOnly
+GET /api/v1/search response 400
+GET /api/v1/search response 400 content application/json type=object
+GET /api/v1/search response 400 content application/json.error required=false type=string
+GET /api/v1/search response 400 header Ochakai-Read-Only ref=ReadOnly
+GET /api/v1/search response 403 ref=Forbidden
+GET /api/v1/search response 405 ref=Error
+GET /api/v1/search response 500 ref=Error
+GET /api/v1/stats
+GET /api/v1/stats query days required=false type=integer
+GET /api/v1/stats query prefix required=false type=array
+GET /api/v1/stats query prefix[] type=string
+GET /api/v1/stats response 200
+GET /api/v1/stats response 200 content application/json ref=Stats
+GET /api/v1/stats response 200 header Ochakai-Read-Only ref=ReadOnly
+GET /api/v1/stats response 400 ref=Error
+GET /api/v1/stats response 403 ref=Forbidden
+GET /api/v1/stats response 405 ref=Error
+GET /api/v1/stats response 500 ref=Error
+GET /api/v1/usage/{id}
+GET /api/v1/usage/{id} path id required=true type=string
+GET /api/v1/usage/{id} response 200
+GET /api/v1/usage/{id} response 200 content application/json ref=Usage
+GET /api/v1/usage/{id} response 200 header Ochakai-Read-Only ref=ReadOnly
+GET /api/v1/usage/{id} response 403 ref=Forbidden
+GET /api/v1/usage/{id} response 404 ref=Error
+GET /api/v1/usage/{id} response 405 ref=Error
+GET /api/v1/usage/{id} response 500 ref=Error
+POST /api/v1/move
+POST /api/v1/move body application/json required=true type=object
+POST /api/v1/move body application/json.from required=true type=string
+POST /api/v1/move body application/json.to required=true type=string
+POST /api/v1/move header Ochakai-On-Behalf-Of ref=OnBehalfOf
+POST /api/v1/move header Ochakai-Producer ref=Producer
+POST /api/v1/move response 200
+POST /api/v1/move response 200 content application/json ref=View
+POST /api/v1/move response 200 header ETag ref=ETag
+POST /api/v1/move response 200 header Ochakai-Read-Only ref=ReadOnly
+POST /api/v1/move response 400 ref=Error
+POST /api/v1/move response 403 ref=Forbidden
+POST /api/v1/move response 404 ref=Error
+POST /api/v1/move response 405 ref=Error
+POST /api/v1/move response 409 ref=Error
+POST /api/v1/move response 500 ref=Error
+POST /api/v1/reembed
+POST /api/v1/reembed query cursor required=false type=string
+POST /api/v1/reembed query limit required=false type=integer
+POST /api/v1/reembed response 200
+POST /api/v1/reembed response 200 content application/json type=object
+POST /api/v1/reembed response 200 content application/json.concepts required=false type=integer
+POST /api/v1/reembed response 200 content application/json.cursor required=false type=string
+POST /api/v1/reembed response 200 content application/json.failed required=false type=integer
+POST /api/v1/reembed response 200 content application/json.files required=false type=integer
+POST /api/v1/reembed response 200 content application/json.missing required=false type=integer
+POST /api/v1/reembed response 200 header Ochakai-Read-Only ref=ReadOnly
+POST /api/v1/reembed response 400 ref=Error
+POST /api/v1/reembed response 403 ref=Forbidden
+POST /api/v1/reembed response 405 ref=Error
+POST /api/v1/reembed response 500 ref=Error
+POST /api/v1/reembed response 501 ref=Error
+POST /api/v1/review/{id}
+POST /api/v1/review/{id} body application/json required=true type=object
+POST /api/v1/review/{id} body application/json.note required=false type=string
+POST /api/v1/review/{id} body application/json.ruling required=true type=string enum=["verified" "rejected" "withdrawn"]
+POST /api/v1/review/{id} header Ochakai-On-Behalf-Of ref=OnBehalfOf
+POST /api/v1/review/{id} header Ochakai-Producer ref=Producer
+POST /api/v1/review/{id} path id required=true type=string
+POST /api/v1/review/{id} response 200
+POST /api/v1/review/{id} response 200 content application/json ref=View
+POST /api/v1/review/{id} response 200 header ETag ref=ETag
+POST /api/v1/review/{id} response 200 header Ochakai-Read-Only ref=ReadOnly
+POST /api/v1/review/{id} response 400
+POST /api/v1/review/{id} response 400 content application/json type=object
+POST /api/v1/review/{id} response 400 content application/json.error required=false type=string
+POST /api/v1/review/{id} response 400 header Ochakai-Read-Only ref=ReadOnly
+POST /api/v1/review/{id} response 403 ref=Forbidden
+POST /api/v1/review/{id} response 404 ref=Error
+POST /api/v1/review/{id} response 405 ref=Error
+POST /api/v1/review/{id} response 409
+POST /api/v1/review/{id} response 409 content application/json type=object
+POST /api/v1/review/{id} response 409 content application/json.error required=false type=string
+POST /api/v1/review/{id} response 500 ref=Error
+POST /api/v1/usage/{id}
+POST /api/v1/usage/{id} body application/json required=true type=object
+POST /api/v1/usage/{id} body application/json.note required=false type=string
+POST /api/v1/usage/{id} body application/json.outcome required=true type=string enum=["worked" "failed"]
+POST /api/v1/usage/{id} header Ochakai-On-Behalf-Of ref=OnBehalfOf
+POST /api/v1/usage/{id} header Ochakai-Producer ref=Producer
+POST /api/v1/usage/{id} path id required=true type=string
+POST /api/v1/usage/{id} response 200
+POST /api/v1/usage/{id} response 200 content application/json ref=Usage
+POST /api/v1/usage/{id} response 200 header Ochakai-Read-Only ref=ReadOnly
+POST /api/v1/usage/{id} response 400 ref=Error
+POST /api/v1/usage/{id} response 403 ref=Forbidden
+POST /api/v1/usage/{id} response 404 ref=Error
+POST /api/v1/usage/{id} response 405 ref=Error
+POST /api/v1/usage/{id} response 500 ref=Error
+PUT /api/v1/bundle/{path}
+PUT /api/v1/bundle/{path} header If-Match ref=IfMatch
+PUT /api/v1/bundle/{path} header If-None-Match ref=IfNoneMatch
+PUT /api/v1/bundle/{path} header Ochakai-On-Behalf-Of ref=OnBehalfOf
+PUT /api/v1/bundle/{path} header Ochakai-Producer ref=Producer
+PUT /api/v1/bundle/{path} query dry_run required=false type=boolean
+PUT /api/v1/bundle/{path} response 200
+PUT /api/v1/bundle/{path} response 200 content application/json
+PUT /api/v1/bundle/{path} response 200 content application/json/anyOf/0 ref=View
+PUT /api/v1/bundle/{path} response 200 content application/json/anyOf/1 ref=File
+PUT /api/v1/bundle/{path} response 200 content text/markdown type=string
+PUT /api/v1/bundle/{path} response 200 header ETag ref=ETag
+PUT /api/v1/bundle/{path} response 200 header Ochakai-Note ref=Note
+PUT /api/v1/bundle/{path} response 200 header Ochakai-Plan ref=Plan
+PUT /api/v1/bundle/{path} response 200 header Ochakai-Read-Only ref=ReadOnly
+PUT /api/v1/bundle/{path} response 200 header Ochakai-Unchanged
+PUT /api/v1/bundle/{path} response 201
+PUT /api/v1/bundle/{path} response 201 content application/json
+PUT /api/v1/bundle/{path} response 201 content application/json/anyOf/0 ref=View
+PUT /api/v1/bundle/{path} response 201 content application/json/anyOf/1 ref=File
+PUT /api/v1/bundle/{path} response 201 content text/markdown type=string
+PUT /api/v1/bundle/{path} response 201 header ETag ref=ETag
+PUT /api/v1/bundle/{path} response 201 header Ochakai-Note ref=Note
+PUT /api/v1/bundle/{path} response 201 header Ochakai-Read-Only ref=ReadOnly
+PUT /api/v1/bundle/{path} response 400 ref=Error
+PUT /api/v1/bundle/{path} response 403 ref=Forbidden
+PUT /api/v1/bundle/{path} response 405 ref=Error
+PUT /api/v1/bundle/{path} response 409
+PUT /api/v1/bundle/{path} response 409 content application/json type=object
+PUT /api/v1/bundle/{path} response 409 content application/json.error required=false type=string
+PUT /api/v1/bundle/{path} response 409 header Ochakai-Read-Only ref=ReadOnly
+PUT /api/v1/bundle/{path} response 412
+PUT /api/v1/bundle/{path} response 412 content application/json type=object
+PUT /api/v1/bundle/{path} response 412 content application/json.error required=false type=string
+PUT /api/v1/bundle/{path} response 413 ref=Error
+PUT /api/v1/bundle/{path} response 415 ref=Error
+PUT /api/v1/bundle/{path} response 500 ref=Error
+PUT /api/v1/bundle/{path} response 501 ref=Error
+components/headers/ETag
+components/headers/ETag schema type=string
+components/headers/Note
+components/headers/Note schema type=string
+components/headers/Plan
+components/headers/Plan schema type=string enum=["created" "updated" "unchanged"]
+components/headers/ReadOnly
+components/headers/ReadOnly schema type=string enum=["true"]
+components/parameters/IfMatch name=If-Match in=header required=false
+components/parameters/IfMatch schema type=string
+components/parameters/IfNoneMatch name=If-None-Match in=header required=false
+components/parameters/IfNoneMatch schema type=string
+components/parameters/OnBehalfOf name=Ochakai-On-Behalf-Of in=header required=false
+components/parameters/OnBehalfOf schema type=string
+components/parameters/Producer name=Ochakai-Producer in=header required=false
+components/parameters/Producer schema type=string
+components/responses/Error
+components/responses/Error content application/json type=object
+components/responses/Error content application/json.error required=false type=string
+components/responses/Error header Ochakai-Read-Only ref=ReadOnly
+components/responses/Forbidden
+components/responses/Forbidden content application/json type=object
+components/responses/Forbidden content application/json.error required=false type=string
+components/responses/Forbidden header Ochakai-Read-Only ref=ReadOnly
+components/schemas/Actor type=object
+components/schemas/Actor.kind required=false type=string enum=["human" "process"]
+components/schemas/Actor.name required=false type=string
+components/schemas/Actor.producer required=false type=string
+components/schemas/Actor.via required=false type=string
+components/schemas/BundleListing type=object
+components/schemas/BundleListing.concepts required=false type=array
+components/schemas/BundleListing.concepts[] type=object
+components/schemas/BundleListing.concepts[].description required=false type=string
+components/schemas/BundleListing.concepts[].id required=false type=string
+components/schemas/BundleListing.concepts[].status required=false ref=Status
+components/schemas/BundleListing.concepts[].title required=false type=string
+components/schemas/BundleListing.concepts[].type required=false ref=Type
+components/schemas/BundleListing.concepts[].updated_at required=false type=string
+components/schemas/BundleListing.dirs required=false type=array
+components/schemas/BundleListing.dirs[] type=object
+components/schemas/BundleListing.dirs[].count required=false type=integer
+components/schemas/BundleListing.dirs[].name required=false type=string
+components/schemas/BundleListing.files required=false type=array
+components/schemas/BundleListing.files[] type=object
+components/schemas/BundleListing.files[].created_at required=false type=string
+components/schemas/BundleListing.files[].media_type required=false type=string
+components/schemas/BundleListing.files[].name required=false type=string
+components/schemas/BundleListing.files[].path required=false type=string
+components/schemas/BundleListing.files[].size required=false type=integer
+components/schemas/BundleListing.truncated required=false type=boolean
+components/schemas/BundleLog type=object
+components/schemas/BundleLog.changes required=true type=array
+components/schemas/BundleLog.changes[] ref=Change
+components/schemas/Change type=object
+components/schemas/Change.change required=false type=string enum=["create" "update" "verify" "reject" "withdraw" "delete" "move" "add_file" "remove_file"]
+components/schemas/Change.changed_at required=false type=string
+components/schemas/Change.changed_by required=false ref=Actor
+components/schemas/Change.path required=false type=string
+components/schemas/Change.title required=false type=string
+components/schemas/ContextOutline type=object
+components/schemas/ContextOutline.bytes required=false type=integer
+components/schemas/ContextOutline.description required=false type=string
+components/schemas/ContextOutline.id required=false type=string
+components/schemas/ContextOutline.status required=false ref=Status
+components/schemas/ContextOutline.title required=false type=string
+components/schemas/ContextOutline.type required=false ref=Type
+components/schemas/ContextRank type=object
+components/schemas/ContextRank.id required=false type=string
+components/schemas/ContextRank.score required=false type=number
+components/schemas/ContextRank.status required=false ref=Status
+components/schemas/ContextRank.title required=false type=string
+components/schemas/ContextRank.trust required=false
+components/schemas/ContextRank.trust/allOf/0 ref=Trust
+components/schemas/ContextRank.type required=false ref=Type
+components/schemas/File type=object
+components/schemas/File.created_at required=false type=string
+components/schemas/File.created_by required=false ref=Actor
+components/schemas/File.media_type required=false type=string
+components/schemas/File.name required=false type=string
+components/schemas/File.path required=false type=string
+components/schemas/File.sha256 required=false type=string
+components/schemas/File.size required=false type=integer
+components/schemas/Generated type=object
+components/schemas/Generated.at required=false type=string
+components/schemas/Generated.by required=false ref=Actor
+components/schemas/Link type=object
+components/schemas/Link.target required=false type=string
+components/schemas/Link.text required=false type=string
+components/schemas/ObjectHistory type=object
+components/schemas/ObjectHistory.revisions required=true type=array
+components/schemas/ObjectHistory.revisions[] ref=Revision
+components/schemas/Observed type=object
+components/schemas/Observed.created_by required=false ref=Actor
+components/schemas/Observed.generated required=false ref=Generated
+components/schemas/Observed.rejection required=false
+components/schemas/Observed.rejection/allOf/0 ref=Rejection
+components/schemas/Observed.verified required=false type=array
+components/schemas/Observed.verified[] ref=Verification
+components/schemas/QueueCounts type=object
+components/schemas/QueueCounts.drafts required=false type=integer
+components/schemas/QueueCounts.failed required=false type=integer
+components/schemas/QueueCounts.stale_after required=false type=integer
+components/schemas/Rejection type=object
+components/schemas/Rejection.at required=false type=string
+components/schemas/Rejection.by required=false ref=Actor
+components/schemas/Rejection.note required=false type=string
+components/schemas/Revision type=object
+components/schemas/Revision.change required=false type=string enum=["create" "update" "verify" "reject" "withdraw" "delete" "move" "add_file" "remove_file"]
+components/schemas/Revision.changed_at required=false type=string
+components/schemas/Revision.changed_by required=false ref=Actor
+components/schemas/Revision.document required=false type=string
+components/schemas/Revision.rev required=false type=integer
+components/schemas/SearchHit
+components/schemas/SearchHit/allOf/0 ref=Summary
+components/schemas/SearchHit/allOf/1 type=object
+components/schemas/SearchHit/allOf/1.files required=false type=array
+components/schemas/SearchHit/allOf/1.files[] ref=File
+components/schemas/SearchHit/allOf/1.score required=false type=number
+components/schemas/SearchHit/allOf/1.usage required=false
+components/schemas/SearchHit/allOf/1.usage/allOf/0 ref=Usage
+components/schemas/Stats type=object
+components/schemas/Stats.at required=false type=string
+components/schemas/Stats.concepts required=false type=object
+components/schemas/Stats.concepts.created required=false type=integer
+components/schemas/Stats.concepts.rejected required=false type=integer
+components/schemas/Stats.concepts.status required=false type=object
+components/schemas/Stats.concepts.status.* type=integer
+components/schemas/Stats.concepts.total required=false type=integer
+components/schemas/Stats.concepts.trust required=false type=object
+components/schemas/Stats.concepts.trust.* type=integer
+components/schemas/Stats.misses required=false type=object
+components/schemas/Stats.misses.count required=false type=integer
+components/schemas/Stats.misses.queries required=false type=array
+components/schemas/Stats.misses.queries[] type=object
+components/schemas/Stats.misses.queries[].count required=false type=integer
+components/schemas/Stats.misses.queries[].last_at required=false type=string
+components/schemas/Stats.misses.queries[].query required=false type=string
+components/schemas/Stats.misses.recording required=false type=boolean
+components/schemas/Stats.outcomes required=false type=object
+components/schemas/Stats.outcomes.failed required=false type=integer
+components/schemas/Stats.outcomes.worked required=false type=integer
+components/schemas/Stats.queues required=false
+components/schemas/Stats.queues/allOf/0 ref=QueueCounts
+components/schemas/Stats.review required=false type=object
+components/schemas/Stats.review.verifications required=false type=integer
+components/schemas/Stats.window_days required=false type=integer
+components/schemas/Status type=string enum=["draft" "stable" "deprecated"]
+components/schemas/Summary type=object
+components/schemas/Summary.content_hash required=true type=string
+components/schemas/Summary.created_at required=true type=string
+components/schemas/Summary.description required=false type=string
+components/schemas/Summary.id required=true type=string
+components/schemas/Summary.links required=false type=array
+components/schemas/Summary.links[] ref=Link
+components/schemas/Summary.rejected required=true type=boolean
+components/schemas/Summary.resource required=false type=string
+components/schemas/Summary.stale_after required=false type=string
+components/schemas/Summary.status required=true ref=Status
+components/schemas/Summary.tags required=false type=array
+components/schemas/Summary.tags[] type=string
+components/schemas/Summary.title required=true type=string
+components/schemas/Summary.trust required=true
+components/schemas/Summary.trust/allOf/0 ref=Trust
+components/schemas/Summary.type required=true ref=Type
+components/schemas/Summary.updated_at required=true type=string
+components/schemas/Summary.verified_at required=false type=string
+components/schemas/Trust type=string enum=["unverified" "machine-confirmed" "human-reviewed"]
+components/schemas/Type type=string
+components/schemas/Usage type=object
+components/schemas/Usage.failed required=false type=integer
+components/schemas/Usage.fetches required=false type=integer
+components/schemas/Usage.last_used_at required=false type=string
+components/schemas/Usage.search_hits required=false type=integer
+components/schemas/Usage.worked required=false type=integer
+components/schemas/Verification type=object
+components/schemas/Verification.at required=false type=string
+components/schemas/Verification.by required=false ref=Actor
+components/schemas/View type=object
+components/schemas/View.document required=true type=string
+components/schemas/View.files required=false type=array
+components/schemas/View.files[] ref=File
+components/schemas/View.id required=true type=string
+components/schemas/View.observed required=true ref=Observed
+components/schemas/View.summary required=true ref=Summary
+components/securitySchemes/GoogleIDToken type=http scheme=bearer format=JWT
+security (anonymous)
+security GoogleIDToken

--- a/cmd/ochakai/clidocs_test.go
+++ b/cmd/ochakai/clidocs_test.go
@@ -20,7 +20,11 @@ import (
 // the OpenAPI contract test does for the REST surface (design doc 0035).
 const cliDocsPath = "../../docs/cli.md"
 
-var updateCLIDocs = flag.Bool("update", false, "rewrite docs/cli.md from the CLI's own help")
+// -update rewrites the files this package checks in and regenerates:
+// docs/cli.md from the CLI's own help, and api/openapi.frozen.txt from the
+// REST contract (frozenwire_test.go). One flag, because a contributor
+// should not have to learn which golden takes which switch.
+var updateGolden = flag.Bool("update", false, "rewrite the checked-in generated files (docs/cli.md, api/openapi.frozen.txt)")
 
 const cliDocsHeader = `<!-- Generated from the CLI's own help. Do not edit by hand:
      go test ./cmd/ochakai -run TestCLIReferenceIsCurrent -update -->
@@ -50,7 +54,7 @@ either command still prints its own copy in full.
 // the checked-in copy.
 func TestCLIReferenceIsCurrent(t *testing.T) {
 	got := renderCLIDocs(t)
-	if *updateCLIDocs {
+	if *updateGolden {
 		if err := os.WriteFile(cliDocsPath, []byte(got), 0o600); err != nil {
 			t.Fatal(err)
 		}

--- a/cmd/ochakai/frozenwire_test.go
+++ b/cmd/ochakai/frozenwire_test.go
@@ -1,0 +1,423 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+	"testing"
+
+	yaml "go.yaml.in/yaml/v3"
+)
+
+// REST stops at /api/v1 (design doc 0064): api/openapi.yaml is the address
+// list a client can hold onto, and after the freeze the only thing that may
+// still break it is a security defect (§11, docs/compatibility.md). Nothing
+// checked that. The counters in surface_test.go read the same file, but they
+// count names in a list — a rename that keeps the count is invisible to
+// them, and `concepts` → `entries`, `Ochakai-Plan` → `Ochakai-Planned`, a
+// 201 becoming a 200 or a required field going optional all pass every other
+// check in the repo. The largest promise here was held up by prose alone,
+// which is the thing design doc 0035 says not to do: read the invariant from
+// outside rather than trust the convention.
+//
+// api/openapi.frozen.txt is that reading, checked in. Every line is one
+// thing a client can observe — an operation, a parameter or header wire
+// name, a status code, a media type, a schema property with its
+// requiredness, type and enum — derived from the spec and sorted, so a diff
+// names exactly what moved.
+//
+// **Prose is deliberately not in it.** description, summary, example and
+// examples are dropped on the way through, so the documentation in the
+// contract can still be rewritten, corrected and translated freely after the
+// freeze. What is frozen is the wire, not the words about it.
+//
+// The division of labour with the other contract test: checkedServer in
+// internal/restapi/openapi_test.go runs every request and response of the
+// integration tests past this spec, which keeps the *server* honest to the
+// spec. This one keeps the *spec* honest to the freeze. Neither alone pins
+// the server — the first would follow the spec anywhere it went, and the
+// second cannot see the code — and together they do.
+const frozenWirePath = "../../api/openapi.frozen.txt"
+
+// The header the generated file carries, so a reader who opens it knows what
+// it is and how to rebuild it before reading a single line of it.
+const frozenWireHeader = `# The frozen REST wire, read out of api/openapi.yaml by
+# cmd/ochakai/frozenwire_test.go. Generated — do not edit by hand:
+#
+#	go test ./cmd/ochakai -run TestFrozenWireHasNotMoved -update
+#
+# One line per thing a client can observe. Prose (description, summary,
+# example, examples) is left out on purpose: documentation stays free to
+# improve after the freeze. Moving any line below is a change to a contract
+# design doc 0064 froze at /api/v1, and §11 says the only reason left is a
+# security defect.
+
+`
+
+// TestFrozenWireHasNotMoved compares the fingerprint of api/openapi.yaml
+// with the golden file. The golden is regenerated deliberately, in the PR
+// that changes the wire, which is the whole point: the freeze becomes
+// something a diff shows rather than something a convention asks for.
+func TestFrozenWireHasNotMoved(t *testing.T) {
+	got := frozenWire(t)
+	if *updateGolden {
+		if err := os.WriteFile(frozenWirePath, []byte(got), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	raw, err := os.ReadFile(frozenWirePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := string(raw)
+	if want == got {
+		return
+	}
+	t.Errorf(`the frozen REST wire moved:
+
+%s
+REST is frozen at /api/v1 (design doc 0064, docs/compatibility.md): this
+contract is the address list a client holds onto, and after the freeze the
+only reason to move a line above is a security defect (0064 §11). Prose is
+not fingerprinted, so a documentation edit never lands here.
+
+If this change is meant, regenerate the golden in the same PR and say in the
+description which security defect it closes:
+
+	go test ./cmd/ochakai -run TestFrozenWireHasNotMoved -update`,
+		wireDiff(want, got))
+}
+
+// wireDiff names what moved, rather than leaving the author to diff two
+// sorted lists by eye. Both sides are sorted already, so a merge walk is
+// enough; comment and blank lines are the generated header, which carries no
+// contract.
+func wireDiff(want, got string) string {
+	const shown = 40
+	a, b := fingerprintLines(want), fingerprintLines(got)
+	var out []string
+	for i, j := 0, 0; i < len(a) || j < len(b); {
+		switch {
+		case j == len(b) || (i < len(a) && a[i] < b[j]):
+			out = append(out, "- "+a[i])
+			i++
+		case i == len(a) || b[j] < a[i]:
+			out = append(out, "+ "+b[j])
+			j++
+		default:
+			i, j = i+1, j+1
+		}
+	}
+	if len(out) == 0 {
+		return "  (only the generated header differs — regenerate it)\n"
+	}
+	extra := ""
+	if len(out) > shown {
+		extra = fmt.Sprintf("  ... and %d more\n", len(out)-shown)
+		out = out[:shown]
+	}
+	return "  " + strings.Join(out, "\n  ") + "\n" + extra
+}
+
+func fingerprintLines(content string) []string {
+	var out []string
+	for _, line := range strings.Split(content, "\n") {
+		if line != "" && !strings.HasPrefix(line, "#") {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+// frozenWire renders the fingerprint: the header, then every observable line
+// in sorted order. Sorting is what makes it stable — nothing here depends on
+// where in the spec a key happens to be written, so moving a block of YAML
+// around is not a wire change and does not read as one.
+func frozenWire(t *testing.T) string {
+	t.Helper()
+	f := &wireFingerprint{t: t, doc: readSpecTree(t)}
+	f.walk()
+	if len(f.lines) == 0 {
+		t.Fatal("no wire found in openapi.yaml: this check now guards nothing")
+	}
+	slices.Sort(f.lines)
+	f.lines = slices.Compact(f.lines)
+	return frozenWireHeader + strings.Join(f.lines, "\n") + "\n"
+}
+
+func readSpecTree(t *testing.T) map[string]any {
+	t.Helper()
+	content, err := os.ReadFile(openAPISpec)
+	if err != nil {
+		t.Fatalf("read openapi.yaml: %v", err)
+	}
+	var doc any
+	if err := yaml.Unmarshal(content, &doc); err != nil {
+		t.Fatalf("parse openapi.yaml: %v", err)
+	}
+	return wireMap(doc)
+}
+
+// wireFingerprint accumulates the lines. It reads the spec as a plain tree
+// rather than through a typed struct: the point is to see everything a
+// client can observe, and a struct only sees the keys somebody thought to
+// declare — which is the failure mode this test exists to close.
+type wireFingerprint struct {
+	t     *testing.T
+	doc   map[string]any
+	lines []string
+}
+
+// add writes one line: a location, then the tokens that describe it. Empty
+// tokens drop out, so a caller can pass a value that may not apply.
+func (f *wireFingerprint) add(loc string, tokens ...string) {
+	for _, tok := range tokens {
+		if tok != "" {
+			loc += " " + tok
+		}
+	}
+	f.lines = append(f.lines, loc)
+}
+
+func (f *wireFingerprint) walk() {
+	f.walkPaths()
+	f.walkComponents()
+	f.walkSecurity()
+}
+
+func (f *wireFingerprint) walkPaths() {
+	for path, item := range wireMap(f.doc["paths"]) {
+		pathItem := wireMap(item)
+		shared := wireSeq(pathItem["parameters"])
+		for method, node := range pathItem {
+			if !httpMethods[method] {
+				continue
+			}
+			op := wireMap(node)
+			loc := strings.ToUpper(method) + " " + path
+			f.add(loc)
+			for _, p := range append(append([]any{}, shared...), wireSeq(op["parameters"])...) {
+				f.parameter(loc, p)
+			}
+			f.requestBody(loc, wireMap(op["requestBody"]))
+			for status, resp := range wireMap(op["responses"]) {
+				f.response(loc+" response "+status, wireMap(resp))
+			}
+		}
+	}
+}
+
+// parameter records one parameter under the name it travels by, which is the
+// name in components/parameters when the operation shares one — an operation
+// that says $ref and one that spells the parameter out are the same thing on
+// the wire. The shared parameter's own schema is fingerprinted once, where it
+// is declared, rather than repeated at every operation that points at it.
+func (f *wireFingerprint) parameter(loc string, node any) {
+	p := wireMap(node)
+	if ref := wireStr(p["$ref"]); ref != "" {
+		target := wireMap(wireMap(wireMap(f.doc["components"])["parameters"])[shortRef(ref)])
+		if target == nil {
+			f.t.Fatalf("%s: parameter $ref %q names no component", loc, ref)
+		}
+		f.add(f.paramLoc(loc, target), "ref="+shortRef(ref))
+		return
+	}
+	f.schema(f.paramLoc(loc, p), p["schema"], requiredToken(p["required"]))
+}
+
+func (f *wireFingerprint) paramLoc(loc string, p map[string]any) string {
+	return loc + " " + wireStr(p["in"]) + " " + wireStr(p["name"])
+}
+
+func (f *wireFingerprint) requestBody(loc string, body map[string]any) {
+	if body == nil {
+		return
+	}
+	for media, node := range wireMap(body["content"]) {
+		f.schema(loc+" body "+media, wireMap(node)["schema"], requiredToken(body["required"]))
+	}
+}
+
+// response records the status code, then the header names and media types
+// under it. A response that is a $ref is recorded as the component it names:
+// the component itself is fingerprinted once below, so a rename inside it
+// shows on one line instead of on every operation that shares it.
+func (f *wireFingerprint) response(loc string, resp map[string]any) {
+	if ref := wireStr(resp["$ref"]); ref != "" {
+		f.add(loc, "ref="+shortRef(ref))
+		return
+	}
+	f.add(loc)
+	for name, node := range wireMap(resp["headers"]) {
+		f.add(loc+" header "+name, refToken(node))
+	}
+	for media, node := range wireMap(resp["content"]) {
+		f.schema(loc+" content "+media, wireMap(node)["schema"], "")
+	}
+}
+
+func (f *wireFingerprint) walkComponents() {
+	components := wireMap(f.doc["components"])
+	for name, node := range wireMap(components["parameters"]) {
+		p := wireMap(node)
+		loc := "components/parameters/" + name
+		f.add(loc, "name="+wireStr(p["name"]), "in="+wireStr(p["in"]), requiredToken(p["required"]))
+		f.schema(loc+" schema", p["schema"], "")
+	}
+	for name, node := range wireMap(components["headers"]) {
+		loc := "components/headers/" + name
+		f.add(loc)
+		f.schema(loc+" schema", wireMap(node)["schema"], "")
+	}
+	for name, node := range wireMap(components["responses"]) {
+		f.response("components/responses/"+name, wireMap(node))
+	}
+	for name, node := range wireMap(components["schemas"]) {
+		f.schema("components/schemas/"+name, node, "")
+	}
+	for name, node := range wireMap(components["securitySchemes"]) {
+		s := wireMap(node)
+		f.add("components/securitySchemes/"+name,
+			"type="+wireStr(s["type"]), "scheme="+wireStr(s["scheme"]), "format="+wireStr(s["bearerFormat"]))
+	}
+}
+
+// walkSecurity records what the API requires of a caller. The empty
+// alternative beside GoogleIDToken is the whole of "a public deployment
+// answers a caller with no Authorization header" (design docs 0040, 0042),
+// and dropping it would be as breaking as dropping an endpoint.
+func (f *wireFingerprint) walkSecurity() {
+	for _, req := range wireSeq(f.doc["security"]) {
+		names := make([]string, 0, 1)
+		for name := range wireMap(req) {
+			names = append(names, name)
+		}
+		if len(names) == 0 {
+			f.add("security (anonymous)")
+			continue
+		}
+		slices.Sort(names)
+		f.add("security " + strings.Join(names, "+"))
+	}
+}
+
+// schema records one schema node and everything under it: its type, its enum
+// verbatim when it has one, and one line per property, fully qualified and
+// carrying whether the property is required. Nothing about how the schema is
+// described is read — the prose keys are simply never visited.
+func (f *wireFingerprint) schema(loc string, node any, required string) {
+	s := wireMap(node)
+	if s == nil {
+		f.add(loc, required)
+		return
+	}
+	if ref := wireStr(s["$ref"]); ref != "" {
+		f.add(loc, required, "ref="+shortRef(ref))
+		return
+	}
+	f.add(loc, required, typeToken(s["type"]), enumToken(s["enum"]))
+
+	names := map[string]bool{}
+	for _, name := range wireSeq(s["required"]) {
+		names[wireStr(name)] = true
+	}
+	for name, prop := range wireMap(s["properties"]) {
+		f.schema(loc+"."+name, prop, requiredToken(names[name]))
+		delete(names, name)
+	}
+	// A required name with no property declared is a hole in the contract,
+	// not something to drop silently on the way to the golden file.
+	for name := range names {
+		f.add(loc+"."+name, "required=true", "(declared required, no such property)")
+	}
+	if items, ok := s["items"]; ok {
+		f.schema(loc+"[]", items, "")
+	}
+	if extra, ok := s["additionalProperties"]; ok && wireMap(extra) != nil {
+		f.schema(loc+".*", extra, "")
+	}
+	for _, combinator := range []string{"allOf", "anyOf", "oneOf"} {
+		for i, sub := range wireSeq(s[combinator]) {
+			f.schema(fmt.Sprintf("%s/%s/%d", loc, combinator, i), sub, "")
+		}
+	}
+}
+
+// shortRef is the last segment of a $ref: what the pointer names, without
+// the pointer. "#/components/schemas/Summary" is Summary wherever it is
+// pointed at from.
+func shortRef(ref string) string {
+	return ref[strings.LastIndex(ref, "/")+1:]
+}
+
+func refToken(node any) string {
+	if ref := wireStr(wireMap(node)["$ref"]); ref != "" {
+		return "ref=" + shortRef(ref)
+	}
+	return ""
+}
+
+// requiredToken always says which way it went. "absent means optional" would
+// make a required field going optional a deletion in the diff rather than a
+// change, and that is one of the renames this test exists to catch.
+func requiredToken(v any) string {
+	if b, ok := v.(bool); ok && b {
+		return "required=true"
+	}
+	return "required=false"
+}
+
+func typeToken(v any) string {
+	switch t := v.(type) {
+	case string:
+		return "type=" + t
+	case []any:
+		names := make([]string, 0, len(t))
+		for _, one := range t {
+			names = append(names, fmt.Sprint(one))
+		}
+		return "type=" + strings.Join(names, "|")
+	}
+	return ""
+}
+
+// enumToken quotes each value, so an enum whose values contain a space or
+// look like numbers still reads as exactly what the spec wrote. Document
+// order is kept: verbatim is the promise.
+func enumToken(v any) string {
+	values := wireSeq(v)
+	if len(values) == 0 {
+		return ""
+	}
+	quoted := make([]string, 0, len(values))
+	for _, one := range values {
+		quoted = append(quoted, fmt.Sprintf("%q", fmt.Sprint(one)))
+	}
+	return "enum=[" + strings.Join(quoted, " ") + "]"
+}
+
+func wireMap(v any) map[string]any {
+	switch m := v.(type) {
+	case map[string]any:
+		return m
+	case map[any]any: // a mapping with a non-string key anywhere in it
+		out := make(map[string]any, len(m))
+		for k, value := range m {
+			out[fmt.Sprint(k)] = value
+		}
+		return out
+	}
+	return nil
+}
+
+func wireSeq(v any) []any {
+	s, _ := v.([]any)
+	return s
+}
+
+func wireStr(v any) string {
+	s, _ := v.(string)
+	return s
+}

--- a/cmd/ochakai/surface_test.go
+++ b/cmd/ochakai/surface_test.go
@@ -156,9 +156,13 @@ type wireOperation struct {
 
 var httpMethods = map[string]bool{"get": true, "put": true, "post": true, "delete": true, "patch": true}
 
+// The contract itself, read by the counters here and by the freeze ratchet
+// in frozenwire_test.go.
+const openAPISpec = "../../api/openapi.yaml"
+
 func readWireSpec(t *testing.T) *wireSpec {
 	t.Helper()
-	content, err := os.ReadFile("../../api/openapi.yaml")
+	content, err := os.ReadFile(openAPISpec)
 	if err != nil {
 		t.Fatalf("read openapi.yaml: %v", err)
 	}

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -29,7 +29,13 @@ moves:
   `/api/v1/attachments/{id}/{name}`, `/api/v1/backlinks/{id}`,
   `/api/v1/export`) rather than deprecating them. That history does not
   repeat: [api/openapi.yaml](../api/openapi.yaml) is now the address list
-  a client can hold onto.
+  a client can hold onto. **The freeze is checked, not promised.**
+  [api/openapi.frozen.txt](../api/openapi.frozen.txt) is a fingerprint of
+  everything that file lets a client observe — every operation, parameter,
+  header, status code and schema field — and CI fails when the two disagree
+  (`cmd/ochakai/frozenwire_test.go`), so a rename that keeps every count
+  still cannot land quietly. Prose is deliberately outside it: the
+  documentation in the contract stays free to improve.
 - **MCP** — tool names, arguments, and which tools exist at all.
   `compile_sql` existed until `0.13.0` and does not now, and the five
   tools that said `knowledge` say `concept`.


### PR DESCRIPTION
## What and why

`api/openapi.yaml` is frozen. Design doc
[0064](docs/design/0064-rest-stops-at-api-v1.md) says REST stops at `/api/v1`,
and §11 leaves a security defect as the only reason left to break it;
`docs/compatibility.md` repeats that to the person deciding whether to build on
it. Nothing enforced any of it. `cmd/ochakai/surface_test.go` reads the same
file, but it counts **names in a list**: `concepts` → `entries`,
`Ochakai-Plan` → `Ochakai-Planned`, a 201 becoming a 200, a `required` field
going optional — every one of those keeps the count and passes every check this
repo has. The largest promise in the tree was held up by prose alone, which is
the thing design doc [0035](docs/design/0035-verifiability.md) says not to do:
read the invariant from outside rather than trust the convention.

`cmd/ochakai/frozenwire_test.go` derives a fingerprint of everything a REST
client can observe in that spec and compares it with `api/openapi.frozen.txt`,
committed beside it. 444 lines, sorted, one line per observable thing:

- every `method path` pair;
- per operation: query and header parameter names (a `$ref` resolved to the
  name it travels by), request body media types, response status codes;
- per response: header names and media types;
- every schema property, fully qualified (`components/schemas/Summary.title`),
  with whether it is required, its type, and its `enum` verbatim;
- the `components/parameters`, `components/headers`, `components/responses` and
  `components/securitySchemes` entries, and the top-level `security`
  alternatives — including the empty one that makes a public deployment
  legal.

**Prose is deliberately outside it.** `description`, `summary`, `example` and
`examples` are never visited, so the documentation in the contract stays free
to be corrected, tightened and translated after the freeze. That exclusion is
stated in the test's doc comment and in the generated file's own header.

On failure the test prints a `-`/`+` diff naming exactly the lines that moved,
says that the freeze is what it is, and gives the regeneration command.
Regenerating is the deliberate act: `go test ./cmd/ochakai -run
TestFrozenWireHasNotMoved -update`, in the same PR, with §11's reason named in
the description.

**What this does not catch.** It reads the spec, not the intent. It cannot say
whether a change deserved to happen, whether the security defect claimed is
real, or whether the wire it fingerprints is a good one — and it cannot see the
implementation at all: a spec and a server that drift together are two tests'
problem, not this one's. All it does is make a wire change impossible to make
quietly. That is the same bargain `docs/surface.md` describes for itself — the
ceiling is one line anybody can raise, and what it buys is that raising it is a
sentence somebody has to write.

**Division of labour with the existing contract test**, stated in the doc
comment so the next reader does not have to work it out: `checkedServer` in
`internal/restapi/openapi_test.go` runs every request and response of the
integration tests past this spec, keeping the *server* honest to the spec. This
one keeps the *spec* honest to the freeze. Neither pins the server alone — the
first would follow the spec anywhere it went, the second cannot see the code —
and together they do.

Three smaller things came with it:

- `-update` is now one flag for both generated files in this package
  (`docs/cli.md` and `api/openapi.frozen.txt`); `updateCLIDocs` is renamed
  `updateGolden`. A second `flag.Bool("update", …)` in one package would panic,
  and a contributor should not have to learn which golden takes which switch.
- The path to the spec is a constant, `openAPISpec`, read by the counters and
  the ratchet — one spelling of one path.
- `.github/PULL_REQUEST_TEMPLATE.md` gains one checkbox, and
  `docs/compatibility.md` one sentence in the bullet that already declares the
  freeze: it is checked, not promised. The manual is 5,144 lines against
  `DOC-LINES: 5200`, so no ceiling moved.

**No numbered design doc.** Nothing a user can observe changes: the wire is
byte-for-byte what it was, and the golden is a reading of it. Design doc
[0048](docs/design/0048-decision-records-for-wire-contracts.md) puts internal
verification in the PR description, which is this.

**No CHANGELOG entry.** That file keeps what an operator upgrading needs to
know, and an operator does nothing differently: no behavior, no configuration
and no stored shape moved. The freeze is already announced there and in
`docs/compatibility.md`, which is where the promise this test now checks is
made.

Surface: nothing added, nothing widened, no surface count moved, so
`docs/surface.md`'s three questions do not arise — the change is a test and a
golden file.

## Checks

CI runs the same script; make it pass locally first (CONTRIBUTING.md has the
context, including the store integration test and the fuzz targets).

- [x] `scripts/check` is clean — add `--db` when the change touches the store

  `scripts/check core` and `scripts/check lint` pass. `vuln` and the
  Docker-based checks could not run in this sandbox (egress to vuln.go.dev is
  blocked); nothing here touches dependencies. The store is untouched, so
  `--db` does not apply.
- [x] Behavior changes come with tests

  The change *is* the test. It was proved to fail rather than assumed to: with
  `concepts` renamed back to `entries` in `BundleListing` it failed naming all
  eight moved lines; with `Ochakai-Plan` renamed, a `201` changed and
  `updated_at` dropped from `Summary.required` it named those three too; with
  a `summary:` and a parameter `description:` rewritten it passed, which is the
  prose exclusion working. The spec was restored afterwards — `git diff` on
  `api/openapi.yaml` is empty.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing; a new endpoint has an
      integration test, which is what puts it under the OpenAPI contract check

  Unchanged, and now checked from a second direction.
- [x] The change lands on every surface it belongs on — REST / MCP / CLI /
      Web UI — and what it stays off is deliberate (design doc 0015)

  No surface is touched. The `-update` flag is a test flag, not a CLI one.
- [x] `api/openapi.frozen.txt` is untouched. REST is frozen at `/api/v1`
      (design doc 0064), and `cmd/ochakai/frozenwire_test.go` fails on any
      wire change; regenerating that file is a decision, and §11 leaves a
      security defect as the only reason — say which one, here

  This PR introduces the file at the wire's current state. No line of
  `api/openapi.yaml` moved, so nothing was regenerated against a change.
- [ ] Widens a surface — a REST operation, an MCP tool, a CLI command, an
      environment variable? `docs/surface.md` is updated
      (`cmd/ochakai/surface_test.go` says so), the description names which of
      its eight conditions the addition serves, and the three questions are
      answered under *What and why*: who actually got stuck, why an existing
      surface does not already cover it, and what is folded away in exchange.
      The default answer is no

  Not applicable: no surface widens. Nothing a user calls, reads or configures
  is added.

## Design docs

- [ ] Alters an accepted decision? A new numbered doc under `docs/design` is in
      this PR — or: it does not, and this box is not applicable. The index
      entries, the `Status:` headers at both ends and the two indexes agreeing
      about them are checked by `cmd/ochakai/designdocs_test.go`; what is left
      for a human is whether the index's opening table still points at the doc
      to read now, and whether the English summary says what was decided

  Not applicable. This alters no decision — it enforces one 0064 already made.
- [x] Commit messages and code comments are in English


---
_Generated by [Claude Code](https://claude.ai/code/session_016TQTqYQuWcQ3WV9h4ggWsY)_