### PR TITLE
Attest the catalog sync, and ship the day-one procedure beside it

### DIFF
--- a/examples/bigquery-catalog/README.md
+++ b/examples/bigquery-catalog/README.md
@@ -15,7 +15,7 @@ of the same REST API the CLI uses, under your own service account.
 
 ## It ships as knowledge, not as a script in a folder
 
-`bundle/` is a two-concept OKF bundle. Import it and the job documents
+`bundle/` is a three-concept OKF bundle. Import it and the job documents
 itself in the knowledge base it writes to:
 
 ```sh
@@ -24,9 +24,11 @@ ochakai import examples/bigquery-catalog/bundle
 
 | Concept | Type | |
 |---|---|---|
+| [`skills/build-the-first-catalog`](bundle/skills/build-the-first-catalog.md) | Skill | **start here** — the day-one order: pick a small scope, settle the address, project the tables in, verify one, and only then attach a computation |
 | [`jobs/sync-bigquery-catalog`](bundle/jobs/sync-bigquery-catalog.md) | Attested Computation | `runtime: python`, the parameters, the receipt, and every decision the projection makes |
 | [`skills/run-a-python-job`](bundle/skills/run-a-python-job.md) | Skill | what the `executor` points at: the identity to run as, the IAM roles, the receipt fields |
 
+Two files travel with the concepts.
 [`sync-bigquery-catalog.py`](bundle/jobs/sync-bigquery-catalog/sync-bigquery-catalog.py)
 is the computation itself. It is named by the concept's `computation` key as
 a file rather than pasted into a `# Computation` fence — the form
