### PR TITLE
Say that the catalog example's files need a bucket, and how to skip them

### DIFF
--- a/examples/bigquery-catalog/README.md
+++ b/examples/bigquery-catalog/README.md
@@ -22,6 +22,18 @@ itself in the knowledge base it writes to:
 ochakai import examples/bigquery-catalog/bundle
 ```
 
+**The two files need a bucket.** An instance without `OCHAKAI_GCS_BUCKET`
+answers `501` for any file
+([0075](../../docs/design/0075-the-bundle-is-the-address-space.md) §1), so
+that import writes the three concepts and fails on the first `.py`. Cloud
+Run has the bucket; `deploy/compose.yaml` does not, and there the concepts
+are the half worth reading — the code is already in front of you:
+
+```sh
+tar czf - -C examples/bigquery-catalog/bundle --exclude='*.py' . |
+  ochakai import -
+```
+
 | Concept | Type | |
 |---|---|---|
 | [`skills/build-the-first-catalog`](bundle/skills/build-the-first-catalog.md) | Skill | **start here** — the day-one order: pick a small scope, settle the address, project the tables in, verify one, and only then attach a computation |


### PR DESCRIPTION
## What and why

`ochakai import examples/bigquery-catalog/bundle` is the command this
README gives, and **it exits 1 on the setup the project's own quick start
tells you to build.**

The bundle carries two `.py` files. An instance with no
`OCHAKAI_GCS_BUCKET` answers `501` for any file
([0075](docs/design/0075-the-bundle-is-the-address-space.md) §1), so the
import writes the three concepts and then dies on the first one:

```
created ochakai://jobs/sync-bigquery-catalog
created ochakai://skills/build-the-first-catalog
created ochakai://skills/run-a-python-job
ochakai import: write attesters/catalog-sync.py: files are not supported
without GCS: this instance stores markdown concepts only; set
OCHAKAI_GCS_BUCKET (design doc 0075 §1)
```

The attributed-file loop in `runImport` returns the error rather than
skipping it — unlike the loose-file loop directly beneath it, which
tolerates an invalid path and reports a skip — so there is no partial
success to report. Just a red command after the concepts already landed.

**This has been true since the bundle was added.** It shipped a `.py` from
the start and nothing said so; #495 added a second file to a bundle that
already had one. It is not a format problem, so #496's bundle test does
not see it either — that check reads the directory, and this only happens
against a server.

### Documented, not worked around

A file living beside the contract that names it is the arrangement
[0077](docs/design/0077-one-address-for-a-file.md) settled on, and
stripping the code out of the bundle to keep a credential-free instance
happy would undo it for everyone in order to help the one case that cannot
store files. What the local harness can have is the concepts — the half a
reader is there for, since the code is already checked out in front of
them.

So the README now says the requirement plainly and gives the form that
works without a bucket:

```sh
tar czf - -C examples/bigquery-catalog/bundle --exclude='*.py' . |
  ochakai import -
```

### Verified

Both paths, against `deploy/compose.yaml`:

| command | exit | result |
|---|---|---|
| `ochakai import examples/bigquery-catalog/bundle` | 1 | 3 concepts created, then the 501 above |
| the `tar … \| ochakai import -` form | 0 | `imported 3 concepts (3 created, 0 attributed, 0 loose, 0 skipped)` |

`GET /api/v1/bundle/attesters/catalog-sync.py` answers `501` on that
instance either way, which is the underlying fact and is not a bug.

## Checks

- [x] `scripts/check` is clean — `scripts/check core` green; store tests
      skipped locally, CI runs them
- [x] Behavior changes come with tests — no behavior changed; this is a
      README. The commands in it were both run against compose rather than
      reasoned about

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`,
      `internal/apiclient` — untouched
- [x] Lands on every surface it belongs on — not applicable
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens a surface — **no**. `DOC-LINES` goes 5,286 → 5,298 against an
      unchanged ceiling of 5,300. It was drafted at 5,299 and tightened,
      because leaving one line of headroom would hand the ceiling decision
      to whoever touched a manual page next, for no reason of their own

## Design docs

- [x] Alters an accepted decision — **no**. Nothing user-observable
      changed; this documents behaviour that already shipped
      ([0048](docs/design/0048-decision-records-for-wire-contracts.md))
- [x] Commit messages and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)
