### PR TITLE
Answer the field review: ownership by producer, and a calmer night

### DIFF
--- a/examples/bigquery-catalog/README.md
+++ b/examples/bigquery-catalog/README.md
@@ -1,6 +1,7 @@
 # BigQuery カタログの同期
 
-BigQuery のテーブルメタデータを `BigQuery Table` concept として ochakai に
+BigQuery のテーブルメタデータを `BigQuery Table` concept として、
+データセットごとの一覧を `BigQuery Dataset` concept として ochakai に
 投影する、毎日のジョブ。`shop.orders` について訊いたエージェントが、
 カラムと、忘れてはいけないパーティションフィルタと、その後に人が下に
 書き足したことを見つけられるようにする。

--- a/examples/bigquery-catalog/bundle/attesters/catalog-sync.py
+++ b/examples/bigquery-catalog/bundle/attesters/catalog-sync.py
@@ -16,10 +16,15 @@ does the same two jobs for `runtime: bigquery`:
      for a catalog whose primary key is its bundle path.
 
   2. Fidelity — does the reported outcome hold together? Every table the
-     run enumerated has to be accounted for by exactly one outcome, and
-     none of them may have failed. `tables_seen` is counted before a write
-     is attempted and the four outcomes after it, so a mismatch means a
-     table left the loop without being counted.
+     run enumerated — plus one dataset entry per dataset it was scoped to
+     — has to be accounted for by exactly one outcome, and none of them
+     may have failed. `tables_seen` is counted before a write is attempted
+     and the five outcomes after it, so a mismatch means a table left the
+     loop without being counted. `missing` is an outcome and not a
+     failure: a table dropped between the listing and the read is a
+     warehouse's ordinary day, and a check that turns red for it is a red
+     nobody reads. What guards against the catalog actually draining away
+     is check 4, which sees the trend, not the night.
 
   3. Ownership — the run still projected something. `written` and
      `unchanged` are the two outcomes that leave an entry the sync's;
@@ -67,6 +72,7 @@ RECEIPT_FIELDS = (
     "written",
     "unchanged",
     "skipped",
+    "missing",
     "failed",
 )
 