@@ -37,6 +39,16 @@ concept as a file, so `ochakai get jobs/sync-bigquery-catalog
 concept-named directory beside the document, which is where `ochakai export`
 puts a file and what the web UI's files tab tells you to
 reference (design doc [0075](../../docs/design/0075-the-bundle-is-the-address-space.md) §5).
+
+[`catalog-sync.py`](bundle/attesters/catalog-sync.py) is the other, named by
+`attester.resource`: the code that decides whether a run counted. It checks
+that the run used the sanctioned scope — the entry id is derived from it, so
+a run under the wrong prefix silently builds a second catalog — that the
+counts conserve, and that the catalog did not collapse overnight. No
+network, no LLM, no read of the knowledge base; the receipt and the
+authorized values are the whole input. It follows
+`attesters/sql_equality.py` in the OKF reference bundle, which asks the
+first two of those questions about a SQL run.
 
 That shape is the point as much as the sync is. An agent told to refresh
 the catalog gets a contract that says *supply these parameters and run this

--- a/examples/bigquery-catalog/bundle/attesters/catalog-sync.py
+++ b/examples/bigquery-catalog/bundle/attesters/catalog-sync.py
@@ -1,0 +1,185 @@
+"""Deterministic attester for jobs/sync-bigquery-catalog.
+
+Checks a receipt produced by skills/run-a-python-job.md. The first two
+checks mirror attesters/sql_equality.py in the OKF reference bundle, which
+does the same two jobs for `runtime: bigquery`:
+
+  1. Provenance — did the executor run what was sanctioned? For a SQL
+     computation that question is about the query text. Here it is about
+     scope: every entry id is derived as
+     `<prefix>/<project>/<dataset>/<table>`, so a run under a different
+     prefix, project or dataset list did not refresh this catalog. It
+     wrote a second one, at addresses nobody is watching, and left the
+     first to go stale in silence. Palantir's ontology manager asks the
+     same question before it saves an object type — a primary key must be
+     unique and must not change between builds — and this is that check
+     for a catalog whose primary key is its bundle path.
+
+  2. Fidelity — does the reported outcome hold together? Every table the
+     run enumerated has to be accounted for by exactly one outcome, and
+     none of them may have failed. `tables_seen` is counted before a write
+     is attempted and the four outcomes after it, so a mismatch means a
+     table left the loop without being counted.
+
+  3. Continuity — only when a previous receipt is supplied: the catalog
+     did not collapse between two runs. A dataset that silently loses read
+     access looks exactly like a warehouse that got smaller.
+
+Every field is type-checked before it is compared, and a value of the
+wrong shape is a failed verdict rather than a coerced one. A verifier is
+the wrong place to be accommodating: `sorted("shop")` is
+`['h','o','p','s']`, which compares equal to every anagram of it, and
+`True` is an instance of `int`, so a receipt of booleans would otherwise
+conserve its way to a clean verdict.
+
+Returns a verdict dict:
+  { "ok": bool, "reason": str | None, "details": { ... } }
+
+Never uses an LLM. Never makes network calls. Never reads the knowledge
+base. Safe to run consumer-side, and safe to run from the scheduler that
+ran the job.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# The fields skills/run-a-python-job.md says a run has to bring back, and
+# the same list the concept declares in `executor.receipt`.
+RECEIPT_FIELDS = (
+    "sync_identity",
+    "project",
+    "datasets",
+    "prefix",
+    "tables_seen",
+    "written",
+    "unchanged",
+    "skipped",
+    "failed",
+)
+
+# A catalog may legitimately shrink — a dataset is retired, a table is
+# dropped. It may not halve overnight. This is a floor on the ratio
+# between two runs, not a claim about the warehouse.
+DEFAULT_MIN_RATIO = 0.5
+
+_SCOPE_STRINGS = ("sync_identity", "project", "prefix")
+_OUTCOMES = ("written", "unchanged", "skipped", "failed")
+
+
+def _verdict(ok: bool, reason: str | None, **details: Any) -> dict[str, Any]:
+    return {"ok": ok, "reason": reason, "details": details}
+
+
+def _count(value: Any) -> int | None:
+    """A non-negative integer, or None. Booleans are not integers here."""
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
+def _datasets(value: Any) -> list[str] | None:
+    """The dataset list, sorted, or None when it is not a list of names.
+
+    A bare string is refused rather than sorted, because sorting one gives
+    its letters and any anagram would then compare equal to it.
+    """
+    if isinstance(value, str) or not isinstance(value, (list, tuple)):
+        return None
+    if not value or not all(isinstance(d, str) and d for d in value):
+        return None
+    return sorted(value)
+
+
+def _scope(source: dict[str, Any]) -> tuple[dict[str, Any] | None, str]:
+    """The four fields entry ids are derived from, or why they are unusable."""
+    out: dict[str, Any] = {}
+    for key in _SCOPE_STRINGS:
+        value = source.get(key)
+        if not isinstance(value, str) or not value:
+            return None, f"{key} is missing or not a non-empty string"
+        out[key] = value
+    datasets = _datasets(source.get("datasets"))
+    if datasets is None:
+        return None, "datasets is not a non-empty list of names"
+    out["datasets"] = datasets
+    return out, ""
+
+
+def attest(
+    *,
+    sanctioned: dict[str, Any],
+    receipt: dict[str, Any],
+    previous: dict[str, Any] | None = None,
+    min_ratio: float = DEFAULT_MIN_RATIO,
+) -> dict[str, Any]:
+    """Verify one catalog sync receipt.
+
+    Args:
+      sanctioned: the run as it was authorized — `sync_identity`, `project`,
+                  `datasets` and `prefix`. These are the parameter values
+                  the concept was verified with, not whatever the run chose.
+      receipt:    the JSON object the run printed to stdout.
+      previous:   the receipt of the last run that passed, if there is one.
+                  Omit it for the first run; the continuity check is then
+                  skipped rather than assumed.
+      min_ratio:  the floor for `tables_seen` against `previous`.
+
+    Returns:
+      A verdict dict. Callers MUST treat the catalog as unrefreshed when
+      verdict["ok"] is False — the entries that did get written are still
+      there, and that is the point: a bad run is visible rather than
+      undone.
+    """
+    if absent := [f for f in RECEIPT_FIELDS if f not in receipt]:
+        return _verdict(False, "receipt is missing fields", missing=absent,
+                        receipt_keys=sorted(receipt))
+
+    # 1. Provenance. The sanctioned side is checked first and separately,
+    # so an under-specified authorization reads as the caller's mistake
+    # rather than as an accusation against the run.
+    want, why = _scope(sanctioned)
+    if want is None:
+        return _verdict(False, f"sanctioned scope is unusable: {why}",
+                        sanctioned_keys=sorted(sanctioned))
+    got, why = _scope(receipt)
+    if got is None:
+        return _verdict(False, f"receipt scope is unusable: {why}")
+    if want != got:
+        differing = {k: {"sanctioned": want[k], "ran_with": got[k]}
+                     for k in want if want[k] != got[k]}
+        return _verdict(False, "run scope does not match the sanctioned scope",
+                        differing=differing)
+
+    # 2. Fidelity.
+    counts: dict[str, int] = {}
+    for field in ("tables_seen", *_OUTCOMES):
+        value = _count(receipt[field])
+        if value is None:
+            return _verdict(False, f"{field} is not a non-negative integer",
+                            value=repr(receipt[field]))
+        counts[field] = value
+
+    accounted = sum(counts[f] for f in _OUTCOMES)
+    if accounted != counts["tables_seen"]:
+        return _verdict(False, "tables seen and tables accounted for disagree",
+                        tables_seen=counts["tables_seen"], accounted=accounted,
+                        counts=counts)
+
+    if counts["failed"]:
+        return _verdict(False, "the run reported failed tables",
+                        failed=counts["failed"])
+
+    # 3. Continuity.
+    if previous is not None:
+        before = _count(previous.get("tables_seen"))
+        if before is None:
+            return _verdict(False, "previous receipt has no usable tables_seen",
+                            previous_tables_seen=repr(previous.get("tables_seen")))
+        if before and counts["tables_seen"] < before * min_ratio:
+            return _verdict(
+                False, "the catalog shrank past the floor between two runs",
+                tables_seen=counts["tables_seen"], previous=before,
+                min_ratio=min_ratio)
+
+    return _verdict(True, None, scope=got, counts=counts)

--- a/examples/bigquery-catalog/bundle/jobs/sync-bigquery-catalog.md
+++ b/examples/bigquery-catalog/bundle/jobs/sync-bigquery-catalog.md
@@ -18,7 +18,9 @@ parameters:
 computation: /jobs/sync-bigquery-catalog/sync-bigquery-catalog.py
 executor:
   resource: /skills/run-a-python-job.md
-  receipt: [sync_identity, tables_seen, written, skipped, failed]
+  receipt: [sync_identity, project, datasets, prefix, tables_seen, written, unchanged, skipped, failed]
+attester:
+  resource: /attesters/catalog-sync.py
 ---
 
 The sanctioned way to get BigQuery table metadata into this knowledge base.
@@ -121,20 +123,46 @@ prints its receipt to stdout as JSON and its progress to stderr:
 
 ```json
 {"sync_identity": "catalog-sync@my-project.iam.gserviceaccount.com",
- "tables_seen": 84, "written": 3, "skipped": 12, "failed": 0}
+ "project": "my-project", "datasets": ["marketing", "shop"],
+ "prefix": "catalog/bigquery",
+ "tables_seen": 84, "written": 3, "unchanged": 69, "skipped": 12, "failed": 0}
 ```
 
-There is no `attester` on this entry, which is the honest state of things:
-nothing checks these runs today. One would be easy and worth writing —
-`sync_identity` has to be the account you scheduled and no other, `failed`
-has to be zero, and `tables_seen` should not fall off a cliff between two
-nights, which is what a dataset silently losing read access looks like.
-Until that exists, a non-zero exit code and a red Cloud Scheduler run are
-the whole alarm.
+`attester.resource` points at
+[catalog-sync.py](/attesters/catalog-sync.py), which decides whether a run
+counts. It asks three things, and the first two are the two questions the
+reference bundle's `sql_equality.py` asks of a SQL run:
+
+1. **Provenance — did the executor run what was sanctioned?** For a query
+   that is about the SQL text. Here it is about **scope**: the four fields
+   above the counts are exactly what an entry id is derived from, so a run
+   with a different `prefix` did not refresh this catalog. It wrote a
+   second one at addresses nobody is watching and left the first to rot.
+   This is why the scope is in the receipt at all.
+2. **Fidelity — does the outcome hold together?** `written + unchanged +
+   skipped + failed` must equal `tables_seen`, and `failed` must be zero.
+   The count is taken before a write is attempted and the outcomes after,
+   so a disagreement means a table left the loop uncounted.
+3. **Continuity** — given the previous passing receipt, `tables_seen` has
+   not halved. A dataset silently losing read access looks exactly like a
+   warehouse that got smaller.
+
+Check 1 is the one worth dwelling on, because it is the check a platform
+with an ontology manager runs before it saves an object type: **a primary
+key must be unique and must not change between builds.** A catalog whose
+primary key is its bundle path has the same failure mode, and nothing in
+the knowledge base can notice it — every entry the bad run wrote is a
+perfectly valid entry.
+
+A failed verdict does not undo anything, deliberately. The entries that
+were written stay written, because a bad run you can see beats a bad run
+that cleaned up after itself.
 
 ochakai stores this contract and executes none of it: running the
 computation and checking the receipt belong to whoever runs the job
-(SPEC §10.5).
+(SPEC §10.5). The attester never calls it either — no network, no LLM, no
+read of the knowledge base, just the receipt and the values the run was
+authorized with.
 
 # What this deliberately does not do
 

--- a/examples/bigquery-catalog/bundle/jobs/sync-bigquery-catalog/sync-bigquery-catalog.py
+++ b/examples/bigquery-catalog/bundle/jobs/sync-bigquery-catalog/sync-bigquery-catalog.py
@@ -414,7 +414,22 @@ def main() -> int:
     # The receipt the entry's executor declares. Every field here is one a
     # run has to bring back; checking them is the consumer's job, never
     # ochakai's (OKF SPEC §10.5).
-    print(json.dumps({"sync_identity": identity, **counts}))
+    #
+    # The scope fields are not decoration. Each entry id is derived as
+    # <prefix>/<project>/<dataset>/<table>, so these four values decide
+    # *which* catalog a run refreshed. A run under a different prefix
+    # writes a whole second catalog at addresses nobody is watching and
+    # leaves the first to go stale in silence — which is why
+    # /attesters/catalog-sync.py compares them before it looks at a single
+    # count, the way the reference bundle's sql_equality.py compares the
+    # SQL that ran against the SQL that was sanctioned.
+    print(json.dumps({
+        "sync_identity": identity,
+        "project": args.project,
+        "datasets": sorted(args.datasets),
+        "prefix": args.prefix,
+        **counts,
+    }))
     return 1 if counts["failed"] else 0
 
 

--- a/examples/bigquery-catalog/bundle/skills/build-the-first-catalog.md
+++ b/examples/bigquery-catalog/bundle/skills/build-the-first-catalog.md
@@ -1,0 +1,122 @@
+---
+type: Skill
+title: Build the first catalog
+description: The day-one procedure for a new knowledge base — choose a scope, project the tables in, verify what a person can vouch for, and only then attach computations
+tags: [bigquery, catalog, onboarding, runbook]
+generated: { by: human:na0fu3y, at: 2026-08-05T00:00:00Z }
+status: draft
+---
+
+The order to do things in on the first day, and where to stop.
+
+This exists because nobody is coming to do it for you. A platform that
+sells an ontology sends a forward-deployed engineer who has done this
+before and knows which step is load-bearing; ochakai does not have one, so
+the procedure has to ship as a document you can run. That is the whole
+difference between the two things — not the steps, which are nearly the
+same steps.
+
+## When to use
+
+A knowledge base with nothing in it, or a new BigQuery project arriving in
+one that already has knowledge. Run it once per project.
+
+## Preconditions
+
+- A reachable ochakai instance and `ochakai whoami` returning your identity.
+- Read access to the datasets you intend to catalog.
+- [sync the BigQuery catalog](/jobs/sync-bigquery-catalog.md) imported, so
+  the contract lives in the base rather than in your shell history.
+
+## Steps
+
+### 1. Choose the scope, and make it small
+
+Name the datasets your agents actually query. Not the warehouse — the job
+has no "all datasets" flag on purpose. The review feeds this base is built
+around assume a person can empty them, and a few thousand unreviewed
+machine drafts is how a queue stops being read. Two datasets is a fine
+first day; you can add the third next week and nothing about that is a
+retreat.
+
+### 2. Dry-run it and read one document end to end
+
+```sh
+ochakai get jobs/sync-bigquery-catalog --download .
+python sync-bigquery-catalog.py \
+  --project my-project --datasets shop \
+  --ochakai-url "$OCHAKAI_URL" --dry-run
+```
+
+The download brings back two files beside each other — the computation and
+the attester you will need in step 4 — because both are the job's, and a
+contract you can read without the code it names is half a contract.
+
+No credentials for ochakai are needed for the run itself. Read **one** of the printed
+documents completely — the columns, the partition filter, the empty
+`# Caveats` section. What you are checking is whether an agent handed this
+document could write a correct query against that table. If it could not,
+the fix is upstream in BigQuery's own table and column descriptions, and
+doing it there fixes every consumer rather than this one.
+
+### 3. Settle the address before the first real run
+
+The entry id is `<prefix>/<project>/<dataset>/<table>`. This is the primary
+key, and it is the one decision on this page that is expensive to revisit:
+changing `--prefix` later does not rename anything, it writes a **second**
+catalog beside the first and leaves the first to go stale where nobody is
+looking. Pick the prefix now, write it down, and pass the same one every
+run. The attester's first check exists for exactly this.
+
+### 4. Run it, then attest the run
+
+Run without `--dry-run`, capture the receipt from stdout, and hand it to
+the attester the job names — with the scope you authorized in step 3, not
+with whatever the run reports. A non-zero exit code is not the check: a run
+that wrote a whole second catalog under the wrong prefix exits 0 and looks
+like a good night. What the three checks are, and why the first one is the
+one that bites, is in [the job itself](/jobs/sync-bigquery-catalog.md).
+
+Everything is now a draft written by a machine. Nothing here is knowledge
+yet.
+
+### 5. Turn one table into knowledge
+
+Pick the table your agents get wrong most often. Write its `# Caveats`
+section — the filter that is always required, the column that lies, the
+timezone the timestamps are in — and then `ochakai verify` it. Two things
+happen: the sync stops overwriting it, and its trust tier changes, so
+agents can tell it apart from the 83 projections beside it.
+
+**Do one.** The point of day one is not a verified catalog, it is a base
+that has one entry a person will vouch for and a procedure for making the
+next. A catalog of 84 machine drafts and one verified table is in better
+shape than 84 drafts, and it is in better shape than nothing, which is what
+you get from a plan to verify all of them.
+
+### 6. Only now, attach a computation
+
+With the tables in place, write the first `Attested Computation` — the
+query somebody keeps asking for — pointing its `sources` at the table
+entries from step 4 and its `executor` at the skill that runs it. Then
+`ochakai list --links-to catalog/bigquery/my-project/shop/orders` answers
+"what do we know about this table", computations included.
+
+The order matters and it is not ochakai's invention: a platform whose
+ontology manager creates object types from datasets puts *Actions* after
+properties and marks the step optional. Semantics first, because a
+computation that cites a table nobody has described is a query with a
+comment on it.
+
+## Post-conditions
+
+At the end of the day the base holds the tables an agent will meet, one of
+them carries something only a person knew, the daily run is scheduled, and
+a failed run is visible. Stop there. Step 6 repeats for as long as the base
+is useful, and there is no step 7.
+
+## What this is not
+
+Not an ingestion pipeline. The job runs outside the server, under your
+service account, as an ordinary REST client — ochakai holds no warehouse
+credentials and gains no connectors by your running this.

