### PR TITLE
Let the server say whether it wants an identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,23 @@ last entry.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The CLI can reach a public deployment without a Google account.**
+  Against any `https://` URL it used to resolve a Google ID token before
+  sending anything and abort when it found none — so `ochakai use
+  https://demo.example` saved fine and the next command died with "no
+  Google credentials", on the one posture that reads no identity and
+  never answers 401
+  ([0066](docs/design/0066-four-postures-one-word.md) §3). The client no
+  longer predicts the server's answer: holding no credentials it sends
+  none, and a deployment that wanted an identity says so with a 401 —
+  which is where the `gcloud auth login` advice now appears, carrying the
+  reason the request went out bare. Nothing changes for a caller who has
+  credentials, and `ochakai ui` and `ochakai mcp-stdio` reach a public
+  demo by the same path. No new flag, variable or command
+  ([docs/guides/operating.md](docs/guides/operating.md#public-demo)).
+
 ## [0.19.0] - 2026-08-05
 
 ### Added

--- a/cmd/ochakai/instances.go
+++ b/cmd/ochakai/instances.go
@@ -195,8 +195,11 @@ func cmdWhoami(ctx context.Context, args []string) error {
 
 	c, err := newClient(ctx, *target)
 	if err != nil {
+		// Not missing credentials any more: a client that cannot resolve
+		// them is still built and still asks the server (apiclient.New).
+		// What reaches here is a URL or a producer this shell got wrong.
 		report.Error = err.Error()
-		report.Health = "skipped (no credentials)"
+		report.Health = "skipped (no client)"
 	} else {
 		var actor string
 		if actor, report.Auth, err = c.Identity(); err != nil {

--- a/docs/guides/operating.md
+++ b/docs/guides/operating.md
@@ -785,6 +785,27 @@ curl -s -o /dev/null -w '%{http_code}\n' -X DELETE "$OCHAKAI_URL/api/v1/bundle/q
 read-only になった後では拒否される。デモのバンドルにはファイルが無い
 ので、デプロイガイド §4b のバケットはこれには要らない。
 
+### 訪問者が何を打つか
+
+Google アカウントを持たない人が、curl だけでなく CLI でも到達できる。
+クライアントは https だからという理由で資格情報を要求したりはせず、
+持っていなければ持たずに送り、**要ると言うかどうかはサーバーに任せる**
+— public は 401 を返さないので、そのまま通る:
+
+```sh
+go install github.com/na0fu3y/ochakai/cmd/ochakai@latest
+ochakai use https://demo.example      # デモの URL
+ochakai context "why is revenue down?"
+```
+
+`ochakai whoami` はこのとき `human:anonymous (no Google credentials
+found)` と表示する。これは推測ではなく、public が全員をそう解決する
+ことそのものである(設計ドキュメント 0066 §3)。`ochakai ui` と
+`ochakai mcp-stdio` も同じ資格情報無しの経路で動くので、web UI を
+公開ホストしなくても、訪問者は自分の loopback で UI を開ける。
+資格情報を要求するデプロイに同じことをすれば、サーバーが 401 で
+そう言い、CLI はそこで初めて `gcloud auth login` を促す。
+
 ### コスト
 
 デプロイガイド冒頭の表と同じ形である — デモは一つの Cloud Run サービス

--- a/internal/apiclient/apiclient.go
+++ b/internal/apiclient/apiclient.go
@@ -22,16 +22,29 @@ import (
 )
 
 type Client struct {
-	base     string // scheme://host, no trailing slash
-	http     *http.Client
-	tokens   oauth2.TokenSource // nil for plain-http development servers
-	auth     string             // human-readable auth path, for Identity
-	producer string             // "<producer>/<version>", sent on every request when set
+	base   string // scheme://host, no trailing slash
+	http   *http.Client
+	tokens oauth2.TokenSource // nil when this client sends no credentials
+	auth   string             // human-readable auth path, for Identity
+	// noCreds is why tokens is nil on an https server: the credentials
+	// could not be resolved. Nil when they were, and on plain http, where
+	// sending none is the intent rather than a failure.
+	noCreds  error
+	producer string // "<producer>/<version>", sent on every request when set
 }
 
 // New builds a client for the ochakai server at baseURL. For https URLs a
 // Google ID token source is resolved (design doc 0004 §4); plain http is
 // for local development and sends no credentials.
+//
+// Failing to resolve credentials is not an error here. Whether a
+// deployment wants an identity is the server's answer, and the client
+// cannot read it off the URL: a public demo (design doc 0066 §3) reads no
+// identity and never answers 401, so a caller with no Google account is
+// exactly who it is for. Refusing to send the request would deny that
+// caller on the client's guess. The reason is kept instead and surfaced
+// if the server does answer 401 — the deployments that need credentials
+// say so themselves, and only they.
 func New(ctx context.Context, baseURL string) (*Client, error) {
 	u, err := url.Parse(baseURL)
 	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
@@ -39,12 +52,16 @@ func New(ctx context.Context, baseURL string) (*Client, error) {
 	}
 	c := &Client{base: strings.TrimRight(baseURL, "/"), http: http.DefaultClient, auth: "plain http, no credentials"}
 	if u.Scheme == "https" {
-		if c.tokens, c.auth, err = tokenSource(ctx, u.Scheme+"://"+u.Host); err != nil {
-			return nil, err
+		if c.tokens, c.auth, err = resolveTokenSource(ctx, u.Scheme+"://"+u.Host); err != nil {
+			c.noCreds, c.auth = err, "no Google credentials found"
 		}
 	}
 	return c, nil
 }
+
+// resolveTokenSource is tokenSource, indirected so tests can drive both
+// outcomes without depending on the machine's Google credentials.
+var resolveTokenSource = tokenSource
 
 // SetProducer declares the software this client runs as, in SPEC §7's
 // "<producer>/<version>" form. It rides on every request and the server
@@ -56,14 +73,18 @@ func (c *Client) SetProducer(p string) { c.producer = p }
 
 // TokenSource exposes the resolved Google ID token source so callers can
 // build request paths of their own (e.g. `ochakai ui`'s reverse proxy).
-// Nil for plain-http development servers — send no credentials then.
+// Nil for plain-http development servers and for an https server this
+// machine has no credentials for — send no credentials then, and let the
+// server say whether it wanted any.
 func (c *Client) TokenSource() oauth2.TokenSource { return c.tokens }
 
 // Identity resolves, locally, the identity this client would present:
 // the ID token's email, prefixed the way the server maps actors (design
 // doc 0002) — service accounts to process:, everyone else to human:.
-// Plain-http development servers see human:anonymous. The server's actor
-// resolution is authoritative; this is the client's best-effort view.
+// A client sending no credentials — plain http, or an https server this
+// machine has none for — presents human:anonymous, which is what a public
+// deployment resolves every caller to (design doc 0066 §3). The server's
+// actor resolution is authoritative; this is the client's best-effort view.
 func (c *Client) Identity() (actor, auth string, err error) {
 	if c.tokens == nil {
 		return "human:anonymous", c.auth, nil
@@ -791,6 +812,14 @@ func (c *Client) doRaw(ctx context.Context, method, path string, query url.Value
 		data, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 		if json.Unmarshal(data, &msg) == nil {
 			apiErr.Message = msg.Error
+		}
+		// This client sent nothing because it had nothing, and this
+		// server — unlike a public one, which never answers 401 (design
+		// doc 0066 §3) — wanted an identity. Say why the request went out
+		// bare: Cloud Run rejects ahead of the container, so the body is
+		// Google's HTML and APIError alone would say only "Unauthorized".
+		if resp.StatusCode == http.StatusUnauthorized && c.noCreds != nil {
+			return nil, fmt.Errorf("server answered %w: %w", apiErr, c.noCreds)
 		}
 		return nil, apiErr
 	}

--- a/internal/apiclient/identity_test.go
+++ b/internal/apiclient/identity_test.go
@@ -36,6 +36,104 @@ func TestIdentityPlainHTTPIsAnonymous(t *testing.T) {
 	}
 }
 
+// withoutCredentials makes credential resolution fail for one test, the
+// way it fails on a machine with no service-account ADC and no gcloud.
+func withoutCredentials(t *testing.T) error {
+	t.Helper()
+	boom := errors.New("no Google credentials for the audience: need service-account ADC or the gcloud CLI (run `gcloud auth login`)")
+	saved := resolveTokenSource
+	resolveTokenSource = func(context.Context, string) (oauth2.TokenSource, string, error) {
+		return nil, "", boom
+	}
+	t.Cleanup(func() { resolveTokenSource = saved })
+	return boom
+}
+
+// A caller with no Google credentials must still get a client for an
+// https server: whether the deployment wants an identity is the server's
+// answer, and a public demo (design doc 0066 §3) wants none.
+func TestHTTPSWithoutCredentialsStillBuildsAnAnonymousClient(t *testing.T) {
+	withoutCredentials(t)
+	c, err := New(context.Background(), "https://demo.example/")
+	if err != nil {
+		t.Fatalf("New refused to build a client: %v", err)
+	}
+	if c.tokens != nil || c.TokenSource() != nil {
+		t.Error("client carries a token source it could not resolve")
+	}
+	actor, auth, err := c.Identity()
+	if err != nil || actor != "human:anonymous" || auth != "no Google credentials found" {
+		t.Errorf("actor = %q, auth = %q, err = %v", actor, auth, err)
+	}
+}
+
+// The public posture never answers 401 and reads no identity, so the
+// request goes out bare and succeeds — the whole point of the deferral.
+func TestPublicServerAnswersAnUncredentialedClient(t *testing.T) {
+	withoutCredentials(t)
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Errorf("sent Authorization %q; want none", got)
+		}
+		_, _ = w.Write([]byte(`{"hits":[]}`))
+	}))
+	defer srv.Close()
+
+	c, err := New(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.http = srv.Client()
+	if _, err := c.Search(context.Background(), SearchParams{Query: "revenue"}); err != nil {
+		t.Errorf("public server refused an anonymous search: %v", err)
+	}
+}
+
+// A server that does want an identity says so with 401, and only then
+// does the caller hear why the request went out without one.
+func TestUnauthorizedExplainsTheMissingCredentials(t *testing.T) {
+	boom := withoutCredentials(t)
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Cloud Run rejects ahead of the container: HTML, not JSON.
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("<html><title>401</title></html>"))
+	}))
+	defer srv.Close()
+
+	c, err := New(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.http = srv.Client()
+	err = c.Health(context.Background())
+	if !errors.Is(err, boom) {
+		t.Errorf("401 did not carry the credential reason: %v", err)
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusUnauthorized {
+		t.Errorf("401 did not stay inspectable as an APIError: %v", err)
+	}
+}
+
+// A 403 is a caller IAM refuses, not a caller with nothing to present;
+// nothing about credentials belongs in that message.
+func TestForbiddenIsNotBlamedOnCredentials(t *testing.T) {
+	boom := withoutCredentials(t)
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	c, err := New(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.http = srv.Client()
+	if err := c.Health(context.Background()); errors.Is(err, boom) {
+		t.Errorf("403 blamed on missing credentials: %v", err)
+	}
+}
+
 func TestIdentityPrefixesActors(t *testing.T) {
 	for email, want := range map[string]string{
 		"someone@example.com":                 "human:someone@example.com",


### PR DESCRIPTION
## Who got stuck, doing what

Someone with no Google account, trying to reach a public demo with the CLI.

`OCHAKAI_MODE=public` exists so that a deployment can be open to anyone: it reads no identity, never answers 401, and refuses every write (design doc [0066](https://github.com/na0fu3y/ochakai/blob/main/docs/design/0066-four-postures-one-word.md) §3). The operating guide's [Public demo](https://github.com/na0fu3y/ochakai/blob/main/docs/guides/operating.md#public-demo) section already tells an operator to verify it with a plain `curl` and no token.

The CLI could not do the same thing. `apiclient.New` resolved a Google ID token for any `https` URL **before sending anything** and returned the error when it found none, so the visitor the posture was built for got:

```
$ ochakai use https://demo.example        # fine, writes config, no network
$ ochakai context "why is revenue down?"
ochakai context: no Google credentials for https://demo.example:
need service-account ADC or the gcloud CLI (run `gcloud auth login`)
```

The client was answering a question only the server can answer, and answering it wrong for the one deployment shape that has no credentials to want.

## What changed

`New` no longer fails when credentials cannot be resolved. It keeps the reason, builds an anonymous client, and lets the request go out bare. If the server did want an identity it says so with a 401, and only then is the reason reported:

```
server answered Unauthorized: no Google credentials for https://...:
need service-account ADC or the gcloud CLI (run `gcloud auth login`)
```

The 401 stays inspectable as an `APIError`, so callers checking status codes are unaffected. A 403 is a caller IAM refuses rather than a caller with nothing to present, so nothing about credentials is added to it.

Nothing changes for a caller who has credentials: same single request, same token, no extra round trip. `ochakai ui` and `ochakai mcp-stdio` already accepted a nil token source, so they reach a public demo by the same path — a visitor can open the web UI on their own loopback against the demo, with no public UI to host.

## Surface

None added. No flag, no environment variable, no command; `TestSurfaceStaysUnderItsCaps` and the nine count checks pass untouched. Docs land at 5,582 lines against the 5,600 ceiling, inside `DOC-LINES-SLACK`.

No design record: 0066 §3 already decided that public reads no identity and answers no 401. This makes the client agree with it rather than deciding anything new.

## Verification

Four tests in `internal/apiclient/identity_test.go` drive credential resolution through a test seam so they do not depend on the machine's Google setup: the client is still built and still anonymous; a public server answers an uncredentialed search with no `Authorization` header sent; a 401 carries both the reason and the `APIError`; a 403 is not blamed on credentials. Reverting `New` to the old behavior fails three of them.

End to end, old and new binaries in the same empty environment (no `gcloud`, no ADC):

```
BEFORE: ochakai search: no Google credentials for https://example.com: ...
AFTER:  ochakai search: Not Found          # example.com's 404 — the request reached the network
```