### PR TITLE
Render GFM tables in the web UI's markdown body

### DIFF
--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -340,6 +340,9 @@
   .md p { margin: .5em 0; }
   .md ul, .md ol { margin: .4em 0; padding-left: 1.5em; }
   .md img { max-width: 100%; border: 1px solid var(--border); border-radius: 8px; display: block; margin: .6rem 0; }
+  .md table { border-collapse: collapse; margin: .6em 0; max-width: 100%; }
+  .md th, .md td { border: 1px solid var(--border); padding: .35rem .6rem; }
+  .md th { background: var(--code-bg); font-weight: 600; text-align: left; }
 
   /* ---- browse tree ---- */
   .browse details.node > summary {
@@ -611,7 +614,7 @@ function crumbTrail(dirs, leaf) {
   return leaf === undefined ? out : out + esc(leaf);
 }
 
-/* ---- tiny markdown renderer (headings, lists, code, links, emphasis, images) ---- */
+/* ---- tiny markdown renderer (headings, lists, code, links, emphasis, images, tables) ---- */
 // resolveFile maps a reference from the body to a file URL (the
 // detail view resolves entry-relative references against the entry's
 // files); references it cannot resolve stay literal text rather than
@@ -652,7 +655,27 @@ function md(src, resolveFile, resolveEntry) {
     );
   const flushPara = () => { if (para.length) { out += '<p>' + inline(para.join(' ')) + '</p>'; para = []; } };
   const flushList = () => { if (inList) { out += `</${inList}>`; inList = null; } };
-  for (const line of lines) {
+  // GFM table: a header row followed by a `|---|---|` delimiter row (with
+  // optional `:` alignment markers), then body rows until a blank line.
+  // Requiring a delimiter with at least two columns keeps a lone `---`
+  // (used as prose, not markup, elsewhere in this parser) from matching.
+  const isTableSep = line => /^\s*\|?\s*:?-+:?\s*(\|\s*:?-+:?\s*)+\|?\s*$/.test(line);
+  const splitRow = line => {
+    const cells = [];
+    let cur = '', esc = false;
+    for (const ch of line.trim()) {
+      if (esc) { cur += ch; esc = false; continue; }
+      if (ch === '\\') { esc = true; continue; }
+      if (ch === '|') { cells.push(cur); cur = ''; continue; }
+      cur += ch;
+    }
+    cells.push(cur);
+    if (cells.length > 1 && !cells[0].trim()) cells.shift();
+    if (cells.length > 1 && !cells[cells.length - 1].trim()) cells.pop();
+    return cells.map(c => c.trim());
+  };
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
     if (/^```/.test(line)) {
       flushPara(); flushList();
       out += inCode ? '</code></pre>' : '<pre><code>';
@@ -660,6 +683,21 @@ function md(src, resolveFile, resolveEntry) {
       continue;
     }
     if (inCode) { out += esc(line) + '\n'; continue; }
+    if (line.includes('|') && i + 1 < lines.length && isTableSep(lines[i + 1])) {
+      flushPara(); flushList();
+      const aligns = splitRow(lines[i + 1]).map(a => {
+        const left = a.startsWith(':'), right = a.endsWith(':');
+        return left && right ? 'center' : right ? 'right' : left ? 'left' : '';
+      });
+      const row = (cells, tag) => '<tr>' + cells.map((c, ci) =>
+        `<${tag}${aligns[ci] ? ` style="text-align:${aligns[ci]}"` : ''}>${inline(c)}</${tag}>`).join('') + '</tr>';
+      out += '<table><thead>' + row(splitRow(line), 'th') + '</thead><tbody>';
+      i += 2;
+      for (; i < lines.length && lines[i].includes('|') && lines[i].trim(); i++) out += row(splitRow(lines[i]), 'td');
+      out += '</tbody></table>';
+      i--;
+      continue;
+    }
     const h = line.match(/^(#{1,3})\s+(.*)/);
     if (h) { flushPara(); flushList(); out += `<h${h[1].length}>${inline(h[2])}</h${h[1].length}>`; continue; }
     const li = line.match(/^\s*([-*]|\d+\.)\s+(.*)/);


### PR DESCRIPTION
<!-- Keep PRs small and focused. Link the issue or design doc, if there is one. -->

## What and why

The web UI's detail view renders a document body through a hand-rolled
`md()` markdown parser (`internal/webui/index.html`). It had no notion
of pipe tables, so a GFM table in a document body fell through every
branch and rendered as a single paragraph with the pipes and dashes
shown as literal text — reported by a user pasting a table like:

```
| 項目 | 値 |
|---|---|
| テーブル名 | `sample` |
```

This adds table parsing directly to `md()` rather than pulling in a
markdown library. [Design doc 0072](docs/design/0072-the-web-ui-serves-and-edits-documents.md)
keeps the web UI a single self-contained `index.html` with no build
step and no CDN (§1, §2), and already declined a comparable
convenience — document syntax highlighting — for exactly this reason:
"依存を増やす" (§4). A vendored or CDN-loaded library would either
break that constraint outright or bring in far more machinery (raw
HTML passthrough, footnotes, nested lists) than a table needs, while a
server-side render would turn the UI into more than a thin client of
`/api/v1` (§2). Extending the existing minimal parser keeps the same
trade-off already made for headings, lists, and code fences.

The new code follows the header / delimiter / body row shape GFM
tables use (including `:---`, `:---:`, `---:` alignment and `\|`
escaping), reuses the existing `inline()` pass for cell content so
links, code spans, and emphasis keep working inside cells, and adds
matching CSS for `.md table/th/td` following the existing `table.kv`
styling.

Verified in-browser: fed the reported example plus alignment and
escaped-pipe cases through `md()` and rendered the output — tables,
alignment, and inline code all render correctly, and a stray `|` in
prose with no delimiter row still renders as plain text.

## Checks

- [x] `scripts/check` is clean
- [x] Behavior changes come with tests — no dedicated test added; this
      file has no JS test runner, and existing tests in
      `internal/webui/webui_test.go` pin specific historical
      regressions by string-matching the source rather than exercising
      `md()`'s output. Verified instead by evaluating `md()` directly
      in a browser (see above).

## Surfaces and contract

- [x] N/A — no REST/MCP/CLI/API surface touched
- [x] Web UI only; a display-fidelity fix to the existing document
      body rendering, not a new surface. `docs/surface.md` is
      unaffected.
- [x] `api/openapi.frozen.txt` untouched
- [x] Does not widen a surface — no new endpoint, tool, command, or
      env var; `docs/surface.md` unchanged

## Design docs

- [x] N/A — no accepted decision altered. This closes a gap against
      0072 rather than changing it: nothing in 0072 says tables were a
      deliberate omission, so no `Status:` change or new record is
      needed.
- [x] Commit messages and code comments are in English