### PR TITLE
Prepare 0.20.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Version
       description: Output of `ochakai version`, or the image tag you deployed.
-      placeholder: "0.19.1"
+      placeholder: "0.20.0"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,21 @@ last entry.
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-08-07
+
+### Added
+
+- **Each CLI release archive ships with an SPDX SBOM** (`*.sbom.json`,
+  attached to the GitHub release beside the archive), so a dependency
+  scanner can read what is inside without unpacking anything. The
+  container image already carried an SBOM in its manifest; the archives
+  now match ([docs/guides/operating.md](docs/guides/operating.md)
+  (Japanese) has the verification commands).
+
 ### Changed
 
-- **Text is now embedded in the region you deployed to, not in
-  `us-central1`.** A deployment that names no model discovers its project
+- **BREAKING (deployment behavior)** — text is now embedded in the region
+  you deployed to, not in `us-central1`. A deployment that names no model discovers its project
   from the metadata server and turns semantic search on; until now the
   *region* of that call was a constant the product held, so a service
   running in `asia-northeast1` sent every concept body and every search
@@ -42,17 +53,6 @@ last entry.
   all of this — and naming `gemini-embedding-2` still means
   `global`/`us`/`eu`, so that choice moves the call out of your region on
   purpose.
-
-### Added
-
-- **Each CLI release archive ships with an SPDX SBOM** (`*.sbom.json`,
-  attached to the GitHub release beside the archive), so a dependency
-  scanner can read what is inside without unpacking anything. The
-  container image already carried an SBOM in its manifest; the archives
-  now match ([docs/guides/operating.md](docs/guides/operating.md)
-  (Japanese) has the verification commands).
-
-### Changed
 
 - **The two records a newcomer opens first no longer describe a world
   that is gone.** `0001` (the founding architecture record) named six MCP
@@ -74,6 +74,33 @@ last entry.
   names design doc 0080 §5, and semantic search being off names 0080 §1.
   The retired records stay in the tree as tombstones pointing at their
   replacements, so every existing link still lands somewhere.
+
+- **The BigQuery catalog example answers a deployment that grows its
+  catalog on demand.** Ownership of a projected entry is now keyed to the
+  `Ochakai-Producer` stamp rather than to the account that ran the job, so
+  any run recognizes every other run's entries while a person's edit still
+  takes an entry out of the projection. A table that disappears between the
+  listing and the read is recorded as `missing` — an outcome the
+  conservation check expects, not a failed night. `OCHAKAI_ID_TOKEN` lets a
+  person run the job by hand, because user ADC cannot mint an ID token. And
+  each dataset gets its own entry at `<prefix>/<project>/<dataset>`, written
+  only by a run that enumerated the whole dataset, so its table list never
+  recites tables the run did not see. The bundle ships in the release
+  archives ([examples/bigquery-catalog](examples/bigquery-catalog)).
+
+### Fixed
+
+- **The web UI's type dropdown does something again.** It had been inert
+  since `0.16.0`: reseeding was gated on the form's dirty flag, and a
+  `<select>` raises `input` before its own `change`, so the flag was always
+  up by the time the handler read it — picking a type silently did nothing,
+  on the one control that tells a writer an Attested Computation needs a
+  `runtime` before the server's 400 does. The gate now asks the document
+  whether it is still the one that was seeded. Choosing a type in a document
+  somebody has already written in edits the type line in place instead of
+  doing nothing, carrying the keys that type is refused without, and leaving
+  keys the writer already named alone. The label reads "Type" rather than
+  "Start from", because it now edits the document in front of you.
 
 ## [0.19.1] - 2026-08-06
 
@@ -3104,7 +3131,8 @@ worth naming: SQL injection in `compile_sql` through undeclared field
 pass-through, fixed in 0.8.0 — v0.7.0 and earlier are affected. Details
 are in git history.
 
-[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.19.1...HEAD
+[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.20.0...HEAD
+[0.20.0]: https://github.com/na0fu3y/ochakai/compare/v0.19.1...v0.20.0
 [0.19.1]: https://github.com/na0fu3y/ochakai/compare/v0.19.0...v0.19.1
 [0.19.0]: https://github.com/na0fu3y/ochakai/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/na0fu3y/ochakai/compare/v0.17.0...v0.18.0

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -83,7 +83,7 @@ info:
     is a security defect, shipped in the next release with no deprecation
     window (SECURITY.md). MCP, the CLI and the stored shape stay unstable
     while the major version is 0 and may still change in a minor release.
-  version: 0.19.1
+  version: 0.20.0
   license:
     name: MIT
 servers:

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -79,7 +79,7 @@ export IMAGE=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:$VERSION
 `:latest` ではなくバージョンを固定し、再デプロイを意識的な判断にする。
 `gh` CLI が無ければ
 [リリースページ](https://github.com/na0fu3y/ochakai/releases)から番号
-を読み、手で設定する — `export VERSION=0.19.1`。
+を読み、手で設定する — `export VERSION=0.20.0`。
 
 (このガイドは 0.9.0 以降を前提にしている。それより前のリリースは
 [retract](https://go.dev/ref/mod#go-mod-file-retract) 済みでサポート外


### PR DESCRIPTION
The preparation PR for 0.20.0. **The tag is not pushed yet** — see the note at the bottom.

## Version

**Minor, not patch.** The embedding-region change is marked **BREAKING (deployment behavior)**: a deployment in a region that has no `gemini-embedding-001` (`asia-northeast2`, for one) silently loses semantic search on upgrade and has to name a region to get it back. That is the "what does an operator have to do about it" test the changelog's BREAKING marker exists for, and it follows the `BREAKING (deploy/terraform)` precedent from 0.19.0.

## The four files

Changelog heading + compare links, `api/openapi.yaml` `info.version`, the bug-report placeholder, and the deploy guide's hand-set `export VERSION=`. The one remaining `0.19.1` in the tree is `internal/webui/webui_test.go`'s "shipped inert from v0.16.0 to v0.19.1", which is history and correct to leave.

## What reading the entries against the log found

`git log v0.19.1..origin/main` shows eight PRs; the unreleased section had three entries and a duplicated heading.

- **#514 had no entry**, and it touches `internal/webui` — it ships in the binary. The type dropdown had been inert since 0.16.0. Added under **Fixed**.
- **#510 had no entry.** The BigQuery catalog bundle ships inside the release archives (since 0.19.0), and it gained producer-keyed ownership, the `missing` outcome, `OCHAKAI_ID_TOKEN`, and per-dataset entries. Added under **Changed**.
- **Two `### Changed` headings**, one opened by each of #516 and #517, left the SBOM entry filed under the wrong one. Now one section each, in Keep a Changelog order.
- #511, #512, #513 are documentation only — no entry, deliberately.

## Checks

`scripts/check --db` passes end to end on this branch — gofmt, vet, `go test -race` including the store tests against a throwaway PostgreSQL, the CGO-free build, golangci-lint (0 issues) and govulncheck (no vulnerabilities).

**Worth stating explicitly:** GitHub Actions is in a major outage, so CI has not run on this branch or on the two commits already merged to main. I ran the same script CI runs, with the database, locally on merged main and again here.

## Before tagging

`release.yaml` builds the image, the archives, the SBOMs and the attestations, and it is triggered by the tag-push webhook — which the outage is throttling. A tag is permanent and the module proxy caches it forever, so **the tag waits until Actions is healthy**, or 0.20.0 becomes a permanent version with no artifacts behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)