--- a/examples/bigquery-catalog/bundle/skills/run-a-python-job.md
+++ b/examples/bigquery-catalog/bundle/skills/run-a-python-job.md
@@ -58,22 +58,36 @@ billed query — small, not free.
 
 ## The receipt
 
-`receipt: [sync_identity, tables_seen, written, skipped, failed]`, printed
-to stdout as one JSON object. Progress goes to stderr, so a scheduler can
-capture the receipt on its own.
+Printed to stdout as one JSON object. Progress goes to stderr, so a
+scheduler can capture the receipt on its own. Return **exactly** the fields
+the entry's `executor.receipt` declares — the attester refuses a receipt
+that is missing one rather than guessing what it meant.
 
 | Field | Where it comes from |
 |---|---|
 | `sync_identity` | the email claim of the ID token the run used — who the entries will say wrote them |
+| `project` | the `--project` the run used |
+| `datasets` | the `--datasets` it was given, sorted |
+| `prefix` | the `--prefix` the ids were built under |
 | `tables_seen` | tables and views considered, before any ownership check |
 | `written` | entries created or updated |
+| `unchanged` | entries whose bytes already matched, so no revision was made |
 | `skipped` | entries left alone because a person had verified or edited them |
 | `failed` | tables that errored; the run's exit code is non-zero when this is not 0 |
 
