### PR TITLE
Put examples/ in the release archives, so a bundle is reachable without git

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -50,6 +50,18 @@ archives:
     files:
       - LICENSE
       - README.md
+      # The bundles the README tells you to import, and the hooks it tells
+      # you to install. `ochakai import` takes a directory or a tar.gz and
+      # not a URL, and the container image carries only the binary, so
+      # without these the sole way to reach examples/bigquery-catalog was
+      # to clone the repository for a bundle whose whole point is that it
+      # runs outside the server.
+      #
+      # The directory, not a glob: `examples/**/*` silently drops the files
+      # sitting directly in it — examples/README.md, which is the page that
+      # says what the bundles are, and examples/golden-query.md, which the
+      # same page hands to `ochakai put -f`.
+      - examples
 
 checksum:
   name_template: checksums.txt


### PR DESCRIPTION
## What and why

The release archives carried `LICENSE` and `README.md`. That README tells
the reader to `import examples/demo`, and points at
`examples/bigquery-catalog` from the refusal table — and **neither was in
the archive.** The container image carries only the binary
(`COPY --from=build /ochakai /ochakai`), `go install` only the binary, and
`ochakai import` takes a directory or a `tar.gz`, not a URL.

So the only way to reach the catalog bundle was to clone the repository —
for a bundle whose whole point is that it runs *outside* the server, as an
ordinary client under the reader's own service account. `/examples` exists
in the quick start only because `deploy/compose.yaml` bind-mounts
`../examples:/examples:ro`.

### The entry is a directory, not a glob

`examples/**/*` was tried first, and it silently dropped the two files
sitting directly in `examples/`:

- `examples/README.md` — the page that says what the bundles are
- `examples/golden-query.md` — which that same page hands to `ochakai put -f`

21 of 23 files, with no warning: the kind of nearly-right that ships. The
directory form takes all 23.

### Verified

Built the snapshot archives locally (goreleaser v2.17.1) and used one the
way somebody with no checkout would — extract, then run the *extracted*
binary against the compose harness:

```
$ ./ochakai version
v0.18.0
$ tar czf - -C examples/bigquery-catalog/bundle --exclude='*.py' . | ./ochakai import -
imported 3 concepts (3 created, 0 attributed, 0 loose, 0 skipped, 3 notes)
$ ./ochakai import examples/demo
imported 10 concepts (10 created, 0 attributed, 0 loose, 0 skipped, 10 notes)
$ ./ochakai search "catalog"
{"hits":[{"id":"tables/shop-orders", ...
```

- archive holds **23** paths under `examples/`; `git ls-files examples`
  holds **23**
- file modes come across as the repository has them (the hooks are
  non-executable in git and non-executable in the archive — unchanged, not
  fixed here)
- archive size is unchanged at 12M to the megabyte; the binary is all of it

The `tar … --exclude='*.py'` form is the one #497 documented, because the
compose harness has no `OCHAKAI_GCS_BUCKET` and cannot store files. On a
real deployment the plain `import examples/bigquery-catalog/bundle` is the
command, and it is now available to an archive user.

## Checks

- [x] `scripts/check` is clean — unchanged by this; no Go code or docs
      touched. `goreleaser check` validates the config, and the archives
      were actually built and unpacked rather than reasoned about
- [x] Behavior changes come with tests — packaging has no test hook in
      this repo; the snapshot build above is the check, and it is the same
      command `.github/workflows/release.yaml` runs minus `--snapshot`

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`,
      `internal/apiclient` — untouched
- [x] Lands on every surface it belongs on — not applicable, packaging
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens a surface — **no**. Nothing `docs/surface.md` counts moves;
      `DOC-LINES` is unchanged at 5,298

## Design docs

- [x] Alters an accepted decision — **no**. What ships in an archive is not
      the wire, the stored form, identity, a Google Cloud dependency, or a
      refusal ([0048](docs/design/0048-decision-records-for-wire-contracts.md))
- [x] Commit messages and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)
