### PR TITLE
Prepare release v0.19.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Version
       description: Output of `ochakai version`, or the image tag you deployed.
-      placeholder: "0.19.0"
+      placeholder: "0.19.1"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ last entry.
 
 ## [Unreleased]
 
+## [0.19.1] - 2026-08-06
+
 ### Fixed
 
 - **The CLI can reach a public deployment without a Google account.**
@@ -3046,7 +3048,8 @@ worth naming: SQL injection in `compile_sql` through undeclared field
 pass-through, fixed in 0.8.0 — v0.7.0 and earlier are affected. Details
 are in git history.
 
-[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.19.0...HEAD
+[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.19.1...HEAD
+[0.19.1]: https://github.com/na0fu3y/ochakai/compare/v0.19.0...v0.19.1
 [0.19.0]: https://github.com/na0fu3y/ochakai/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/na0fu3y/ochakai/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/na0fu3y/ochakai/compare/v0.16.1...v0.17.0

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -83,7 +83,7 @@ info:
     is a security defect, shipped in the next release with no deprecation
     window (SECURITY.md). MCP, the CLI and the stored shape stay unstable
     while the major version is 0 and may still change in a minor release.
-  version: 0.19.0
+  version: 0.19.1
   license:
     name: MIT
 servers:

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -79,7 +79,7 @@ export IMAGE=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:$VERSION
 `:latest` ではなくバージョンを固定し、再デプロイを意識的な判断にする。
 `gh` CLI が無ければ
 [リリースページ](https://github.com/na0fu3y/ochakai/releases)から番号
-を読み、手で設定する — `export VERSION=0.19.0`。
+を読み、手で設定する — `export VERSION=0.19.1`。
 
 (このガイドは 0.9.0 以降を前提にしている。それより前のリリースは
 [retract](https://go.dev/ref/mod#go-mod-file-retract) 済みでサポート外


### PR DESCRIPTION
## Summary
- Bump `[Unreleased]` to `[0.19.1] - 2026-08-06` in CHANGELOG.md (patch bump: the only unreleased entry is a Fixed item, no BREAKING)
- Bump version in `api/openapi.yaml`, `.github/ISSUE_TEMPLATE/bug_report.yml`, and `deploy/cloudrun/README.md`

## Test plan
- [x] `scripts/check` passes