-`sync_identity` is the field worth checking hardest. The whole ownership
-rule rests on the job recognizing its own past writes, so a run under an
+The four scope fields are there because the entry id is derived from them.
+`sync_identity` is the one worth checking hardest: the whole ownership rule
+rests on the job recognizing its own past writes, so a run under an
 unexpected account does not merely mislabel provenance — it stops seeing
 the entries as its own and skips the entire catalog, quietly.
+
+## Post-conditions
+
+Hand the receipt to the entry's `attester.resource` together with the
+values the run was authorized with. Do not report the catalog as refreshed
+until the attester returns `ok: true`; a verdict that fails names which of
+the three checks it was, and the run's own exit code cannot tell you —
+a run that wrote a whole second catalog under the wrong prefix exits 0.
 
 ## What this is not
 


### PR DESCRIPTION
## What and why

The BigQuery catalog example declared an `executor` and no `attester`, and
said so itself: *"There is no attester on this entry, which is the honest
state of things."* Verifying a run **after** it happened is the one thing
OKF's kinetic half has that a platform gating writes up front does not —
and no example in this repo demonstrated it. `examples/demo` points its
`attester.resource` at an invented URL, which is right for a bundle whose
README says every number in it is made up, and wrong as the only answer
the project has.

### The attester

`bundle/attesters/catalog-sync.py` follows the shape of
[`attesters/sql_equality.py`](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/bundles/acme_retail/attesters/sql_equality.py)
in the OKF reference bundle — `attest()` returning `{ok, reason, details}`,
no network, no LLM, no read of the knowledge base. It asks the reference
attester's two questions and one more:

