### PR TITLE
Rank a concept named by the query ahead of ones that merely mention it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,24 @@ last entry.
 
 ### Changed
 
+- **A search for a name now finds the concept with that name.** Ask for
+  売上 and the concept *called* 売上 comes first, ahead of the reports
+  that mention the word — which is not what happened before: the lexical
+  haystack is one column (id, title, description, tags, body, filenames
+  concatenated), so a concept whose whole name is the query and a monthly
+  report that says the word eight times in five kilobytes contained the
+  same fragments and the same whole query, scored identically, and the
+  order between them was whatever the scan produced. Two terms fix it.
+  Fragments landing in the name count half again, weighted the same way,
+  so it works for a question and not only for a keyword; and a name that
+  *is* the query outranks everything that merely contains it. Either name
+  serves — the title, or the id's last segment, since a filename is a name
+  somebody chose (design doc 0022). The rule survives fusion, which reads
+  rank alone and would otherwise hand the top back to whatever the vectors
+  liked, and every face reads the same ranking, `get_context` included.
+  No migration, no reindex, no reembed: both terms are expressions on rows
+  the scan already reads, and the candidate set is unchanged (a Japanese
+  keyword scan measured about 4% slower on 5,000 entries).
 - **The write faces now say what each recommended type holds**, one line
   per type, instead of handing over nine spellings and nothing to tell
   them apart: `put_concept`'s description and `ochakai put -h` both render

--- a/internal/service/search.go
+++ b/internal/service/search.go
@@ -89,17 +89,49 @@ func (s *Service) search(ctx context.Context, query string, f store.Filter, limi
 	if err != nil {
 		return nil, err
 	}
-	fused := rrfFuse(limit, lexical, vector, attachments)
+	fused := rrfFuse(query, limit, lexical, vector, attachments)
 	return fused, nil
 }
 
+// namedBy reports whether the query is what the concept is called, rather
+// than something it mentions. Either name answers, as in the store's
+// scorer: the title, or the id's last segment (design doc 0022).
+//
+// The comparison is the store's, repeated here rather than carried: a hit
+// arrives with both fields on it, and a flag would be a new thing to keep
+// in sync across three lists that come from three queries.
+func namedBy(h domain.SearchHit, query string) bool {
+	name := h.ID
+	if i := strings.LastIndexByte(name, '/'); i >= 0 {
+		name = name[i+1:]
+	}
+	return strings.EqualFold(domain.Normalize(h.Title), query) ||
+		strings.EqualFold(domain.Normalize(name), query)
+}
+
 // rrfFuse merges ranked lists with reciprocal rank fusion (k=60), adding a
