### PR TITLE
Make the editor's type dropdown do something

### DIFF
--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -1911,28 +1911,39 @@ async function viewDetail(id) {
   });
 }
 
-// withStatus returns doc with its status line set: the line replaced when
-// the document has one, and appended to the frontmatter when it does not.
-// A writer who named no status leaves the key absent, and the server does
-// not fill it in (design doc 0046 §3.9) — so promoting such an entry has
-// to add the line, or the button would report success and change nothing.
+// withFrontmatterKey returns doc with one scalar frontmatter key set: the
+// line replaced when the document has one, and appended to the
+// frontmatter when it does not. A writer who named no value leaves the
+// key absent, and the server does not fill it in (design doc 0046 §3.9) —
+// so an edit that only replaced would report success and change nothing.
 //
 // Still a line edit rather than a parser (design doc 0044 §2.1 refuses
-// the parser; this refuses to need one). The alternative, rebuilding a
-// document from the fields the page holds, is what erased data before:
-// the page holds the projection, and a document assembled from it would
-// drop everything the projection does not carry — the citations, the
+// the parser; this refuses to need one), which is why it is only ever
+// asked for scalars — a repeating structure is what would need the
+// parser 0072 §3.1 turned down. The alternative, rebuilding a document
+// from the fields the page holds, is what erased data before: the page
+// holds the projection, and a document assembled from it would drop
+// everything the projection does not carry — the citations, the
 // contract, the body (design doc 0035 §4 is the same bug with fewer
 // fields).