1. **Provenance** — did the run use the sanctioned scope? An entry id is
   derived as `<prefix>/<project>/<dataset>/<table>`, so a run under a
   different prefix did not refresh this catalog: it wrote a **second** one
   at addresses nobody is watching and left the first to go stale. Every
   entry the bad run wrote is a perfectly valid entry, which is exactly why
   nothing inside the knowledge base can notice. This is the check a
   platform with an ontology manager runs before it saves an object type —
   a primary key must be unique and must not change between builds — for a
   catalog whose primary key is its bundle path.
2. **Fidelity** — `written + unchanged + skipped + failed == tables_seen`,
   and `failed == 0`.
3. **Continuity** — given the previous passing receipt, `tables_seen` has
   not halved. A dataset silently losing read access looks exactly like a
   warehouse that got smaller.

**The declared receipt was wrong, and that is what surfaced it.** The job
has always printed `unchanged`; `executor.receipt` never listed it, so the
conservation check was not expressible against the declared contract. The
receipt now declares nine fields — the four scope fields and the five
counts — and the job prints exactly those, in that order.

### The procedure

`bundle/skills/build-the-first-catalog.md` is the day-one procedure: pick a
small scope, read one document end to end, **settle the address before the
first real run**, attest, turn one table into knowledge, and only then
attach a computation.

