### PR TITLE
Keep the history tests off the shared root window

### DIFF
--- a/internal/restapi/restapi_integration_test.go
+++ b/internal/restapi/restapi_integration_test.go
@@ -313,6 +313,10 @@ func TestRESTIntegration(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("archive status = %d: %s", resp.StatusCode, b)
+	}
 	gz, err = gzip.NewReader(resp.Body)
 	if err != nil {
 		t.Fatal(err)
@@ -2238,6 +2242,10 @@ func TestRESTIntegrationIndexListsTheFilesInADirectory(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("archive status = %d: %s", resp.StatusCode, b)
+	}
 	gz, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		t.Fatal(err)
@@ -2293,6 +2301,12 @@ func TestRESTIntegrationTheArchiveCarriesTheHistory(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer resp.Body.Close()
+	// An error answer is JSON, not an archive: naming the status and the
+	// body beats failing on "gzip: invalid header" (#546).
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("archive status = %d: %s", resp.StatusCode, b)
+	}
 	gz, err := gzip.NewReader(resp.Body)
 	if err != nil {
 		t.Fatal(err)
@@ -2403,18 +2417,30 @@ func TestRESTIntegrationHistoryIsAtTheObjectAndTheDirectory(t *testing.T) {
 		t.Errorf("the directory's history = %+v, want the concept and its file", log.Changes)
 	}
 
-	// The root, likewise — and it is the same set the markdown lists.
+	// And the markdown beside it lists the same set. The agreement is
+	// checked here and not at the root: nothing else writes under this
+	// prefix, so the two reads see one feed. The root's window is shared
+	// with every parallel test, and an entry another test pushed past its
+	// edge between the JSON read and the markdown read failed the
+	// comparison there (#546).
+	dirDoc := getMarkdown(t, srv.URL+"/api/v1/bundle/"+typ+"/log.md")
+	for _, c := range log.Changes {
+		if rel := strings.TrimPrefix(c.Path, typ+"/"); !strings.Contains(dirDoc, "("+rel+")") {
+			t.Errorf("the JSON names %s and the document does not:\n%s", c.Path, dirDoc)
+			break
+		}
+	}
+
+	// The root, likewise, in both representations — existence only, for
+	// the same reason the archive test reads only the root history's
+	// title.
 	log.Changes = nil
 	getJSON(t, srv.URL+"/api/v1/bundle/log.md", &log)
 	if len(log.Changes) == 0 {
 		t.Error("the root history has no JSON representation")
 	}
-	rootDoc := getMarkdown(t, srv.URL+"/api/v1/bundle/log.md")
-	for _, c := range log.Changes {
-		if !strings.Contains(rootDoc, "(/"+c.Path+")") && !strings.Contains(rootDoc, c.Path) {
-			t.Errorf("the JSON names %s and the document does not:\n%s", c.Path, rootDoc)
-			break
-		}
+	if rootDoc := getMarkdown(t, srv.URL+"/api/v1/bundle/log.md"); !strings.Contains(rootDoc, "# Update Log") {
+		t.Errorf("the root history is not titled as one:\n%s", rootDoc)
 	}
 
 	// ?history on the concept: its own revisions, carrying the document.


### PR DESCRIPTION
## What and why

#546 の一件目の flake の修正と、二件目の誤誘導の除去。テストのみの変更で、製品コードは動かない。

**一件目(構造的に解消)。** `TestRESTIntegrationHistoryIsAtTheObjectAndTheDirectory` は root の `log.md` を JSON → markdown の二回の GET で読み、JSON が名指す全パスが markdown にもあることを要求していた。root の履歴は DB を共有する全並走テストの**有界の窓**なので、二回の GET の間に他のテストの書き込みが挟まると、JSON が名指した端のエントリが markdown 側から押し出されて落ちる — `searchtsv` テスト(200 文書の連続書き込み)が main に入って発火確率が跳ねた。二表現の一致の検証は**自分の接頭辞のディレクトリの `log.md`** に移した(そこには誰も書かないので二回の読みが一つのフィードを見る)。root は「JSON 表現が存在する・文書がタイトルを持つ」ことだけ確認する — `TestRESTIntegrationTheArchiveCarriesTheHistory` が同じ理由で既に宣言していた境界(「root の窓で自分の行を主張することは、誰も忙しくなかったと主張することである」)に揃えた形。

**二件目(誤誘導の除去)。** archive の応答をステータスを見ずに `gzip.NewReader` に渡す箇所が三つあり、ストリーム開始前の一時的な 500(`BeginExport` 中の `connection reset` — 2026-08-07 の main の失敗ログと一致)が `gzip: invalid header` という無関係な顔で現れていた。三箇所にステータスと本文を名指す確認を足した。**背後の一時的な接続断そのものはこの PR では扱わず、#546 に残す**ので `Closes` ではなく参照に留める。

## Checks

CI runs the same script; make it pass locally first (CONTRIBUTING.md has the
context, including the store integration test and the fuzz targets).

- [x] `scripts/check` is clean — add `--db` when the change touches the store(`--db core` を二周、`lint` も緑。govulncheck はこの環境のプロキシが vuln.go.dev を拒むため CI に委ねる)
- [x] Behavior changes come with tests(テストのみの変更 — 製品の挙動は変わらない)

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — ワイヤに変更なし
- [x] The change lands on every surface it belongs on — 面に触れない
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens a surface? — しない。`docs/surface.md` は動かない

## Design docs

- [x] Alters an accepted decision? — しない。テストの検証位置の是正のみ
- [x] Commit messages and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6ZJJvFRFw6fcwVTYBxvME

---
_Generated by [Claude Code](https://claude.ai/code/session_01X6ZJJvFRFw6fcwVTYBxvME)_