### PR TITLE
The record corpus ceiling stops being a line every PR rewrites

### DIFF
--- a/.claude/skills/design-doc/SKILL.md
+++ b/.claude/skills/design-doc/SKILL.md
@@ -91,16 +91,20 @@ what citing it is for. If it genuinely is that large, raise the number in
 the same PR and say why. Do not answer the ceiling by compressing the
 prose: a record nobody finishes costs more than a long one.
 
-CONTRIBUTING.md also caps the corpus as a whole: `RECORD-COUNT` for how
-many records exist, `RECORD-CORPUS-LINES` for how many lines they total —
-both count every record, Superseded ones included, since they still ship
-in the tree and a reader following a `Status:` trail still opens them.
-`TestDesignRecordCorpusStaysUnderItsCeiling` reads both back. Landing a
-new record can push the corpus over either one even when the record
-itself is well under `RECORD-LINES`; the same two escapes apply, just
-visible only once the whole corpus is counted — this decision restates
-one already on file (cite it instead), or two subjects have been sharing
-one number and would read better split.
+CONTRIBUTING.md also caps the corpus as a whole: `RECORD-CORPUS-LINES`
+for how many lines its records total, counting every record, Superseded
+ones included, since they still ship in the tree and a reader following a
+`Status:` trail still opens them.
+`TestDesignRecordCorpusStaysUnderItsCeiling` reads it back.
+
+**Usually you will not touch it.** The ceiling sits on a grid the width
+of `RECORD-CORPUS-LINES-SLACK`, so a record that fits inside the current
+boundary moves no number — which is deliberate, so that concurrent PRs do
+not all collide on one line. When your record *does* cross the boundary,
+raise the ceiling to the next multiple in the same PR and say why: the
+same two escapes apply, just visible only once the whole corpus is
+counted — this decision restates one already on file (cite it instead),
+or two subjects have been sharing one number and would read better split.
 
 **4. Update the older docs' `Status:` headers.** Every doc the new one
 supersedes or amends gets a line pointing at the new number. See 0011 or

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,9 +32,12 @@ an index that disagrees with a record's `Status:` header about whether it
 is current, or a supersession recorded at only one end.
 
 **A record has a ceiling, and so does the corpus.** CONTRIBUTING.md
-declares `RECORD-LINES` for one record's length and `RECORD-COUNT` /
+declares `RECORD-LINES` for one record's length and
 `RECORD-CORPUS-LINES` for all of `docs/design` together, Superseded
-records included; the same test file reads all three back. 0048 narrowed
+records included; the same test file reads both back. The corpus ceiling
+sits on a grid the width of its own slack, so adding a record usually
+moves no number at all — it moves when the corpus crosses a boundary,
+which is when the paragraph explaining it is worth reading. 0048 narrowed
 what earns a number, not how many records pile up or how long they run
 together — that was the direction the corpus grew, 4.6x against non-test
 Go's 2.3x. Over a line usually means two decisions, or a record restating

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -498,34 +498,46 @@ only thing that can stop its body from describing a world that ended is
 something superseding it** — which is the whole argument for this program,
 now with numbers.
 
-72 → 73 while 4,270 → 4,430 is 0078, which folds five environment
-variables into one the way 0066 folded three. It amends 0073 rather than
-replacing it: what changes is how a deployment writes its embedding
-configuration down, not what embeddings are or when they apply, and 0073's
-own header now says which of its sections that reaches.
+    RECORD-CORPUS-LINES: 4500
+    RECORD-CORPUS-LINES-SLACK: 500
 
-    RECORD-COUNT: 73
-    RECORD-CORPUS-LINES: 4430
-    RECORD-CORPUS-LINES-SLACK: 15
+`RECORD-CORPUS-LINES` counts every record under `docs/design`, Superseded
+ones included: they still ship in the tree, and a reader following a
+`Status:` header still opens them. Counting only what is current would let
+a supersession buy headroom for the next addition — the file stays on disk
+either way, so that would be the next escape hatch rather than a saving.
 
