### PR TITLE
Fix the three places the second day-one run-through stopped

### DIFF
--- a/examples/bigquery-catalog/bundle/jobs/sync-bigquery-catalog.md
+++ b/examples/bigquery-catalog/bundle/jobs/sync-bigquery-catalog.md
@@ -66,10 +66,12 @@ Three of those choices are load-bearing:
 - **No `title`.** The id's last segment is the display name, and that
   segment is the table id already.
 - **The entry cites the table as its own source**, so
-  `ochakai search --source bigquery://my-project.shop.orders` returns the
+  `ochakai list --source bigquery://my-project.shop.orders` returns the
   catalog entry *and* every insight or computation written against the same
-  table. That reverse lookup only works if everyone spells the URI the same
-  way — pick the spelling once and keep it.
+  table. `list`, not `search`: a reverse lookup is a listing and has no
+  query to rank by, which is the whole of design doc 0062. That lookup only
+  works if everyone spells the URI the same way — pick the spelling once
+  and keep it.
 - **Query counts go in `sources[].usage_count`, never into ochakai's usage
   telemetry.** ochakai counts how often *its knowledge* was retrieved; this
   counts how often *a table* was queried. Same word, two subjects, and

--- a/examples/bigquery-catalog/bundle/skills/build-the-first-catalog.md
+++ b/examples/bigquery-catalog/bundle/skills/build-the-first-catalog.md
@@ -96,16 +96,34 @@ catalog under the wrong prefix exits 0 and looks like a good night. What
 the four checks are, and why the first one bites hardest, is in
 [the job itself](/jobs/sync-bigquery-catalog.md).
 
+**This step wants the deployment, not a local instance.** `sync_identity`
+is the email claim of the ID token the run minted, and an instance you can
+reach without credentials makes it mint none — the field comes back empty
+and the attester refuses the receipt rather than attest a run that cannot
+say who made it. That is the right answer, and it means the dev instance
+you dry-ran against in step 2 cannot carry you past here.
+
 Everything is now a draft written by a machine. Nothing here is knowledge
 yet.
 
 ### 5. Turn one table into knowledge
 
-Pick the table your agents get wrong most often. Write its `# Caveats`
-section — the filter that is always required, the column that lies, the
-timezone the timestamps are in — and then `ochakai verify` it. Two things
-happen: the sync stops overwriting it, and its trust tier changes, so
-agents can tell it apart from the 83 projections beside it.
+Pick the table your agents get wrong most often. The entry is a document,
+so editing it is a round trip through one:
+
+```sh
+ochakai get catalog/bigquery/my-project/shop/orders > orders.md
+$EDITOR orders.md          # fill in the empty `# Caveats` section
+ochakai put catalog/bigquery/my-project/shop/orders -f orders.md
+ochakai verify catalog/bigquery/my-project/shop/orders
+```
+
+Write what an agent has to know before it queries the table — the filter
+that is always required, the column that lies, the timezone the timestamps
+are in. Leave the rest of the document alone; the sync owns it and will
+keep it current. Two things then happen: the sync stops overwriting the
+entry, and its trust tier changes, so agents can tell it apart from the 83
+projections beside it.
 
 **Do one.** The point of day one is not a verified catalog, it is a base
 that has one entry a person will vouch for and a procedure for making the

--- a/examples/bigquery-catalog/bundle/skills/run-a-python-job.md
+++ b/examples/bigquery-catalog/bundle/skills/run-a-python-job.md
@@ -65,7 +65,7 @@ that is missing one rather than guessing what it meant.
 
 | Field | Where it comes from |
 |---|---|
-| `sync_identity` | the email claim of the ID token the run used — who the entries will say wrote them |
+| `sync_identity` | the email claim of the ID token the run used — who the entries will say wrote them. Empty when there was no token to mint, and the attester refuses a receipt that cannot name its run |
 | `project` | the `--project` the run used |
 | `datasets` | the `--datasets` it was given, sorted |
 | `prefix` | the `--prefix` the ids were built under |


### PR DESCRIPTION
## What and why

Second unaided run-through of the day-one procedure, on a fresh empty
instance against real BigQuery (`bigquery-public-data.austin_bikeshare`).
**Steps 1–5 completed** — six tables catalogued, one verified with a
person's caveats on it, `ochakai context` returning it first. The three
stops from the first run-through (#501) did not recur, and the reader
reached the procedure in three hops from `README.md:50` without grepping.

These are the three places it was harder than it had to be.

### 1. A shipped concept taught a command that does not exist

`jobs/sync-bigquery-catalog.md` justified the "cite the table as its own
source" decision with:

> `ochakai search --source bigquery://my-project.shop.orders` returns the
> catalog entry *and* every insight or computation written against the
> same table.