@@ -76,7 +82,7 @@ RECEIPT_FIELDS = (
 DEFAULT_MIN_RATIO = 0.5
 
 _SCOPE_STRINGS = ("sync_identity", "project", "prefix")
-_OUTCOMES = ("written", "unchanged", "skipped", "failed")
+_OUTCOMES = ("written", "unchanged", "skipped", "missing", "failed")
 
 
 def _verdict(ok: bool, reason: str | None, **details: Any) -> dict[str, Any]:
@@ -172,21 +178,28 @@ def attest(
                             value=repr(receipt[field]))
         counts[field] = value
 
+    # One outcome per table enumerated, plus one per dataset in scope —
+    # each dataset's own entry leaves the run by the same five doors.
     accounted = sum(counts[f] for f in _OUTCOMES)
-    if accounted != counts["tables_seen"]:
-        return _verdict(False, "tables seen and tables accounted for disagree",
-                        tables_seen=counts["tables_seen"], accounted=accounted,
-                        counts=counts)
+    expected = counts["tables_seen"] + len(got["datasets"])
+    if accounted != expected:
+        return _verdict(False, "objects seen and outcomes accounted for disagree",
+                        tables_seen=counts["tables_seen"],
+                        dataset_entries=len(got["datasets"]),
+                        accounted=accounted, counts=counts)
 
     if counts["failed"]:
         return _verdict(False, "the run reported failed tables",
                         failed=counts["failed"])
 
-    # 3. Ownership.
+    # 3. Ownership. `expected` is never zero — a run is scoped to at least
+    # one dataset, whose own entry it must keep current or be told a
+    # person took the whole catalog.
     projected = counts["written"] + counts["unchanged"]
-    if counts["tables_seen"] and not projected:
-        return _verdict(False, "the run projected nothing: every table was skipped",
-                        tables_seen=counts["tables_seen"], skipped=counts["skipped"])
+    if not projected:
+        return _verdict(False, "the run projected nothing: every entry was skipped or gone",
+                        tables_seen=counts["tables_seen"], skipped=counts["skipped"],
+                        missing=counts["missing"])
 
     # 4. Continuity.
     if previous is not None:

--- a/examples/bigquery-catalog/bundle/jobs/sync-bigquery-catalog.md
+++ b/examples/bigquery-catalog/bundle/jobs/sync-bigquery-catalog.md
@@ -18,7 +18,7 @@ parameters:
 computation: /jobs/sync-bigquery-catalog/sync-bigquery-catalog.py
 executor:
   resource: /skills/run-a-python-job.md
-  receipt: [sync_identity, project, datasets, prefix, tables_seen, written, unchanged, skipped, failed]
+  receipt: [sync_identity, project, datasets, prefix, tables_seen, written, unchanged, skipped, missing, failed]
 attester:
   resource: /attesters/catalog-sync.py
 ---
@@ -61,6 +61,17 @@ partition filter is mandatory, which is the thing an agent most needs to
 know before it writes a query — the row count, the view SQL when it is a
 view, and an empty `# Caveats` section for a person to fill in.
 
+And one entry per dataset, at `catalog/bigquery/<project>/<dataset>` —
+the dataset's own description and a table list linking to the entries
+under it, which is the address "what is in shop?" resolves to. The
+concept and the directory of its tables share that name by design
+(design doc 0075 §2), and the OKF reference bundle keeps a dataset
+concept beside its table concepts for the same reason. One discipline
+travels with it: the list is a claim about the *whole* dataset, so only
+a run that enumerated the whole dataset writes it. If you narrow this
+script — one table, one glob — leave the dataset entry alone rather
+than have it recite tables the run never saw.
+
 Three of those choices are load-bearing:
 
 - **No `title`.** The id's last segment is the display name, and that
@@ -82,10 +93,27 @@ Three of those choices are load-bearing:
 
 The obvious failure mode of any sync is that it flattens what a person
 wrote, the next morning, silently. This one writes an entry only while
-**nobody has ruled on it and the last writer was the sync account**, and
-the write is conditional on the version it read, so an edit landing
+**nobody has ruled on it and the standing text is the projection's own**,
+and the write is conditional on the version it read, so an edit landing
 between the read and the write loses the race instead of being erased by
 it.
+
+"The projection's own" is recognized by the `Ochakai-Producer` stamp
+every write here carries (`sync-bigquery-catalog/2`, design doc 0052) —
+deliberately the stamp, not the account. A catalog grown on demand is
+refreshed by whoever needed it: A's morning run under A's account, B's
+under B's, the nightly one under the scheduler's. A rule keyed to one
+account would have B's run skip every entry A projected, forever. Keyed
+to the producer, every run of this computation recognizes every other
+run's writes as machine-owned, while a person's edit — through the CLI,
+the web UI, an agent — names a different producer or none, and that is
+what takes the entry out. The stamp is self-declared and recorded beside
+the authenticated actor, never in place of it, so this is a courtesy
+contract between runs rather than a lock — which is all a sync needs:
+the point was never to stop a person, only to notice one. (Entries
+written before the stamp existed carry no producer; for those, and only
+those, the last-writer account still decides, so the first run under the
+old identity re-stamps them and the rule converges.)
 
 "Nobody has ruled on it" is three separate questions, because ochakai
 keeps the three apart: the **lifecycle** is what the writer declared —
@@ -103,8 +131,8 @@ different things:
 - **`ochakai verify`** — "I checked this and it is right." The entry stops
   being a projection and becomes curated knowledge. Its status does not
   change; its trust tier does, and that is what the sync sees.
-- **Editing the body** — enough on its own; the sync sees a different
-  writer and leaves it alone from then on.
+- **Editing the body** — enough on its own; the sync sees a write that
+  does not carry its producer and leaves the entry alone from then on.
 
 The cost is real: a frozen entry stops receiving schema changes, so a
 column added next month will not appear in it. If what you wrote is *about*
@@ -129,7 +157,8 @@ prints its receipt to stdout as JSON and its progress to stderr:
 {"sync_identity": "catalog-sync@my-project.iam.gserviceaccount.com",
  "project": "my-project", "datasets": ["marketing", "shop"],
  "prefix": "catalog/bigquery",
- "tables_seen": 84, "written": 3, "unchanged": 69, "skipped": 12, "failed": 0}
+ "tables_seen": 84, "written": 3, "unchanged": 70, "skipped": 12,
+ "missing": 1, "failed": 0}
 ```
 
 `attester.resource` points at
@@ -144,9 +173,15 @@ reference bundle's `sql_equality.py` asks of a SQL run:
    second one at addresses nobody is watching and left the first to rot.
    This is why the scope is in the receipt at all.
 2. **Fidelity — does the outcome hold together?** `written + unchanged +
