### PR TITLE
Close four trust holes: backups on, bounded reads, Vertex retry, concurrent import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,31 @@ last entry.
 
 ### Changed
 
+- **`ochakai import` keeps eight requests in flight instead of one.** An
+  import (and its `--dry-run`, which makes the same round trips) was one
+  sequential HTTP call per document, which priced a real catalog
+  projection — thousands of documents — in tens of minutes against a
+  Cloud Run service. The counts and the exit code are unchanged; output
+  lines now land in completion order, so the summary line is the stable
+  thing to read. A fatal error (auth, network, 5xx) still aborts: it
+  cancels the requests not yet started and returns once the ones in
+  flight finish.
+- **A transient Vertex AI failure no longer silently degrades search on
+  the first try.** An embedding call now gets three attempts with a short
+  backoff on a 429, a 5xx or a dropped connection, and a 30-second
+  per-attempt deadline instead of none — a call that hung held the
+  search that was waiting on it. A 4xx is still never retried.
+- **Daily Cloud SQL backups are on by default in the Terraform module.**
+  The database is the knowledge base, and the copy-paste starting
+  configuration protected everything except it. The cost example rises by
+  under a dollar; a throwaway evaluation can still opt out with
+  `database_backups = false`.
+- **The server now bounds request reads and idle keep-alive.** A body
+  must arrive within a minute (the largest accepted body is the 4 MiB
+  PUT cap) and an idle connection is closed after two; previously only
+  header reads had a deadline, so a slow-drip body or a hoarded
+  connection was held open indefinitely. Response writes stay unbounded,
+  deliberately: MCP's streamable GET is a hanging stream by design.
 - **A search for a name now finds the concept with that name.** Ask for
   売上 and the concept *called* 売上 comes first, ahead of the reports
   that mention the word — which is not what happened before: the lexical

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -18,7 +18,10 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/na0fu3y/ochakai/internal/apiclient"
 	"github.com/na0fu3y/ochakai/internal/domain"
@@ -1383,6 +1386,28 @@ func cmdExport(ctx context.Context, args []string) error {
 	return nil
 }
 
