### PR TITLE
Prepare release v0.18.0

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -33,7 +33,7 @@ top of a red main.
 
 ## 1. The preparation PR
 
-Branch off `origin/main`. Three files, all of which drift silently —
+Branch off `origin/main`. Four files, all of which drift silently —
 nothing fails when they are stale:
 
 1. **`CHANGELOG.md`**
@@ -43,6 +43,12 @@ nothing fails when they are stale:
      repoint `[Unreleased]` at the new tag
 2. **`api/openapi.yaml`** — `info.version`
 3. **`.github/ISSUE_TEMPLATE/bug_report.yml`** — the version placeholder
+4. **`deploy/cloudrun/README.md`** — the hand-set `export VERSION=`
+   example, for the reader with no `gh` CLI
+
+`grep -rn '<prev>' --exclude-dir=.git .` catches a fifth if one appears;
+`CHANGELOG.md` and `docs/design` name old versions legitimately, so read
+the hits rather than replacing them.
 
 Read the unreleased entries as you go and confirm they match what
 actually landed (`git log v<prev>..origin/main --oneline`). A missing

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Version
       description: Output of `ochakai version`, or the image tag you deployed.
-      placeholder: "0.17.0"
+      placeholder: "0.18.0"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ last entry.
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-08-04
+
 ### Fixed
 
 - **A refused concept no longer takes its files down with it.** When the
@@ -2918,7 +2920,8 @@ worth naming: SQL injection in `compile_sql` through undeclared field
 pass-through, fixed in 0.8.0 — v0.7.0 and earlier are affected. Details
 are in git history.
 
-[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.17.0...HEAD
+[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.18.0...HEAD
+[0.18.0]: https://github.com/na0fu3y/ochakai/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/na0fu3y/ochakai/compare/v0.16.1...v0.17.0
 [0.16.1]: https://github.com/na0fu3y/ochakai/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/na0fu3y/ochakai/compare/v0.15.0...v0.16.0

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -83,7 +83,7 @@ info:
     is a security defect, shipped in the next release with no deprecation
     window (SECURITY.md). MCP, the CLI and the stored shape stay unstable
     while the major version is 0 and may still change in a minor release.
-  version: 0.17.0
+  version: 0.18.0
   license:
     name: MIT
 servers:

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -79,7 +79,7 @@ export IMAGE=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:$VERSION
 `:latest` ではなくバージョンを固定し、再デプロイを意識的な判断にする。
 `gh` CLI が無ければ
 [リリースページ](https://github.com/na0fu3y/ochakai/releases)から番号
-を読み、手で設定する — `export VERSION=0.17.0`。
+を読み、手で設定する — `export VERSION=0.18.0`。
 
 (このガイドは 0.9.0 以降を前提にしている。それより前のリリースは
 [retract](https://go.dev/ref/mod#go-mod-file-retract) 済みでサポート外


### PR DESCRIPTION
The version bump for `v0.18.0`, ahead of the tag. 185 commits since `v0.17.0`, and the unreleased section carries 15 **BREAKING** entries — a minor bump while the major version is 0.

**This is the release that freezes `/api/v1`.** [0064](docs/design/0064-rest-stops-at-api-v1.md) is Accepted and unreleased today; the moment this tag ships, the wire cannot move again for any reason short of a security defect, and `api/openapi.frozen.txt` + `cmd/ochakai/frozenwire_test.go` hold it.

## What changed here

| File | Change |
|---|---|
| `CHANGELOG.md` | `[Unreleased]` → `[0.18.0] - 2026-08-04`, fresh empty `[Unreleased]` above it, compare links repointed |
| `api/openapi.yaml` | `info.version` 0.17.0 → 0.18.0 |
| `.github/ISSUE_TEMPLATE/bug_report.yml` | version placeholder |
| `deploy/cloudrun/README.md` | the hand-set `export VERSION=` example |
| `.claude/skills/release/SKILL.md` | the file list goes three → four, plus the grep that finds a fifth |

**The fourth file is the finding.** `deploy/cloudrun/README.md:82` teaches the reader with no `gh` CLI to type `export VERSION=0.17.0`, and no release has ever updated it because the skill listed three files — an operator copying it verbatim deploys the previous version. The skill now lists it and names `grep -rn '<prev>' --exclude-dir=.git .` as the check that would have caught it, with the caveat that `CHANGELOG.md` and `docs/design` name old versions legitimately.

## Verification

`scripts/check` is green. The unreleased entries were read against `git log v0.17.0..origin/main` for coverage — a separate pass is checking that the section names everything a user or operator can observe, and anything it turns up lands here before merge rather than after the tag.

The three operator actions this release requires — set `OCHAKAI_EMBEDDINGS` before upgrading (four variables retired, and a deployment that misses it does **not** look broken), migration `0035` running automatically, and the web-UI-first upgrade order — go in the annotated tag message, which is what the release workflow copies onto the Releases page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)