-   skipped + failed` must equal `tables_seen`, and `failed` must be zero.
-   The count is taken before a write is attempted and the outcomes after,
-   so a disagreement means a table left the loop uncounted.
+   skipped + missing + failed` must equal `tables_seen` plus one dataset
+   entry per dataset in scope, and `failed` must be zero. The count is
+   taken before a write is attempted and the outcomes after, so a
+   disagreement means a table left the loop uncounted. `missing` — a
+   table dropped between the listing and the read — is an outcome, not a
+   failure: deletion is a warehouse's ordinary day, and a nightly job
+   that turns red for the world changing normally is a red nobody reads.
+   What failed asks is whether the *run* broke; whether the *catalog* is
+   draining away is check 4's question, asked across nights.
 3. **Ownership** — the run projected something. `written` and `unchanged`
    leave an entry the job's; `skipped` says a person took it. A night where
    every table was skipped refreshed nothing, and the two checks above call
@@ -197,5 +232,6 @@ authorized with.
   datasets your agents actually query, and add more when that stops being
   true.
 - **No deletes.** A table that disappears from BigQuery leaves its entry
-  behind. Removing knowledge is a human decision, and the entry may be the
-  only remaining record of what the table meant.
+  behind — the run counts it `missing` and moves on. Removing knowledge is
+  a human decision, and the entry may be the only remaining record of what
+  the table meant.

--- a/examples/bigquery-catalog/bundle/jobs/sync-bigquery-catalog/sync-bigquery-catalog.py
+++ b/examples/bigquery-catalog/bundle/jobs/sync-bigquery-catalog/sync-bigquery-catalog.py
@@ -12,7 +12,8 @@ under your own service account, against the same REST API the CLI uses.
 
 Reads BigQuery, writes ochakai, and holds no secret: BigQuery is reached
 with Application Default Credentials, and ochakai with a Google-minted ID
-token for the Cloud Run service.
+token for the Cloud Run service — or with OCHAKAI_ID_TOKEN, for a person
+whose own ADC cannot mint one.
 
     pip install google-cloud-bigquery google-auth requests
 
@@ -26,15 +27,24 @@ import argparse
 import base64
 import datetime
 import json
+import os
 import sys
 
 import google.auth
 import google.auth.transport.requests
 import google.oauth2.id_token
 import requests
+from google.api_core.exceptions import NotFound
 from google.cloud import bigquery
 
 TIMEOUT = 30
+
+# The stamp every write carries, as Ochakai-Producer (design doc 0052).
+# Ownership below is keyed to it rather than to an account, so any run of
+# this computation — the nightly service account, a person refreshing the
+# dataset they need this morning — recognizes every other run's writes as
+# the projection's. Bump the version when the documents change shape.
+PRODUCER = "sync-bigquery-catalog/2"
 
 
 # --------------------------------------------------------------- identity
@@ -43,10 +53,18 @@ TIMEOUT = 30
 def id_token_for(audience: str) -> str:
     """Mint a Google ID token for a private Cloud Run service.
 
-    Returns "" when the environment cannot mint one — a user's own ADC
-    cannot — which is fine against a local OCHAKAI_INSECURE_DEV server and
-    fatal against Cloud Run, where the server says so itself with a 403.
+    OCHAKAI_ID_TOKEN, when set, is used as-is and wins: a person's own ADC
+    cannot mint an ID token, so a human running this by hand brings one in
+    with
+
+        OCHAKAI_ID_TOKEN=$(gcloud auth print-identity-token)
+
+    Returns "" when the variable is unset and the environment cannot mint
+    one either — which is fine against a local OCHAKAI_INSECURE_DEV server
+    and fatal against Cloud Run, where the server says so itself with a 403.
     """
+    if token := os.environ.get("OCHAKAI_ID_TOKEN", ""):
+        return token
     try:
         request = google.auth.transport.requests.Request()
         return google.oauth2.id_token.fetch_id_token(request, audience)
