### PR TITLE
Look a Japanese term up instead of reading the table for it

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -69,14 +69,17 @@ if the proposal is concrete.
 
 ## Next
 
-- **Japanese lexical search does not stay fast forever.** A trigram index
-  cannot serve a two-character pattern, so Japanese terms are answered by
-  scanning: about 16 ms across 5000 concepts, against 0.2 ms for a latin word.
-  That is fine at the scale a curated knowledge base reaches, and embeddings
-  are the answer — which is why they stopped being opt-in: running on Google
-  Cloud, ochakai turns them on by itself
-  ([0080](docs/design/0080-search-and-how-a-deployment-embeds.md)). A better lexical index
-  has not been designed, and nothing here promises one.
+- **Lexical ranking saturates.** The scan this entry used to describe is gone:
+  a trigram index cannot serve a two-character pattern, so Japanese terms are
+  now looked up in one whose entries are the same two-character windows a
+  question is cut into, and latin words stem on the way. Embeddings remain the
+  other half of the answer and stay on by default
+  ([0080](docs/design/0080-search-and-how-a-deployment-embeds.md)). What the
+  index exposed is the score — a fraction reaching 1.0 whenever a concept holds
+  every term, so a short question leaves several tied at the top and the reader
+  gets whichever the scan produced. Term frequency was tried as the tie-break
+  and measured worse. Nothing here promises the next attempt, but the golden
+  query set now says whether one worked.
 
 Beyond that this roadmap is thin, and honestly so. Work has been arriving from
 use and from release reviews rather than from a plan; the open issues are the

