### PR TITLE
Answer the two questions an evaluator hits a dead end on

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -109,6 +109,19 @@ reject したり、ファイルを添えたりしても precondition は有効�
 [動作要件と設定](configuration.md#authentication-has-no-configuration)に
 ある。
 
+**境界が要るなら、インスタンスを分ける。** 部門ごとに読める範囲を変え
+たいときの答えは concept ごとの権限ではなく、デプロイをもう一つ立てる
+ことである。増えるのは Cloud Run のサービスと、**同じ Cloud SQL イン
+スタンスの中の別データベース**だけで — `OCHAKAI_DATABASE_URL` の dbname
+を変え、[deploy ガイド](../deploy/cloudrun/README.md)の bootstrap SQL を
+その新しいデータベースにもう一度流す — インスタンスは増えない。Cloud
+Run はリクエスト課金なので、境界一つの限界費用はほぼゼロである。
+
+**しかも二重に効く。** 境界ごとに専用のサービスアカウントを使えば、誰が
+到達できるかを Cloud Run IAM が決め、そのサービスがどのデータベースを
+開けるかを Cloud SQL IAM の GRANT が決める。どちらの層にも置く secret
+は無い。
+
 ### ochakai を使うのをやめたら、ナレッジはどうなるか
 
 `ochakai export ./knowledge` がベース全体を、git に置ける OKF v0.2 の
@@ -118,6 +131,23 @@ reject したり、ファイルを添えたりしても precondition は有効�
 は[デプロイの運用](guides/operating.md#backup-and-restore)にある。
 Git をレビュー経路にする運用そのものは
 [Git をレビュー経路にする](guides/git-review.md)にある。
+
+### 維持者が止まったら、どうなるか
+
+維持者は一人で([SUPPORT.md](../SUPPORT.md))、後任も、それを約束する
+組織も無い。答えはサポート体制ではなく、**人質を取っていない**ことで
+ある。
+
+動いているデプロイは止まらない。ochakai が話す相手はあなた自身の
+プロジェクトの Google Cloud API だけで、ライセンスサーバーにも SaaS
+にもテレメトリにも問い合わせない — 上流が消えた日に期限切れになる
+ものが一つも無い。ナレッジは一つ上の問いのとおり丸ごと出て、MIT なので
+フォークできる。
+
+止まるのは**次のリリース**である。最新リリースだけがサポートされ
+バックポートは無いので([互換性とサポート](compatibility.md#support))、
+その時点で脆弱性修正も止まる。選択はフォークして直すか、バンドルを
+持って出るかで、どちらも今日できる。
 
 ### ホスティング版はあるか
 


### PR DESCRIPTION
## What and why

An evaluation of this repository as an enterprise reader would see it found two
questions whose answers already exist but are written nowhere. Both have the
same shape: the project has a good answer, and leaves the reader to infer it.

**"What happens when the maintainer stops?"** — `SUPPORT.md` states the fact
(one maintainer, no successor, no support contract) without its consequence,
and an OSS review board reads the fact alone as the end of the road. The
consequence is small, and it is the interesting half: ochakai talks to nothing
but the reader's own Google Cloud APIs, so a running deployment does not stop
and nothing expires on the day upstream does. What stops is the next release —
and since only the latest is supported with no backporting
(`docs/compatibility.md`), security fixes stop with it. Fork or leave with the
bundle, both available today. New FAQ entry, placed after the exit question it
follows from.

**"What do I do when I need a reading boundary?"** — 0065 §1 and 0075 §6 both
answer "split the instance", and neither prices it, so the reader reasonably
assumes a second Cloud SQL instance and a doubled bill. It is a second Cloud
Run service against a second *database* on the same instance: the deploy
guide's bootstrap SQL run again with a different dbname, and
`OCHAKAI_DATABASE_URL` pointed at it. Cloud Run bills per request, so the
marginal cost of a boundary is about zero.

The part worth saying out loud is that it holds twice. With a service account
per boundary, Cloud Run IAM decides who reaches the service and Cloud SQL IAM
decides which database that service may open — and neither layer has a secret
to place (C2). That is a stronger separation story than per-concept
permissions would be, and it is the reason per-concept permissions stay
declined: an ACL needs a subject set, which is either a user database (0065
refuses) or a key in the document it guards, which anyone who can write can
widen.

Added to the existing "誰が読み書きできるか" entry rather than a new one, and
it links the deploy guide's bootstrap SQL rather than copying it — the recipe
is the same block with one word changed.

## Checks

- [x] `scripts/check core` is clean (docs-only; the store is untouched, so
      `--db` adds nothing here)
- [x] Behavior changes come with tests — none; this is prose

## Surfaces and contract

- [x] Nothing widens. No endpoint, tool, command or variable is added; `DOC`
      stays at 24 pages and `DOC-LINES` lands at 5,654 under its 5,700 ceiling,
      so no ceiling moves either
- [x] `api/openapi.frozen.txt` untouched

## Design docs

- [x] Not applicable — no accepted decision moves. 0065 §1's "no authorization"
      and 0075 §6's "split the instance if you need a viewing boundary" are
      both restated exactly as they stand; what is new is the price and the
      procedure, which is manual, not decision
- [x] Commit message in English
