### PR TITLE
Give a description back the line breaks it was stored with

### DIFF
--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -342,6 +342,15 @@
   .md table { border-collapse: collapse; margin: .6em 0; max-width: 100%; }
   .md th, .md td { border: 1px solid var(--border); padding: .35rem .6rem; }
   .md th { background: var(--code-bg); font-weight: 600; text-align: left; }
+  /* A description is markdown too (see descHTML), so it carries the
+     rules above. What it must not do is out-shout what it describes: on
+     a card it sits under the title, so a description opening with
+     "## Overview" keeps body-sized headings, and it neither leads nor
+     trails with a margin of its own. */
+  .desc.md > :first-child { margin-top: 0; }
+  .desc.md > :last-child { margin-bottom: 0; }
+  .card .desc h1, .card .desc h2, .card .desc h3 { font-size: .95rem; margin: .6em 0 .2em; }
+  .desc.lead { font-size: 1.02rem; }
 
   /* ---- browse tree ---- */
   .browse details.node > summary {
@@ -712,6 +721,21 @@ function md(src, resolveFile, resolveEntry) {
   if (inCode) out += '</code></pre>';
   flushPara(); flushList();
   return out;
+}
+
+// A description is prose written inside a markdown document, so it is
+// rendered the way the body is. It is stored with its line structure
+// intact — OKF writes a multi-line one as a `description: |-` block —
+// and putting that text in an element as-is loses exactly that, because
+// HTML collapses the newlines: a description that opens with a heading
+// came back as one run-on line.
+//
+// No resolvers: a reference from a description is not a link the server
+// derives an edge from (design doc 0024 reads the body), so rendering
+// one as a link here would draw an edge that does not exist. An http(s)
+// target is a link, as it is anywhere else.
+function descHTML(text, cls) {
+  return `<div class="desc md${cls ? ' ' + cls : ''}">${md(text)}</div>`;
 }
 
 /* ============================== api ============================== */
@@ -1152,7 +1176,7 @@ function hitCard(h) {
       <span class="badge ${esc(h.status)}">${esc(h.status)}</span>
       ${tags}
     </div>
-    ${h.description ? `<div class="desc">${esc(h.description)}</div>` : ''}
+    ${h.description ? descHTML(h.description) : ''}
     ${sql}
     ${cardThumbs(h)}
   </article>`;
@@ -1691,7 +1715,7 @@ async function viewDetail(id) {
     // their own: OKF's own model is body footnotes keyed to source ids, so
     // whoever is reading the body is exactly who needs the list.
     overview: () => `
-      ${entry.description ? `<p style="font-size:1.02rem">${esc(entry.description)}</p>` : ''}
+      ${entry.description ? descHTML(entry.description, 'lead') : ''}
       ${docBody ? `<div class="md">${md(docBody, resolveFile, resolveEntry)}</div>` : ''}
       ${!entry.description && !docBody ? '<div class="empty">No description or body.</div>' : ''}`,
     // The document, whole and unrendered. It replaced tabs that each
@@ -2176,7 +2200,7 @@ function reviewCard(h) {
       </span>
     </div>
     <div class="meta">${meta}</div>
-    ${h.description ? `<div class="desc">${esc(h.description)}</div>` : ''}
+    ${h.description ? descHTML(h.description) : ''}
     ${cardThumbs(h)}
   </article>`;
 }

--- a/internal/webui/webui_test.go
+++ b/internal/webui/webui_test.go
@@ -415,6 +415,31 @@ func TestBodyLinksToFilesResolve(t *testing.T) {
 	}
 }
 
+// A description keeps its line structure through the store — OKF writes
+// a multi-line one as a `description: |-` block — and the page used to
+// drop that on the floor, putting the text in an element where HTML
+// collapses every newline into a space. A description written as
+// several lines, or opening with a heading, arrived as one run-on line.
+// Every place that shows one now goes through the same renderer the
+// body does, so the guard is that no call site escapes the text into an
+// element by hand again.
+func TestADescriptionIsRenderedAsTheMarkdownItIs(t *testing.T) {
+	page := string(Index)
+	body := section(t, page, "function descHTML(", "\n}")
+	if !strings.Contains(body, "md(text)") {
+		t.Errorf("descHTML no longer renders the description as markdown:\n%s", body)
+	}
+	// The old failure mode, in the form it would come back.
+	for _, gone := range []string{"esc(h.description)", "esc(entry.description)"} {
+		if strings.Contains(page, gone) {
+			t.Errorf("a description is escaped into an element again (%s), so its line breaks are lost", gone)
+		}
+	}
+	if n := len(indexesOf(page, "descHTML(")); n < 4 {
+		t.Errorf("only %d descHTML references; a place that shows a description stopped using it", n)
+	}
+}
+
 // The loop strip is the human side of design doc 0051: the review page
 // is where the person who runs the loop already is, so the instance's
 // numbers are drawn there rather than on a page of their own.


### PR DESCRIPTION
## What and why

A description is prose written inside a markdown document, and it is stored as
one: OKF writes a multi-line description as a `description: |-` block and the
round trip keeps every line (`internal/okf/okf_test.go` pins that). The web UI
then put that text into an element as escaped plain text, where HTML collapses
newlines into spaces — so a registered description reading

```
## Overview
Transactions.
```

arrived on screen as one run-on line, hash marks and all. Nothing was lost in
the store; the only place it went missing was the page a person reads.

Every place that shows a description now renders it through the same markdown
renderer the body already goes through — the entry's Overview tab, the search
and browse cards, and the review queue — behind one `descHTML` so there is a
single place that decides this.

- No resolvers are passed. A reference written in a description is not a link
  the server derives an edge from (design doc 0024 reads the body), so drawing
  one as an entry link would claim an edge that does not exist. An http(s)
  target is a link, as it is anywhere else. Escaping is unchanged: everything
  still goes through the renderer's `esc`.
- On a card the description supports the title rather than competing with it,
  so headings inside one stay near body size and the block neither leads nor
  trails with a margin of its own.

Not a new feature and not a widened surface — the page draws a field it was
already showing, so the three questions do not apply here.

## Checks

- [x] `scripts/check` is clean — add `--db` when the change touches the store

  `scripts/check core` and `scripts/check lint` are green (0 issues). The store
  is untouched. `scripts/check vuln` is not verifiable in this environment (the
  proxy refuses vuln.go.dev); CI runs it.
- [x] Behavior changes come with tests

  `TestADescriptionIsRenderedAsTheMarkdownItIs` guards that every call site goes
  through `descHTML`, and that the old form — escaping the description into an
  element by hand — cannot come back unnoticed.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — untouched; no wire change.
- [x] The change lands on every surface it belongs on. This is a rendering fix
      on the one surface that renders: the web UI. REST, MCP and the CLI hand a
      description back as the text it is, which was already correct.
- [x] `api/openapi.frozen.txt` is untouched.
- [x] Widens no surface, so `docs/surface.md` is unchanged.

## Design docs

- [x] Not applicable: no accepted decision is altered. The wire, the stored form
      and its round trip are unchanged.
- [x] Commit messages and code comments are in English.

---
_Generated by [Claude Code](https://claude.ai/code/session_019xp7UHxxrNBNwqe2XYk1Th)_