--- a/internal/service/searcheval_integration_test.go
+++ b/internal/service/searcheval_integration_test.go
@@ -22,8 +22,9 @@ import (
 // The corpus is examples/demo — the same ten concepts the quick start
 // loads — imported under a run-unique prefix so a shared test database
 // neither collides nor pollutes, plus three Japanese concepts defined
-// inline: the demo bundle is English, and the two-character-window scan
-// (design doc 0080 §1) needs Japanese text to be exercised at all.
+// inline: the demo bundle is English, and the two-character windows a
+// Japanese question is cut into (migration 0036) need Japanese text to
+// be exercised at all.
 //
 // Embeddings are off in the test environment, so the numbers measure
 // the lexical half and the fusion around it. That is the half a
@@ -95,11 +96,23 @@ var japaneseSupplement = map[string]string{
 		"受注は支払い確定時点で数える。キャンセルは受注から差し引く。\n",
 }
 
-// Floors pin the measured baseline: recall@10 = 1.00, MRR = 0.90 as of
-// the harness landing (lexical-only, 14 cases). They sit one notch
-// under those numbers so ordinary noise passes and a real regression
-// does not; a change that moves them — either way — should say so in
-// its PR, because that is the point of having them.
+// Floors pin the measured baseline: recall@10 = 1.00, MRR = 0.85 as of
+// the indexed lexical search (lexical-only, 14 cases). They sit under
+// those numbers so ordinary noise passes and a real regression does
+// not; a change that moves them — either way — should say so in its PR,
+// because that is the point of having them.
+//
+// MRR was 0.90 when this harness landed, against the ILIKE haystack.
+// What took it to 0.85 is not a ranking that got worse but one that
+// stopped being decided by an accident: a fragment no document contains
+// used to earn the largest possible weight (rarity is the weight), and
+// concepts whose *name* contained such a fragment collected half of it.
+// English stopwords are exactly those fragments now that the query is
+// stemmed, so "by" in a title was worth more than any term anybody
+// searched for. Removing it leaves the ties it had been hiding: five of
+// these ten concepts score identically for "why is revenue down", and
+// the order among them is arbitrary. That is the next thing to fix, and
+// it is measured here rather than argued about.
 const (
 	evalK           = 10
 	evalRecallFloor = 0.92 // one miss out of 14 passes; two fail

--- a/internal/store/migrations/0036_lexical_search_is_indexed.sql
+++ b/internal/store/migrations/0036_lexical_search_is_indexed.sql
@@ -1,0 +1,136 @@
+-- Japanese lexical search stops reading the table, and English stops
+-- missing plurals.
+--
+-- 0016 measured what pg_trgm could not do: '%売上%' is two characters,
+-- no whole trigram can be extracted from it, and the planner reads every
+-- row — 16 ms against 0.2 ms for a latin word, on 5,000 entries, and
+-- growing with the corpus. 0016 called that scan the price of finding
+-- 売上, 原価 and 客数 at all, and ROADMAP has carried "a better lexical
+-- index has not been designed" ever since. This is that index.
+--
+-- The index a two-character term can be looked up in is one whose
+-- entries *are* two-character terms. Every run of Han/kana in the
+-- haystack is cut into the same sliding two-character windows the query
+-- is cut into (store.queryFragments), and those windows are stored as
+-- tsvector lexemes: the substring test '%売上%' becomes the lexeme
+-- 売上, which GIN finds by equality. The corpus stops being read.
+--
+-- Latin text goes through to_tsvector('english', ...) in the same
+-- column, which buys the other half of the problem for free: 'revenue'
+-- and 'revenues' stem to one lexeme, so a plural finds a body that says
+-- the singular. ILIKE could not do that at any index cost, and the
+-- search that missed was recorded as a knowledge gap (0051) — a recall
+-- defect arriving at the curator as "write this".
+--
+-- Positions are stripped. The scorer asks whether a fragment is present
+-- and weights it by how rare it is across the candidates
+-- (SearchLexical); it does not read term frequency, deliberately —
+-- "frequency in a body is not aboutness". Reading it was tried here and
+-- measured: keeping positions and breaking the score's ties with
+-- ts_rank moved the golden set's MRR from 0.85 to 0.84, whether the
+-- normalization divided by document length or not, so the column does
+-- not carry what nothing uses.
+--
+-- search_text stays. It is the raw haystack the whole-query bonus still
+-- reads, and it is what this column is derived from, so the one trigger
+-- that has always maintained it now feeds both.
+
+-- The scripts that do not separate words with spaces, so a term in them
+-- has to be found by window rather than by word boundary. Generated
+-- from Go's unicode.Han, unicode.Hiragana and unicode.Katakana — the
+-- three tables store.scriptWithoutSpaces asks — and pinned to them by
+-- TestCJKClassAgreesWithGo, because a character the query windows and
+-- the document does not (or the reverse) is a term that can never be
+-- found, and nothing else would report it.
+CREATE OR REPLACE FUNCTION ochakai_cjk_class() RETURNS text
+LANGUAGE sql IMMUTABLE PARALLEL SAFE AS $$
+    SELECT '⺀-⺙⺛-⻳⼀-⿕々〇〡-〩'
+        || '〸-〻ぁ-ゖゝ-ゟァ-ヺヽ-ヿ'
+        || 'ㇰ-ㇿ㋐-㋾㌀-㍗㐀-䶿一-鿿'
+        || '豈-舘並-龎ｦ-ｯｱ-ﾝ'
+        || '\U00016FE2-\U00016FE3\U00016FF0-\U00016FF1'
+        || '\U0001AFF0-\U0001AFF3\U0001AFF5-\U0001AFFB\U0001AFFD-\U0001AFFE'
+        || '\U0001B000-\U0001B122\U0001B132\U0001B150-\U0001B152\U0001B155'
+        || '\U0001B164-\U0001B167\U0001F200'
+        || '\U00020000-\U0002A6DF\U0002A700-\U0002B739\U0002B740-\U0002B81D'
+        || '\U0002B820-\U0002CEA1\U0002CEB0-\U0002EBE0\U0002F800-\U0002FA1D'
+        || '\U00030000-\U0003134A\U00031350-\U000323AF'
+$$;
+
+-- Every sliding two-character window of every space-less run, space
+-- separated so to_tsvector reads each as its own lexeme.
+--
+-- All windows, unlike the query side. contentWindows keeps only the
+-- windows that begin a content word, because a query has to choose what
+-- to ask for; a document has to be able to answer whatever is asked, so
+-- it stores every window. A run of one character is stored as itself —
+-- otherwise a lone 円 between latin words would be in no lexeme at all.
+--
+-- Set-based rather than a loop: this runs on every write, and appending
+-- to an array in plpgsql would make a 5 kB Japanese body quadratic.
+CREATE OR REPLACE FUNCTION ochakai_cjk_bigrams(p_text text) RETURNS text
+LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT AS $$
+    SELECT COALESCE(string_agg(
+        CASE WHEN char_length(run) = 1 THEN run ELSE substr(run, g, 2) END, ' '), '')
+    FROM regexp_split_to_table(p_text, '[^' || ochakai_cjk_class() || ']+') AS run,
+         LATERAL generate_series(1, GREATEST(char_length(run) - 1, 1)) AS g
+    WHERE run <> ''
+$$;
+
+-- The haystack as an index can hold it: stemmed latin words, and the
+-- windows of everything written without spaces.
+--
+-- The two passes read disjoint halves of the text. Han and kana are cut
+-- out before the english pass, so a paragraph of Japanese never reaches
+-- a stemmer that has nothing to say about it — and, more to the point,
+-- never arrives as one token: the default parser reads an unbroken run
+-- as a single word, and a lexeme over 2 kB raises "word is too long" —
+-- which would be a document somebody could no longer save, not merely
+-- one that searches badly. The second replace drops any run of 510 or
+-- more non-space characters for that reason. What that long and
+-- unbroken actually is, is a base64 blob pasted into a body; a URL is
+-- shorter than the threshold and, below it, the default parser splits
+-- it into host and path itself. (510 rather than one bound of 2047:
+-- Postgres caps a regex repetition count at 255, so the floor is
+-- written as two of them.)
+-- Everything that is not a letter or a digit becomes a space before the
+-- english pass, which is what keeps a filename findable by its parts.
+-- The default parser is cleverer than that and it is the wrong kind of
+-- clever here: it reads sales-seeds.txt as one host-shaped token and
+-- metrics/sales/revenue as one file-shaped one, so "seeds" would not
+-- find the concept carrying sales-seeds.txt — a promise design doc 0020
+-- makes — and a path segment would not be a term at all, though the id
+-- is in the haystack precisely so that it is one (design doc 0022).
+-- Splitting on punctuation costs the parser's URL and email handling
+-- and buys every word inside a name; for a haystack whose whole purpose
+-- is that names are searchable, that is the right side of the trade.
+CREATE OR REPLACE FUNCTION ochakai_search_tsv(p_text text) RETURNS tsvector
+LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT AS $$
+    SELECT strip(
+        to_tsvector('english', regexp_replace(
+            regexp_replace(
+                regexp_replace(p_text, '[' || ochakai_cjk_class() || ']+', ' ', 'g'),
+                '[^[:alnum:]]+', ' ', 'g'),
+            '[^[:space:]]{255}[^[:space:]]{255}[^[:space:]]*', ' ', 'g'))
+        || to_tsvector('simple', ochakai_cjk_bigrams(p_text)))
+$$;
+
+-- Generated rather than triggered: search_text already arrives correct
+-- from the trigger 0016 installed (Postgres computes stored generated
+-- columns after BEFORE row triggers), so there is nothing for a second
+-- trigger to remember. The cost of the choice is that replacing the
+-- function above does not recompute what is stored — a migration that
+-- changes the derivation has to rewrite the column, the way this one
+-- does by adding it.
+ALTER TABLE object ADD COLUMN IF NOT EXISTS search_tsv tsvector
+    GENERATED ALWAYS AS (ochakai_search_tsv(search_text)) STORED;
+
+CREATE INDEX IF NOT EXISTS object_search_tsv ON object USING gin (search_tsv);
+
+-- The trigram index has no reader left. SearchLexical's candidate
+-- predicate was the only thing that could use it; the whole-query bonus
+-- and the name test are expressions over rows already chosen, and an
+-- index nobody reads is paid for on every write. pg_trgm itself stays
+-- installed (0001) — retiring the extension is a change to what a
+-- deployment requires, and that is not this migration's business.
+DROP INDEX IF EXISTS knowledge_search_trgm;

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -1,7 +1,8 @@
-// Search: turning a question into a ranking. Lexical fragmentation for
-// pg_trgm, the two vector searches, and the ANN tuning around them. What
-// narrows a search rather than orders it is in filter.go; what lists
-// instead of ranking is in list.go (design doc 0050).
+// Search: turning a question into a ranking. Lexical fragmentation and
+// the tsquery each fragment becomes, the two vector searches, and the ANN
+// tuning around them. What narrows a search rather than orders it is in
+// filter.go; what lists instead of ranking is in list.go (design doc
+// 0050).
 package store
 
 import (
@@ -39,15 +40,16 @@ const maxQueryFragments = 24
 // for Japanese, and the smallest unit that still carries meaning (売上,
 // 受注, 原価).
 //
-// Two characters is below what a trigram index can serve, and pg_trgm
-// does not narrow the scan for such a pattern: LIKE '%売上%' has no word
-// boundary to pad against, so no whole trigram can be extracted and the
-// planner reads the table. Measured on 5000 entries, '%revenue%' and
-// '%売上の%' are index scans at 0.2ms while '%売上%' is a sequential scan
-// at 16ms. Three-character windows would restore the index and lose 売上,
-// 原価, 客数 — the terms the search is for — so the scan is the price of
-// finding them. SearchLexical keeps that scan cheap by scoring over ids
-// alone.
+// Two characters is below what a trigram index can serve — LIKE '%売上%'
+// has no word boundary to pad against, so no whole trigram can be
+// extracted and the planner reads the table — and for as long as the
+// haystack was matched with ILIKE, that scan was the price of finding
+// 売上, 原価 and 客数 at all (16ms against 0.2ms for a latin word, on
+// 5000 entries, and growing with the corpus). It is not any more.
+// Migration 0036 stores the document's own windows as lexemes, so the
+// window this function cuts is looked up rather than searched for: the
+// index entries are the same two characters the query is. What each
+// fragment becomes on the way there is fragmentQuery.
 func queryFragments(query string) []string {
 	// Fragments are collected per run and then interleaved, so the cap
 	// falls evenly across the query instead of truncating its tail. A
@@ -164,6 +166,40 @@ func contentChar(r rune) bool {
 	return unicode.Is(unicode.Han, r) || unicode.Is(unicode.Katakana, r)
 }
 
+// fragmentQuery renders the tsquery that finds one fragment in
+// search_tsv, as SQL reading the fragment from parameter n.
+//
+// Which of the three it is follows from what the fragment is made of,
+// because migration 0036 built the column that way: a space-less script
+// is in there as windows and is asked for with the 'simple' dictionary,
+// which normalizes case and stems nothing; everything else is in there
+// stemmed by the 'english' dictionary and has to be asked for the same
+// way, or "revenues" would not find the body that says "revenue" — the
+// recall this replaced ILIKE to get.
+//
+// A one-character fragment is the exception, and it is asked for as a
+// prefix. queryFragments keeps a run of one or two characters whole, so
+// 額 arrives alone; the document holds two-character windows, and no
+// lexeme equals 額 unless the document had it alone as well. 額:* finds
+// the windows it begins. It cannot find the ones it ends — a cost worth
+// naming, and cheaper than storing every unigram beside every window.
+func fragmentQuery(frag string, n int) string {
+	runes := []rune(frag)
+	switch {
+	case len(runes) == 0:
+		return "''::tsquery"
+	case !scriptWithoutSpaces(runes[0]):
+		return fmt.Sprintf("plainto_tsquery('english', $%d::text)", n)
+	case len(runes) == 1:
+		// to_tsquery parses its argument, so a lexeme that happened to
+		// spell an operator would be syntax rather than a term. None of
+		// the scripts this branch sees has one.
+		return fmt.Sprintf("to_tsquery('simple', $%d::text || ':*')", n)
+	default:
+		return fmt.Sprintf("plainto_tsquery('simple', $%d::text)", n)
+	}
+}
+
 // nameText is the entry's name as a search matches it: the title, and the
 // id's last segment beside it.
 //
@@ -185,7 +221,10 @@ const (
 // title optional, the filename may be the entry's only name), the
 // envelope fields, the body, and the attachment filenames (design doc
 // 0020 — "seeds" finds the entry carrying seeds.txt, embedder or not),
-// maintained by trigger.
+// maintained by trigger. Terms are matched against search_tsv, which is
+// that same text as an index can hold it — stemmed latin words, and the
+// two-character windows of the scripts written without spaces
+// (migration 0036).
 //
 // The score is the fraction of the query's fragments the entry contains,
 // plus a bonus when the whole query appears verbatim (a keyword search
@@ -212,20 +251,22 @@ const (
 //     売上 puts 売上 first. Either name serves — the deep-linked filename
 //     is a name a person chose as much as the title is.
 //
-// Both terms read expressions on the row the scan already has, and a name
-// match implies a search_text match (title and id are both inside it), so
-// the candidate set is unchanged and no index is asked for anything new.
+// Both terms read expressions on the row the candidate scan already has,
+// and a name match implies a search_tsv match (title and id are both
+// inside the haystack it is built from), so the candidate set is
+// unchanged and no index is asked for anything new.
 //
-// Every term of that is a substring test — against search_text, or
-// against the name read off the same row — so the candidate predicate and
-// the score read the same expressions, and the GIN trigram index serves
-// the ones it can: patterns of three characters or more (migration 0016;
-// two-character Japanese windows are answered by a scan, see
-// queryFragments). Fragment matching
-// replaced a similarity()/`%` pair that could not work: `%` is true only
-// above pg_trgm.similarity_threshold (0.3) and a real query never scores
-// that against a real document, so the candidate set was whatever the
-// whole-query substring test found — nothing, for a question.
+// The candidate predicate is one tsquery — the fragments OR-ed together
+// — so the GIN index on search_tsv answers the whole disjunction in a
+// single scan, and it answers it for Japanese too: the two-character
+// windows this splits a question into are exactly the lexemes migration
+// 0036 stores. The per-fragment tests below repeat the same expressions,
+// so what makes a row a candidate and what scores it stay one thing.
+//
+// The whole-query bonus is still a substring test against search_text,
+// and stays one on purpose. It asks whether the question appears
+// verbatim, which is a question about the raw text rather than about
+// terms; it reads rows the tsquery already chose, so it costs no index.
 func (s *Store) SearchLexical(ctx context.Context, query string, f Filter, limit int) ([]domain.SearchHit, error) {
 	where, args := f.buildWhere("k.")
 	// Each pattern is escaped: unescaped, a query containing '%' matches
@@ -239,14 +280,33 @@ func (s *Store) SearchLexical(ctx context.Context, query string, f Filter, limit
 	frags := queryFragments(query)
 	var hit, weight, weighted, named, weights, tests []string
 	for i, frag := range frags {
+		// Two spellings of the same fragment: the term itself, which the
+		// tsquery reads, and the escaped pattern the name test reads. The
+		// name is one short string on the row, so it is matched as a
+		// substring rather than through the index the body needs.
+		args = append(args, frag)
+		match := fragmentQuery(frag, len(args))
 		args = append(args, "%"+escapeLike(frag)+"%")
-		tests = append(tests, fmt.Sprintf("k.search_text ILIKE $%d", len(args)))
-		hit = append(hit, fmt.Sprintf("k.search_text ILIKE $%d AS h%d", len(args), i))
+		tests = append(tests, match)
+		hit = append(hit, fmt.Sprintf("k.search_tsv @@ %s AS h%d", match, i))
 		hit = append(hit, fmt.Sprintf("nm.name ILIKE $%d AS n%d", len(args), i))
 		// Document frequency over the candidates, not the whole table: one
 		// window pass, no extra scans.
+		//
+		// A fragment no candidate has weighs nothing. Candidates are the
+		// union of the fragments, so a count of zero here means the term
+		// is nowhere in the corpus — and the score is a fraction whose
+		// denominator is the weight of everything asked for, so leaving
+		// such a term in it would dilute every row by the same amount
+		// while ranking none of them. Worse, it would dilute by the
+		// *largest* amount: rarity is the weight, and a term nobody has
+		// is as rare as a term can be. English stopwords land here now
+		// that the query is stemmed ("why is revenue down" asks for four
+		// terms and two of them are dropped by the dictionary), which is
+		// how this came to be measured rather than reasoned about.
 		weight = append(weight, fmt.Sprintf(
-			"ln(1 + total::float / GREATEST(count(*) FILTER (WHERE h%d) OVER (), 1)) AS w%d", i, i))
+			"CASE WHEN count(*) FILTER (WHERE h%[1]d) OVER () = 0 THEN 0 "+
+				"ELSE ln(1 + total::float / count(*) FILTER (WHERE h%[1]d) OVER ()) END AS w%[1]d", i))
 		weighted = append(weighted, fmt.Sprintf("CASE WHEN h%d THEN w%d ELSE 0 END", i, i))
 		// A fragment in the name is scored with the same weight it earns
 		// in the body, so a rare term stays rare wherever it lands.
@@ -256,7 +316,9 @@ func (s *Store) SearchLexical(ctx context.Context, query string, f Filter, limit
 	// Scoring carries ids and booleans, never rows. The window functions
 	// force every candidate to be materialized before LIMIT can apply, and
 	// the candidate set is an OR over fragments — one common two-character
-	// window and it is most of the table. Selecting k.* through those
+	// window and it is a large part of the table, found by index now
+	// rather than by reading it, but still materialized. Selecting k.*
+	// through those
 	// layers would push every body, and search_text (a near-copy of the
 	// body) alongside it, through a sort node: tens of megabytes on a
 	// corpus of a few thousand, spilling work_mem on the instance size
@@ -277,7 +339,7 @@ func (s *Store) SearchLexical(ctx context.Context, query string, f Filter, limit
 						CASE WHEN EXISTS (SELECT 1 FROM knowledge_verification v
 							WHERE v.id = k.id) THEN 0.05 ELSE 0 END AS verified
 					FROM object k, LATERAL (SELECT `+nameText+` AS name) nm
-					WHERE (%[8]s) AND %[9]s
+					WHERE k.search_tsv @@ (%[8]s) AND %[9]s
 				) c
 			) w
 			ORDER BY score DESC LIMIT %[10]d
@@ -288,7 +350,7 @@ func (s *Store) SearchLexical(ctx context.Context, query string, f Filter, limit
 		strings.Join(weighted, " + "), strings.Join(named, " + "),
 		strings.Join(weights, " + "),
 		strings.Join(weight, ", "), strings.Join(hit, ", "), wholeParam, nameParam,
-		strings.Join(tests, " OR "), where, limit)
+		strings.Join(tests, " || "), where, limit)
 	rows, err := s.pool.Query(ctx, q, args...)
 	if err != nil {
 		return nil, err

--- a/internal/store/searchtsv_integration_test.go
+++ b/internal/store/searchtsv_integration_test.go
@@ -1,0 +1,267 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/na0fu3y/ochakai/internal/domain"
+	"github.com/na0fu3y/ochakai/internal/testdb"
+)
+
+// The lexical index (migration 0036) is two halves that have to agree
+// with Go about the same thing. queryFragments decides which runs of a
+// question get cut into two-character windows; ochakai_cjk_class decides
+// which runs of a document do. A character on one side and not the other
+// is a term nobody can find — silently, because both halves keep working
+// for everything else. These tests are that agreement, and the index
+// lookup the whole migration exists for.
+
+// newSearchStore dials the test database the way every other integration
+// test in this package does, skipping without OCHAKAI_TEST_DATABASE_URL.
+func newSearchStore(t *testing.T, ctx context.Context) *Store {
+	t.Helper()
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	s, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(s.Close)
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+// TestCJKClassAgreesWithGo walks every code point the two classifiers
+// could disagree about and asks the database what it thinks.
+//
+// The whole range rather than a sample: the ranges are the thing being
+// pinned, so a test that checked 売 and 一 would pass on any table that
+// happened to contain the common characters and miss the edges — which
+// is exactly where a transcribed range list goes wrong.
+func TestCJKClassAgreesWithGo(t *testing.T) {
+	ctx := context.Background()
+	s := newSearchStore(t, ctx)
+
+	goSaysCJK := func(r rune) bool {
+		return unicode.Is(unicode.Han, r) ||
+			unicode.Is(unicode.Hiragana, r) || unicode.Is(unicode.Katakana, r)
+	}
+	// The planes these scripts live in, plus latin, Cyrillic and
+	// punctuation to catch a class that matches too much.
+	spans := [][2]rune{
+		{0x0020, 0x0500},   // ASCII, latin-1, latin extended, Cyrillic
+		{0x2000, 0x9FFF},   // punctuation through the CJK main block
+		{0xF900, 0xFAFF},   // compatibility ideographs
+		{0xFF00, 0xFFEF},   // halfwidth and fullwidth forms
+		{0x16F00, 0x1B2FF}, // Nushu, kana extensions and supplements
+		{0x1F000, 0x1F2FF}, // enclosed ideographic supplement
+		{0x20000, 0x2FA1F}, // ideographic extensions B through F
+		{0x30000, 0x323AF}, // extensions G and H
+	}
+	for _, span := range spans {
+		var chars []string
+		for r := span[0]; r <= span[1]; r++ {
+			// Surrogates are not characters and cannot be sent at all.
+			if r >= 0xD800 && r <= 0xDFFF {
+				continue
+			}
+			chars = append(chars, string(r))
+		}
+		// Classified by the same expression the bigram function splits on.
+		rows, err := s.pool.Query(ctx, `
+			SELECT c, c ~ ('[' || ochakai_cjk_class() || ']') FROM unnest($1::text[]) AS c`, chars)
+		if err != nil {
+			t.Fatalf("classify U+%04X..U+%04X: %v", span[0], span[1], err)
+		}
+		mismatched := 0
+		for rows.Next() {
+			var char string
+			var sqlSaysCJK bool
+			if err := rows.Scan(&char, &sqlSaysCJK); err != nil {
+				rows.Close()
+				t.Fatal(err)
+			}
+			r := []rune(char)[0]
+			if sqlSaysCJK == goSaysCJK(r) {
+				continue
+			}
+			mismatched++
+			if mismatched <= 8 {
+				t.Errorf("U+%04X (%q): ochakai_cjk_class says %v, Go says %v — "+
+					"a query fragment and the document's windows would not meet",
+					r, char, sqlSaysCJK, goSaysCJK(r))
+			}
+		}
+		err = rows.Err()
+		rows.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if mismatched > 8 {
+			t.Errorf("...and %d more disagreements in U+%04X..U+%04X", mismatched-8, span[0], span[1])
+		}
+	}
+}
+
+// TestJapaneseSearchUsesTheIndex is the migration's whole point: a
+// two-character Japanese term is looked up rather than scanned for.
+// Before 0036 this plan was a sequential scan by construction — pg_trgm
+// can extract no whole trigram from two characters — and its cost grew
+// with the corpus.
+//
+// The assertion is on the plan rather than on a duration, because a
+// timing on a test machine says as much about the machine as about the
+// query, and on the plan under enable_seqscan=off rather than on which
+// plan the planner prefers, because at two hundred rows it should
+// prefer the scan and that preference is not what changed.
+//
+// What changed is that the predicate became indexable at all. Turning
+// enable_seqscan off only makes a scan expensive; it cannot make an
+// index serve a predicate it has no entries for, which is why the same
+// setting would leave '%売上%' on a sequential scan however costly the
+// scan was made. The second assertion is what migration 0016 warns
+// about — an index that answers by reading all of itself reads as an
+// index scan — so the number of rows the lookup actually returned is
+// checked too.
+func TestJapaneseSearchUsesTheIndex(t *testing.T) {
+	ctx := context.Background()
+	s := newSearchStore(t, ctx)
+	run := testdb.Unique(t, "tsvidx")
+	actor := domain.Actor{Kind: domain.ActorHuman, Name: "test"}
+
+	// Enough rows that the planner has a reason to prefer the index, and
+	// bodies that differ so the term stays selective — the case the
+	// index is for.
+	for i := range 200 {
+		body := fmt.Sprintf("これは %d 番目の記録である。原価と客数について書いてある。", i)
+		if i == 7 {
+			// 鵺鵼 is the term the plan is read for: the test database is
+			// shared by every package, so a common word like 売上 is in
+			// the index from other tests too and the lookup's row count
+			// would say nothing about this corpus.
+			body = "売上は八月に下がるが季節性である。鵺鵼と呼ぶ。"
+		}
+		k := &domain.Knowledge{
+			Type: domain.TypeInsights, ID: fmt.Sprintf("%s/doc-%03d", run, i),
+			Title: fmt.Sprintf("記録 %d", i), Body: body,
+			Status: domain.StatusStable, CreatedBy: actor,
+		}
+		if err := s.Create(ctx, k, false); err != nil {
+			t.Fatalf("create %s: %v", k.ID, err)
+		}
+	}
+	if _, err := s.pool.Exec(ctx, `ANALYZE object`); err != nil {
+		t.Fatal(err)
+	}
+
+	plan := explainJapaneseLookup(t, ctx, s)
+	if !strings.Contains(plan, "object_search_tsv") {
+		t.Errorf("a two-character Japanese term does not reach the index; the plan was:\n%s\n"+
+			"migration 0036 exists so this lookup stops reading the table", plan)
+	}
+	// And it discriminated: the lookup returned a handful of rows rather
+	// than the table. Measured against the table's size rather than
+	// against 1, because the test database is shared and holds what
+	// earlier runs of this same test wrote — the claim is that the index
+	// finds the lexeme, not that this run is alone in it.
+	m := regexp.MustCompile(`Bitmap Index Scan on object_search_tsv \(actual rows=(\d+) loops`).FindStringSubmatch(plan)
+	if m == nil {
+		t.Fatalf("no bitmap index scan on object_search_tsv to read row counts from:\n%s", plan)
+	}
+	var total int
+	if err := s.pool.QueryRow(ctx, `SELECT count(*) FROM object`).Scan(&total); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := strconv.Atoi(m[1])
+	if total < 200 {
+		t.Fatalf("only %d rows in object: too few for the lookup's selectivity to mean anything", total)
+	}
+	if got*10 > total {
+		t.Errorf("the index lookup returned %d rows of %d for a term almost nothing has: "+
+			"it is answering by reading itself, not by finding the lexeme\n%s", got, total, plan)
+	}
+
+	// And it still answers. An index the planner likes but that holds the
+	// wrong lexemes would pass the assertion above.
+	hits, err := s.SearchLexical(ctx, "売上", Filter{Prefixes: []string{run}}, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) != 1 || !strings.HasSuffix(hits[0].ID, "doc-007") {
+		t.Errorf("searching 売上 returned %d hits; want the one concept that says it", len(hits))
+	}
+}
+
+// explainJapaneseLookup returns the analyzed plan for the two-character
+// lookup, with the sequential scan priced out of the running for the
+// length of the transaction.
+func explainJapaneseLookup(t *testing.T, ctx context.Context, s *Store) string {
+	t.Helper()
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = tx.Rollback(context.WithoutCancel(ctx)) }()
+	if _, err := tx.Exec(ctx, `SET LOCAL enable_seqscan = off`); err != nil {
+		t.Fatal(err)
+	}
+	rows, err := tx.Query(ctx, `
+		EXPLAIN (ANALYZE, TIMING OFF, COSTS OFF) SELECT k.id FROM object k
+		WHERE k.search_tsv @@ plainto_tsquery('simple', '鵺鵼')`)
+	if err != nil {
+		t.Fatalf("explain: %v", err)
+	}
+	defer rows.Close()
+	var plan []string
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			t.Fatal(err)
+		}
+		plan = append(plan, line)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	return strings.Join(plan, "\n")
+}
+
+// TestEnglishSearchStems pins the recall ILIKE could not have: a plural
+// finds the body that says the singular. A search that found nothing was
+// recorded as a knowledge gap (design doc 0051), so this defect used to
+// reach the curator as "somebody should write this".
+func TestEnglishSearchStems(t *testing.T) {
+	ctx := context.Background()
+	s := newSearchStore(t, ctx)
+	run := testdb.Unique(t, "tsvstem")
+
+	k := &domain.Knowledge{
+		Type: domain.TypeMetrics, ID: run + "/revenue", Title: "net revenue",
+		Body:      "Recognized when the order completes.",
+		Status:    domain.StatusStable,
+		CreatedBy: domain.Actor{Kind: domain.ActorHuman, Name: "test"},
+	}
+	if err := s.Create(ctx, k, false); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, query := range []string{"revenue", "revenues", "recognizing an order", "orders"} {
+		hits, err := s.SearchLexical(ctx, query, Filter{Prefixes: []string{run}}, 10)
+		if err != nil {
+			t.Fatalf("search %q: %v", query, err)
+		}
+		if len(hits) == 0 {
+			t.Errorf("%q found nothing; the stored form stems, so the query has to as well", query)
+		}
+	}
+}


### PR DESCRIPTION
<!-- Keep PRs small and focused. Link the issue or design doc, if there is one. -->

## What and why

Closes the first half of #531 (plan #540), measured with the harness from #528.

A trigram index cannot serve a two-character pattern, so every Japanese term was answered by a sequential scan — 16 ms against 0.2 ms for a latin word on 5,000 concepts, growing with the corpus. 0016 measured that and called the scan the price of finding 売上 at all; ROADMAP has carried *"a better lexical index has not been designed"* ever since.

**The index a two-character term can be looked up in is one whose entries are two-character terms.** Migration 0036 cuts every Han/kana run in the haystack into the same sliding windows `store.queryFragments` already cuts a question into, and stores them as `tsvector` lexemes, so the substring test becomes a lexeme equality GIN answers. Latin text goes through `to_tsvector('english', …)` in the same column, which buys the other half for free: `revenues` now finds the body that says `revenue`. That mattered beyond recall — a search that found nothing was recorded as a knowledge gap (0051), so a recall defect was reaching the curator as *"somebody should write this"*.

Three things worth a reviewer's attention:

- **Names are split on punctuation before the english pass.** The default parser reads `sales-seeds.txt` as one host-shaped token and a path as one file-shaped token, which would have broken 0020's promise that `seeds` finds the concept carrying `sales-seeds.txt`. `TestIntegrationAttachmentSearch` caught it; reasoning had not.
- **One scoring change, forced by the stemming.** A fragment no document contains earned the *largest* possible weight, since rarity is the weight. English stopwords became exactly those fragments once the query stemmed, so `by` in a title outweighed every term anybody searched for. Such a fragment now weighs nothing.
- **The trigram index is dropped** — nothing reads it, and it was paid for on every write. `pg_trgm` stays installed; retiring the extension changes what a deployment requires, which is not this PR's business.

### Numbers

| | before | after |
|---|---|---|
| recall@10 (14 golden queries) | 1.00 | 1.00 |
| MRR | 0.90 | 0.85 |
| two-character Japanese term | sequential scan | index lookup, 1 row of the table |
| `revenues` → body saying `revenue` | no hit | hit |

The MRR drop is the accident above going away and leaving the ties it had been hiding: five of ten demo concepts score *identically* for "why is revenue down", and the order among them is whatever the scan produced. **Term frequency was tried as the tie-break** — `ts_rank` with and without length normalization, keeping positions — and measured worse (0.84) both ways, so it is not shipped and the positions it would have needed are stripped. Length normalization was actively wrong here: the expected answer for that query is the longest document. ROADMAP now describes the saturation instead of the scan, and I have left the remaining half of #531 open with this evidence rather than guessing at a fix the golden set cannot yet adjudicate.

### On design docs

I judged this internal per 0048: no wire, stored form, round trip, identity, or Google Cloud dependency moves, and no surface count changes. What a user observes is that Japanese search stops degrading with corpus size and that plurals match. Say the word if you read that as a decision needing a number, and I will write it.

## Checks

CI runs the same script; make it pass locally first (CONTRIBUTING.md has the
context, including the store integration test and the fuzz targets).

- [x] `scripts/check` is clean — ran `core` with `--db` twice end to end (all green; one earlier `restapi` history failure did not reproduce in isolation or in either later full run — shared-database flake) and `lint` reports 0 issues. `govulncheck` cannot reach vuln.go.dev from this sandbox, so that step is unverified here and left to CI
- [x] Behavior changes come with tests — `TestCJKClassAgreesWithGo` walks every code point in the relevant planes and pins the SQL character class to Go's own `unicode.Han`/`Hiragana`/`Katakana` tables, because a character one side windows and the other does not is a term nobody can find; `TestJapaneseSearchUsesTheIndex` reads the plan under `enable_seqscan=off` (which cannot make an index serve a predicate it has no entries for) and checks the lookup's selectivity against the table size; `TestEnglishSearchStems` pins the plural

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — none of them changed; this is
      the store's ranking, reached identically by every face
- [x] The change lands on every surface it belongs on — all four read the same
      `SearchLexical`, so all four get it
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens a surface? No — no operation, tool, command, or variable is added;
      `docs/surface.md` is unchanged. `ROADMAP.md` prose shrank slightly, and
      the manual stays under `DOC-LINES` without moving the ceiling

## Design docs

- [x] Alters an accepted decision? See *On design docs* above — I read this as
      internal under 0048 and have described it here instead
- [x] Commit messages and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BATZn1qmJosokMG8HGxRi8

---
_Generated by [Claude Code](https://claude.ai/code/session_01BATZn1qmJosokMG8HGxRi8)_