### PR TITLE
Prepare release v0.19.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Version
       description: Output of `ochakai version`, or the image tag you deployed.
-      placeholder: "0.18.0"
+      placeholder: "0.19.0"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,40 @@ last entry.
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-08-05
+
+### Added
+
+- **`examples/bigquery-catalog`** gained a day-one procedure, a sync job,
+  and the first attester in the repository that verifies a run *after* it
+  happened — OKF's kinetic half, which no other example demonstrated.
+  Docs now point at it from the three pages a new user actually reads —
+  the quick start, the Cloud Run guide, and the manual's index — where
+  before the only mention was a parenthetical inside a refusal table.
+- Release archives now carry `examples/` alongside `LICENSE` and
+  `README.md`; the demo and catalog bundles the top-level README tells a
+  reader to import are reachable without cloning the repository.
+
+### Fixed
+
+- **BREAKING (deploy/terraform)** — the module's attachment-era names are
+  retired to match the wire's "file"
+  ([0064](docs/design/0064-rest-stops-at-api-v1.md) §6, which reached
+  REST/MCP but never this corner): `enable_gcs_attachments` →
+  `enable_gcs_files`, the `attachments_bucket` output → `files_bucket`,
+  and the `google_storage_bucket.attachments` resource → `.files`. An
+  operator applying this module after upgrading gets a rename Terraform
+  wants to apply as a destroy-and-recreate.
+- The web UI's markdown renderer had no notion of GFM pipe tables; one in
+  a document body rendered as a paragraph with the pipes and dashes shown
+  literally. `md()` now parses tables directly, including alignment and
+  escaped pipes.
+- `get_context`'s hint taught `search statuses=["rejected"]`, a spelling
+  the status vocabulary retired for `rejected=true` back in
+  [0043](docs/design/0043-document-first.md) §§3.2-3.3; an agent that
+  followed it got a 400 instead of the rejection ledger. The hint is
+  fixed, and the two guards that missed the drift now catch it.
+
 ## [0.18.0] - 2026-08-04
 
 ### Added
@@ -2995,7 +3029,8 @@ worth naming: SQL injection in `compile_sql` through undeclared field
 pass-through, fixed in 0.8.0 — v0.7.0 and earlier are affected. Details
 are in git history.
 
-[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.18.0...HEAD
+[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.19.0...HEAD
+[0.19.0]: https://github.com/na0fu3y/ochakai/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/na0fu3y/ochakai/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/na0fu3y/ochakai/compare/v0.16.1...v0.17.0
 [0.16.1]: https://github.com/na0fu3y/ochakai/compare/v0.16.0...v0.16.1

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -83,7 +83,7 @@ info:
     is a security defect, shipped in the next release with no deprecation
     window (SECURITY.md). MCP, the CLI and the stored shape stay unstable
     while the major version is 0 and may still change in a minor release.
-  version: 0.18.0
+  version: 0.19.0
   license:
     name: MIT
 servers:

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -79,7 +79,7 @@ export IMAGE=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:$VERSION
 `:latest` ではなくバージョンを固定し、再デプロイを意識的な判断にする。
 `gh` CLI が無ければ
 [リリースページ](https://github.com/na0fu3y/ochakai/releases)から番号
-を読み、手で設定する — `export VERSION=0.18.0`。
+を読み、手で設定する — `export VERSION=0.19.0`。
 
 (このガイドは 0.9.0 以降を前提にしている。それより前のリリースは
 [retract](https://go.dev/ref/mod#go-mod-file-retract) 済みでサポート外


### PR DESCRIPTION
## What and why

Version-bump PR for v0.19.0. Since [v0.18.0](https://github.com/na0fu3y/ochakai/releases/tag/v0.18.0), 12 PRs landed on `main`, none of which touched `CHANGELOG.md` themselves — three of them noted explicitly that the release skill writes that section. This PR is that pass.

**Minor bump, not patch**: `deploy/terraform`'s attachment-era name retirement (#493) is a breaking rename of the module's variables/outputs/resource, which this repo's convention (see the 0.18.0 entry for `OCHAKAI_EMBEDDINGS`, and the Terraform `webui_image_tag` entry before it) treats as BREAKING even outside the frozen REST surface.

### CHANGELOG entries added

**Added**
- `examples/bigquery-catalog` gained a day-one procedure, a sync job, and the first attester in the repo verifying a run after it happened (#495, #496, #497, #500)
- Release archives now carry `examples/` (#499)

**Fixed**
- **BREAKING (deploy/terraform)** — attachment-era names retired to match the wire's "file" (#493)
- Web UI's markdown renderer now parses GFM pipe tables (#494)
- `get_context`'s hint no longer teaches a retired status spelling (#498)

### Deliberately left out of the CHANGELOG

#491 (stale doc/test-comment counts), #496 (test-only), #497/#500/#502 (doc navigation and day-one run-through fixes to the brand-new example — folded into the Added entry above since the example never shipped in a working state before this release), #503 (doc-only operating.md fix). None of these touch the binary or its contract.

### Files changed

- `CHANGELOG.md` — `[Unreleased]` → `[0.19.0] - 2026-08-05`, fresh empty `[Unreleased]`, compare links
- `api/openapi.yaml` — `info.version` → `0.19.0`
- `.github/ISSUE_TEMPLATE/bug_report.yml` — version placeholder → `0.19.0`
- `deploy/cloudrun/README.md` — hand-set `export VERSION=` example → `0.19.0`

`grep -rn '0.18.0'` confirms the only remaining hits are legitimate historical references in `docs/guides/operating.md` and `docs/guides/troubleshooting.md`.

## Checks

- [x] `scripts/check` is clean (store tests skipped locally, CI runs them)
- [x] CI on `main` at the tip commit (#503) — confirmed green after a rerun; the first run's failure (`gzip: invalid header`, DB connection errors) was flaky, since the exact same commit had already passed all four required checks (test/lint/govulncheck/quickstart) as a PR before merging

## Test plan

- [ ] Merge this PR
- [ ] Tag the merged commit `v0.19.0` with the release notes as the annotated tag message
- [ ] Verify the published release (archives, checksums, attestations, `./ochakai version`, module proxy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)