-// small boost for verified concepts so certified knowledge surfaces first.
-func rrfFuse(limit int, lists ...[]domain.SearchHit) []domain.SearchHit {
+// small boost for verified concepts so certified knowledge surfaces first,
+// and keeping a concept the query names ahead of the rest.
+//
+// Fusion is where a name would otherwise be lost. The store ranks an
+// exact name first by a margin no other term can close, but RRF reads
+// rank alone: at k=60 a concept topping one list scores 1/61 and a
+// concept placing well in all three scores three times that, so 売上 the
+// concept lands below whatever the vectors liked — the store's ruling
+// undone by the arithmetic of the merge, not by a judgement about
+// relevance. So it is a sort key rather than another addend. Any weight
+// large enough to be reliable here would be large enough to dominate
+// every fused score, which is the same rule written less legibly.
+//
+// Ties among several concepts of the same name — the same filename in two
+// bundles — fall through to the fused score, which is the ordering the
+// question deserves.
+func rrfFuse(query string, limit int, lists ...[]domain.SearchHit) []domain.SearchHit {
 	const k = 60
 	type entry struct {
 		hit   domain.SearchHit
 		score float64
+		named bool
 	}
 	byKey := map[string]*entry{}
 	for _, list := range lists {
@@ -107,13 +139,13 @@ func rrfFuse(limit int, lists ...[]domain.SearchHit) []domain.SearchHit {
 			key := hit.ID
 			e, ok := byKey[key]
 			if !ok {
-				e = &entry{hit: hit}
+				e = &entry{hit: hit, named: namedBy(hit, query)}
 				byKey[key] = e
 			}
 			e.score += 1.0 / float64(k+rank+1)
 		}
 	}
-	out := make([]domain.SearchHit, 0, len(byKey))
+	ranked := make([]*entry, 0, len(byKey))
 	for _, e := range byKey {
 		// Any confirmation earns the nudge, whichever tier it is: the
 		// boost is about "somebody checked this", and weighting the tiers
@@ -123,14 +155,21 @@ func rrfFuse(limit int, lists ...[]domain.SearchHit) []domain.SearchHit {
 			e.score += 0.002
 		}
 		e.hit.Score = e.score
+		ranked = append(ranked, e)
+	}
+	sort.Slice(ranked, func(i, j int) bool {
+		if ranked[i].named != ranked[j].named {
+			return ranked[i].named
+		}
+		if ranked[i].hit.Score != ranked[j].hit.Score {
+			return ranked[i].hit.Score > ranked[j].hit.Score
+		}
+		return ranked[i].hit.ID < ranked[j].hit.ID
+	})
+	out := make([]domain.SearchHit, 0, len(ranked))
+	for _, e := range ranked {
 		out = append(out, e.hit)
 	}
-	sort.Slice(out, func(i, j int) bool {
-		if out[i].Score != out[j].Score {
-			return out[i].Score > out[j].Score
-		}
-		return out[i].ID < out[j].ID
-	})
 	if len(out) > limit {
 		out = out[:limit]
 	}

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -67,7 +67,7 @@ func verifiedHit(id string) domain.SearchHit {
 func TestRRFFuseMergesAndRanks(t *testing.T) {
 	lexical := []domain.SearchHit{hit("a", domain.StatusDraft), hit("b", domain.StatusDraft)}
 	vector := []domain.SearchHit{hit("b", domain.StatusDraft), hit("c", domain.StatusDraft)}
-	out := rrfFuse(10, lexical, vector)
+	out := rrfFuse("q", 10, lexical, vector)
 	if len(out) != 3 {
 		t.Fatalf("want 3 fused hits, got %d", len(out))
 	}
@@ -81,9 +81,49 @@ func TestRRFFuseBoostsVerified(t *testing.T) {
 	// Same single-list rank; verified must win the tie.
 	lexical := []domain.SearchHit{hit("draft-doc", domain.StatusDraft)}
 	vector := []domain.SearchHit{verifiedHit("verified-doc")}
-	out := rrfFuse(10, lexical, vector)
+	out := rrfFuse("q", 10, lexical, vector)
 	if out[0].ID != "verified-doc" {
 		t.Errorf("verified concept should outrank draft at equal RRF score, got %s first", out[0].ID)
+	}
+}
+
+// The store ranks the concept a query names first, and RRF must not undo
+// it. A concept placing in all three lists earns three times the reciprocal
+// of one that tops a single list, so nothing short of a sort key keeps 売上
+// above the entries the vectors liked (design doc 0022 for the two names).
+func TestRRFFuseKeepsTheNamedConceptFirst(t *testing.T) {
+	titled := hit("metrics/kpi", domain.StatusStable)
+	titled.Title = "売上"
+	byFilename := hit("metrics/売上", domain.StatusStable)
+	popular := verifiedHit("reports/monthly")
+	popular.Title = "売上の推移レポート"
+
+	for _, tc := range []struct {
+		name  string
+		named domain.SearchHit
+	}{
+		{"title is the name", titled},
+		{"filename is the name", byFilename},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// The named concept tops the lexical list alone; the other
+			// concept places in all three, and is verified besides.
+			out := rrfFuse("売上", 10,
+				[]domain.SearchHit{tc.named, popular},
+				[]domain.SearchHit{popular},
+				[]domain.SearchHit{popular})
+			if out[0].ID != tc.named.ID {
+				t.Errorf("fused ranking put %s first, want the concept named 売上 (%s)",
+					out[0].ID, tc.named.ID)
+			}
+		})
+	}
+
+	// Merely containing the query is not being named by it, or every
+	// report about 売上 would claim the top of the list.
+	out := rrfFuse("売上", 10, []domain.SearchHit{popular, titled})
+	if out[0].ID != titled.ID {
+		t.Errorf("fused ranking put %s first, want the concept named 売上", out[0].ID)
 	}
 }
 
@@ -92,7 +132,7 @@ func TestRRFFuseLimit(t *testing.T) {
 	for _, id := range []string{"a", "b", "c", "d"} {
 		list = append(list, hit(id, domain.StatusDraft))
 	}
-	if got := len(rrfFuse(2, list)); got != 2 {
+	if got := len(rrfFuse("q", 2, list)); got != 2 {
 		t.Errorf("want limit 2, got %d", got)
 	}
 }

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -164,24 +164,64 @@ func contentChar(r rune) bool {
 	return unicode.Is(unicode.Han, r) || unicode.Is(unicode.Katakana, r)
 }
 
-// SearchLexical ranks entries by how much of the query they contain,
-// verified entries boosted. The haystack is the search_text column
-// (migration 0016): the id (design doc 0022 — with title optional, the
-// filename may be the entry's only name), the envelope fields, the body,
-// and the attachment filenames (design doc 0020 — "seeds" finds the entry
-// carrying seeds.txt, embedder or not), maintained by trigger.
+// nameText is the entry's name as a search matches it: the title, and the
+// id's last segment beside it.
+//
+// Both, not the resolved one. domain.DisplayTitle picks the title when
+// there is one and falls back to the filename, because a reader needs a
+// single string to print; a search is not printing anything, and an entry
+// titled "月次の数字" filed at metrics/売上 is named 売上 by whoever filed
+// it there (design doc 0022). The parent segments stay out: under
+// 売上/2026-q1 every child would otherwise be named 売上, which is what
+// the prefix filter is for.
+const (
+	filenameText = `regexp_replace(k.id, '^.*/', '')`
+	nameText     = `k.title || ' ' || ` + filenameText
+)
+
+// SearchLexical ranks entries by how much of the query they contain and
+// by where it lands, verified entries boosted. The haystack is the
+// search_text column (migration 0016): the id (design doc 0022 — with
+// title optional, the filename may be the entry's only name), the
+// envelope fields, the body, and the attachment filenames (design doc
+// 0020 — "seeds" finds the entry carrying seeds.txt, embedder or not),
+// maintained by trigger.
 //
 // The score is the fraction of the query's fragments the entry contains,
 // plus a bonus when the whole query appears verbatim (a keyword search
 // should outrank an entry that merely shares terms with a question), plus
-// the verified boost. An entry containing none of the fragments is not a
-// result — the floor is "matched something", not a magic number.
+// the two name terms below, plus the verified boost. An entry containing
+// none of the fragments is not a result — the floor is "matched
+// something", not a magic number.
 //
-// Every term of that is a substring test against one column, so the
-// candidate predicate and the score read the same expressions, and the
-// GIN trigram index serves the ones it can — patterns of three characters
-// or more (migration 0016; two-character Japanese windows are answered by
-// a scan, see queryFragments). Fragment matching
+// The name terms are what makes a keyword search find a definition. That
+// haystack is one column, so a concept whose entire name is 売上 and a
+// monthly report that says the word eight times in five kilobytes contain
+// the same fragments and the same whole query: identical scores, and the
+// order between them was whatever the scan produced. Frequency in a body
+// is not aboutness, and the column cannot express the difference —
+// nameText can.
+//
+//   - Fragments landing in the name count half again, per fragment and
+//     weighted the same way, so it works for the question get_context is
+//     built for and not only for a keyword: "なぜ売上が下がっているのか"
+//     lifts the concept named 売上 without the question matching it whole.
+//   - A name that *is* the query outranks every entry that merely
+//     contains it. The bonus is 1.0 against a ceiling of 1.85 for
+//     everything else, so this is a rule rather than a nudge: asking for
+//     売上 puts 売上 first. Either name serves — the deep-linked filename
+//     is a name a person chose as much as the title is.
+//
+// Both terms read expressions on the row the scan already has, and a name
+// match implies a search_text match (title and id are both inside it), so
+// the candidate set is unchanged and no index is asked for anything new.
+//
+// Every term of that is a substring test — against search_text, or
+// against the name read off the same row — so the candidate predicate and
+// the score read the same expressions, and the GIN trigram index serves
+// the ones it can: patterns of three characters or more (migration 0016;
+// two-character Japanese windows are answered by a scan, see
+// queryFragments). Fragment matching
 // replaced a similarity()/`%` pair that could not work: `%` is true only
 // above pg_trgm.similarity_threshold (0.3) and a real query never scores
 // that against a real document, so the candidate set was whatever the
@@ -192,17 +232,25 @@ func (s *Store) SearchLexical(ctx context.Context, query string, f Filter, limit
 	// every entry and flattens the ranking ('_' matches any one character).
 	args = append(args, "%"+escapeLike(query)+"%")
 	wholeParam := len(args)
+	// The same escaped query with no wildcards around it: ILIKE without a
+	// pattern is case-insensitive equality, which is the exact-name test.
+	args = append(args, escapeLike(query))
+	nameParam := len(args)
 	frags := queryFragments(query)
-	var hit, weight, weighted, weights, tests []string
+	var hit, weight, weighted, named, weights, tests []string
 	for i, frag := range frags {
 		args = append(args, "%"+escapeLike(frag)+"%")
 		tests = append(tests, fmt.Sprintf("k.search_text ILIKE $%d", len(args)))
 		hit = append(hit, fmt.Sprintf("k.search_text ILIKE $%d AS h%d", len(args), i))
+		hit = append(hit, fmt.Sprintf("nm.name ILIKE $%d AS n%d", len(args), i))
 		// Document frequency over the candidates, not the whole table: one
 		// window pass, no extra scans.
 		weight = append(weight, fmt.Sprintf(
 			"ln(1 + total::float / GREATEST(count(*) FILTER (WHERE h%d) OVER (), 1)) AS w%d", i, i))
 		weighted = append(weighted, fmt.Sprintf("CASE WHEN h%d THEN w%d ELSE 0 END", i, i))
+		// A fragment in the name is scored with the same weight it earns
+		// in the body, so a rare term stays rare wherever it lands.
+		named = append(named, fmt.Sprintf("CASE WHEN n%d THEN w%d ELSE 0 END", i, i))
 		weights = append(weights, fmt.Sprintf("w%d", i))
 	}
 	// Scoring carries ids and booleans, never rows. The window functions
@@ -216,24 +264,30 @@ func (s *Store) SearchLexical(ctx context.Context, query string, f Filter, limit
 	// known.
 	q := fmt.Sprintf(`
 		WITH scored AS (
-			SELECT w.id, (%[1]s) / NULLIF(%[2]s, 0) + w.whole + w.verified AS score
+			SELECT w.id,
+				((%[1]s) + 0.5 * (%[2]s)) / NULLIF(%[3]s, 0)
+					+ w.whole + w.named + w.verified AS score
 			FROM (
-				SELECT c.*, %[3]s FROM (
-					SELECT k.id, %[4]s, count(*) OVER () AS total,
-						CASE WHEN k.search_text ILIKE $%[5]d THEN 0.3 ELSE 0 END AS whole,
+				SELECT c.*, %[4]s FROM (
+					SELECT k.id, %[5]s, count(*) OVER () AS total,
+						CASE WHEN k.search_text ILIKE $%[6]d THEN 0.3 ELSE 0 END AS whole,
+						CASE WHEN k.title ILIKE $%[7]d
+							OR `+filenameText+` ILIKE $%[7]d
+							THEN 1 ELSE 0 END AS named,
 						CASE WHEN EXISTS (SELECT 1 FROM knowledge_verification v
 							WHERE v.id = k.id) THEN 0.05 ELSE 0 END AS verified
-					FROM object k
-					WHERE (%[6]s) AND %[7]s
+					FROM object k, LATERAL (SELECT `+nameText+` AS name) nm
+					WHERE (%[8]s) AND %[9]s
 				) c
 			) w
-			ORDER BY score DESC LIMIT %[8]d
+			ORDER BY score DESC LIMIT %[10]d
 		)
 		SELECT `+knowledgeSelectK+`, scored.score
 		FROM object k JOIN scored ON scored.id = k.id
 		ORDER BY scored.score DESC`,
-		strings.Join(weighted, " + "), strings.Join(weights, " + "),
-		strings.Join(weight, ", "), strings.Join(hit, ", "), wholeParam,
+		strings.Join(weighted, " + "), strings.Join(named, " + "),
+		strings.Join(weights, " + "),
+		strings.Join(weight, ", "), strings.Join(hit, ", "), wholeParam, nameParam,
 		strings.Join(tests, " OR "), where, limit)
 	rows, err := s.pool.Query(ctx, q, args...)
 	if err != nil {

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -1758,6 +1758,113 @@ func TestIntegrationLexicalSearchAnswersQuestions(t *testing.T) {
 	}
 }
 
+// A keyword search is a search for a name. Ask for 売上 and the concept
+// *called* 売上 is the answer; the twenty that mention it in a body are
+// context, however often they say the word.
+//
+// Fragment scoring alone cannot tell those apart. The haystack is one
+// column — id, title, description, tags, body, filenames concatenated —
+// so an entry whose whole name is the query and an entry that says the
+// word once in five kilobytes both contain every fragment and both
+// contain the query verbatim: identical scores, and the order between
+// them is whatever the scan happened to produce. This plants exactly that
+// tie and requires the name to break it.
+func TestIntegrationLexicalSearchRanksTheNamedConceptFirst(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(s.Close)
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	actor := domain.Actor{Kind: "human", Name: "test"}
+
+	run := testdb.Unique(t, "it-name-")
+	mine := Filter{Tags: []string{run}}
+	// Two shapes of name, because an entry has two (design doc 0022): the
+	// id's last segment when no title is set, and the title when one is.
+	byID, byTitle := run+"/売上", run+"/cogs"
+	titled := run + "/revenue-howto"
+	ids := []string{byID, byTitle, titled}
+	for i := range 20 {
+		ids = append(ids, fmt.Sprintf("%s/filler-%d", run, i))
+	}
+	t.Cleanup(func() {
+		for _, id := range ids {
+			_, _ = s.pool.Exec(ctx, `DELETE FROM object WHERE id = $1`, id)
+			_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_revision WHERE id = $1`, id)
+		}
+	})
+	create := func(id, title, body string) {
+		t.Helper()
+		if err := s.Create(ctx, &domain.Knowledge{
+			Type: domain.TypeInsights, ID: id, Title: title, Tags: []string{run},
+			Status: domain.StatusDraft, CreatedBy: actor, Body: body,
+		}, false); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+	// Written worst-first on purpose. Tied scores come back in whatever
+	// order the scan produced, which is insertion order, so a fixture that
+	// plants the answer first passes without ranking anything — this one
+	// fails unless the score really separates them.
+	//
+	// The fillers say both words far more often than the definitions do,
+	// which is also the point: frequency in a body is not aboutness.
+	for i := range 20 {
+		create(fmt.Sprintf("%s/filler-%d", run, i), fmt.Sprintf("月次レポート %d", i),
+			strings.Repeat("今月の売上と原価の内訳、売上の推移、原価の推移。", 8))
+	}
+	create(titled, "売上の読み方", "売上は前年同期比で見ないと誤読する。原価と併せて読む。")
+	create(byID, "", "全社の売上をどう数えるかの定義。")
+	create(byTitle, "原価", "原価に何を含めるかの定義。")
+
+	rank := func(hits []domain.SearchHit, id string) int {
+		for i, h := range hits {
+			if h.ID == id {
+				return i
+			}
+		}
+		return -1
+	}
+	for _, tc := range []struct{ query, first, why string }{
+		{"売上", byID, "the id's last segment is the concept's name"},
+		{"原価", byTitle, "the title is the concept's name"},
+	} {
+		hits, err := s.SearchLexical(ctx, tc.query, mine, 50)
+		if err != nil {
+			t.Fatalf("SearchLexical(%q): %v", tc.query, err)
+		}
+		if len(hits) == 0 || hits[0].ID != tc.first {
+			got := "nothing"
+			if len(hits) > 0 {
+				got = hits[0].ID
+			}
+			t.Errorf("SearchLexical(%q) ranked %s first, want %s (%s)",
+				tc.query, got, tc.first, tc.why)
+		}
+	}
+
+	// A name the query only partly matches is still a name: "売上の読み方"
+	// is more about 売上 than a report that lists the word eight times.
+	hits, err := s.SearchLexical(ctx, "売上", mine, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range 20 {
+		filler := fmt.Sprintf("%s/filler-%d", run, i)
+		if got, other := rank(hits, titled), rank(hits, filler); other >= 0 && other < got {
+			t.Fatalf("SearchLexical(売上) ranked %s (mentions only) above %s (named)", filler, titled)
+		}
+	}
+}
+
 // Verify is the exit from both review feeds (design doc 0025 §6). It
 // stamps a fresh verified_at even when the entry is already verified —
 // which Update cannot do — and an entry whose last failure report predates


### PR DESCRIPTION
## What and why

Search for 売上 and the concept *called* 売上 should come first — instead it tied with every report that mentions the word, because the lexical haystack is one column (id, title, description, tags, body, filenames concatenated). A concept whose whole name is the query and a report that says the word eight times in five kilobytes contained the same fragments and the same whole query: identical scores, and the order between them was whatever the scan happened to produce (insertion order, in practice).

Two terms fix it in `internal/store/search.go`:
- Fragments landing in the name (title, or the id's last segment — design doc 0022) count half again, weighted the same as body fragments, so it works for a question (`get_context`'s input) and not only for a keyword.
- A name that *is* the query outranks everything that merely contains it — a rule, not a nudge, since the bonus exceeds every other term's ceiling.

RRF fusion (`internal/service/search.go`) reads rank alone, which would otherwise hand the top spot back to whatever the vector search liked (an entry placing in all three lists beats a single-list leader on raw RRF arithmetic). Fixed by making "named by the query" a sort key ahead of fused score, rather than another addend competing with everything else.

No migration, reindex, or reembed: both terms are expressions on rows the scan already reads, and the candidate set (search_text ILIKE) is unchanged, since a name match implies a search_text match. Measured ~4% slower on a 5,000-entry Japanese-keyword scan (`売上`: 262ms → 272ms best-of-5).

Not a numbered design doc: this doesn't change the wire, stored form, identity/provenance, or a GCP dependency — it's a ranking-formula change within the fragment-scoring approach 0080 §4 already describes.

## Checks

- [x] `scripts/check --db` is clean
- [x] Behavior changes come with tests — new store integration test (adversarial insertion order, so a passing fixture can't just be "the answer happened to sort first") and new `rrfFuse` unit tests

## Surfaces and contract

- [x] No wire change — `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, `internal/apiclient` untouched
- [x] Lands via the shared `Service.Search`, so REST / MCP / CLI / Web UI / `get_context` all get the same ranking automatically
- [x] `api/openapi.frozen.txt` untouched
- [x] No surface widened — no new endpoint, tool, command, or env var

## Design docs

- [x] Not applicable — ranking-formula change, not a decision about the wire, stored form, identity/provenance, or a new GCP dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)