### PR TITLE
Declare the draft the projection claims to be, and catch the night it froze

### DIFF
--- a/examples/bigquery-catalog/bundle/attesters/catalog-sync.py
+++ b/examples/bigquery-catalog/bundle/attesters/catalog-sync.py
@@ -21,7 +21,16 @@ does the same two jobs for `runtime: bigquery`:
      is attempted and the four outcomes after it, so a mismatch means a
      table left the loop without being counted.
 
-  3. Continuity — only when a previous receipt is supplied: the catalog
+  3. Ownership — the run still projected something. `written` and
+     `unchanged` are the two outcomes that leave an entry the sync's;
+     `skipped` is the one that says a person took it. A run where every
+     table was skipped refreshed nothing, and checks 1 and 2 call that a
+     clean night — the counts conserve, nothing failed, the catalog is
+     the same size as yesterday. It is what a projection that has quietly
+     stopped looks like, and equally what a catalog nobody needs a
+     schedule for looks like; both are worth a person's attention.
+
+  4. Continuity — only when a previous receipt is supplied: the catalog
      did not collapse between two runs. A dataset that silently loses read
      access looks exactly like a warehouse that got smaller.
 
@@ -42,6 +51,9 @@ ran the job.
 
 from __future__ import annotations
 
+import argparse
+import json
+import sys
 from typing import Any
 
 # The fields skills/run-a-python-job.md says a run has to bring back, and