```
$ ochakai search --source bigquery://…
ochakai search: search needs a query; `ochakai list` is the command for
the feeds and the reverse lookups
```

The spelling is `ochakai list --source`. This is the sentence that
*explains the design decision*, and its command is wrong in precisely the
way [0062](docs/design/0062-a-listing-is-not-a-search.md) exists to
prevent — a reverse lookup is a listing and has nothing to rank by. It
ships inside the knowledge base, so an agent reads it as sanctioned. The
fix says which and why, in one clause.

### 2. Step 5 had no command

*"Write its `# Caveats` section"* is the step the whole page builds toward
and it was the only one with no fence under it — step 2, the dry run, has
one. A stored concept is a document, so editing it is a round trip, and
nothing said so. The run-through did line arithmetic on the output twice
and shipped a document with two `# Caveats` headings before catching it in
a `context` call.

Step 5 now prints the round trip, and says to leave the rest of the
document alone because the sync still owns it.

### 3. Step 4 was unreachable from the instance the README steers you to

Without credentials the run mints no ID token, so `sync_identity` comes
back empty and the attester refuses:

```
"reason": "sanctioned scope is unusable: sync_identity is missing or not a
           non-empty string"
```

**That is the right answer** — a run that cannot say who made it should not
be attested — but no document stated the dependency, so a first-timer
following "Try it without touching anything" hits a hard stop at the step
that decides whether the run counted. Step 4 now says it wants the
deployment rather than the dev instance, and the receipt table in
`run-a-python-job.md` says the field is empty without a token.

## Deliberately not changed

Two findings from the run-through were checked and left alone:

- **`curl /api/v1/bundle/<concept-id>` returning a file error** — not a
  defect. The `.md` was missing; a concept lives at `<id>.md`, and with it
  the request returns the concept. Verified both ways.
- **The ownership guard's writer clause being inert when identity is
  empty** (`if identity and writer != identity`) — accurate, but in `dev`
  and `public` every caller is the same identity, so the clause could not
  discriminate whether or not it ran. Documenting it would buy prose and
  no protection.

Also left: `--sync-identity` wants `anonymous` where `whoami` prints
`human:anonymous`. Dev-only — on Cloud Run both are the service-account
email.

## Checks

- [x] `scripts/check` is clean — `scripts/check core` green;
      `TestExampleBundlesReadCleanly` passes; store tests skipped locally,
      CI runs them
- [x] Behavior changes come with tests — documentation only, but **every
      command added here was run against a live instance before it was
      written down**, which is how finding 1 surfaced at all:

| command | result |
|---|---|
| `ochakai list --source bigquery://my-project.shop.orders` | returns the entry |
| `ochakai search --source …` | refuses — the command that shipped |
| `get > f.md` → edit → `put -f f.md` → `verify` | caveat lands; entry ends `status: draft, trust: human-reviewed` |
| attester on a receipt with empty `sync_identity` | `ok: false`, names the field |

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`,
      `internal/apiclient` — untouched
- [x] Lands on every surface it belongs on — not applicable, example content
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens a surface — **no**. All three files are bundle documents,
      which `docs/surface.md` does not count; `DOC-LINES` unchanged at 5,326

## Design docs

- [x] Alters an accepted decision — **no**. 0062 already decided that a
      listing is not a search; this stops an example contradicting it
      ([0048](docs/design/0048-decision-records-for-wire-contracts.md))
- [x] Commit messages and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)