-Both `RECORD-COUNT` and `RECORD-CORPUS-LINES` count every record under
-`docs/design`, Superseded ones included: they still ship in the tree, and
-a reader following a `Status:` header still opens them. Counting only
-what is current would let a supersession buy headroom for the next
-addition — the file stays on disk either way, so that would be the next
-escape hatch rather than a saving.
+It is `DOC-LINES`'s argument applied to this corpus: a record that never
+crosses `RECORD-LINES` can still add to what a reader gets through, and
+enough of them doing it at once moves nothing else.
 
-The two catch different shapes. `RECORD-CORPUS-LINES` is `DOC-LINES`'s
-argument applied to this corpus: a record that never crosses
-`RECORD-LINES` can still add to what a reader gets through, and enough of
-them doing it at once moves nothing else. `RECORD-COUNT` is for the shape
-a line total cannot see at all — 0054/0057 and 0055/0056 were one subject
-apiece, told across two numbers, until this pass folded each pair into one
-full record and a tombstone. `RECORD-COUNT` does not move for that: a
-tombstoned record still occupies its number and its file, for the same
-reason a Superseded record was never exempt from `RECORD-CORPUS-LINES`
-either — but a reader following either area now meets one record to read,
-not two.
+**It is also `DOC-LINES`'s width, and for `DOC-LINES`'s reason.** This
+ceiling used to sit at the exact total with 15 lines of tolerance, beside
+a second one — `RECORD-COUNT` — that had to match the number of records
+exactly. Both are gone in favour of one number on a 500-line grid, after
+six records were written in parallel and every one of them had to rewrite
+the same two lines. [docs/surface.md](../docs/surface.md) had already
+diagnosed this and prescribed the cure for the manual: **an alarm that
+sounds every time tells nobody anything**, and a line every concurrent PR
+edits is a line every concurrent PR conflicts on. A ceiling meant to make
+growth a sentence somebody writes cannot be a line somebody rewrites by
+reflex.
+
+So the ceiling is the corpus rounded up to the next 500, the slack is the
+same 500, and the two facts together make it a single derived number —
+which is what lets the check keep both directions. Growth still has to be
+said out loud; it just gets said when the corpus crosses a boundary worth
+a paragraph, roughly every third record, rather than on every record that
+lands.
+
+`RECORD-COUNT` is not replaced by anything, because it was never
+independent: a record has lines, so nothing can raise the count without
+raising the total. It was introduced for a shape a line total was thought
+not to see — 0054/0057 and 0055/0056, one subject apiece told across two
+numbers — but the fold that fixed those *lowered* the corpus by more than
+any record adds, and the grid sees that in the direction that matters.
+What is lost with it is the exact-match rule; what is bought is that
+adding a record touches no shared line at all.
 
 Every ceiling in this file and in [docs/surface.md](docs/surface.md) used
 to check only one direction: over the number fails, under it is free. That
