### PR TITLE
Stop the context hint from teaching a retired status value

### DIFF
--- a/cmd/ochakai/retired_test.go
+++ b/cmd/ochakai/retired_test.go
@@ -34,11 +34,22 @@ var retiredSpellings = []retiredSpelling{
 	{
 		// OKF's lifecycle has three values (SPEC §5.4). Confirmation is
 		// the ledger's business, and it answers in trust tiers.
+		//
+		// The plural spellings are the filter's, and they are here because
+		// the server's own get_context hint taught `statuses=["rejected"]`
+		// long after the value stopped being a status — a call every
+		// surface answers with a 400 (service.checkedFilter), handed to
+		// the hosts that have no Stop hook and see this string only. The
+		// singular forms above did not match it: `["` sits between the
+		// key and the value. Both quotings are listed because a Go string
+		// literal escapes the inner quotes and no other file does.
 		forms: []string{
 			"status: verified", "status: rejected",
 			"status=verified", "status=rejected",
 			"--status verified", "--status rejected",
 			`"status": "verified"`, `"status": "rejected"`,
+			`statuses=["verified"`, `statuses=["rejected"`,
+			`statuses=[\"verified\"`, `statuses=[\"rejected\"`,
 		},
 		instead: "draft | stable | deprecated, with verification carried by the ledger (design docs 0043 §3.2, 0046 §§3.9-3.10)",
 	},

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -564,7 +564,7 @@ func contextHint(truncated int) string {
 	hint := "After acting on this knowledge, call report_outcome (worked/failed) on the concepts you " +
 		"used — failed reports are how stale verified knowledge gets caught. If this session " +
 		"produced reusable knowledge, write it back with put_concept as a draft; search " +
-		"statuses=[\"rejected\"] first so you do not re-propose something already turned down."
+		"rejected=true first so you do not re-propose something already turned down."
 	if truncated > 0 {
 		hint += fmt.Sprintf(" %d concepts did not fit the budget and are listed under \"outline\" — "+
 			"fetch any of them by id with get_concept.", truncated)

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -410,12 +410,24 @@ func TestContextSchemaBoundsResponse(t *testing.T) {
 // TestContextHint pins the habit the server hands every host. Claude Code
 // sites can install it as a Stop hook; a browser-based host has no shell,
 // so this string is the only copy it will ever see.
+//
+// The habit has to be callable, not merely mentioned. This asked for
+// "rejected" alone for as long as the hint spelled the filter
+// `statuses=["rejected"]` — the value's own retirement as a status
+// (design doc 0043 §3.3) left that call answering 400, and a host with no
+// other copy of the habit had no way to recover. So the filter is pinned
+// by the spelling searchIn accepts, and the status vocabulary is named as
+// what the hint must not reach for.
 func TestContextHint(t *testing.T) {
 	plain := contextHint(0)
-	for _, want := range []string{"report_outcome", "put_concept", "rejected"} {
+	for _, want := range []string{"report_outcome", "put_concept", "rejected=true"} {
 		if !strings.Contains(plain, want) {
 			t.Errorf("hint does not mention %q: %s", want, plain)
 		}
+	}
+	if strings.Contains(plain, "statuses") {
+		t.Errorf("rejected is a ruling, not a lifecycle status: the hint must ask for it "+
+			"with the rejected filter, not through statuses: %s", plain)
 	}
 	if strings.Contains(plain, "outline") {
 		t.Errorf("nothing was dropped; hint must not mention the outline: %s", plain)

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -254,7 +254,6 @@
   .badge.verified-mark { color: var(--verified-fg); background: var(--verified-bg); border-color: var(--verified-bd); }
   .badge.rejected-mark { color: var(--rejected-fg); background: var(--rejected-bg); border-color: var(--rejected-bd); }
   .badge.deprecated { color: var(--deprecated-fg); background: var(--deprecated-bg); border-color: var(--deprecated-bd); }
-  .badge.rejected { color: var(--rejected-fg); background: var(--rejected-bg); border-color: var(--rejected-bd); }
   /* The status badge doubles as its own picker: one control shows the
      status and changes it, where four transition buttons used to sit.
      The select sits transparent over the label so the pill hugs the
@@ -386,7 +385,6 @@
   }
   .status-dot.draft { background: var(--draft-fg); }
   .status-dot.deprecated { background: var(--deprecated-fg); }
-  .status-dot.rejected { background: var(--rejected-fg); }
   /* Drag-and-drop move targets (directories and the root). */
   .browse details.node > summary.drop-hover, #tree.drop-hover { background: var(--accent-weak); border-radius: 6px; }
 


### PR DESCRIPTION
## What and why

`get_context`'s hint told every agent to `search statuses=["rejected"]` before
writing a concept back. `rejected` stopped being a lifecycle status in design
doc [0043](docs/design/0043-document-first.md) §§3.2-3.3 — it became the
rejection ledger's ruling, asked for with the `rejected` filter — so the call
the hint teaches is one `service.checkedFilter` answers with a 400: *status must
be one of draft, stable, deprecated*. The hint now says `rejected=true`, the
spelling `searchIn` accepts.

This is the one string where that mistake costs the most. The habit it carries
is the write-back loop, and a browser-based host has no shell to hang a Stop
hook on, so the server's copy is the only one it will ever see. The agent that
follows it gets an error instead of the list of things already turned down, and
re-proposes — which is exactly what the sentence exists to prevent.

Two guards each missed it, for reasons worth closing:

- `TestRetiredSpellingsAreNotTaught` reads literals, and `["` sits between the
  key and the value, so the existing `status=rejected` form did not match.
  Added the plural forms in both quotings — a Go string literal escapes the
  inner quotes and no other file does. Verified they fire by putting both
  spellings in a throwaway file.
- `TestContextHint` asserted only that `"rejected"` appeared somewhere in the
  hint, which the broken spelling satisfied. It now pins `rejected=true` and
  fails if the hint reaches for `statuses` at all.

Also dropped two dead CSS rules the same retirement left in the web UI:
`.status-dot.rejected` and `.badge.rejected`. Both key off a status value, and
the badge and dot render `entry.status`, which has been three values since
migration `0023_status_and_ledgers.sql`.

Nothing else survived the sweep: `domain.Statuses` is the three OKF values, the
store's CHECK constraint agrees, an imported `status: rejected` parses as a
draft, and every other `rejected` in the tree is the ruling or the filter.

## Checks

- [x] `scripts/check` is clean — add `--db` when the change touches the store
      (ran with `--db`; the store is untouched, but the sweep read it)
- [x] Behavior changes come with tests

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — the filter was already spelled
      `rejected` on all four; only the MCP hint disagreed
- [x] The change lands on every surface it belongs on — the hint is MCP's
      alone (REST and the CLI have no equivalent string), and the web UI
      cleanup is the same retirement one file over
- [x] `api/openapi.frozen.txt` is untouched
- [x] Does not widen a surface: no new operation, tool, command or variable,
      so `docs/surface.md` is unchanged

## Design docs

- [x] Does not alter an accepted decision — 0043 already retired the status
      value; this finishes applying it — no new numbered doc
- [x] Commit messages and code comments are in English

## Not in this PR

No `CHANGELOG.md` entry, matching how the fixes since 0.18.0 have landed — the
release skill writes that section. Say the word if you want it in `[Unreleased]`
now instead.