The ordering is not an invention here. A platform whose ontology manager
creates object types from datasets puts *Actions* after properties and
marks that step optional; semantics land first. What ochakai declines is
the forward-deployed engineer, not the procedure they carry — so the
procedure ships as a concept in the bundle rather than as tribal knowledge
(C4).

### Format

Checked against all three OKF reference bundles. Three deliberate
divergences:

- **No `index.md` / `log.md`.** The reference bundles have one per
  directory. ochakai reserves both names and regenerates them
  ([0075](docs/design/0075-the-bundle-is-the-address-space.md) §4.2,
  [0079](docs/design/0079-taking-the-document.md)); a hand-written one
  imports as the note *"index.md is a filename OKF reserves (SPEC §3.1) …
  not imported"*, which `--strict` reads as refusal. Verified by adding one
  and watching it happen.
- **`/`-rooted resource links** where the reference bundle uses relative
  ones. Both are SPEC §5 forms and `resolveTarget` handles both; this
  matches the spelling already used in this bundle.
- **No `[^footnote]` citations into `sources[]`.** The reference bundle
  ties individual body claims to a `sources[].id`. These concepts carry no
  `sources`. Worth revisiting; not done here.

One find worth recording: acme_retail's `log.md` says the bundle was
*"bootstrapped … from the BigQuery `INFORMATION_SCHEMA` and a 90-day sample
of `region-us.INFORMATION_SCHEMA.JOBS_BY_PROJECT`"* — the same two sources
this job reads, once instead of nightly.

