### PR TITLE
Put the public demo first in the quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,22 @@ to verify or reject them](docs/images/webui-review.png)
 
 ## Quick start
 
+A public demo already holds the knowledge base below. It reads no
+identity and writes nothing, which is what makes it safe to leave open
+([design doc 0066](docs/design/0066-four-postures-one-word.md) §3), so
+there is no account and nothing to configure:
+
+```sh
+go install github.com/na0fu3y/ochakai/cmd/ochakai@latest
+ochakai use https://demo.ochak.ai
+ochakai context "why is revenue down?"
+```
+
+It is also the one deployment where plain curl works — nothing to sign:
+`curl 'https://demo.ochak.ai/api/v1/search?q=revenue'`.
+
+To hold knowledge of your own, run a server:
+
 ```sh
 git clone https://github.com/na0fu3y/ochakai && cd ochakai
 docker compose -f deploy/compose.yaml up -d


### PR DESCRIPTION
The README opened by asking the reader to clone the repository and run Postgres before ochakai answered anything. A public demo is up now, so the first thing the quick start asks for is a question:

```sh
go install github.com/na0fu3y/ochakai/cmd/ochakai@latest
ochakai use https://demo.ochak.ai
ochakai context "why is revenue down?"
```

The local compose stack keeps its place directly below, under "To hold knowledge of your own".

## Why this instance can be named here

It runs `OCHAKAI_MODE=public` (design doc [0066](https://github.com/na0fu3y/ochakai/blob/main/docs/design/0066-four-postures-one-word.md) §3): it reads no identity, resolves every caller to `human:anonymous`, and refuses every write. That is also why plain `curl` works against it and against nothing else, which the README now says.

It was stood up by the documented order in [operating.md](https://github.com/na0fu3y/ochakai/blob/main/docs/guides/operating.md#public-demo): deploy private and writable, `import examples/demo`, set `OCHAKAI_MODE=public`, then grant `allUsers`. Embeddings are off; `--max-instances=1` is kept.

## Reaching it with the CLI needs 0.19.1

Before [#508](https://github.com/na0fu3y/ochakai/pull/508) the client resolved a Google ID token for any `https` URL and aborted when it found none, so the one posture built to be reachable by anyone was not reachable by the CLI. `go install ...@latest` now resolves to v0.19.1, which carries the fix — checked, not assumed (below).

## Verified against the live instance

Every line the README now prints was run, from a clean `HOME` with no `gcloud` binary and no ADC:

```
$ go install github.com/na0fu3y/ochakai/cmd/ochakai@latest   # -> v0.19.1
$ ochakai use https://demo.ochak.ai
$ ochakai whoami
identity:  human:anonymous (no Google credentials found)
health:    ok
mode:      read-only
$ ochakai context "why is revenue down?"        # returns the knowledge
$ ochakai verify metrics/revenue
ochakai verify: this ochakai is read-only: it serves knowledge but does not change it
```

The posture itself, over HTTP:

| check | result |
|---|---|
| read, no token | 200 |
| read, forged unsigned token | 200 (input-independent) |
| write, no token | 403 |
| write, forged token | 403 |
| write with `Ochakai-On-Behalf-Of` | 403 |
| `Ochakai-Read-Only` header | `true` |
| MCP `tools/list`, no credentials | 4 tools: `get_concept`, `get_context`, `get_file`, `search_concepts` — the two write tools are not registered |

## One thing to decide at review

These 16 lines take `DOC-LINES` from 5,583 to **5,599 against the 5,600 ceiling**. CI passes, but the next documentation line anyone adds will fail. Raising the ceiling to 5,700 is a decision rather than a side effect, so this PR does not take it. Say the word and I will add it here.