+// importWorkers is how many requests an import (or its dry run) keeps in
+// flight. The unit of work is one small HTTP round trip, so the win is
+// latency hiding, not bandwidth — eight is enough to hide a Cloud Run
+// round trip without turning an import into a load test of the smallest
+// instance this is documented to run on.
+const importWorkers = 8
+
+// eachConcurrently runs fn(i) for every i in [0, n) across importWorkers
+// goroutines. The first error cancels the context the remaining calls
+// see and is the one returned; calls already in flight finish.
+func eachConcurrently(ctx context.Context, n int, fn func(ctx context.Context, i int) error) error {
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(importWorkers)
+	for i := range n {
+		if ctx.Err() != nil {
+			break
+		}
+		g.Go(func() error { return fn(ctx, i) })
+	}
+	return g.Wait()
+}
+
 func cmdImport(ctx context.Context, args []string) error {
 	fs, url := newFlagSet(
 		"import",
@@ -1437,8 +1462,17 @@ func cmdImport(ctx context.Context, args []string) error {
 	// frozen into the wire forever (design doc 0064).
 	//
 	// Anything else (auth, network, 5xx) still aborts.
+	//
+	// The loop keeps importWorkers requests in flight: a real catalog is
+	// thousands of documents, and one round trip at a time priced the
+	// flagship use case in minutes. Lines land in completion order, so
+	// two runs of the same bundle may print them differently — the
+	// summary line is the stable part.
 	var created, updated, unchanged int
 	refused := map[string]bool{}
+	// One mutex guards the counters, the skip list and the output; the
+	// network calls happen outside it.
+	var mu sync.Mutex
 	skipEntry := func(k *domain.Knowledge, err error) {
 		refused[k.ID] = true
 		skipped = append(skipped, k.ID+".md: refused as a concept and not stored: "+err.Error()+
@@ -1451,22 +1485,24 @@ func cmdImport(ctx context.Context, args []string) error {
 	// this instance's ledger: what the document said stays a claim beside
 	// it (design doc 0046 §2.2), and the verification recorded here is
 	// the importer's own.
-	confirm := func(d *okf.Doc) {
+	confirm := func(ctx context.Context, d *okf.Doc) string {
 		if !d.Verified {
-			return
+			return ""
 		}
 		if _, err := c.Verify(ctx, d.ID); err != nil {
-			noted++
-			fmt.Fprintf(os.Stderr, "note: %s imported, but recording its verification failed: %v\n", d.ID, err)
+			return fmt.Sprintf("%s imported, but recording its verification failed: %v", d.ID, err)
 		}
+		return ""
 	}
-	for i := range entries {
+	err = eachConcurrently(ctx, len(entries), func(ctx context.Context, i int) error {
 		d := &entries[i]
 		k := &d.Knowledge
 		doc, err := documentOf(k)
 		if err != nil {
+			mu.Lock()
+			defer mu.Unlock()
 			skipEntry(k, err)
-			continue
+			return nil
 		}
 		// One call per document, with no precondition: import deliberately
 		// replaces whatever is stored (the bundle is the source of truth
@@ -1475,8 +1511,10 @@ func cmdImport(ctx context.Context, args []string) error {
 		stored, wasCreated, changed, notes, err := c.Put(ctx, k.ID, doc, "", false)
 		if err != nil {
 			if isInvalid(err) {
+				mu.Lock()
+				defer mu.Unlock()
 				skipEntry(k, err)
-				continue
+				return nil
 			}
 			return fmt.Errorf("%s: %w", k.URI(), err)
 		}
@@ -1487,25 +1525,37 @@ func cmdImport(ctx context.Context, args []string) error {
 		// (design doc 0046 §2.2), which is what keeps the Git review loop
 		// note-free.
 		notes = okf.NoteStoredClaim(notes, d.Claimed, stored.Document)
+		verifyNote := ""
+		if wasCreated || changed {
+			verifyNote = confirm(ctx, d)
+		}
+		mu.Lock()
+		defer mu.Unlock()
 		noted += len(notes)
 		reportNotes(notes)
-		if wasCreated {
-			created++
-			confirm(d)
-			fmt.Printf("created %s\n", k.URI())
-			continue
+		if verifyNote != "" {
+			noted++
+			fmt.Fprintln(os.Stderr, "note:", verifyNote)
 		}
-		if !changed {
+		switch {
+		case wasCreated:
+			created++
+			fmt.Printf("created %s\n", k.URI())
+		case !changed:
 			unchanged++
 			fmt.Printf("unchanged %s\n", k.URI())
-			continue
+		default:
+			updated++
+			fmt.Printf("updated %s\n", k.URI())
 		}
-		updated++
-		confirm(d)
-		fmt.Printf("updated %s\n", k.URI())
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 	attached, orphaned := 0, 0
-	for _, a := range atts {
+	err = eachConcurrently(ctx, len(atts), func(ctx context.Context, i int) error {
+		a := atts[i]
 		// At the path the bundle carried it at, which is the whole of
 		// what preserving a foreign location means now (design doc 0046
 		// §3.3): the concept claims it because its body points there.
@@ -1520,13 +1570,19 @@ func cmdImport(ctx context.Context, args []string) error {
 		// refusal cost every file the document pointed at (design doc
 		// 0079 §1). It is written either way; only the line saying who
 		// claims it changes, because right now nobody does.
+		mu.Lock()
+		defer mu.Unlock()
 		if refused[a.ID] {
 			orphaned++
 			fmt.Printf("wrote %s (its concept %s was not imported)\n", a.Path, a.ID)
-			continue
+			return nil
 		}
 		attached++
 		fmt.Printf("attached %s (%s)\n", a.Path, a.ID)
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 	// The files that belong to no concept, at the paths they arrived at.
 	// A bundle carries more than its concepts, and what enters it leaves
@@ -1535,17 +1591,26 @@ func cmdImport(ctx context.Context, args []string) error {
 	// type. Whether a concept ever claims one is a question that concept's
 	// body answers (§3.3), so nothing is attributed here.
 	var written int
-	for _, f := range loose {
+	err = eachConcurrently(ctx, len(loose), func(ctx context.Context, i int) error {
+		f := loose[i]
 		if _, err := c.PutBundleFile(ctx, f.Path, f.Data); err != nil {
 			if !isInvalid(err) {
 				return fmt.Errorf("write %s: %w", f.Path, err)
 			}
+			mu.Lock()
+			defer mu.Unlock()
 			skipped = append(skipped, f.Path+": rejected by the server: "+err.Error())
 			fmt.Fprintln(os.Stderr, "skip:", skipped[len(skipped)-1])
-			continue
+			return nil
 		}
+		mu.Lock()
+		defer mu.Unlock()
 		written++
 		fmt.Printf("wrote %s\n", f.Path)
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 	// A file whose concept was refused belongs to nobody, so it counts
 	// where the bundle's other unclaimed objects do.
@@ -1577,28 +1642,35 @@ func cmdImport(ctx context.Context, args []string) error {
 func dryRunImport(ctx context.Context, c *apiclient.Client, entries []okf.Doc,
 	atts []okf.AttributedFile, loose []okf.BundleFile, skipped []string, noted int, strict bool,
 ) error {
+	// Concurrent for the same reason the real import is: the dry run is
+	// the same N round trips, and a CI gate pays for them on every push.
 	var created, updated, unchanged int
 	refused := map[string]bool{}
+	var mu sync.Mutex
 	skip := func(what, why string) {
 		skipped = append(skipped, what+": "+why)
 		fmt.Fprintln(os.Stderr, "skip:", skipped[len(skipped)-1])
 	}
-	for i := range entries {
+	err := eachConcurrently(ctx, len(entries), func(ctx context.Context, i int) error {
 		d := &entries[i]
 		k := &d.Knowledge
 		doc, err := documentOf(k)
 		if err != nil {
+			mu.Lock()
+			defer mu.Unlock()
 			refused[k.ID] = true
 			skip(k.ID+".md", "rejected by the server: "+err.Error())
-			continue
+			return nil
 		}
 		planned, plan, notes, err := c.Plan(ctx, k.ID, doc)
 		if err != nil {
 			if isInvalid(err) {
+				mu.Lock()
+				defer mu.Unlock()
 				refused[k.ID] = true
 				skip(k.ID+".md", "refused as a concept and not stored: "+err.Error()+
 					" — the document is still in the bundle you imported from")
-				continue
+				return nil
 			}
 			return fmt.Errorf("%s: %w", k.URI(), err)
 		}
@@ -1606,6 +1678,8 @@ func dryRunImport(ctx context.Context, c *apiclient.Client, entries []okf.Doc,
 		// claim still on the concept the write would leave behind is one
 		// the document made and this instance did not observe.
 		notes = okf.NoteStoredClaim(notes, d.Claimed, planned.Document)
+		mu.Lock()
+		defer mu.Unlock()
 		noted += len(notes)
 		reportNotes(notes)
 		switch plan {
@@ -1619,50 +1693,64 @@ func dryRunImport(ctx context.Context, c *apiclient.Client, entries []okf.Doc,
 			updated++
 			fmt.Printf("would update %s\n", k.URI())
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 	// A file's plan is a yes or a no: the counts the summary keeps for
 	// files are of the objects the bundle carries, not of the rows they
 	// would move, so ok=false means the server refused this one.
-	planFile := func(path string, data []byte) (ok bool, err error) {
+	planFile := func(ctx context.Context, path string, data []byte) (ok bool, err error) {
 		if _, err := c.PlanBundleFile(ctx, path, data); err != nil {
 			if !isInvalid(err) {
 				return false, fmt.Errorf("write %s: %w", path, err)
 			}
+			mu.Lock()
+			defer mu.Unlock()
 			skip(path, "rejected by the server: "+err.Error())
 			return false, nil
 		}
 		return true, nil
 	}
 	attached, orphaned := 0, 0
-	for _, a := range atts {
-		ok, err := planFile(a.Path, a.Data)
-		if err != nil {
+	err = eachConcurrently(ctx, len(atts), func(ctx context.Context, i int) error {
+		a := atts[i]
+		ok, err := planFile(ctx, a.Path, a.Data)
+		if err != nil || !ok {
 			return err
-		}
-		if !ok {
-			continue
 		}
 		// Written whether or not its concept was — the write loop's rule
 		// (design docs 0075 §5, 0079 §1), planned rather than done.
+		mu.Lock()
+		defer mu.Unlock()
 		if refused[a.ID] {
 			orphaned++
 			fmt.Printf("would write %s (its concept %s would not be imported)\n", a.Path, a.ID)
-			continue
+			return nil
 		}
 		attached++
 		fmt.Printf("would attach %s (%s)\n", a.Path, a.ID)
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 	var wrote int
-	for _, f := range loose {
-		ok, err := planFile(f.Path, f.Data)
-		if err != nil {
+	err = eachConcurrently(ctx, len(loose), func(ctx context.Context, i int) error {
+		f := loose[i]
+		ok, err := planFile(ctx, f.Path, f.Data)
+		if err != nil || !ok {
 			return err
 		}
-		if !ok {
-			continue
-		}
+		mu.Lock()
+		defer mu.Unlock()
 		wrote++
 		fmt.Printf("would write %s\n", f.Path)
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 	wrote += orphaned
 	fmt.Printf("dry run: %d concepts (%d created, %d updated, %d unchanged, %d attributed, %d loose, %d skipped, %d notes)\n",

--- a/cmd/ochakai/client_test.go
+++ b/cmd/ochakai/client_test.go
@@ -16,6 +16,7 @@ import (
 	"reflect"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -246,6 +247,51 @@ func TestRenderContext(t *testing.T) {
 	}
 	if !strings.Contains(s, "1 more concepts beyond --budget") {
 		t.Errorf("omitted concepts must be reported:\n%s", s)
+	}
+}
+
+// The import loop keeps several requests in flight, so the properties a
+// sequential loop gave for free are pinned here instead: every index
+// runs exactly once, and the first fatal error stops new work rather
+// than draining the rest of a five-thousand-document bundle against a
+// server that already said no.
+func TestEachConcurrently(t *testing.T) {
+	var mu sync.Mutex
+	ran := map[int]int{}
+	if err := eachConcurrently(context.Background(), 100, func(_ context.Context, i int) error {
+		mu.Lock()
+		defer mu.Unlock()
+		ran[i]++
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(ran) != 100 {
+		t.Errorf("ran %d distinct indices, want 100", len(ran))
+	}
+	for i, n := range ran {
+		if n != 1 {
+			t.Errorf("index %d ran %d times", i, n)
+		}
+	}
+
+	boom := errors.New("boom")
+	started := 0
+	err := eachConcurrently(context.Background(), 1000, func(ctx context.Context, i int) error {
+		mu.Lock()
+		started++
+		mu.Unlock()
+		if i == 0 {
+			return boom
+		}
+		<-ctx.Done() // the error must reach later calls as cancellation
+		return ctx.Err()
+	})
+	if !errors.Is(err, boom) {
+		t.Errorf("err = %v, want the first real error, not a cancellation", err)
+	}
+	if started >= 1000 {
+		t.Error("an early error should stop new work from starting")
 	}
 }
 

--- a/cmd/ochakai/main.go
+++ b/cmd/ochakai/main.go
@@ -305,6 +305,19 @@ func runServer(ctx context.Context, addr string, handler http.Handler) error {
 	server := &http.Server{
 		Handler:           handler,
 		ReadHeaderTimeout: 10 * time.Second,
+		// A request body arrives within a minute or not at all: the
+		// largest accepted body is the 4 MiB PUT cap, so this asks
+		// ~70 KB/s of the slowest legitimate writer while ending the
+		// slow-drip connection that ReadHeaderTimeout cannot see.
+		ReadTimeout: time.Minute,
+		// Idle keep-alive connections are the other way to hoard a
+		// listener without ever tripping a per-request deadline.
+		IdleTimeout: 2 * time.Minute,
+		// WriteTimeout stays unset, deliberately: the MCP endpoint is a
+		// streamable-HTTP handler whose GET is a hanging stream by
+		// design, and a write deadline would sever it — and sever an
+		// export to a slow reader with it. Where response duration
+		// needs a bound, Cloud Run's own request timeout is that bound.
 	}
 	return serveAndDrain(ctx, server, ln)
 }

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -14,12 +14,15 @@
 ## 何を作るか
 
 既定値はガイドのコスト最小化した例(月 $10 程度、そのほとんどが Cloud SQL
-インスタンス)を再現する:
+インスタンス)を一箇所だけ除いて再現する — **日次バックアップは既定で on**
+である(ガイドの例は `--no-backup`)。データベースはナレッジベースそのもの
+であり、そこだけは安さより先に立つ。上乗せはこの規模で月 $1 に届かない程度
+で、使い捨ての評価なら `database_backups = false` で外せる:
 
 | | |
 |---|---|
 | Artifact Registry | `ghcr.io` をプロキシする**リモートリポジトリ**(§1)— Cloud Run は GHCR から直接 pull できない |
-| Cloud SQL | `db-f1-micro`、Postgres 17、10 GB SSD、単一ゾーン、バックアップ無し、`cloudsql.iam_authentication=on`(§2) |
+| Cloud SQL | `db-f1-micro`、Postgres 17、10 GB SSD、単一ゾーン、日次バックアップ、`cloudsql.iam_authentication=on`(§2) |
 | サービスアカウント | `ochakai-run`。`roles/cloudsql.client` + `roles/cloudsql.instanceUser` と、IAM データベースログイン(§3) |
 | Cloud Run | ochakai サービス本体、scale-to-zero、**公開呼び出し不可**、`OCHAKAI_DB_IAM_AUTH=true`(§3) |
 | IAM | 名指したメンバーへの `roles/run.invoker` — アクセス制御の面はこれがすべて |
@@ -130,7 +133,7 @@ GRANT "<database_user output>" TO "you@your-org.example";
 | `read_only` | §5d | `OCHAKAI_MODE=read-only` を設定する — 非公開のままである。on にする*前*にベースへ import しておくこと: read-only なデプロイには import できない。 |
 | `public_read_only` | §5d | `OCHAKAI_MODE=public` を設定し、このモジュール唯一の `allUsers` を付与する。`read_only` を含意する。その姿勢が何を手放すかは[デプロイガイド](../cloudrun/README.md#5d-optional-a-public-read-only-demo-the-one-public-posture)にある。書き込み可能な状態で apply し、`ochakai import examples/demo` した後、これを on にして再度 apply する。 |
 | `maintenance_users` | §6 | 人のための Cloud SQL IAM ログイン、パスワードは無い。 |
-| `database_backups` | §6 | 日次バックアップ。コストのため既定は off。大事なものには on にする。 |
+| `database_backups` | §6 | 日次バックアップ。**既定で on** — データベースはナレッジベースそのものである。使い捨ての評価だけ off にしてよい。 |
 
 web UI を有効にすると `google-beta` provider が付いてくる: Cloud Run 上の
 IAP(`iap_enabled`)はまだベータの面だからである。provider はどちらにせよ

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -52,8 +52,10 @@ invoker_members = [
 # get an IAM login (cloud-sql-proxy --auto-iam-authn), never a password.
 # maintenance_users = ["you@your-org.example"]
 
-# Real knowledge deserves backups; the cost example skips them.
-# database_backups = true
+# Daily backups are ON by default — the database is the knowledge base.
+# Opting out is for throwaway evaluations only.
+# database_backups = false
 
-# Set to false and apply once before `terraform destroy`.
-# deletion_protection = true
+# Deletion protection is ON by default. Set to false and apply once
+# before `terraform destroy`.
+# deletion_protection = false

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -171,9 +171,9 @@ variable "database_disk_size_gb" {
 }
 
 variable "database_backups" {
-  description = "Enable daily backups. Off by default to match the guide's cost-minimized example; turn it on for anything you care about (deploy/cloudrun/README.md §6)."
+  description = "Enable daily backups. On by default: the database is the knowledge base, and losing it to a zonal incident is the one cost this module must not minimize. Set to false only for a throwaway evaluation (deploy/cloudrun/README.md §6)."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "database_backup_start_time" {

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/pb33f/libopenapi-validator v0.14.0
 	go.yaml.in/yaml/v3 v3.0.5
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sync v0.22.0
 	golang.org/x/text v0.40.0
 	google.golang.org/api v0.291.0
 )
@@ -71,7 +72,6 @@ require (
 	go.yaml.in/yaml/v4 v4.0.0-rc.6 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto v0.0.0-20260519071638-aa98bba5eb94 // indirect

--- a/internal/embed/vertex.go
+++ b/internal/embed/vertex.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"time"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -42,12 +43,18 @@ func NewVertex(ctx context.Context, project, location, model string, dim int) (*
 	if err != nil {
 		return nil, fmt.Errorf("Vertex AI credentials (ADC) not found: %w", err)
 	}
+	client := oauth2.NewClient(ctx, ts)
+	// A call that hangs is worse than one that fails: search falls back
+	// to lexical the moment this errors, but only once it errors. The
+	// deadline is per attempt; the retry loop in post decides how many
+	// attempts a call gets.
+	client.Timeout = 30 * time.Second
 	return &Vertex{
 		model: model,
 		dim:   dim,
 		base: fmt.Sprintf("https://%s/v1/projects/%s/locations/%s/publishers/google/models/%s",
 			vertexHost(location), project, location, model),
-		client:       oauth2.NewClient(ctx, ts),
+		client:       client,
 		embedContent: strings.HasPrefix(model, "gemini-embedding-2"),
 	}, nil
 }
@@ -256,25 +263,61 @@ func (v *Vertex) embedContentOne(ctx context.Context, req embedContentRequest) (
 	return out.Embedding.Values, nil
 }
 
+// post sends one embedding request, retrying what deserves a retry. A
+// transient failure here does not merely fail the call: a search that
+// cannot embed its query silently degrades to lexical, and a write leaves
+// the entry out of vector search until `ochakai reembed` — so a 429, a
+// 5xx or a dropped connection gets three attempts with a short backoff
+// before the caller hears about it. A 4xx is the request's own fault and
+// is never retried.
 func (v *Vertex) post(ctx context.Context, url string, req any) ([]byte, error) {
 	body, err := json.Marshal(req)
 	if err != nil {
 		return nil, err
 	}
+	var lastErr error
+	backoff := vertexBackoff
+	for attempt := 0; attempt < 3; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(backoff):
+			}
+			backoff *= 4
+		}
+		respBody, retryable, err := v.postOnce(ctx, url, body)
+		if err == nil {
+			return respBody, nil
+		}
+		if !retryable || ctx.Err() != nil {
+			return nil, err
+		}
+		lastErr = err
+	}
+	return nil, lastErr
+}
+
+// vertexBackoff is the wait before the first retry; each further retry
+// waits four times longer. A variable so tests do not sleep for real.
+var vertexBackoff = 500 * time.Millisecond
+
+// postOnce is one attempt; retryable says whether post may try again.
+func (v *Vertex) postOnce(ctx context.Context, url string, body []byte) (respBody []byte, retryable bool, err error) {
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 
 	resp, err := v.client.Do(httpReq)
 	if err != nil {
-		return nil, fmt.Errorf("Vertex AI embeddings: %w", err)
+		return nil, true, fmt.Errorf("Vertex AI embeddings: %w", err)
 	}
 	defer resp.Body.Close()
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 32<<20))
+	respBody, err = io.ReadAll(io.LimitReader(resp.Body, 32<<20))
 	if err != nil {
-		return nil, err
+		return nil, true, err
 	}
 	if resp.StatusCode != http.StatusOK {
 		err := fmt.Errorf("Vertex AI embeddings: %s: %s", resp.Status, truncate(string(respBody), 500))
@@ -284,7 +327,7 @@ func (v *Vertex) post(ctx context.Context, url string, req any) ([]byte, error) 
 		// rather than by giving up on the entry.
 		if resp.StatusCode == http.StatusBadRequest {
 			if inputTooLong(string(respBody)) {
-				return nil, fmt.Errorf("%w: %w", ErrInputTooLong, err)
+				return nil, false, fmt.Errorf("%w: %w", ErrInputTooLong, err)
 			}
 			// Every other 400 is logged loudly, because the phrase list
 			// below is the only thing standing between a token-limit
@@ -294,9 +337,9 @@ func (v *Vertex) post(ctx context.Context, url string, req any) ([]byte, error) 
 			slog.Warn("Vertex AI rejected the request and the reason was not recognized as a token limit;"+
 				" if it is one, the shorten-and-retry path is not running", "body", truncate(string(respBody), 200))
 		}
-		return nil, err
+		return nil, resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500, err
 	}
-	return respBody, nil
+	return respBody, false, nil
 }
 
 // inputTooLong recognizes the model's complaint about input length in a

--- a/internal/embed/vertex_test.go
+++ b/internal/embed/vertex_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 // newTestVertex points a Vertex at a fake API and captures request bodies.
@@ -163,5 +164,55 @@ func TestVertexDimensionMismatch(t *testing.T) {
 	})
 	if _, err := v.Embed(context.Background(), TaskQuery, []string{"x"}); err == nil {
 		t.Error("dimension mismatch should error")
+	}
+}
+
+// A transient failure does not merely fail the call — search degrades to
+// lexical and a write leaves vector search — so a 5xx is retried before
+// the caller hears about it, and a 4xx is not: it is the request's own
+// fault and would fail the same way three times.
+func TestVertexRetriesTransientFailures(t *testing.T) {
+	old := vertexBackoff
+	vertexBackoff = time.Millisecond
+	t.Cleanup(func() { vertexBackoff = old })
+
+	calls := 0
+	v := newTestVertex(t, "gemini-embedding-2", true, func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		if calls < 3 {
+			http.Error(w, "backend overloaded", http.StatusServiceUnavailable)
+			return
+		}
+		fmt.Fprint(w, `{"embedding":{"values":[1,2,3,4]}}`)
+	})
+	if _, err := v.Embed(context.Background(), TaskQuery, []string{"x"}); err != nil {
+		t.Fatalf("two 503s then success should succeed, got %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("calls = %d, want 3", calls)
+	}
+
+	calls = 0
+	exhausted := newTestVertex(t, "gemini-embedding-2", true, func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		http.Error(w, "backend overloaded", http.StatusServiceUnavailable)
+	})
+	if _, err := exhausted.Embed(context.Background(), TaskQuery, []string{"x"}); err == nil {
+		t.Error("a 503 on every attempt should error")
+	}
+	if calls != 3 {
+		t.Errorf("calls = %d, want 3 attempts before giving up", calls)
+	}
+
+	calls = 0
+	badRequest := newTestVertex(t, "gemini-embedding-2", true, func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		http.Error(w, "invalid argument", http.StatusBadRequest)
+	})
+	if _, err := badRequest.Embed(context.Background(), TaskQuery, []string{"x"}); err == nil {
+		t.Error("a 400 should error")
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d, want no retry on a 400", calls)
 	}
 }


### PR DESCRIPTION
## What and why

IMPROVEMENT_PLAN.md(#548)の Phase 0「信頼の穴を塞ぐ」から、表面を一つも動かさずに直せる 4 件。

- **Terraform モジュールの日次バックアップを既定オンに**(計画 #1)。ナレッジベースそのものである DB だけが、コピペ初期構成で保護されていなかった。上乗せはこの規模で月 $1 未満で、`deploy/terraform/README.md` のコスト説明と `terraform.tfvars.example` を追随させた(`deletion_protection` は元から既定 true — example の書き方だけ「off にする行」を示す形に直した)。使い捨て評価は `database_backups = false` で外せる。
- **HTTP サーバがボディ読みと idle keep-alive に期限を持つ**(計画 #5)。従来は `ReadHeaderTimeout` のみで、slow-drip なボディや放置されたコネクションが無期限に居座れた。`ReadTimeout` 1 分(受け付ける最大ボディは 4 MiB の PUT 上限なので最遅の正当な書き手にも ~70KB/s しか求めない)、`IdleTimeout` 2 分。`WriteTimeout` は意図して置かない — MCP の streamable GET は設計上ハングするストリームで、export を遅い読み手に届ける経路でもある。理由はコメントに残した。
- **Vertex 埋め込み呼び出しに retry と期限**(計画 #6)。一過性の 429/5xx/切断で検索が初回から黙ってレキシカルに退化していた。3 回・バックオフ付き(500ms→2s)、attempt ごと 30 秒の deadline。4xx は従来どおり再試行しない(トークン上限の 400 を `ErrInputTooLong` に写す既存の経路は不変)。`TestVertexRetriesTransientFailures` が 503→成功 / 503 連続 / 400 の三態を固定する。
- **`ochakai import`(と `--dry-run`)が 8 リクエストを同時に飛ばす**(計画 #3 の表面ゼロ形)。実カタログの投影は数千文書で、1 往復ずつでは旗艦ユースケースが数十分になっていた。集計と exit code は不変、出力行は完了順(summary 行が安定した読み先)。致命的エラー(認証・ネットワーク・5xx)は従来どおり中断する — 未開始の呼び出しを取り消し、飛行中のものは終わってから返る。`--strict` の関門と ordering(concepts → attributed files → loose files)は保存。新フラグは足していない — サーバ側バルク import を断った判断(0067 §5.2)とは独立の、クライアント側の修正である。

三つの問い: 表面はどこも増えていないので該当なし(`golang.org/x/sync` が indirect → direct になったのみ)。

## Checks

- [x] `scripts/check core` と `scripts/check lint` はローカルで緑(store 統合テストはこの環境では skip、CI が回す。`vuln` は egress ポリシーで検証不能)
- [x] Behavior changes come with tests — `TestEachConcurrently`(全件一度ずつ・先頭エラーで新規停止)、`TestVertexRetriesTransientFailures`。既存の import 系テスト(unchanged 集計・strict・foreign bundle)は並列版の下でそのまま通る

## Surfaces and contract

- [x] REST/MCP/CLI/ENV とも変更なし — `api/openapi.yaml`・`internal/restapi`・`internal/mcpserver`・`internal/apiclient` は未変更
- [x] 面に載せる新機能なし(0067 の判断対象なし)
- [x] `api/openapi.frozen.txt` は未変更
- [x] 表面を広げないので `docs/surface.md` の数は動かない(CI の surface_test で確認済み)

## Design docs

- [x] 採択済みの決定は変えていない — ワイヤ・保存形・identity とも不変。Terraform の既定値変更は deploy ガイド側の記述と整合させた(モジュール README が「ガイドの例との唯一の差」として明記)
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_014Mfkjj6NfFFTx1KszwJG3y)_