### PR TITLE
Fix operating.md's stale $IMAGE section and warnings-only claim

### DIFF
--- a/docs/guides/operating.md
+++ b/docs/guides/operating.md
@@ -129,8 +129,11 @@ provenance はそれが起きるのを見ていたインスタンスに属する
 ### ログ
 
 すべては `slog` を通した JSON なので、Cloud Logging は手を加えずに
-パースできる。アラートや保存クエリを組む価値があるメッセージは、
-すべて**劣化しているが動いている**ことを表す warning である:
+パースできる。アラートや保存クエリを組む価値があるメッセージは次の
+表の通りである。ほとんどは**劣化しているが動いている**ことを表す
+warning だが、レベルで絞り込むとこの表を素通りする行が三つ混ざって
+いる: `Error` が一つ(export の失敗)、エラーではないキュレーション
+行為の監査ログが二つ(検証・破棄)である。
 
 | メッセージ | 意味 |
 |---|---|
@@ -568,7 +571,7 @@ gcloud run services add-iam-policy-binding ochakai --region=$REGION \
   --member=serviceAccount:ochakai-webui@$PROJECT_ID.iam.gserviceaccount.com \
   --role=roles/run.invoker
 
-# IAP を前段に立てて非公開でデプロイする — デプロイガイド §3 と同じ $IMAGE。
+# IAP を前段に立てて非公開でデプロイする — デプロイガイド §1 と同じ $IMAGE。
 # (--iap には gcloud beta コンポーネントが要る; 下の iap web コマンドには
 #  Resource Manager API が要る)
 gcloud services enable iap.googleapis.com cloudresourcemanager.googleapis.com


### PR DESCRIPTION
## Summary
- `$IMAGE` is exported in the deploy guide's §1 (`deploy/cloudrun/README.md:76`), not §3. The prose two paragraphs above the IAP deploy command already says §1 correctly; the comment inside the command block said §3 — fixed to say §1.
- The log table's preamble claimed every row was a warning meaning "degraded but working." Three rows aren't: `export truncated after the response began` is `Log.Error` (`internal/restapi/restapi.go:107`), and `knowledge verified` / `knowledge purged` are `Log.Info` audit logs (`internal/service/service.go:511,576`), which the table itself already labels "not errors." Reworded the preamble so it no longer contradicts its own rows.

Closes #469.

## Test plan
- [x] `scripts/check core` passes