@@ -535,17 +547,18 @@ gap without moving a number anyone would see in the diff. It happened to
 `DOC-LINES` once: a PR that shortened the deploy guide raised the ceiling
 5,753 → 5,790 for room the fold needed, landed at 5,762, and left 28 lines
 nobody returned ([#376](https://github.com/na0fu3y/ochakai/issues/376)).
-`RECORD-COUNT`, like the name-counted dimensions in docs/surface.md's 上限
-section, now has to match exactly — a record either exists or it does
-not, so there is no amount of drift small enough to deserve headroom.
-`RECORD-CORPUS-LINES` is an amount, not a list, so instead it gets a
-stated tolerance: `RECORD-CORPUS-LINES-SLACK` is how far the ceiling may
-sit above the actual total before that gap is itself a failure. Both are
+`RECORD-CORPUS-LINES` is an amount, not a list, so it gets a stated
+tolerance: `RECORD-CORPUS-LINES-SLACK` is how far the ceiling may
+sit above the actual total before that gap is itself a failure, and the
+ceiling has to be a multiple of it — the same pair of rules
+`DOC-LINES` and `DOC-LINES-SLACK` already run under, so a fold that
+lowers the total still has to lower the ceiling once it crosses a
+boundary. Both are
 read back by `TestDesignRecordCorpusStaysUnderItsCeiling`, and both are
 checked the same way `RECORD-LINES` already was — one number in one file,
 raised or lowered in the PR that earns it.
 
-These live here, next to `RECORD-LINES`, rather than as extra lines in
+These live here, next to `RECORD-LINES`, rather than as an extra line in
 [docs/surface.md](docs/surface.md)'s 上限 section. A record is read by
 somebody changing ochakai, not somebody using it — that document's DOC
 section already excludes `docs/design` from the manual on that basis — and
@@ -561,7 +574,7 @@ it retires or revises, and the older one saying so — a new record has to
 fit under its own
 ceiling, a Superseded one has to be a tombstone
 (`TestSupersededRecordsAreTombstones`), and the corpus as a whole has to
-fit under `RECORD-COUNT` and `RECORD-CORPUS-LINES`, with no more slack than
+fit under `RECORD-CORPUS-LINES`, with no more slack than
 `RECORD-CORPUS-LINES-SLACK` allows (`TestDesignRecordCorpusStaysUnderItsCeiling`).
 What no test can read is the judgment: whether the opening table's row still
 points at the doc somebody should actually read. That is where the attention goes.

--- a/cmd/ochakai/designdocs_test.go
+++ b/cmd/ochakai/designdocs_test.go
@@ -423,38 +423,36 @@ Japanese.`, r.file, lines, limit, contributing)
 }
 
 // recordCorpusCapRe reads a ceiling on the corpus as a whole rather than on
-// one record: "RECORD-COUNT: 59", "RECORD-CORPUS-LINES: 10292" or
-// "RECORD-CORPUS-LINES-SLACK: 10", declared beside RECORD-LINES in
+// one record: "RECORD-CORPUS-LINES: 10500" or
+// "RECORD-CORPUS-LINES-SLACK: 500", declared beside RECORD-LINES in
 // CONTRIBUTING.md rather than as an eleventh cap in docs/surface.md's 上限
 // section — a record is read by somebody changing ochakai, not somebody
 // using it, so its ceiling lives with the other ceiling for that same
 // reader.
-var recordCorpusCapRe = regexp.MustCompile(`(?m)^\s*(RECORD-COUNT|RECORD-CORPUS-LINES|RECORD-CORPUS-LINES-SLACK): (\d+)$`)
+var recordCorpusCapRe = regexp.MustCompile(`(?m)^\s*(RECORD-CORPUS-LINES|RECORD-CORPUS-LINES-SLACK): (\d+)$`)
 
 // TestDesignRecordCorpusStaysUnderItsCeiling reads docs/design as a whole:
-// how many records it holds, and how many lines they total. Superseded
-// records count in both — they still ship in the tree, and a reader
-// following a Status: header still opens them. Counting only what is
-// current would let a supersession buy headroom for the next addition, and
-// the file stays on disk either way, so that would be the next escape
-// hatch rather than a saving.
+// how many lines its records total. Superseded records count — they still
+// ship in the tree, and a reader following a Status: header still opens
+// them. Counting only what is current would let a supersession buy headroom
+// for the next addition, and the file stays on disk either way, so that
+// would be the next escape hatch rather than a saving.
 //
-// The two catch different shapes. RECORD-CORPUS-LINES is DOC-LINES's
-// argument applied to this corpus: a record that never crosses RECORD-LINES
-// can still add to what a reader gets through, and enough of them doing it
-// at once moves nothing else. RECORD-COUNT is for the shape a line total
-// cannot see at all — 0054/0057 and 0055/0056 are one subject apiece, told
-// across two numbers, and no per-record cap can notice that a second
-// number was the wrong fix.
+// RECORD-CORPUS-LINES is DOC-LINES's argument applied to this corpus: a
+// record that never crosses RECORD-LINES can still add to what a reader
+// gets through, and enough of them doing it at once moves nothing else.
 //
-// RECORD-COUNT is a name count exactly like DOC or VOCAB — a record either
-// exists or it does not, so its ceiling is exact and a drop has to lower it
-// in the same PR. RECORD-CORPUS-LINES is an amount, like DOC-LINES, and
-// gets the same stated tolerance rather than an exact match: editing a
-// handful of records should not fail CI, but the gap docs/surface.md
-// describes for DOC-LINES — a fold that lowers what is declared and leaves
-// the ceiling where it was — is exactly as possible here, so
-// RECORD-CORPUS-LINES-SLACK bounds it the same way.
+// It is also DOC-LINES's *width*, on the same reasoning docs/surface.md
+// gives for the manual: a ceiling that every record-adding PR has to
+// rewrite is a line every concurrent PR conflicts on, and an alarm that
+// sounds every time tells nobody anything. So the ceiling sits on a grid
+// the size of the slack — checked below — and moves when the corpus
+// crosses a boundary rather than when it grows at all.
+//
+// A companion ceiling on the *number* of records was retired with that
+// change: a record has lines, so nothing could raise the count without
+// raising the total, and its exact-match rule was the half that guaranteed
+// the conflict. CONTRIBUTING.md carries the argument in full.
 func TestDesignRecordCorpusStaysUnderItsCeiling(t *testing.T) {
 	content, err := os.ReadFile(contributing)
 	if err != nil {
@@ -468,7 +466,7 @@ func TestDesignRecordCorpusStaysUnderItsCeiling(t *testing.T) {
 		}
 		caps[m[1]] = n
 	}
-	for _, name := range []string{"RECORD-COUNT", "RECORD-CORPUS-LINES", "RECORD-CORPUS-LINES-SLACK"} {
+	for _, name := range []string{"RECORD-CORPUS-LINES", "RECORD-CORPUS-LINES-SLACK"} {
 		if _, ok := caps[name]; !ok {
 			t.Fatalf("%s declares no %s ceiling: this check now guards nothing", contributing, name)
 		}
@@ -480,25 +478,17 @@ func TestDesignRecordCorpusStaysUnderItsCeiling(t *testing.T) {
 		totalLines += strings.Count(r.body, "\n")
 	}
 
-	switch count, limit := len(records), caps["RECORD-COUNT"]; {
-	case count > limit:
-		t.Errorf(`docs/design holds %d records, over the RECORD-COUNT ceiling of %d in %s.
-
-Going over is a decision to make the corpus bigger, so it is made by
-raising the number in the same PR, having said why — or by finding that the
-new record restates one already on file, or that two subjects have been
-sharing one number and would read better split.`, count, limit, contributing)
-	case count < limit:
-		t.Errorf(`docs/design holds %d records, under the RECORD-COUNT ceiling of %d in %s.
-
-A record either exists or it does not, so this ceiling carries no
-headroom: it is the count this project agreed the corpus holds, not a
-limit not to cross. Lower it to %d in the same PR that retired a record
-— otherwise the gap is spare capacity the next addition spends without
-moving a number anyone would see.`, count, limit, contributing, count)
-	}
-
 	got, limit, slack := totalLines, caps["RECORD-CORPUS-LINES"], caps["RECORD-CORPUS-LINES-SLACK"]
+	if slack <= 0 || limit%slack != 0 {
+		t.Errorf(`RECORD-CORPUS-LINES is %d, which is not a multiple of the %d
+RECORD-CORPUS-LINES-SLACK in %s.
+
+The ceiling sits on a grid the width of the slack so that it is a derived
+number rather than one to negotiate: the corpus rounded up to the next
+boundary. Pinning it to the exact total instead leaves no room, and the
+next record lands back on this line — which is the conflict the grid
+exists to stop.`, limit, slack, contributing)
+	}
 	switch headroom := limit - got; {
 	case got > limit:
 		t.Errorf(`docs/design totals %d lines across %d records, over the RECORD-CORPUS-LINES
@@ -506,8 +496,10 @@ ceiling of %d in %s.
 
 A record can stay under RECORD-LINES on its own and still add to what a
 reader gets through if enough records do it at once, which is what this
-ceiling is for. Raise it in the same PR, having said why.`,
-			got, len(records), limit, contributing)
+ceiling is for. The corpus has crossed a %d-line boundary: raise the
+ceiling to %d in the same PR, having said why — that paragraph is the
+whole point of the number.`,
+			got, len(records), limit, contributing, slack, ((got/slack)+1)*slack)
 	case headroom > slack:
 		t.Errorf(`docs/design totals %d lines across %d records, %d under the
 RECORD-CORPUS-LINES ceiling of %d — more than the %d RECORD-CORPUS-LINES-SLACK
@@ -515,9 +507,9 @@ allows.
 
 A ceiling on an amount that is left standing after the amount drops is
 headroom nobody has to justify before spending it, which is the same gap
-docs/surface.md describes for DOC-LINES. Lower the ceiling to %d, or close
-to it, in the same PR that lowered the total.`,
-			got, len(records), headroom, limit, slack, got)
+docs/surface.md describes for DOC-LINES. The corpus has fallen back below
+a boundary: lower the ceiling to %d in the same PR that lowered the total.`,
+			got, len(records), headroom, limit, slack, ((got/slack)+1)*slack)
 	}
 }
 

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -609,9 +609,11 @@ PR ごとの増減は [CHANGELOG](../CHANGELOG.md) の仕事で、ここでは�
   [0048](design/0048-decision-records-for-wire-contracts.md) が既に
   狭めているが、取った後に**何冊積み上がるか**は別の問いで、これは
   数えていなかった — v0.10.0 の 19 記録から現在の 59 記録へ、この文書の
-  どの次元よりも速く増えている。冊数と総行数の天井は
-  [CONTRIBUTING.md](../CONTRIBUTING.md) の `RECORD-COUNT` /
-  `RECORD-CORPUS-LINES` に置く。読むのは利用者ではなく変える人で、
+  どの次元よりも速く増えている。総行数の天井は
+  [CONTRIBUTING.md](../CONTRIBUTING.md) の
+  `RECORD-CORPUS-LINES` に置く(冊数を数える `RECORD-COUNT` もあったが、
+  この節が `DOC-LINES` について書いたのと同じ理由 —
+  毎回鳴る警報と、並行 PR の唯一の衝突点 — で退役した)。読むのは利用者ではなく変える人で、
   `RECORD-LINES`(一冊の天井)と同じ読者の同じ種類の天井だから、ここに
   十一本目の上限を足すより、その天井の隣に置くほうが筋が通る。
 - **OKF ドキュメント。** `examples/demo` の 10 件も


### PR DESCRIPTION
## What and why

Adding a design record meant rewriting two lines in `CONTRIBUTING.md`:
`RECORD-COUNT`, which had to match the number of records **exactly**, and
`RECORD-CORPUS-LINES`, which sat 15 lines above the total. Six records were
written in parallel for the current batch of work, and every one of those PRs
edited the same two lines — so every one of them conflicted with every other,
on a number rather than on a decision.

**`docs/surface.md` had already diagnosed this exact shape and prescribed the
cure**, for `DOC-LINES`, in its own words:

> 一つ。**毎回鳴る警報は何も知らせない。** […] 6 行の翻訳が天井を動かすなら、
> その声は日常の物音になる。
>
> 二つ。**一行と一段落が、並行作業の唯一の衝突点になっていた。**

It fixed that by putting `DOC-LINES` on a 100-line grid with a
`DOC-LINES-SLACK` of 100. This applies the same medicine to the record corpus,
which was left on the old scheme.

**`RECORD-CORPUS-LINES` moves to a 500-line grid**, with
`RECORD-CORPUS-LINES-SLACK: 500` and a new check that the ceiling is a
multiple of the slack. The ceiling becomes a *derived* number — the corpus
rounded up to the next boundary — rather than one to negotiate, which is what
lets the check keep working in both directions. Growth still has to be said out
loud; it gets said when the corpus crosses a boundary worth a paragraph,
roughly every third record, instead of on every record that lands.

**`RECORD-COUNT` is retired, not replaced.** It was never independent: a
record has lines, so nothing could raise the count without raising the total.
It was introduced for a shape a line total was thought not to see — 0054/0057
and 0055/0056, one subject apiece told across two numbers — but the
consolidation that fixed those *lowered* the corpus by far more than any
record adds, and the grid sees that in the direction that matters. What is
lost is its exact-match rule; what is bought is that adding a record touches
no shared line at all.

This is the answer to "何が数える次元として削れるか" asked earlier in this
batch: the one that could be removed without losing a signal was the one that
was measuring the same event twice.

### Not a design record

This is process, and process decisions do not take numbers —
[0048](docs/design/0048-decision-records-for-wire-contracts.md) §3, the same
rule under which `docs/surface.md` declines one for itself. Nothing a user of
ochakai can observe changes.

### Prose kept truthful

`CONTRIBUTING.md`'s ceiling section is rewritten with the argument above;
`CLAUDE.md`, `docs/surface.md`'s 数えていないもの entry and
`.claude/skills/design-doc/SKILL.md` all named `RECORD-COUNT` and now name
what exists — the skill in particular now tells its reader that they will
usually not touch the ceiling at all, which is the behaviour change that
matters for the next contributor. The historical paragraphs recording past
count → count movements are left alone: they are an accurate record of what
happened at the time.

### For the PRs in flight

`claude/ochakai-simplicity-lkul95-mcp-fold` (#479),
`-cli-files` (#481), `-prefreeze` (#482) and `-okf-roundtrip` (#483) each bump
these numbers today and conflict with each other because of it. **Merging this
first removes that conflict from all four**: three of them drop their
`CONTRIBUTING.md` edit entirely, and #482 keeps only its `RECORD-LINES` raise,
which is a genuine decision about one record's length rather than arithmetic.

## Checks

CI runs the same script; make it pass locally first (CONTRIBUTING.md has the
context, including the store integration test and the fuzz targets).

- [x] `scripts/check` is clean — add `--db` when the change touches the store

  `scripts/check core` and `scripts/check lint` (v2.12.2, 0 issues) pass.
  `--db` does not apply — no store change. `vuln` was not run: egress to
  vuln.go.dev is blocked in this environment and the failure would not be real.
- [x] Behavior changes come with tests

  `TestDesignRecordCorpusStaysUnderItsCeiling` keeps both directions and gains
  the grid check. Proved to fail rather than assumed: with the ceiling pinned
  at the exact total (4,430) it fails naming the multiple it wants; restored to
  4,500 it passes. The over-ceiling and excess-headroom messages now name the
  boundary to move to instead of the raw total.

## Surfaces and contract

- [ ] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — not applicable, none touched
- [x] `api/openapi.frozen.txt` is untouched. REST is frozen at `/api/v1`
      (design doc 0064), and `cmd/ochakai/frozenwire_test.go` fails on any
      wire change; regenerating that file is a decision, and §11 leaves a
      security defect as the only reason — say which one, here

  Untouched. No wire change.
- [ ] The change lands on every surface it belongs on — not applicable; this
      is a contributor-facing ceiling, on none of the four faces
- [ ] Widens a surface? No. `docs/surface.md`'s nine dimensions and every one
      of its ceilings are unchanged — the number retired here lives in
      `CONTRIBUTING.md`, deliberately, because a record is read by somebody
      changing ochakai rather than somebody using it

## Design docs

- [ ] Alters an accepted decision? No numbered doc: this is process, which
      0048 §3 keeps out of the numbered series
- [x] Commit messages and code comments are in English


---
_Generated by [Claude Code](https://claude.ai/code/session_016TQTqYQuWcQ3WV9h4ggWsY)_