@@ -170,7 +182,13 @@ def attest(
         return _verdict(False, "the run reported failed tables",
                         failed=counts["failed"])
 
-    # 3. Continuity.
+    # 3. Ownership.
+    projected = counts["written"] + counts["unchanged"]
+    if counts["tables_seen"] and not projected:
+        return _verdict(False, "the run projected nothing: every table was skipped",
+                        tables_seen=counts["tables_seen"], skipped=counts["skipped"])
+
+    # 4. Continuity.
     if previous is not None:
         before = _count(previous.get("tables_seen"))
         if before is None:
@@ -183,3 +201,51 @@ def attest(
                 min_ratio=min_ratio)
 
     return _verdict(True, None, scope=got, counts=counts)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Read a receipt on stdin, take the sanctioned scope as flags, print a verdict.
+
+    The reference bundle's attester is a module and nothing else, which is
+    right for one a consumer calls in-process before it displays a number.
+    This one is the last step of a scheduled job, where the caller is a
+    shell — so it is both, and the step that decides whether a run counted
+    does not start with "write yourself a driver".
+
+    Exit status is the verdict: 0 attested, 1 not. A scheduler can gate on
+    it without reading the JSON.
+    """
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--sync-identity", required=True,
+                   help="the account the run was scheduled to use")
+    p.add_argument("--project", required=True)
+    p.add_argument("--datasets", required=True, nargs="+")
+    p.add_argument("--prefix", default="catalog/bigquery")
+    p.add_argument("--previous", metavar="FILE",
+                   help="the last receipt that passed; omit on the first run, and "
+                        "the continuity check is skipped rather than assumed")
+    args = p.parse_args(argv)
+
+    receipt = json.load(sys.stdin)
+    previous = None
+    if args.previous:
+        with open(args.previous, encoding="utf-8") as f:
+            previous = json.load(f)
+
+    verdict = attest(
+        sanctioned={
+            "sync_identity": args.sync_identity,
+            "project": args.project,
+            "datasets": args.datasets,
+            "prefix": args.prefix,
+        },
+        receipt=receipt,
+        previous=previous,
+    )
+    json.dump(verdict, sys.stdout, indent=2, ensure_ascii=False)
+    print()
+    return 0 if verdict["ok"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/bigquery-catalog/bundle/jobs/sync-bigquery-catalog.md
+++ b/examples/bigquery-catalog/bundle/jobs/sync-bigquery-catalog.md
@@ -86,8 +86,10 @@ between the read and the write loses the race instead of being erased by
 it.
 
 "Nobody has ruled on it" is three separate questions, because ochakai
-keeps the three apart: the **lifecycle** is what the writer declared
-(`draft`), the **trust tier** is what the verification ledger derives, and
+keeps the three apart: the **lifecycle** is what the writer declared —
+`draft`, written into every projection, because a document that declares
+nothing reads as `stable` and this job would then skip its own work — the
+**trust tier** is what the verification ledger derives, and
 a **rejection** is a live ruling beside both. Verifying does not move the
 status — a ruling and a publication are different acts — so a sync
 watching `status` alone would go on overwriting an entry somebody had just
@@ -130,7 +132,7 @@ prints its receipt to stdout as JSON and its progress to stderr:
 
 `attester.resource` points at
 [catalog-sync.py](/attesters/catalog-sync.py), which decides whether a run
-counts. It asks three things, and the first two are the two questions the
+counts. It asks four things, and the first two are the two questions the
 reference bundle's `sql_equality.py` asks of a SQL run:
 
 1. **Provenance — did the executor run what was sanctioned?** For a query
@@ -143,7 +145,17 @@ reference bundle's `sql_equality.py` asks of a SQL run:
    skipped + failed` must equal `tables_seen`, and `failed` must be zero.
    The count is taken before a write is attempted and the outcomes after,
    so a disagreement means a table left the loop uncounted.
-3. **Continuity** — given the previous passing receipt, `tables_seen` has
+3. **Ownership** — the run projected something. `written` and `unchanged`
+   leave an entry the job's; `skipped` says a person took it. A night where
+   every table was skipped refreshed nothing, and the two checks above call
+   it clean: the counts conserve, nothing failed, the catalog is the same
+   size. **This check exists because that state shipped.** Writing no
+   `status` at all does not mean draft — SPEC §5.4 defaults it to `stable`
+   — so every entry this job created came back reading as ruled on by a
+   person, and from the second night on it skipped all of them. One line
+   in `build_document` was the bug; this is the check that would have said
+   so on night two.
+4. **Continuity** — given the previous passing receipt, `tables_seen` has
    not halved. A dataset silently losing read access looks exactly like a
    warehouse that got smaller.
 

--- a/examples/bigquery-catalog/bundle/jobs/sync-bigquery-catalog/sync-bigquery-catalog.py
+++ b/examples/bigquery-catalog/bundle/jobs/sync-bigquery-catalog/sync-bigquery-catalog.py
@@ -159,8 +159,20 @@ def build_document(table, fq: str, dataset: str, usage: dict | None,
     address is a 415 naming this shape. The frontmatter is the metadata
     and the markdown is the body.
 
-    `status` is deliberately absent: create defaults it to draft, and a
-    replace leaves whatever is stored alone. `title` is absent too — the
+    `status: draft` is written rather than left out. Leaving it out does
+    not mean draft: OKF SPEC §5.4 gives `status` a default and that
+    default is `stable` (internal/domain's LifecycleOf). A projection
+    that arrives stable is one this job then reads back as ruled on by a
+    person and skips forever after — the catalog is written once and
+    never updated again, and the receipt calls that a clean night. The
+    lifecycle is the writer's declaration, so the writer declares it.
+
+    Re-writing it costs nothing: the only entry this job ever replaces is
+    one it wrote itself, which was already a draft. A person's edit takes
+    the entry out through the writer check, and a verification through
+    the trust tier — neither is reached by way of `status`.
+
+    `title` is absent too — the
     id's last segment is the display name (design doc 0074 §1), and that
     segment is already the table id. The keys this instance owns —
     `generated`, `verified`, `created_by` — are never written from here:
@@ -192,6 +204,7 @@ def build_document(table, fq: str, dataset: str, usage: dict | None,
         "resource": resource,
         "description": (table.description or "").split("\n")[0][:280],
         "tags": tags,
+        "status": "draft",
         "sources": [source],
     }
     if usage:

--- a/examples/bigquery-catalog/bundle/skills/build-the-first-catalog.md
+++ b/examples/bigquery-catalog/bundle/skills/build-the-first-catalog.md
@@ -52,6 +52,11 @@ The download brings back two files beside each other — the computation and
 the attester you will need in step 4 — because both are the job's, and a
 contract you can read without the code it names is half a contract.
 
+**That download is empty on an instance with no `OCHAKAI_GCS_BUCKET`**, and
+nothing says so: files are not stored there at all, so the concepts arrived
+without them. Take the two `.py` files from the bundle directory or the
+release archive instead.
+
 No credentials for ochakai are needed for the run itself. Read **one** of the printed
 documents completely — the columns, the partition filter, the empty
 `# Caveats` section. What you are checking is whether an agent handed this
@@ -70,12 +75,26 @@ run. The attester's first check exists for exactly this.
 
 ### 4. Run it, then attest the run
 
-Run without `--dry-run`, capture the receipt from stdout, and hand it to
-the attester the job names — with the scope you authorized in step 3, not
-with whatever the run reports. A non-zero exit code is not the check: a run
-that wrote a whole second catalog under the wrong prefix exits 0 and looks
-like a good night. What the three checks are, and why the first one is the
-one that bites, is in [the job itself](/jobs/sync-bigquery-catalog.md).
+Run without `--dry-run`, keep the receipt, and hand it to the attester with
+the scope **you authorized in step 3** — not with whatever the run reports:
+
+```sh
+python sync-bigquery-catalog.py --project my-project --datasets shop \
+  --ochakai-url "$OCHAKAI_URL" > receipt.json
+
+python catalog-sync.py --sync-identity "$SYNC_ACCOUNT" --project my-project \
+  --datasets shop --prefix catalog/bigquery < receipt.json
+```
+
+Progress goes to stderr, so the redirect captures the receipt and nothing
+else. The attester exits 0 only if the run counted; keep the receipt of a
+run that passed and pass it as `--previous` tomorrow, which is what turns
+on the check that the catalog did not collapse overnight.
+
+The job's own exit code is not that check. A run that wrote a whole second
+catalog under the wrong prefix exits 0 and looks like a good night. What
+the four checks are, and why the first one bites hardest, is in
+[the job itself](/jobs/sync-bigquery-catalog.md).
 
 Everything is now a draft written by a machine. Nothing here is knowledge
 yet.


### PR DESCRIPTION
## What and why

**The catalog sync wrote each table once and then skipped it forever.**
Found by running the day-one procedure end to end for the first time, as a
new user would, rather than by reading it.

Three documents claimed the projections were drafts. None was true.

`build_document` left `status` out, on the stated ground that *"create
defaults it to draft"*. It does not — OKF SPEC §5.4 gives `status` a
default and that default is **stable**, which is exactly what
`domain.LifecycleOf` implements. So every entry arrived `stable`, and
`ruled_on()` returns "keep syncing" only for a literal `"draft"`. From the
second night on, the job read its own work as a person's ruling.

Reproduced against real BigQuery before changing anything — six tables of
`bigquery-public-data.austin_bikeshare`:

```
NIGHT 1  {"tables_seen":6,"written":6,"unchanged":0,"skipped":0,"failed":0}
NIGHT 2  skip … bikeshare_stations — stable, a human ruled on it
         skip … bikeshare_trips — stable, a human ruled on it        (×6)
         {"tables_seen":6,"written":0,"unchanged":0,"skipped":6,"failed":0}
```

Nobody had touched them.

### Three consequences, all silent

1. **Schema changes never land.** A daily job that writes once and then
   declines is not a daily job. The ownership rule's whole purpose —
   never flatten what a person wrote — was being met by writing nothing.
2. **The attester passed it.** Counts conserve, `failed` is 0, the catalog
   is the same size as yesterday: a permanently frozen catalog was a clean
   night.
3. **The draft queue stayed empty**, so day-one step 5 — *verify one
   table* — had nothing to act on, while the skill said "Everything is now
   a draft written by a machine".

### The fix (option A, as chosen)

The projection **declares** `status: draft`. Re-writing it costs nothing:
the only entry this job ever replaces is one it wrote itself, which was
already a draft. A person's edit still leaves through the writer check and
a verification through the trust tier — neither is reached by way of
`status`.

### The attester gains the check that would have caught it

A run where **every** table was skipped projected nothing, whatever the
reason. That is now check 3 of four. `written` and `unchanged` are the two
outcomes that leave an entry the job's; `skipped` is the one that says a
person took it.

It also gains a `__main__`. `run-a-python-job.md` said "hand the receipt to
the attester" and there was no runnable form — the step that decides
whether a run counted began with *write yourself a driver*. The day-one
skill now shows the command instead of describing it, including how
`--previous` turns on the continuity check.

### One more thing the run-through caught

`build-the-first-catalog.md` promised `ochakai get … --download .` brings
the two `.py` files back. On an instance with no `OCHAKAI_GCS_BUCKET` it
brings nothing, silently — which is every compose harness. #497 put that
caveat on the example's README; the skill you are told to *start with*
never got it. It has it now.

## Checks

- [x] `scripts/check` is clean — `scripts/check core` green; store tests
      skipped locally, CI runs them. `TestExampleBundlesReadCleanly` (#496)
      still passes.
- [x] Behavior changes come with tests — verified against **real
      BigQuery** on a fresh instance, not reasoned about:

| | result |
|---|---|
| night 1 | `written: 6` — six drafts |
| night 2, nothing changed upstream | `unchanged: 6, skipped: 0` — was `skipped: 6` before |
| a person runs `ochakai verify` on one | — |
| night 3 | `unchanged: 5, skipped: 1` — `skip … bikeshare_trips — human-reviewed, a human ruled on it` |
| `ochakai list usage --status draft` | six entries, all `draft` |
| attester on the **frozen** receipt | `ok: false`, *"the run projected nothing: every table was skipped"*, exit 1 |
| attester on night 2 and night 3 | `ok: true` |
| the 18-case adversarial suite | unchanged, plus `all unchanged` → ok and `every table skipped` → fail |

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`,
      `internal/apiclient` — untouched. The server was right; the example
      was wrong about it
- [x] Lands on every surface it belongs on — not applicable, example content
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens a surface — **no**. `DOC-LINES` unchanged at 5,326: every file
      here is a bundle document or code, which `docs/surface.md` does not
      count

## Design docs

- [x] Alters an accepted decision — **no**. `status` defaulting to `stable`
      is SPEC §5.4 and was already implemented that way; this makes an
      example stop contradicting it
      ([0048](docs/design/0048-decision-records-for-wire-contracts.md))
- [x] Commit messages and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)
