### PR TITLE
Give 0.20.0's changelog the fix that landed beside it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,9 @@ last entry.
 ### Changed
 
 - **BREAKING (deployment behavior)** — text is now embedded in the region
-  you deployed to, not in `us-central1`. A deployment that names no model discovers its project
-  from the metadata server and turns semantic search on; until now the
+  you deployed to, not in `us-central1`. A deployment that names no model
+  discovers its project from the metadata server and turns semantic search
+  on; until now the
   *region* of that call was a constant the product held, so a service
   running in `asia-northeast1` sent every concept body and every search
   query to Vertex AI in the United States to be embedded. That is a
@@ -89,6 +90,20 @@ last entry.
   archives ([examples/bigquery-catalog](examples/bigquery-catalog)).
 
 ### Fixed
+
+- **A description keeps the line breaks it was stored with in the web UI.**
+  OKF stores a multi-line description as a `description: |-` block and the
+  round trip keeps every line, but the page put that text into an element
+  as escaped plain text, where HTML collapses newlines into spaces — so a
+  description written as a heading and a paragraph arrived on screen as one
+  run-on line, hash marks and all. Nothing was ever lost in the store; it
+  went missing only on the page a person reads. Every place a description
+  is shown now renders it through the same markdown renderer the body goes
+  through: the Overview tab, the search and browse cards, and the review
+  queue. References written in a description are not drawn as concept
+  links, because the server derives edges from the body rather than from a
+  description (design doc 0024) and drawing one would claim an edge that
+  does not exist; an `http(s)` target is a link as it is anywhere else.
 
 - **The web UI's type dropdown does something again.** It had been inert
   since `0.16.0`: reseeding was gated on the form's dirty flag, and a


### PR DESCRIPTION
Caught while checking the tree before tagging 0.20.0.

[#519](https://github.com/na0fu3y/ochakai/pull/519) merged to `main` while [#518](https://github.com/na0fu3y/ochakai/pull/518) (the release preparation) was open, so it sits **inside the `## [0.20.0]` heading with no entry of its own**. It touches `internal/webui/index.html`, which ships in the binary: a description stored as a `description: |-` block was being put into the page as escaped plain text, where HTML collapses newlines, so a description written as a heading plus a paragraph arrived as one run-on line. That is a user-visible fix and belongs in the release notes.

Added under **Fixed**, beside the other web UI fix in this release. Also rewraps one line that the version-heading edit in #518 left running past the margin.

This is the third entry the log-versus-changelog check has turned up for 0.20.0 (#514 and #510 were the first two), and the reason the release skill says to do that check before the tag rather than after: the tag is permanent.

`go test ./cmd/ochakai/` passes (the doc, design-record and surface checks).

**Blocks the tag** — 0.20.0 should not be tagged until this is in, or the release page will be missing a fix it ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)