### Surface

**Nothing moves.** No REST operation, MCP tool, CLI command, flag,
environment variable or vocabulary term. Bundle documents are not counted
(`docs/surface.md`, 数えていないもの); the only counted lines are the
README's, and `DOC-LINES` goes 5,274 → 5,286 against an unchanged ceiling
of 5,300 — which is why the prose lives in the concepts and not in the
README.

No CHANGELOG entry: the file keeps "what an operator upgrading needs to
know", and nothing in the binary or its contract changed. Say so if you
would rather have one.

## Checks

- [x] `scripts/check` is clean — `scripts/check core` green; store tests
      skipped locally (no `OCHAKAI_TEST_DATABASE_URL`), CI runs them. No Go
      code changed.
- [x] Behavior changes come with tests — no Go behavior changed, so nothing
      to pin in the suite. What was verified instead:
    - **Receipt agreement across three places** — the `executor.receipt`
      declaration, the dict the job prints, and the attester's
      `RECEIPT_FIELDS` — nine fields, same order, checked mechanically.
      A drift here fails silently, which is the whole hazard.
    - **The conservation invariant actually holds in the job**:
      `tables_seen` increments once per table before any write, `upsert`
      increments exactly one of written/unchanged/skipped, the `except`
      increments `failed`, and no increment has a failure point after it.
    - **The attester against 16 adversarial receipts** — wrong prefix,
      extra dataset, non-conserving counts, a failed table, a missing
      field, a collapsed catalog, a small legitimate shrink, a first run,
      negative counts, garbage in `previous`, and four type-confusion
      cases described below.
    - **The bundle imports** — through `okf.FromBundle`: 3 concepts,
      2 files, nothing loose, no skips, no notes.

  Four defects found in the attester during review and fixed in this
  branch, all in the same family — a verifier being accommodating about
  types:

  - `sorted("shop")` is `['h','o','p','s']`, so a bare string for
    `datasets` was char-sorted and **any anagram compared equal**.
  - `isinstance(True, int)` is `True` in Python, so a receipt whose counts
    were booleans conserved (`1 == 1`) and **returned `ok: True`**.
  - An under-specified `sanctioned` reported "run scope does not match",
    blaming the run for the caller's omission.
  - Negative counts reached the arithmetic instead of being refused.

  Every field is now type-checked before it is compared.

  Not verified: the BigQuery-facing half. `google-cloud-bigquery` is not
  installed here, so no real sync ran. That half is unchanged apart from
  the receipt line.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`,
      `internal/apiclient` — untouched; no wire change.
- [x] Lands on every surface it belongs on — not applicable: this is
      example content, not a capability.
- [x] `api/openapi.frozen.txt` is untouched.
- [x] Widens a surface — **no**. See *Surface* above.

## Design docs

- [x] Alters an accepted decision — **no**. Nothing user-observable changed
      in the wire, the stored form, identity, a Google Cloud dependency, or
      a refusal, which is what earns a number
      ([0048](docs/design/0048-decision-records-for-wire-contracts.md)).
      If `Action` or `Playbook` later earns a place in the recommended
      vocabulary on the strength of examples like this one, *that* moves
      VOCAB and takes a record ([0071](docs/design/0071-the-recommended-type-vocabulary.md) §3).
- [x] Commit messages and code comments are in English.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
