### PR TITLE
Read every example bundle in a test, so a drift in one fails something

### DIFF
--- a/cmd/ochakai/examples_test.go
+++ b/cmd/ochakai/examples_test.go
@@ -8,6 +8,8 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/na0fu3y/ochakai/internal/okf"
 )
 
 // apiPathRe picks the first segment after /api/v1/ out of a line, in any
@@ -68,6 +70,97 @@ func TestExamplesCallAddressesThisBuildServes(t *testing.T) {
 			}
 		}
 	}
+}
+
+// Every bundle this repo ships is read as the bundle it looks like.
+//
+// examples/bigquery-catalog/bundle is where ochakai shows the Attested
+// Computation contract whole — a computation file, an attester file, and
+// body links that attribute both — and none of that was reachable from
+// Go, so a drift in it failed nothing. FromBundle is where a directory
+// stops being a directory and becomes concepts and files, which makes it
+// the first place a drift shows: an index.md copied in to match another
+// producer's layout (OKF reserves the name and ochakai regenerates it, so
+// a hand-written one imports as a note), a body link that stopped
+// resolving after a rename, a file nobody links and therefore nobody
+// finds (design doc 0077).
+//
+// The bundle is read through the CLI's own readBundle, so this fails for
+// the same reasons `ochakai import` would, minus the server.
+func TestExampleBundlesReadCleanly(t *testing.T) {
+	roots := exampleBundleRoots(t)
+	if len(roots) == 0 {
+		t.Fatal("no bundles walked: this check now guards nothing")
+	}
+	for _, root := range roots {
+		t.Run(strings.TrimPrefix(root, "../../"), func(t *testing.T) {
+			files, err := readBundle(root)
+			if err != nil {
+				t.Fatalf("read %s: %v", root, err)
+			}
+			concepts, atts, loose, skipped, notes := okf.FromBundle(files)
+			if len(concepts) == 0 {
+				t.Fatal("bundle holds no concepts")
+			}
+			for _, n := range notes {
+				t.Errorf("note: %s", n)
+			}
+			for _, s := range skipped {
+				t.Errorf("skipped: %s", s)
+			}
+			// A file no concept links is legal in a bundle — what enters
+			// leaves — but in an example it is a file the reader is never
+			// sent to, which is the state design doc 0077 named.
+			for _, l := range loose {
+				t.Errorf("%s is attributed to no concept: nothing's body links it", l.Path)
+			}
+			t.Logf("%d concepts, %d attributed files", len(concepts), len(atts))
+		})
+	}
+}
+
+// exampleBundleRoots lists the OKF bundles under examples/, and fails when
+// a concept document turns up outside every one of them. Listing the roots
+// is unavoidable — a bundle root is not visible in a single file — but a
+// list that silently stops covering things is the failure this whole file
+// exists about, so the list is checked against the tree rather than
+// trusted (design doc 0035).
+func exampleBundleRoots(t *testing.T) []string {
+	t.Helper()
+	roots := []string{"../../examples/bigquery-catalog/bundle", "../../examples/demo"}
+	// examples/golden-query.md is one document for `ochakai put -f`, not a
+	// bundle; TestGoldenQueryExampleParses in internal/service pins it.
+	exempt := map[string]bool{"../../examples/golden-query.md": true}
+
+	err := filepath.WalkDir("../../examples", func(p string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || filepath.Ext(p) != ".md" {
+			return err
+		}
+		content, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		// The same test docs/surface.md's DOC section applies: a file with
+		// frontmatter under examples/ is knowledge, not prose about ochakai.
+		if !strings.HasPrefix(string(content), "---\n") {
+			return nil
+		}
+		slash := filepath.ToSlash(p)
+		if exempt[slash] {
+			return nil
+		}
+		for _, root := range roots {
+			if strings.HasPrefix(slash, root+"/") {
+				return nil
+			}
+		}
+		t.Errorf("%s is a concept document in no known bundle: add its bundle root to exampleBundleRoots", slash)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk examples: %v", err)
+	}
+	return roots
 }
 
 // exampleProgramFiles lists the runnable files under examples/: the ones


### PR DESCRIPTION
## What and why

`examples/bigquery-catalog/bundle` is where ochakai shows the Attested
Computation contract whole — a computation file, an attester file, and the
body links that attribute both — and **none of it was reachable from Go**,
so a drift in it failed nothing. The sibling check in this file
(`TestExamplesCallAddressesThisBuildServes`) exists because an example was
found still calling an endpoint removed three surfaces earlier; the
bundles had the same hole, one layer up.

`okf.FromBundle` is where a directory stops being a directory and becomes
concepts and files, which makes it the first place a drift shows. The test
reads the bundle through the CLI's own `readBundle`, so it fails for the
same reasons `ochakai import` would, minus the server, and it errors on:

- any **note** — an `index.md` copied in to match another producer's
  layout is the live example: OKF reserves the name, ochakai regenerates
  it, and a hand-written one imports as a note that `--strict` reads as
  refusal
- any **skip**
- any file **no concept's body links**. That one is legal in a bundle —
  what enters leaves — but in a teaching example it is the state
  [0077](docs/design/0077-one-address-for-a-file.md) named: a file nobody
  links is a file nobody finds

### Verified it catches what it claims

A test that cannot fail guards nothing, so the bundle was broken four ways
and each one was watched to fail:

| break | what the test said |
|---|---|
| hand-written `attesters/index.md` | `note: index.md is a filename OKF reserves (SPEC §3.1) … not imported` |
| a file nobody links | `attesters/orphan.py is attributed to no concept` |
| a concept document outside every listed root | `… is a concept document in no known bundle: add its bundle root` |
| renaming the attester so the body link stops resolving | the file silently detaches — `3 concepts, 1 attributed files` |

The last is the drift that motivated this: nothing about a rename looks
wrong, and the contract keeps pointing at a file that is no longer
attached to it.

### Why the roots are a list

A bundle root is not visible in any single file, so `exampleBundleRoots`
names them. A list that quietly stops covering the tree is the same
failure this file is about, so it is checked rather than trusted
([0035](docs/design/0035-verifiability.md)): every `.md` under `examples/`
that opens with frontmatter must sit under a listed root, or the test says
which one does not. `examples/golden-query.md` is exempt by name — it is a
single document for `ochakai put -f`, and `internal/service` already pins
its round trip.

### What this does not cover

`ochakai import examples/bigquery-catalog/bundle` **fails on the
docker-compose quick start**, and this test does not catch that, because
it is not a format problem: the bundle carries two `.py` files, and an
instance without `OCHAKAI_GCS_BUCKET` answers `501` for any file
(`files are not supported without GCS`, design doc 0075 §1). The three
concepts land and the command exits 1. That is pre-existing — the bundle
has shipped a `.py` since it was added — and the example's own README
gives that command with no caveat. Filed separately rather than fixed
here; this PR is only the guard.

## Checks

- [x] `scripts/check` is clean — `scripts/check core` green; store tests
      skipped locally, CI runs them
- [x] Behavior changes come with tests — this **is** the test; no
      production code changed

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`,
      `internal/apiclient` — untouched
- [x] Lands on every surface it belongs on — not applicable, no capability
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens a surface — **no**. Nothing counted by `docs/surface.md`
      moves; no example content changed, so `DOC-LINES` is unchanged too

## Design docs

- [x] Alters an accepted decision — **no**. Nothing user-observable
      changed ([0048](docs/design/0048-decision-records-for-wire-contracts.md))
- [x] Commit messages and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)