-function withStatus(doc, status) {
-  const line = 'status: ' + status;
-  if (/^status:.*$/m.test(doc)) return doc.replace(/^status:.*$/m, line);
+//
+// One implementation because there are two callers now, and two copies
+// of an append path only one of which gets a fix is how the type
+// vocabulary drifted before.
+function withFrontmatterKey(doc, key, value) {
+  const line = key + ': ' + value;
+  const re = new RegExp('^' + key + ':.*$', 'm');
+  if (re.test(doc)) return doc.replace(re, line);
   // Append inside the frontmatter block: after the opening delimiter's
   // line, before the closing one. A document with no frontmatter is not
   // one this UI can write, so it is handed back untouched and the PUT
   // fails with the server's own message.
   const m = doc.match(/^(---\r?\n[\s\S]*?)(---\r?\n[\s\S]*)$/);
   return m ? m[1] + line + '\n' + m[2] : doc;
+}
+
+function withStatus(doc, status) {
+  return withFrontmatterKey(doc, 'status', status);
 }
 
 // Apply a status transition (full-replacement PUT), prompting for a
@@ -2196,23 +2207,56 @@ function wireReviewActions(container) {
 /* ============================== editor ============================== */
 
 // Templates for a new entry, one per recommended type (design doc 0038),
-// so a create starts from a shape rather than an empty textarea. The
-// frontmatter is what that type actually needs: an Attested Computation
-// without a runtime is refused by the server, and a Reference with no
-// resource is a mirror of nothing.
-const TEMPLATES = {
-  'Attested Computation': 'runtime: bigquery\nparameters:\n    - name: year\n      type: integer\n      required: true\n',
+// so a create starts from a shape rather than an empty textarea.
+//
+// The two halves are separated because they travel differently. REQUIRED
+// is what the write path refuses the type without — an Attested
+// Computation with no runtime is rejected by the server — so a type
+// change carries it into a document somebody is already writing. SEED is
+// illustrative: a sample parameter, a resource spelled out so a fresh
+// template shows the shape. Pasting an example `year` parameter into a
+// half-written document would be putting words in its writer's mouth,
+// so seeds only ever open an empty one.
+const TYPE_REQUIRED = {
+  'Attested Computation': 'runtime: bigquery\n',
+};
+const TYPE_SEED = {
+  'Attested Computation': 'parameters:\n    - name: year\n      type: integer\n      required: true\n',
   'BigQuery Dataset': 'resource: bigquery://project/dataset\n',
   'BigQuery Table': 'resource: bigquery://project/dataset/table\n',
   Reference: 'resource: https://example.com/the-original\n',
 };
 
 function templateDocument(type, title) {
-  const extra = TEMPLATES[type] || '';
+  const extra = (TYPE_REQUIRED[type] || '') + (TYPE_SEED[type] || '');
   return '---\ntype: ' + type + '\n'
     + (title ? 'title: ' + JSON.stringify(title) + '\n' : '')
     + 'description: ""\nstatus: draft\n' + extra
     + '---\n\n';
+}
+
+// withType returns doc with its type line set, plus any key the new type
+// is refused without and the document does not already name. Setting the
+// type alone would hand back a document the server rejects — the one
+// place a type is held to a schema is an Attested Computation's runtime
+// (design doc 0036 §5) — and reporting success for that is worse than
+// doing nothing, which is what this dropdown used to do.
+//
+// A key the writer already named is theirs, not the template's to
+// overwrite. Keys the *previous* type wanted are left where they stand:
+// no per-type rule rejects them, and removing a line its writer wrote is
+// not this page's to do (design doc 0044 §2.1 is the same posture).
+function withType(doc, type) {
+  let out = withFrontmatterKey(doc, 'type', type);
+  for (const req of (TYPE_REQUIRED[type] || '').split('\n')) {
+    const i = req.indexOf(':');
+    if (i < 0) continue;
+    const key = req.slice(0, i);
+    if (!new RegExp('^' + key + ':', 'm').test(out)) {
+      out = withFrontmatterKey(out, key, req.slice(i + 2));
+    }
+  }
+  return out;
 }
 
 // prefix (create only) seeds the ID field — the per-directory ＋
@@ -2260,10 +2304,12 @@ async function viewEditor(id, prefix = '') {
         ${idField}
         ${editing ? '' : `
         <div class="field">
-          <label class="top" for="e-template">Start from</label>
-          <select id="e-template">${KNOWN_TYPES.map(t =>
+          <label class="top" for="e-type">Type</label>
+          <select id="e-type">${KNOWN_TYPES.map(t =>
             `<option value="${t}"${t === 'Insight' ? ' selected' : ''}>${t}</option>`).join('')}</select>
-          <div class="hint">Seeds the document below with that type's frontmatter. Change the type in the document itself.</div>
+          <div class="hint">Sets <code>type:</code> in the document below, with any key that type is refused without.
+          Until you edit the document it is reseeded whole; after that only those lines change.
+          The document is what gets saved.</div>
         </div>`}
       </div>
       <div class="field">
@@ -2284,13 +2330,26 @@ async function viewEditor(id, prefix = '') {
 
   let dirty = false;
   $('#editor').addEventListener('input', () => { dirty = true; });
-  const tmpl = $('#e-template');
-  if (tmpl) {
-    tmpl.addEventListener('change', () => {
-      // Only reseed while the document is still a template: an edit is
-      // never thrown away by a dropdown.
-      if (dirty) return;
-      $('#e-doc').value = templateDocument(tmpl.value, '');
+  const typeSel = $('#e-type');
+  if (typeSel) {
+    // Two modes, and the question that picks between them is the document
+    // itself — not the form's dirty flag, which a <select> raises with its
+    // own `input` before this `change` ever runs, so gating on it made the
+    // dropdown do nothing at all, ever.
+    //
+    // Untouched, the document is still the one this seeded, and reseeding
+    // it whole costs nothing. Written in, it is the writer's, so the
+    // dropdown edits the type line and leaves the rest — the same line
+    // edit the detail page's status change makes.
+    let seeded = $('#e-doc').value;
+    typeSel.addEventListener('change', () => {
+      const doc = $('#e-doc').value;
+      if (doc === seeded) {
+        seeded = templateDocument(typeSel.value, '');
+        $('#e-doc').value = seeded;
+        return;
+      }
+      $('#e-doc').value = withType(doc, typeSel.value);
     });
   }
   window.onbeforeunload = () => (dirty ? '' : undefined);

--- a/internal/webui/webui_test.go
+++ b/internal/webui/webui_test.go
@@ -84,9 +84,15 @@ func TestAStatusChangeEditsTheDocumentRatherThanRebuildingIt(t *testing.T) {
 	// not write a status its writer left out (design doc 0046 §3.9), and
 	// the document a read hands back is the one that was written (§2.2) —
 	// so a replace-only edit would report success and change nothing.
+	// The append path lives in withFrontmatterKey, which the type
+	// dropdown shares; a second copy is what this guard exists to stop.
 	fn := section(t, page, "function withStatus(doc, status)", "\n}")
-	if !strings.Contains(fn, "doc.match(") {
-		t.Error("withStatus only replaces a status line; a document that names none would come back unchanged")
+	if !strings.Contains(fn, "withFrontmatterKey(doc, 'status', status)") {
+		t.Errorf("withStatus no longer goes through the shared line edit:\n%s", fn)
+	}
+	shared := section(t, page, "function withFrontmatterKey(doc, key, value)", "\n}")
+	if !strings.Contains(shared, "doc.match(") {
+		t.Error("withFrontmatterKey only replaces a line; a document that names no such key would come back unchanged")
 	}
 }
 
@@ -150,6 +156,64 @@ func TestTypeVocabularyMatchesDomain(t *testing.T) {
 		if strings.Contains(icons, retired) {
 			t.Errorf("the page still offers %q, retired by design doc 0038 or 0063", retired)
 		}
+	}
+}
+
+// The editor's type dropdown shipped inert from v0.16.0 to v0.19.1: the
+// reseed was gated on the form's dirty flag, and a <select> fires `input`
+// before its `change`, so the flag the select itself raised was always up
+// by the time the handler read it. Picking a type did nothing, silently,
+// on the one control that tells a writer an Attested Computation needs a
+// runtime before the server's 400 does.
+//
+// What the gate has to ask is whether the document is still the one the
+// dropdown seeded — that is the question the flag was standing in for.
+func TestTheTypeDropdownAsksTheDocumentNotTheDirtyFlag(t *testing.T) {
+	page := string(Index)
+	body := section(t, page, "typeSel.addEventListener('change'", "\n    });")
+	if strings.Contains(body, "dirty") {
+		t.Errorf("the type change is gated on the form's dirty flag again, which the select's own `input` raises before this runs:\n%s", body)
+	}
+	for _, want := range []string{"doc === seeded", "withType(doc, typeSel.value)"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("the type change no longer does %q:\n%s", want, body)
+		}
+	}
+}
+
+// Setting the type on a document somebody is already writing has to carry
+// the keys that type is refused without, or the dropdown hands back a
+// document the server rejects — which is worse than the nothing it used
+// to do, because it looks like it worked. Only Attested Computation has
+// one: runtime is the single place the write path holds a type to a
+// schema (design doc 0036 §5), and internal/service is where that is
+// enforced.
+//
+// The illustrative half must stay out of it. A sample `year` parameter
+// pasted into a half-written document is the page putting words in its
+// writer's mouth.
+func TestATypeChangeCarriesWhatTheTypeIsRefusedWithout(t *testing.T) {
+	page := string(Index)
+	required := section(t, page, "const TYPE_REQUIRED = {", "\n};")
+	if !strings.Contains(required, "'Attested Computation': 'runtime:") {
+		t.Errorf("an Attested Computation no longer requires a runtime here, but the write path still does:\n%s", required)
+	}
+	if strings.Contains(required, "parameters:") || strings.Contains(required, "resource:") {
+		t.Errorf("TYPE_REQUIRED carries illustrative keys, which a type change would paste into a written document:\n%s", required)
+	}
+	// The seed half is what only ever opens an empty document.
+	seed := section(t, page, "const TYPE_SEED = {", "\n};")
+	if !strings.Contains(seed, "parameters:") || !strings.Contains(seed, "resource:") {
+		t.Errorf("the seed templates no longer show the shape of a type:\n%s", seed)
+	}
+	// A key the writer already named is theirs. Overwriting it would be
+	// the dropdown deciding a runtime somebody chose was wrong.
+	fn := section(t, page, "function withType(doc, type)", "\n}")
+	if !strings.Contains(fn, "TYPE_REQUIRED[type]") {
+		t.Errorf("withType does not add the keys the type requires:\n%s", fn)
+	}
+	if !strings.Contains(fn, "if (!new RegExp('^' + key + ':', 'm').test(out))") {
+		t.Errorf("withType no longer checks whether the document already names the key:\n%s", fn)
 	}
 }
 


### PR DESCRIPTION
## 何が壊れていたか

Web UI の新規作成画面にある型のドロップダウン(旧ラベル `Start from`)は、
**v0.16.0 から v0.19.1 まで一度も動いていなかった。**

撒き直しはフォームの `dirty` フラグで gate されていたが、`<select>` は
自分の `change` より先に `input` を発火する。その `input` が `#editor` まで
bubble してフラグを立てるので、直後の `change` ハンドラは必ず `return` する。
**セレクタが自分で自分を無効化していた。**

実際のページを配信してブラウザで確認したイベント順:

```
form(capture)  input     ← dirty = true
select         input
form(capture)  change
select         change    ← if (dirty) return
```

沈黙する故障だったので誰も気づかなかった。効かない対象がいちばん痛いのは
Attested Computation で、`runtime` を撒いてもらえないと Create が必ず 400
になる([internal/service/service.go:719](../blob/main/internal/service/service.go#L719))。

## 直し方

**gate が問う対象を、フォームから文書に変えた。** 「この document はまだ自分が
撒いたものか」——`dirty` が代弁しようとしていたのは元々その問いである。

そのうえで、`dirty` が守っていたケース(既に書き始めた文書)も無反応をやめた。
型の行をその場で編集する。詳細画面のステータス変更が既にやっている行編集と
同じもので、追記パスが二つに分かれて片方だけ直る事故を避けるため、
`withFrontmatterKey` 一つを両方が呼ぶ形にした。

型変更は**その型が無いと拒否されるキーも一緒に運ぶ**。型の行だけ差し替えると
サーバが弾く文書を返すことになり、それは「何も起きない」より悪い——動いたように
見えるからである。該当するのは Attested Computation の `runtime` だけなので、
テンプレートを二つに割った:

- `TYPE_REQUIRED` — 書きかけの文書にも運ぶ
- `TYPE_SEED` — 空の文書を開くときだけ

例示の `year` パラメータを他人の書きかけの契約に貼り付けるのは、ページが書き手の
口に言葉を入れる行為なので運ばない。書き手が既に書いたキーも上書きしない。
前の型のキーも残す——型別の拒否ルールは無く([validateOKF](../blob/main/internal/service/service.go#L678)
が型に課すのは AC の `runtime` だけ)、書き手が書いた行を消すのはこのページの
仕事ではない(0044 §2.1 と同じ姿勢)。

ラベルは `Type` に変更。`Start from` は種まきの名前で、これは目の前の文書を
編集するコントロールになったため。

## 三つの問い

- **誰が詰まったか。** 型を選んだ全員。4 バージョン、沈黙して。
- **既存の表面で足りるか。** 足りている——足していない。壊れていたものを直し、
  同じコントロールが既に主張していた仕事をさせただけである。新しい行編集は
  `withStatus` が既に持っていた機構の共有であって、機構の追加ではない。
- **引き換えに畳めるもの。** `TEMPLATES` の一本を二本に割ったのは増加に見えるが、
  分けた理由は「必須と例示は移動の仕方が違う」という区別で、割らないと
  `withType` が例示を貼り付ける。ヒントの散文は 1 行増えた。

## 表面と設計ドキュメント

- **`docs/surface.md` は動かない。** Web UI は
  [「数えていないもの」](../blob/main/docs/surface.md)——自分のアドレス空間を持たず
  `/api/v1` の client として動くため、増えるなら REST の節に出る。REST は触っていない。
- **新しい設計ドキュメントは取らない。** [0072 §3.1](../blob/main/docs/design/0072-the-web-ui-serves-and-edits-documents.md)
  が退けたのは `sources` / `parameters` の**行エディタ**、つまり YAML パースが要る
  繰り返し構造である。`type` は `status` と同じ単一スカラーで、その行編集は
  `withStatus` として既に着地している。0072 §3.1 が緩和として約束した
  「新規作成はテンプレート文書から始める」を、初めて実際に満たした変更でもある。
- 八つの条件では **C4(No FDE)** ——自分でデプロイして自分で使える、の側。
  ただし条件に当たることは足す理由にならないので、上の三つの問いが本体である。

## 検証

`scripts/check core` は通る(store テストは DB 未設定でスキップ、CI では走る)。

実物の `index.html` を配信してブラウザで確認した:

| 操作 | 結果 |
|---|---|
| ID を先に入力 → AC を選択 | テンプレート全体を撒く(**修正前は無反応**) |
| 書きかけの文書で AC → Metric | `type:` だけ変わり、description・parameters・本文はそのまま |
| 書きかけの文書で Metric → AC | `type:` と `runtime: bigquery` が入り、例示 `parameters:` は入らない |
| 書き手が `runtime: postgres` を書いている状態で AC | `postgres` のまま(上書きしない) |
| `type:` 行の無い文書 | frontmatter の中に追記される |
| frontmatter の無い文書 | 無変更で返り、PUT がサーバのメッセージで落ちる |
| `parameters:` 内の字下げされた `type: integer` | 触られない(行頭アンカー) |

ガードを 2 本追加。1 本は `dirty` に戻すと落ち、修正前の `index.html` に対して
落ちることも確認済み。もう 1 本は必須と例示の分離を留める。既存の `withStatus`
ガードは共有ヘルパーを指すよう更新した——守っている挙動(キーが無い文書は
行を得なければならない)は同じ。

## 残した論点

`window.onbeforeunload` は `dirty` のままなので、型を選んだだけでも離脱確認が
出る。修正前からの挙動で、この PR では変えていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