@@ -168,9 +186,9 @@ def build_document(table, fq: str, dataset: str, usage: dict | None,
     lifecycle is the writer's declaration, so the writer declares it.
 
     Re-writing it costs nothing: the only entry this job ever replaces is
-    one it wrote itself, which was already a draft. A person's edit takes
-    the entry out through the writer check, and a verification through
-    the trust tier — neither is reached by way of `status`.
+    one the projection wrote, which was already a draft. A person's edit
+    takes the entry out through the producer check, and a verification
+    through the trust tier — neither is reached by way of `status`.
 
     `title` is absent too — the
     id's last segment is the display name (design doc 0074 §1), and that
@@ -213,6 +231,51 @@ def build_document(table, fq: str, dataset: str, usage: dict | None,
     return f"---\n{frontmatter(keys)}---\n\n{body}"
 
 
+def build_dataset_document(ds, project: str, dataset: str,
+                           tables: list[tuple[str, str]], prefix: str) -> str:
+    """The dataset as an entry: what it is, and which tables it holds.
+
+    Written only by a run that enumerated the whole dataset. The table
+    list is a claim about everything in it, and a run that looked at less
+    — one table, one glob — has no business making it; narrow this script
+    down and the right move is to leave the dataset entry alone rather
+    than have it recite tables the run never saw. The OKF reference
+    bundle keeps a dataset concept beside its table concepts for the same
+    reason: "what is in shop?" is a question with an address.
+
+    That address is `<prefix>/<project>/<dataset>` — the same name its
+    tables sit under as a directory. A concept and a directory of the
+    same name coexist by design (design doc 0075 §2).
+    """
+    resource = f"bigquery://{project}.{dataset}"
+    keys = {
+        "type": "BigQuery Dataset",
+        "resource": resource,
+        "description": (ds.description or "").split("\n")[0][:280],
+        "tags": ["bigquery", dataset],
+        "status": "draft",
+        "sources": [{"resource": resource, "title": f"{project}.{dataset}"}],
+    }
+    lines = ["# Tables", ""]
+    if tables:
+        lines += ["| table | description |", "|---|---|"]
+        for name, desc in tables:
+            link = f"/{prefix}/{project}/{dataset}/{name}.md"
+            lines.append(f"| [{name}]({link}) | {desc.replace('|', r'\|')} |")
+    else:
+        lines.append("_No tables the run could read._")
+    lines += [
+        "",
+        "# Caveats",
+        "",
+        "_Nothing recorded yet._ Write what an agent has to know before it",
+        "works in this dataset — which table is the source of truth, which",
+        "ones are deprecated, where the bodies are buried. Then `ochakai",
+        "verify` this entry and the sync will leave your text alone.",
+    ]
+    return f"---\n{frontmatter(keys)}---\n\n" + "\n".join(lines) + "\n"
+
+
 # ----------------------------------------------------------------- upsert
 
 
@@ -227,7 +290,13 @@ class Ochakai:
 
     def __init__(self, url: str, token: str):
         self.url = url.rstrip("/")
-        self.headers = {"Authorization": f"Bearer {token}"} if token else {}
+        # Every request names its software. The server records the value
+        # beside the authenticated actor, never in place of it (design doc
+        # 0052) — which is exactly what lets the next run tell a
+        # projection from a person, whoever ran this one.
+        self.headers = {"Ochakai-Producer": PRODUCER}
+        if token:
+            self.headers["Authorization"] = f"Bearer {token}"
 
     def _at(self, entry_id: str) -> str:
         return f"{self.url}/api/v1/bundle/{entry_id}.md"
@@ -292,13 +361,23 @@ def upsert(api: Ochakai, entry_id: str, document: str, identity: str, counts: di
     """Write the projection, unless a person has taken it over.
 
     The rule, in full: write only while nobody has ruled on the entry and
-    this account was its last writer, and make the write conditional so an
-    edit landing between the read and the write loses the race instead of
-    being erased by it (design doc 0030). Verifying an entry — or simply
-    editing it — takes it out of the sync for good. That is the same line
-    design doc 0067 §6 draws for MCP, applied from outside: a machine
-    does not overwrite what a human ruled on. ochakai needs no owner field
-    and no authorization for this; the projection and provenance carry it.
+    the standing text is the projection's own, and make the write
+    conditional so an edit landing between the read and the write loses
+    the race instead of being erased by it (design doc 0030). Verifying an
+    entry — or simply editing it — takes it out of the sync for good. That
+    is the same line design doc 0067 §6 draws for MCP, applied from
+    outside: a machine does not overwrite what a human ruled on. ochakai
+    needs no owner field and no authorization for this; the projection and
+    provenance carry it.
+
+    "The projection's own" is keyed to the producer stamp, not to the
+    account. A catalog grown on demand is refreshed by whoever needed it —
+    A's run under A's account, B's under B's — and a rule keyed to one
+    account would have B skip every entry A projected, forever. Any run of
+    this computation names PRODUCER; a person's edit — CLI, web UI, an
+    agent — names a different producer or none, and that is what takes the
+    entry out. The last-writer identity survives only as a fallback for
+    entries written before the stamp existed.
     """
     view, etag = api.read(entry_id)
     if view is None:
@@ -313,12 +392,13 @@ def upsert(api: Ochakai, entry_id: str, document: str, identity: str, counts: di
         return
 
     # Who wrote the words that stand there now (design doc 0065 §4): under
-    # delegation this is the end user, which is exactly right — a person
-    # who edited through an application is a person who edited.
-    writer = view.get("observed", {}).get("generated", {}).get("by", {}).get("name", "")
-    if identity and writer != identity:
+    # delegation the name is the end user's, which is exactly right — a
+    # person who edited through an application is a person who edited.
+    by = view.get("observed", {}).get("generated", {}).get("by", {})
+    ours = by.get("producer", "") == PRODUCER or not identity or by.get("name", "") == identity
+    if not ours:
         counts["skipped"] += 1
-        print(f"skip   {entry_id} — last written by {writer}", file=sys.stderr)
+        print(f"skip   {entry_id} — last written by {by.get('name', '?')}", file=sys.stderr)
         return
 
     if api.write(entry_id, document, if_match=etag):
@@ -397,8 +477,12 @@ def main() -> int:
               f"in region-{args.jobs_region}", file=sys.stderr)
         usage = usage_counts(client, args.project, args.jobs_region, args.usage_days)
 
-    counts = {"tables_seen": 0, "written": 0, "unchanged": 0, "skipped": 0, "failed": 0}
+    counts = {"tables_seen": 0, "written": 0, "unchanged": 0,
+              "skipped": 0, "missing": 0, "failed": 0}
     for dataset in args.datasets:
+        # (name, first line of its description) for the dataset entry: the
+        # tables this run actually read, which is the only list it may claim.
+        tables: list[tuple[str, str]] = []
         for item in client.list_tables(dataset):
             if item.table_type not in ("TABLE", "VIEW"):
                 continue
@@ -408,6 +492,7 @@ def main() -> int:
             entry_id = f"{args.prefix}/{args.project}/{dataset}/{name}"
             try:
                 table = client.get_table(f"{args.project}.{dataset}.{name}")
+                tables.append((name, (table.description or "").split("\n")[0]))
                 document = build_document(table, fq, dataset,
                                           usage.get(f"{dataset}.{name}"), window,
                                           args.frequent_threshold)
@@ -420,9 +505,38 @@ def main() -> int:
                     print(document)
                     continue
                 upsert(api, entry_id, document, identity, counts)
+            except NotFound:
+                # Dropped between the listing and the read. Deletion is a
+                # warehouse's ordinary day, so it is an outcome, not a
+                # failure — a nightly job that turns red for it is a red
+                # nobody reads. The entry it leaves behind stays (no
+                # deletes, below); a catalog that actually collapses is the
+                # attester's continuity check, not this run's exit code.
+                counts["missing"] += 1
+                print(f"gone   {entry_id} — dropped between list and read", file=sys.stderr)
             except Exception as err:  # noqa: BLE001 — one bad table is not a bad run
                 counts["failed"] += 1
                 print(f"FAIL   {entry_id} — {err}", file=sys.stderr)
+
+        # One entry for the dataset itself, listing the tables read above —
+        # written here, and only here, because this loop enumerated the
+        # whole dataset and can vouch for the list it writes.
+        entry_id = f"{args.prefix}/{args.project}/{dataset}"
+        try:
+            document = build_dataset_document(client.get_dataset(dataset),
+                                              args.project, dataset, tables,
+                                              args.prefix)
+            if args.dry_run:
+                print(f"=== {entry_id}.md")
+                print(document)
+            else:
+                upsert(api, entry_id, document, identity, counts)
+        except NotFound:
+            counts["missing"] += 1
+            print(f"gone   {entry_id} — dropped between list and read", file=sys.stderr)
+        except Exception as err:  # noqa: BLE001
+            counts["failed"] += 1
+            print(f"FAIL   {entry_id} — {err}", file=sys.stderr)
 
     # The receipt the entry's executor declares. Every field here is one a
     # run has to bring back; checking them is the consumer's job, never

--- a/examples/bigquery-catalog/bundle/skills/build-the-first-catalog.md
+++ b/examples/bigquery-catalog/bundle/skills/build-the-first-catalog.md
@@ -79,17 +79,23 @@ Run without `--dry-run`, keep the receipt, and hand it to the attester with
 the scope **you authorized in step 3** — not with whatever the run reports:
 
 ```sh
+export OCHAKAI_ID_TOKEN=$(gcloud auth print-identity-token)
+
 python sync-bigquery-catalog.py --project my-project --datasets shop \
   --ochakai-url "$OCHAKAI_URL" > receipt.json
 
-python catalog-sync.py --sync-identity "$SYNC_ACCOUNT" --project my-project \
+python catalog-sync.py --sync-identity you@example.com --project my-project \
   --datasets shop --prefix catalog/bigquery < receipt.json
 ```
 
-Progress goes to stderr, so the redirect captures the receipt and nothing
-else. The attester exits 0 only if the run counted; keep the receipt of a
-run that passed and pass it as `--previous` tomorrow, which is what turns
-on the check that the catalog did not collapse overnight.
+The first line is what lets day one be run by hand: your own ADC cannot
+mint the ID token a private Cloud Run service wants, so you mint one with
+gcloud and the script uses it as-is. `--sync-identity` is then your own
+email — the identity you authorized the run to use is the one you ran it
+as. Progress goes to stderr, so the redirect captures the receipt and
+nothing else. The attester exits 0 only if the run counted; keep the
+receipt of a run that passed and pass it as `--previous` tomorrow, which
+is what turns on the check that the catalog did not collapse overnight.
 
 The job's own exit code is not that check. A run that wrote a whole second
 catalog under the wrong prefix exits 0 and looks like a good night. What
@@ -97,14 +103,18 @@ the four checks are, and why the first one bites hardest, is in
 [the job itself](/jobs/sync-bigquery-catalog.md).
 
 **This step wants the deployment, not a local instance.** `sync_identity`
-is the email claim of the ID token the run minted, and an instance you can
-reach without credentials makes it mint none — the field comes back empty
+is the email claim of the ID token the run used, and an instance you can
+reach without credentials makes it use none — the field comes back empty
 and the attester refuses the receipt rather than attest a run that cannot
 say who made it. That is the right answer, and it means the dev instance
 you dry-ran against in step 2 cannot carry you past here.
 
 Everything is now a draft written by a machine. Nothing here is knowledge
-yet.
+yet. And nothing here is yours in the ownership rule's eyes, even though
+you ran it as yourself: the writes carry the sync's producer stamp, so
+when the scheduled service account takes over tomorrow it recognizes your
+day-one entries as the projection's and keeps them current, instead of
+skipping a catalog that looks like a person wrote it.
 
 ### 5. Turn one table into knowledge
 

--- a/examples/bigquery-catalog/bundle/skills/run-a-python-job.md
+++ b/examples/bigquery-catalog/bundle/skills/run-a-python-job.md
@@ -20,10 +20,19 @@ The procedure the `runtime: python` entries in this bundle name as their
 2. Pass every entry in `parameters` as the matching `--flag`. `datasets`
    takes several values; `dry_run` prints the documents instead of writing
    them, which is how you check a change before it touches the base.
-3. Run it as a service account, not as yourself. A person's own credentials
-   cannot mint the ID token a private Cloud Run service wants, and — more
-   to the point — provenance should say a job wrote these entries, because
-   a job did.
+3. Run the *scheduled* job as a service account: provenance should say a
+   job wrote these entries, because a job did. Running it by hand — day
+   one, a backfill, the dataset you need refreshed this morning — is done
+   as yourself. A person's own ADC cannot mint the ID token a private
+   Cloud Run service wants, so bring one in:
+
+   ```sh
+   export OCHAKAI_ID_TOKEN=$(gcloud auth print-identity-token)
+   ```
+
+   Provenance then names you, which is true; the `Ochakai-Producer` stamp
+   on every write is what lets the next run — anyone's — recognize your
+   run's entries as the projection's rather than skip them as a person's.
 4. Return the receipt (below).
 
 ```sh
@@ -38,7 +47,10 @@ python sync-bigquery-catalog.py \
 
 A Cloud Run job on a Cloud Scheduler trigger is the obvious shape for the
 daily run; the script exits non-zero if any table failed, so a bad night
-shows red without anyone reading the log.
+shows red without anyone reading the log. A table that vanished between
+the listing and the read is `missing`, not `failed`, and does not turn
+the night red — deletion is a warehouse's ordinary day, and a schedule
+that cries wolf over it stops being believed.
 
 ## What it needs, and what it must not have
 
@@ -65,29 +77,31 @@ that is missing one rather than guessing what it meant.
 
 | Field | Where it comes from |
 |---|---|
-| `sync_identity` | the email claim of the ID token the run used — who the entries will say wrote them. Empty when there was no token to mint, and the attester refuses a receipt that cannot name its run |
+| `sync_identity` | the email claim of the ID token the run used — who the entries will say wrote them. Empty when there was no token to mint or bring, and the attester refuses a receipt that cannot name its run |
 | `project` | the `--project` the run used |
 | `datasets` | the `--datasets` it was given, sorted |
 | `prefix` | the `--prefix` the ids were built under |
 | `tables_seen` | tables and views considered, before any ownership check |
-| `written` | entries created or updated |
+| `written` | entries created or updated, dataset entries included |
 | `unchanged` | entries whose bytes already matched, so no revision was made |
-| `skipped` | entries left alone because a person had verified or edited them |
+| `skipped` | entries left alone because a person had verified, edited or rejected them |
+| `missing` | tables dropped between the listing and the read — the world changed, the run did not break, and the exit code stays 0 |
 | `failed` | tables that errored; the run's exit code is non-zero when this is not 0 |
 
 The four scope fields are there because the entry id is derived from them.
-`sync_identity` is the one worth checking hardest: the whole ownership rule
-rests on the job recognizing its own past writes, so a run under an
-unexpected account does not merely mislabel provenance — it stops seeing
-the entries as its own and skips the entire catalog, quietly.
+Ownership itself no longer hangs on `sync_identity` — the producer stamp
+is what a run recognizes its predecessors by, whoever ran them — but the
+receipt still has to name who ran, because the attester's provenance
+check is about whether the run was the one sanctioned, and entries from
+before the stamp existed are still recognized by account.
 
 ## Post-conditions
 
 Hand the receipt to the entry's `attester.resource` together with the
 values the run was authorized with. Do not report the catalog as refreshed
-until the attester returns `ok: true`; a verdict that fails names which of
-the three checks it was, and the run's own exit code cannot tell you —
-a run that wrote a whole second catalog under the wrong prefix exits 0.
+until the attester returns `ok: true`; a verdict that fails names which
+check it was, and the run's own exit code cannot tell you — a run that
+wrote a whole second catalog under the wrong prefix exits 0.
 
 ## What this is not
 


### PR DESCRIPTION
## What and why

Field review from someone actually loading a BigQuery catalog into
ochakai. Four findings against `examples/bigquery-catalog`, all four
adopted; nothing in the server changes, because nothing in the server was
wrong.

**1. The ownership rule assumed a single scheduled account.** The
last-writer check reads "was this entry's last writer me?", which is true
of one service account on a cron and false the moment the catalog is
grown the way ochakai says knowledge should be grown — on demand, by
whoever needs it. A's run projects `shop.orders`; B's run then sees a
different last writer and skips it, forever. The reporter's own
deployment worked around it by deleting the writer check entirely and
ruling on the lifecycle/trust/rejection triple alone — which is a real
deviation: an entry a person edited but left `draft` and unverified goes
back to being machine-owned, and gets flattened the next morning.

The fix they pointed at is the one taken: **provenance already carries
this, so use it.** Every write now sends
`Ochakai-Producer: sync-bigquery-catalog/2` (design doc 0052), and
ownership is keyed to the stamp rather than the account. Every run of the
computation recognizes every other run's projections whoever ran them; a
person's edit — CLI, web UI, an agent — carries a different producer or
none, and still takes the entry out. Entries written before the stamp
existed carry no producer, so for those and only those the last-writer
account still decides, and the first run under the old identity
re-stamps them. No new mechanism, no owner field, no authorization: a
header that could already carry this is now carried.

**2. Making a dropped table `failed` cries wolf.** Deleting a table is a
warehouse's ordinary day, so a nightly job that exits 1 for it goes red
for the world changing normally, and a red nobody reads is worse than no
check. `NotFound` between the listing and the read is now a `missing`
outcome inside the conservation law, and the exit code stays 0. The
separation the reporter drew is the right one and is now written down:
`failed` asks whether the *run* broke; whether the *catalog* is draining
away is the attester's continuity check, asked across nights.

**3. No ID-token path for a person running it by hand.** `id_token_for()`
cannot mint from a user's own ADC, so a human following the day-one skill
sends nothing and gets a 403. `OCHAKAI_ID_TOKEN` is now used as-is when
set — three lines — and the day-one skill's step 4 opens with
`export OCHAKAI_ID_TOKEN=$(gcloud auth print-identity-token)`. This
lands well next to (1): running day one as yourself records *you* as the
writer, which is true, and the producer stamp is what lets tomorrow's
scheduled account adopt those entries instead of skipping a catalog that
looks like a person wrote it.

**4. No dataset entry.** The OKF reference bundle has a dataset concept;
this example had tables only. One entry per dataset now lands at
`<prefix>/<project>/<dataset>` — the dataset's description and a linked
table list, which is the address "what is in shop?" resolves to. That
name is also the directory its tables sit in, and the two coexist by
design (0075 §2 — independently confirmed by this deployment, see below).
The reporter's discipline travels with it, because it is the load-bearing
half: the list is a claim about the *whole* dataset, so only a run that
enumerated the whole dataset writes it. Narrow the script to one table
and the right move is to leave the dataset entry alone rather than have
it recite tables the run never saw.

### Reported working as documented

Worth recording, since it is the first outside confirmation of four
decisions and one of them is what (4) above stands on:

- Conditional writes (`If-Match` / `If-None-Match`) and
  `Ochakai-Unchanged` behaved exactly as documented — zero revision noise
  across daily re-runs (0030).
- Block scalars in frontmatter and a ~23 KB `description` were accepted
  and returned unchanged.
- A concept at `bigquery/p/d.md` and a directory `bigquery/p/d/…` coexist
  naturally — the bundle address space (0075) verified in the field.
- Write-time embedding plus Japanese semantic search returned the right
  table for a natural-language question.

## Checks

- [x] `scripts/check` is clean — no store change, so no `--db`
      (golangci-lint 2.12.2: 0 issues; govulncheck: none)
- [x] Behavior changes come with tests — as much as this layer has one.
      The bundle is under `TestExampleBundlesReadCleanly` and
      `TestExamplesCallAddressesThisBuildServes` in
      `cmd/ochakai/examples_test.go`, which is what fails on a broken body
      link, an unattributed file, or a folded-away endpoint. The two
      Python files are not compiled by CI, so their behavior was driven
      directly: the attester over seven receipts (conservation short by
      the dataset entry, `missing` counted, `failed`, every-entry-skipped,
      a pre-`missing` receipt, a halved catalog), and `upsert` over five
      ownership states (other account + our producer → writes; no producer
      + same account → writes; no producer + other account → skips;
      `claude-code/1` → skips; verified + our producer → skips).

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`,
      `internal/apiclient` — untouched, and consistent, because this is a
      client of the contract rather than a change to it
- [x] Lands where it belongs: `examples/` only. Nothing here is a feature
      on any of the four faces (0067)
- [x] `api/openapi.frozen.txt` untouched. No wire change
- [x] **No surface widened.** `docs/surface.md` is unchanged and
      `TestSurfaceDocCountsEnvironmentVariables` still passes:
      `OCHAKAI_ID_TOKEN` is read by an example script, and the ENV count
      is of variables the shipped binary asks for. `Ochakai-Producer` is
      an existing header (HEADER count unchanged) that this example now
      sends. The three questions therefore do not arise — nothing was
      added to ochakai. Serving C7 (a measurable improvement loop) and C4
      (no forward-deployed engineer): the reporter deviated from the
      shipped example to keep working, and an example that has to be
      deviated from is the FDE the project refuses to send, arriving as
      homework instead

## Design docs

- [x] Not applicable. Nothing accepted is altered: ownership by producer
      is 0052's field used as 0052 describes it, provenance is 0065,
      conditional writes are 0030, and the dataset entry sharing a name
      with its directory is 0075 §2. The decisions here are the example's
      own — which outcome a dropped table gets, what a dataset entry may
      claim — and 0048 puts those in the PR description, which is this
- [x] Commit messages and code comments are in English
