### PR TITLE
Build a context pack in a fixed number of reads

### DIFF
--- a/internal/service/context.go
+++ b/internal/service/context.go
@@ -70,44 +70,83 @@ func (s *Service) Context(ctx context.Context, req ContextRequest) (*ContextResu
 	seen := map[string]bool{}
 	var entries []domain.Knowledge
 	addFetched := func(k *domain.Knowledge) {
-		if len(entries) >= 2*limit || seen[k.ID] || k.Rejection != nil {
+		if k == nil || len(entries) >= 2*limit || seen[k.ID] || k.Rejection != nil {
 			return // rejected companions stay out of the pack
 		}
 		seen[k.ID] = true
 		entries = append(entries, *k)
 	}
-	add := func(id string) {
-		if len(entries) >= 2*limit || seen[id] {
-			return
+	// The primaries, a batch at a time. A hit can fail to become one —
+	// deleted between the search and the read, or rejected when the
+	// caller asked for rejected concepts — so this takes the next batch
+	// rather than assuming the first `limit` ids will do. In the ordinary
+	// case that is one round trip and the loop ends.
+	for rest := hits; len(entries) < limit && len(rest) > 0; {
+		n := min(limit-len(entries), len(rest))
+		batch := make([]string, 0, n)
+		for _, h := range rest[:n] {
+			if !seen[h.ID] {
+				batch = append(batch, h.ID)
+			}
 		}
-		k, err := s.Store.Get(ctx, id)
+		rest = rest[n:]
+		found, err := s.Store.GetManyDocs(ctx, batch)
 		if err != nil {
-			return // deleted targets stay out of the pack
+			return nil, err
 		}
-		addFetched(k)
-	}
-	for _, h := range hits {
-		if len(entries) >= limit {
-			break
+		for _, id := range batch {
+			addFetched(found[id])
 		}
-		add(h.ID)
 	}
 	// One hop through the primary concepts' links, both directions: the
 	// query a metric links to, and the insight that links to the metric
 	// (rel: explains points at the metric, not the other way round).
 	// Companions share the 2*limit cap and are never expanded themselves.
-	primaries := len(entries)
+	//
+	// Both directions are read for every primary before any of them is
+	// added, so the whole hop is two round trips rather than two per
+	// primary. The order companions are added in is unchanged — each
+	// primary's forward links, then what links back at it, in rank order
+	// — because that order is what the cap spends on the highest-ranked
+	// concepts first.
+	primaries := entries
+	primaryIDs := make([]string, len(primaries))
+	var targets []string
+	wanted := map[string]bool{}
 	for i := range primaries {
-		for _, l := range entries[i].Links {
-			add(l.Target)
+		primaryIDs[i] = primaries[i].ID
+		for _, l := range primaries[i].Links {
+			// No more than the cap could ever admit, and each id once.
+			// A hub concept linking at five hundred others would
+			// otherwise have all five hundred documents read to fill a
+			// pack that can hold 2*limit of them.
+			if len(targets) >= 2*limit {
+				break
+			}
+			if !seen[l.Target] && !wanted[l.Target] {
+				wanted[l.Target] = true
+				targets = append(targets, l.Target)
+			}
 		}
-		linking, err := s.Store.ListLinkingToDocs(ctx, entries[i].ID, 2*limit)
-		if err != nil {
-			s.Log.Warn("backlink lookup failed", "id", entries[i].ID, "error", err)
-			continue
+	}
+	linked, err := s.Store.GetManyDocs(ctx, targets)
+	if err != nil {
+		return nil, err
+	}
+	linkers, err := s.Store.LinkersByTargetDocs(ctx, primaryIDs, 2*limit)
+	if err != nil {
+		// A pack without its backlinks is worth more than no pack; the
+		// forward hop and the primaries are already in hand.
+		s.Log.Warn("backlink lookup failed", "error", err)
+		linkers = nil
+	}
+	for i := range primaries {
+		for _, l := range primaries[i].Links {
+			addFetched(linked[l.Target])
 		}
-		for j := range linking {
-			addFetched(&linking[j])
+		group := linkers[primaries[i].ID]
+		for j := range group {
+			addFetched(&group[j])
 		}
 	}
 	// Concepts become views here: a context pack hands over the document

--- a/internal/service/contextreads_integration_test.go
+++ b/internal/service/contextreads_integration_test.go
@@ -1,0 +1,91 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/na0fu3y/ochakai/internal/domain"
+	"github.com/na0fu3y/ochakai/internal/store"
+)
+
+// The context pack is the one call an agent is told to make before a
+// data question, and it used to be the slowest thing in the system: one
+// round trip per hit, one per link and one per primary for the
+// backlinks, each waiting on the one before. Fixing that is only worth
+// something if it stays fixed, and nothing about the result says how
+// many times the database was asked to produce it.
+//
+// So it is read from outside (design doc 0035), off the pool's own
+// counter: build a pack twice at sizes an order of magnitude apart and
+// compare what each cost. A count that tracks the pack size is the shape
+// of the defect, whatever the constant happens to be on the day — which
+// is why the assertion is on the difference and not on a number.
+
+// TestContextReadsDoNotGrowWithThePack builds a two-concept pack and a
+// nineteen-concept one and compares their cost in statements.
+func TestContextReadsDoNotGrowWithThePack(t *testing.T) {
+	ctx := context.Background()
+	svc := newIntegrationService(t, ctx)
+	actor := domain.Actor{Kind: domain.ActorHuman, Name: "reads"}
+	run := uid(t, "ctxreads")
+
+	// Two clusters. Every leaf links at its hub and the hub links back at
+	// every leaf, so a pack has both directions to follow — the hop that
+	// used to cost a round trip per primary in each direction.
+	build := func(cluster string, leaves int) {
+		t.Helper()
+		hub := fmt.Sprintf("%s/%s/hub", run, cluster)
+		body := ""
+		for i := range leaves {
+			body += fmt.Sprintf("Links at [%d](/%s/%s/leaf-%02d.md).\n", i, run, cluster, i)
+		}
+		if _, err := svc.Create(ctx, &domain.Knowledge{
+			Type: domain.TypeMetrics, ID: hub, Title: cluster + " hub",
+			Status: domain.StatusStable, Body: body,
+		}, actor); err != nil {
+			t.Fatalf("create %s: %v", hub, err)
+		}
+		for i := range leaves {
+			id := fmt.Sprintf("%s/%s/leaf-%02d", run, cluster, i)
+			if _, err := svc.Create(ctx, &domain.Knowledge{
+				Type: domain.TypeInsights, ID: id, Title: fmt.Sprintf("%s leaf %d", cluster, i),
+				Status: domain.StatusStable,
+				Body:   fmt.Sprintf("About the %s hub, see [hub](/%s.md).", cluster, hub),
+			}, actor); err != nil {
+				t.Fatalf("create %s: %v", id, err)
+			}
+		}
+	}
+	build("small", 1)
+	build("large", 18)
+
+	measure := func(cluster string, wantAtLeast int) int64 {
+		t.Helper()
+		filter := store.Filter{Prefixes: []string{run + "/" + cluster}}
+		before := svc.Store.StatementCount()
+		res, err := svc.Context(ctx, ContextRequest{Query: cluster + " hub", Filter: filter, Limit: 20})
+		if err != nil {
+			t.Fatalf("context %s: %v", cluster, err)
+		}
+		after := svc.Store.StatementCount()
+		if got := len(res.Concepts) + len(res.Outline); got < wantAtLeast {
+			t.Fatalf("the %s pack held %d concepts, want at least %d: the comparison "+
+				"means nothing unless the two packs are different sizes", cluster, got, wantAtLeast)
+		}
+		return after - before
+	}
+	small := measure("small", 2)
+	large := measure("large", 15)
+
+	t.Logf("statements: %d for a 2-concept pack, %d for a 19-concept pack", small, large)
+	// Slack of two, because a pack can take one extra batch of primaries
+	// when a hit does not survive the read, and because the usage flush
+	// that follows a pack is asynchronous and may or may not land inside
+	// the window. What is asserted is that nine times the concepts is not
+	// nine times the statements.
+	if large > small+2 {
+		t.Errorf("a 19-concept pack cost %d statements against %d for a 2-concept pack: "+
+			"the pack is reading once per concept again", large, small)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -602,6 +602,100 @@ func (s *Store) ListLinkingToDocs(ctx context.Context, id string, limit int) ([]
 	return s.listLinkingTo(ctx, id, limit, knowledgeSelectDoc, scanKnowledgeDoc)
 }
 
+// StatementCount reports how many times a statement has taken a
+// connection from the pool since the store opened — one per query, and
+// one per transaction however many statements it runs.
+//
+// It exists so that a caller's cost in round trips can be read from
+// outside rather than reasoned about (design doc 0035). The context pack
+// is the case: it used to read once per hit and once per link, and
+// nothing about its result said so. The difference across a call is what
+// TestContextReadsDoNotGrowWithThePack asserts against.
+func (s *Store) StatementCount() int64 { return s.pool.Stat().AcquireCount() }
+
+// GetManyDocs returns the live entries holding these ids, with their
+// documents, keyed by id. Ids that name nothing live are absent rather
+// than an error: the caller asked about several, and one deleted target
+// is not a failed read of the others.
+//
+// The context pack is why this exists. It used to call Get once per hit
+// and once per link, which is one round trip each — up to sixty for the
+// one call an agent is told to make before a data question, all of them
+// waiting on the previous one. The rows are the same rows; only the
+// number of times the server asks for them changes.
+func (s *Store) GetManyDocs(ctx context.Context, ids []string) (map[string]*domain.Knowledge, error) {
+	out := map[string]*domain.Knowledge{}
+	if len(ids) == 0 {
+		return out, nil
+	}
+	rows, err := s.pool.Query(ctx,
+		`SELECT `+knowledgeSelectDoc+` FROM object WHERE deleted_at IS NULL AND id = ANY($1)`, ids)
+	if err != nil {
+		return nil, err
+	}
+	found, err := pgx.CollectRows(rows, scanKnowledgeDoc)
+	if err != nil {
+		return nil, err
+	}
+	for i := range found {
+		out[found[i].ID] = &found[i]
+	}
+	return out, nil
+}
+
+// LinkersByTargetDocs answers ListLinkingToDocs for several ids at once,
+// grouped by the id linked at and each group ordered and capped exactly
+// as the single-id form is.
+//
+// The lateral join is what makes it the same answer rather than a
+// cheaper approximation: a union ordered globally would let one id's
+// linkers crowd out another's, and the caller reads the groups in rank
+// order precisely because the first id's companions matter most. An
+// entry linking at two of the ids appears in both groups, as it did when
+// each id was asked separately.
+func (s *Store) LinkersByTargetDocs(ctx context.Context, ids []string, perID int) (map[string][]domain.Knowledge, error) {
+	out := map[string][]domain.Knowledge{}
+	if len(ids) == 0 || perID <= 0 {
+		return out, nil
+	}
+	rows, err := s.pool.Query(ctx,
+		`SELECT `+knowledgeSelectDoc+`, t.target
+		 FROM unnest($1::text[]) AS t(target)
+		 CROSS JOIN LATERAL (
+			SELECT * FROM object o
+			WHERE o.deleted_at IS NULL
+			  AND o.links @> jsonb_build_array(jsonb_build_object('target', t.target))
+			ORDER BY o.updated_at DESC LIMIT $2
+		 ) object`, ids, perID)
+	if err != nil {
+		return nil, err
+	}
+	linkers, err := pgx.CollectRows(rows, scanKnowledgeDocForTarget)
+	if err != nil {
+		return nil, err
+	}
+	for _, l := range linkers {
+		out[l.target] = append(out[l.target], l.knowledge)
+	}
+	return out, nil
+}
+
+// targetedKnowledge is one row of LinkersByTargetDocs: the entry, and
+// which of the asked-for ids its links pointed at.
+type targetedKnowledge struct {
+	target    string
+	knowledge domain.Knowledge
+}
+
+func scanKnowledgeDocForTarget(row pgx.CollectableRow) (targetedKnowledge, error) {
+	var t targetedKnowledge
+	dests, finish := knowledgeDestWithDoc(&t.knowledge)
+	if err := row.Scan(append(dests, &t.target)...); err != nil {
+		return t, err
+	}
+	return t, finish()
+}
+
 func (s *Store) listLinkingTo(ctx context.Context, id string, limit int, cols string,
 	scan func(pgx.CollectableRow) (domain.Knowledge, error),
 ) ([]domain.Knowledge, error) {


### PR DESCRIPTION
<!-- Keep PRs small and focused. Link the issue or design doc, if there is one. -->

## What and why

First and largest part of #533 (plan #540).

`get_context` is the one call an agent is told to make before a data question, and it was the slowest path in the system: `Store.Get` once per hit, once per link target, and `ListLinkingToDocs` once per primary — up to sixty statements for one call, each waiting on the one before.

The rows are the same rows; only the number of times the server asks for them changes. Two batched reads replace the loops:

- `GetManyDocs` takes the ids together.
- `LinkersByTargetDocs` answers the reverse edge for every primary at once. **The lateral join is what makes it the same answer rather than a cheaper approximation** — a union ordered globally would let one primary's linkers crowd out another's, and the pack reads the groups in rank order precisely because the first primary's companions matter most.

**The pack is unchanged**: same concepts, same order, same caps. Primaries are still taken in hit order and filtered the same way, so a hit that does not survive the read is still backfilled from the next one — which is why they are fetched a batch at a time rather than all at once (one round trip in the ordinary case, a second only when something was filtered out).

One robustness fix rides along: a hub concept linking at five hundred others no longer has five hundred documents read to fill a pack that can hold `2*limit` of them.

### Measured

`Store.StatementCount` exposes the pool's own acquire counter, so the cost is read from outside rather than reasoned about (0035):

| pack | statements |
|---|---|
| 2 concepts | 3 |
| 19 concepts | 3 |

The test asserts the *difference*, not the constant — a count that tracks the pack size is the shape of the defect, whatever the number happens to be on the day. I first tried `pg_stat_user_tables` for this and dropped it: those counters flush asynchronously from other backends, so the window caught unrelated activity (42 reads for the small pack, 10 for the large — noise, not signal).

### What I did not do, and why

Two items on #533 I deliberately left, with reasons rather than silence:

- **Near-duplicate removal.** Exact ids are already deduplicated. Removing *paraphrases* needs a similarity judgment the store deliberately does not make; content-hash duplicates are exact but dropping one silently is still a judgment — the same knowledge legitimately sits at two addresses on a shared deployment with team prefixes. Worth a decision, not a quiet heuristic.
- **A leading excerpt when rank 1 exceeds the budget.** 0033 decided a concept is delivered whole or not at all, and its reason is a safety one: half of an attested computation's SQL still looks executable. Overriding that to save a round trip is not mine to do on my own; if you want it, it is a decision with a record.

The budget item is also still open there. Re-reading the contract, `budget` is documented precisely — *"max bytes of the knowledge in the response … nothing else carries a body, since `hits` is the ranking only"* — so `hits` riding outside it is stated behavior, not a violation. It is bounded (`2*limit` rows, ~1.2 KB at the default limit, ~5 KB at the maximum). I have left #533 open with that noted rather than changing wire semantics for it.

## Checks

CI runs the same script; make it pass locally first (CONTRIBUTING.md has the
context, including the store integration test and the fuzz targets).

- [x] `scripts/check` is clean — `core` with `--db` (all packages green) and `lint` 0 issues. `govulncheck` cannot reach vuln.go.dev from this sandbox, so that step is unverified here and left to CI
- [x] Behavior changes come with tests — `TestContextReadsDoNotGrowWithThePack` pins the invariant; the existing context integration tests pin that the pack's contents and order did not move

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — none changed; the response is
      byte-identical, only its cost moved
- [x] The change lands on every surface it belongs on — all four reach
      `Service.Context`, so all four get it
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens a surface? No — no operation, tool, command, or variable is added.
      `Store.StatementCount` is an internal-package method; `docs/surface.md`
      counts none of that (*"実装の行数、内部パッケージ、依存"*)

## Design docs

- [x] Alters an accepted decision? It does not — 0033's atomic delivery and
      0067 §4's ranking-only `hits` are both preserved deliberately, and the
      two places I would have had to break them are the two items left open
      above. This box is not applicable
- [x] Commit messages and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BATZn1qmJosokMG8HGxRi8

---
_Generated by [Claude Code](https://claude.ai/code/session_01BATZn1qmJosokMG8HGxRi8)_