### PR TITLE
Retire "attachment" in deploy/terraform, and say why its variables don't count

### DIFF
--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -27,7 +27,7 @@
 Vertex AI embeddings(§4)はサーバーと合わせて**既定で on** である: モジュ
 ールが `roles/aiplatform.user` を付与して API を有効化し、ochakai はそこか
 ら自分のプロジェクトを見つける(設計ドキュメント 0073)。既定で off なのは
-private IP(§2b)、GCS attachments(§4b)、IAP 越しの web UI(§5b)。
+private IP(§2b)、GCS files(§4b)、IAP 越しの web UI(§5b)。
 
 ### パスワードはどこにも無い
 
@@ -125,7 +125,7 @@ GRANT "<database_user output>" TO "you@your-org.example";
 | `enable_private_ip` | §2b | Cloud SQL の公開エンドポイントを落とす。peering range と Cloud Run 側の Direct VPC egress。無料。ローカルの `cloud-sql-proxy` アクセスには、その後 VPC に接続したワークステーションか一時的なパブリック IP が要る。 |
 | `enable_vertex_embeddings` | §4 | **既定で on**: `roles/aiplatform.user` を付与し `aiplatform.googleapis.com` を有効化する。on にすると何が手に入るか、デプロイ後に何をすべきかは[デプロイガイド](../cloudrun/README.md#4-hybrid-semantic-search-vertex-ai-on-by-default)にある。`false` にすると `OCHAKAI_EMBEDDINGS=off` を渡し、何も付与しない。 |
 | `embedding_model` | §4 | 既定は null — ochakai が自分のプロジェクトと製品既定のモデルを使う。モデル・リージョン・プロジェクトを選ぶなら Vertex AI のモデル resource name をそのまま渡す(`OCHAKAI_EMBEDDINGS` はこの一つで三つを運ぶ、設計ドキュメント 0078)。名指したデプロイは semantic search を**要求する**ので、pgvector の bootstrap を先に済ませておくこと。次元は設定できない — モデルのものであってデプロイのものではない。 |
-| `enable_gcs_attachments` | §4b | バケット + `roles/storage.objectUser` + `OCHAKAI_GCS_BUCKET`。無いとファイルの書き込みは 501 を返す。 |
+| `enable_gcs_files` | §4b | バケット + `roles/storage.objectUser` + `OCHAKAI_GCS_BUCKET`。無いとファイルの書き込みは 501 を返す。 |
 | `enable_webui` | §5b | `serve-ui` を、同じイメージ・専用の identity で、IAP の背後にある二つ目の Cloud Run サービスとして立てる。`webui_records_browser_user`(既定 on)は、UI のサービスアカウントではなくブラウザの本人を記録する。 |
 | `read_only` | §5d | `OCHAKAI_MODE=read-only` を設定する — 非公開のままである。on にする*前*にベースへ import しておくこと: read-only なデプロイには import できない。 |
 | `public_read_only` | §5d | `OCHAKAI_MODE=public` を設定し、このモジュール唯一の `allUsers` を付与する。`read_only` を含意する。その姿勢が何を手放すかは[デプロイガイド](../cloudrun/README.md#5d-optional-a-public-read-only-demo-the-one-public-posture)にある。書き込み可能な状態で apply し、`ochakai import examples/demo` した後、これを on にして再度 apply する。 |
@@ -179,8 +179,8 @@ terraform apply -var deletion_protection=false
 terraform destroy
 ```
 
-attachments が有効なら、バケットはオブジェクトを持っている間 destroy を
-拒む — それは誰かが添付したすべてのファイルの、唯一のコピーだからである。
+files が有効なら、バケットはオブジェクトを持っている間 destroy を
+拒む — それは誰かが追加したすべてのファイルの、唯一のコピーだからである。
 本気でやるときは、同じ `apply` に `-var gcs_force_destroy=true` を足す。
 
 有効にした API は有効なままにする: 一つを off にするのはプロジェクト全体

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -84,7 +84,7 @@ locals {
       ])
     },
     local.mode != "" ? { OCHAKAI_MODE = local.mode } : {},
-    var.enable_gcs_attachments ? { OCHAKAI_GCS_BUCKET = local.gcs_bucket_name } : {},
+    var.enable_gcs_files ? { OCHAKAI_GCS_BUCKET = local.gcs_bucket_name } : {},
     # One variable says how this deployment embeds (design doc 0078).
     # Nothing is set when embeddings are on and no model is named:
     # ochakai discovers the project it runs in, and a discovered default
@@ -329,10 +329,10 @@ resource "google_project_iam_member" "ochakai_vertex" {
   member  = "serviceAccount:${google_service_account.ochakai.email}"
 }
 
-# --- 4b. Optional: attachments in GCS -------------------------------------
+# --- 4b. Optional: files in GCS --------------------------------------------
 
-resource "google_storage_bucket" "attachments" {
-  count = var.enable_gcs_attachments ? 1 : 0
+resource "google_storage_bucket" "files" {
+  count = var.enable_gcs_files ? 1 : 0
 
   project                     = var.project_id
   name                        = local.gcs_bucket_name
@@ -340,16 +340,16 @@ resource "google_storage_bucket" "attachments" {
   uniform_bucket_level_access = true
   public_access_prevention    = "enforced"
 
-  # Attachment objects are content-addressed (blob/<sha256>), create-only and
+  # File objects are content-addressed (blob/<sha256>), create-only and
   # never deleted by ochakai, so the bucket holds the only copy of every file
-  # anyone attached.
+  # anyone added.
   force_destroy = var.gcs_force_destroy
 }
 
 resource "google_storage_bucket_iam_member" "ochakai" {
-  count = var.enable_gcs_attachments ? 1 : 0
+  count = var.enable_gcs_files ? 1 : 0
 
-  bucket = google_storage_bucket.attachments[0].name
+  bucket = google_storage_bucket.files[0].name
   role   = "roles/storage.objectUser"
   member = "serviceAccount:${google_service_account.ochakai.email}"
 }

--- a/deploy/terraform/outputs.tf
+++ b/deploy/terraform/outputs.tf
@@ -58,9 +58,9 @@ output "webui_service_account_email" {
   value       = var.enable_webui ? google_service_account.webui[0].email : null
 }
 
-output "attachments_bucket" {
-  description = "Bucket holding attachment bytes, or null when var.enable_gcs_attachments is false."
-  value       = var.enable_gcs_attachments ? google_storage_bucket.attachments[0].name : null
+output "files_bucket" {
+  description = "Bucket holding file bytes, or null when var.enable_gcs_files is false."
+  value       = var.enable_gcs_files ? google_storage_bucket.files[0].name : null
 }
 
 output "database_bootstrap_sql" {

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -22,9 +22,9 @@ invoker_members = [
 # lexical-only: nothing is granted and no external API is called.
 # enable_vertex_embeddings = false
 
-# Attachments. Without a bucket the service is markdown-only and attach
+# Files. Without a bucket the service is markdown-only and add_file
 # operations return 501.
-# enable_gcs_attachments = true
+# enable_gcs_files = true
 
 # Drop the Cloud SQL public endpoint. Free, but local admin access then needs
 # a VPC-attached workstation or a temporary public IP.

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -9,7 +9,7 @@ variable "project_id" {
 variable "region" {
   description = <<-EOT
     Region for Cloud Run, Cloud SQL, Artifact Registry and (if enabled) the
-    attachment bucket. Deliberately has no default: the choice is a latency
+    files bucket. Deliberately has no default: the choice is a latency
     and cost decision. The guide's cost table is quoted for us-central1;
     Asian regions such as asia-northeast1 cost slightly more.
   EOT
@@ -266,26 +266,26 @@ variable "embedding_model" {
   }
 }
 
-# --- Optional: attachments in GCS (guide §4b) -----------------------------
+# --- Optional: files in GCS (guide §4b) -----------------------------------
 
-variable "enable_gcs_attachments" {
+variable "enable_gcs_files" {
   description = <<-EOT
-    Create a bucket for attachment bytes and point ochakai at it. Without it
-    the service runs markdown-only: attach operations return 501 and imports
-    report attachments as failed. Auth is ADC via the service identity.
+    Create a bucket for file bytes and point ochakai at it. Without it
+    the service runs markdown-only: add_file operations return 501 and
+    imports report files as failed. Auth is ADC via the service identity.
   EOT
   type        = bool
   default     = false
 }
 
 variable "gcs_bucket_name" {
-  description = "Name of the attachment bucket. Null means \"<project_id>-ochakai-blobs\"."
+  description = "Name of the files bucket. Null means \"<project_id>-ochakai-blobs\"."
   type        = string
   default     = null
 }
 
 variable "gcs_force_destroy" {
-  description = "Allow `terraform destroy` to delete a bucket that still holds attachment bytes. False by default — those objects are the only copy."
+  description = "Allow `terraform destroy` to delete a bucket that still holds file bytes. False by default — those objects are the only copy."
   type        = bool
   default     = false
 }

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -719,6 +719,23 @@ PR ごとの増減は [CHANGELOG](../CHANGELOG.md) の仕事で、ここでは�
   唯一これに当たる(`TestCLIReferenceIsCurrent`、
   [#371](https://github.com/na0fu3y/ochakai/issues/371))。基準は三条件
   だけで、狭く保つのがこの箇条書き自体の目的である。
+- **`deploy/terraform` の変数。** このモジュールは Cloud Run + Cloud SQL
+  という一つのホスティング経路の上に立つ任意の便宜レイヤーで、
+  [deploy/terraform/README.md](../deploy/terraform/README.md) 自身が
+  「gcloud ガイドは引き続きリファレンスであり正とする情報源」であり
+  二つが食い違えばこちらにバグがあると宣言している —
+  [0067 §1](design/0067-four-faces-and-what-they-decline.md)
+  が既定を決めている REST・CLI・MCP・Web UI の四つの面のどれでもない。
+  ochakai 自身に届く変数(`enable_gcs_files` → `OCHAKAI_GCS_BUCKET`、
+  `read_only` / `public_read_only` → `OCHAKAI_MODE`)は、ENV が既に
+  数えている一語が IaC の綴りを着ているだけであり、二度数えれば VOCAB
+  が退けた「一つのものが二つの名前」を今度は次元をまたいで踏む。届かない
+  変数(`region`・`image_tag`・`database_backups`・`maintenance_users`
+  など)は Cloud SQL・Cloud Run・GCS 側の資源の選択であって、`serve` /
+  `serve-ui` の引数を数えないのと同じ理由で ochakai が知っていることでは
+  ない。読む代金は `deploy/terraform/README.md` として DOC が既に数えて
+  いる — 数えていないのは HCL の変数名で、それはこのモジュールを使わない
+  という選択で丸ごと避けられる代金だからである。
 
 ## この仕組みが持てないもの
 


### PR DESCRIPTION
## What and why

[docs/design/0064](docs/design/0064-rest-stops-at-api-v1.md) §6 (and
[0046](docs/design/0046-bundle-address-space.md) §2.1 before it) retired
"attachment"/"Attachment" as a word — the wire says "file"/"File" now. But
0064's own scope is the wire (REST/MCP), and `deploy/terraform` is neither,
so the retirement never reached it: `enable_gcs_attachments`, the
`attachments_bucket` output, the `google_storage_bucket.attachments`
resource, and prose in the module's README and `terraform.tfvars.example`
all still said the retired word — and one README line mixed both
("GCS attachments" next to "ファイルの書き込みは 501").

This PR closes that corner:

- `enable_gcs_attachments` → `enable_gcs_files`
- `attachments_bucket` output → `files_bucket`
- `google_storage_bucket.attachments` resource → `.files`
- matching prose fixes in `README.md`, `variables.tf`, `outputs.tf`,
  `terraform.tfvars.example`

This is a breaking change to the Terraform module's variable names, but
that's within bounds: 0064 §1 freezes only REST — MCP, CLI, Web UI, and
(a fortiori) deploy tooling stay unstable pre-1.0. No new design doc is
needed since nothing here is a new decision; it's a vocabulary sweep
applying 0064 §6's decision to a corner it didn't originally cover.

Separately, this surfaced a real question: `docs/surface.md` counts nine
dimensions of what a user pays for, but `deploy/terraform` has ~30
variables that were never counted anywhere. Rather than add a tenth
dimension, I answered the question in the doc's own "数えていないもの"
section: this module isn't one of [0067](docs/design/0067-four-faces-and-what-they-decline.md)'s
four faces (its README defers to the gcloud guide as canonical); variables
that reach ochakai's own config just re-spell an already-counted `ENV`
entry under IaC clothing (`enable_gcs_files` → `OCHAKAI_GCS_BUCKET`); the
rest are Google Cloud resource choices, not something ochakai itself knows
— the same reasoning that already excludes `serve`/`serve-ui` flags.

## Checks

- [x] `scripts/check core` is clean (gofmt, go vet, go test -race, build)
- [x] `terraform fmt -check` and `terraform validate` pass on the renamed
      module
- [ ] N/A — no behavior change, so no new tests

## Surfaces and contract

- [ ] N/A — REST/MCP/CLI/Web UI and `api/openapi.yaml` are untouched
- [x] `docs/surface.md` is updated, but not by widening a counted
      dimension — it answers, in prose, why `deploy/terraform`'s variables
      aren't one. `cmd/ochakai/surface_test.go`'s `DOC-LINES` check still
      passes (5273 of 5300, within the 100-line slack)

## Design docs

- [ ] N/A — no accepted decision changes; this applies 0064 §6's existing
      decision to a corner it didn't reach, and answers a question
      `docs/surface.md` already poses to itself (that document takes no
      design-doc number of its own)
- [x] Commit message is in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)