### PR TITLE
Group unanswered questions by what they meant

### DIFF
--- a/internal/domain/knowledge.go
+++ b/internal/domain/knowledge.go
@@ -13,6 +13,7 @@ import (
 	"unicode/utf8"
 
 	"golang.org/x/text/unicode/norm"
+	"golang.org/x/text/width"
 )
 
 // Type is the kind of a knowledge entry. Any single-line string is a valid
@@ -1021,6 +1022,28 @@ func DisplayTitle(title, id string) string {
 // accepts one normalizes first (design doc 0022). Bodies and titles are
 // content, not keys, and are kept as written.
 func Normalize(s string) string { return norm.NFC.String(s) }
+
+// MissKey is what two askings of the same question have to share to be
+// counted as one gap (migration 0037). It is a grouping key and never a
+// stored answer: what a person typed is kept as they typed it, and this
+// only decides which typings land in the same row of the list.
+//
+// Folded, in this order: compatibility normalization, so ＡＢＣ and ABC
+// and ｶﾀｶﾅ and カタカナ are one word; case, so a sentence and its
+// capitalization are one question; inner whitespace, so a double space
+// is not a second gap; and punctuation at either end, so "売上とは?" and
+// "売上とは" are the same asking. Punctuation *inside* stays — "q3" and
+// "q/3" are not obviously the same thing, and a key that folds too much
+// merges gaps that wanted separate answers.
+func MissKey(s string) string {
+	folded := strings.ToLower(width.Fold.String(norm.NFKC.String(s)))
+	return strings.Trim(strings.Join(strings.Fields(folded), " "), missKeyEdge)
+}
+
+// missKeyEdge is the punctuation dropped from either end of a miss key.
+// Latin and Japanese spellings of the same marks, because a question
+// mark is a question mark.
+const missKeyEdge = `?？!！.。,、:：;；'"“”「」『』()（）[]【】 `
 
 // SameContent reports whether o carries the same authored content as k:
 // the fields a writer controls (title, description, resource, tags,

--- a/internal/service/stats_integration_test.go
+++ b/internal/service/stats_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/na0fu3y/ochakai/internal/config"
+	"github.com/na0fu3y/ochakai/internal/domain"
 	"github.com/na0fu3y/ochakai/internal/store"
 	"github.com/na0fu3y/ochakai/internal/testdb"
 )
@@ -167,5 +168,71 @@ func deleteMisses(ctx context.Context, t *testing.T, dbURL, query string) {
 	defer conn.Close(ctx)
 	if _, err := conn.Exec(ctx, `DELETE FROM search_miss WHERE query = $1`, query); err != nil {
 		t.Errorf("cleaning up misses: %v", err)
+	}
+}
+
+// TestMissesGroupByMeaningIntegration pins what migration 0037 bought:
+// the same question asked several ways is one row of the list a curator
+// reads to decide what to write next, not several.
+//
+// The list is ten long, so spellings of one question used to spend the
+// slots that other questions needed — and the count beside each spelling
+// understated how much anybody wanted the answer.
+func TestMissesGroupByMeaningIntegration(t *testing.T) {
+	ctx := context.Background()
+	svc := newIntegrationService(t, ctx)
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	stem := uid(t, "gapit")
+	// One question, five askings: capitalization, a trailing question
+	// mark, doubled spacing, and full-width characters. The words are
+	// nonsense on purpose — the test database is shared, and a question
+	// made of real words would find somebody else's concepts and stop
+	// being a miss at all.
+	askings := []string{
+		stem + " qqzz",
+		stem + " QQZZ",
+		stem + " qqzz?",
+		stem + "  qqzz",
+		stem + " ｑｑｚｚ",
+	}
+	t.Cleanup(func() {
+		for _, q := range askings {
+			deleteMisses(ctx, t, dbURL, q)
+		}
+	})
+
+	since := time.Now().Add(-time.Hour)
+	for _, q := range askings {
+		if hits, err := svc.Search(ctx, q, store.Filter{}, 10); err != nil {
+			t.Fatal(err)
+		} else if len(hits) != 0 {
+			t.Fatalf("%q matched %d concepts; the question has to go unanswered", q, len(hits))
+		}
+	}
+	if err := svc.Store.FlushUsage(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	st, err := svc.Store.Stats(ctx, since, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var rows []domain.MissedQuery
+	for _, q := range st.Misses.Queries {
+		if strings.Contains(q.Query, stem) {
+			rows = append(rows, q)
+		}
+	}
+	if len(rows) != 1 {
+		t.Fatalf("five askings of one question became %d rows, want 1: %+v", len(rows), rows)
+	}
+	if rows[0].Count != int64(len(askings)) {
+		t.Errorf("the gap is counted %d times, want %d — the group carries every asking",
+			rows[0].Count, len(askings))
+	}
+	// Shown in somebody's own words: the query column is never folded,
+	// and the most recent asking is the one a reader is shown.
+	if rows[0].Query != askings[len(askings)-1] {
+		t.Errorf("the row reads %q, want the most recent asking %q", rows[0].Query, askings[len(askings)-1])
 	}
 }

--- a/internal/service/usage.go
+++ b/internal/service/usage.go
@@ -108,7 +108,9 @@ func (s *Service) recordMiss(ctx context.Context, query string) {
 	if query == "" {
 		return
 	}
-	if err := s.Store.RecordMiss(ctx, query, httpauth.Actor(ctx)); err != nil {
+	// The key groups this asking with the others that meant the same
+	// thing; the query is kept as it was typed (migration 0037).
+	if err := s.Store.RecordMiss(ctx, query, domain.MissKey(query), httpauth.Actor(ctx)); err != nil {
 		s.Log.Warn("search miss recording failed", "error", err)
 	}
 }

--- a/internal/store/migrations/0037_a_gap_is_one_question.sql
+++ b/internal/store/migrations/0037_a_gap_is_one_question.sql
@@ -1,0 +1,30 @@
+-- The same gap, asked five ways, is one gap.
+--
+-- 0031 kept the query as it was asked, which is right — it is somebody's
+-- own words, and provenance does not get tidied. What it also did was
+-- group by those exact bytes, so "Revenue by channel", "revenue by
+-- channel" and "revenue by channel?" are three rows in a list ten long
+-- (stats.missQueryLimit). The one signal that says *what to write next*
+-- was spending its ten slots on spellings of the same question, and the
+-- reader could not see how much any of them was actually asked.
+--
+-- So the key moves off the bytes. normalized is what two askings have to
+-- share to count as one question — case folded, width folded, inner
+-- runs of space collapsed, edge punctuation dropped (domain.MissKey) —
+-- and the query column keeps every asking exactly as typed. The list
+-- still shows somebody's words; it groups by what they meant.
+--
+-- Existing rows are keyed by their own query text. Backfilling them
+-- properly would mean a second implementation of MissKey in SQL, which
+-- is the duplication the CJK class in 0036 needed a whole test to keep
+-- honest; here it is not worth it, because misses are pruned at 180 days
+-- (0029 §3.4) and the old rows group as they always did until they age
+-- out.
+
+ALTER TABLE search_miss ADD COLUMN IF NOT EXISTS normalized text NOT NULL DEFAULT '';
+
+UPDATE search_miss SET normalized = query WHERE normalized = '';
+
+-- The read is "the most-asked questions since a moment", so the index
+-- carries the window and the key together.
+CREATE INDEX IF NOT EXISTS search_miss_at_normalized ON search_miss (at DESC, normalized);

--- a/internal/store/stats.go
+++ b/internal/store/stats.go
@@ -216,10 +216,18 @@ func (s *Store) statsMisses(ctx context.Context, st *domain.Stats, since time.Ti
 		`SELECT count(*) FROM search_miss WHERE at >= $1`, since).Scan(&st.Misses.Count); err != nil {
 		return fmt.Errorf("stats: misses: %w", err)
 	}
+	// Grouped by what the askings meant, shown in the words of the most
+	// recent one (migration 0037). DISTINCT ON picks that asking; the
+	// counts and the last time are the whole group's.
 	rows, err := s.pool.Query(ctx, `
-		SELECT query, count(*) AS n, max(at) AS last_at FROM search_miss
-		WHERE at >= $1 GROUP BY query
-		ORDER BY n DESC, last_at DESC, query LIMIT $2`, since, missQueryLimit)
+		SELECT query, n, last_at FROM (
+			SELECT DISTINCT ON (normalized)
+				normalized,
+				first_value(query) OVER (PARTITION BY normalized ORDER BY at DESC, seq DESC) AS query,
+				count(*) OVER (PARTITION BY normalized) AS n,
+				max(at) OVER (PARTITION BY normalized) AS last_at
+			FROM search_miss WHERE at >= $1
+		) g ORDER BY n DESC, last_at DESC, query LIMIT $2`, since, missQueryLimit)
 	if err != nil {
 		return fmt.Errorf("stats: missed queries: %w", err)
 	}

--- a/internal/store/stats_integration_test.go
+++ b/internal/store/stats_integration_test.go
@@ -70,7 +70,7 @@ func TestIntegrationStatsAndMisses(t *testing.T) {
 	// Three misses of one question, buffered: nothing is written until
 	// the flush (design doc 0029's bargain, extended to misses).
 	for range 3 {
-		if err := s.RecordMiss(ctx, query, actor); err != nil {
+		if err := s.RecordMiss(ctx, query, domain.MissKey(query), actor); err != nil {
 			t.Fatalf("RecordMiss: %v", err)
 		}
 	}

--- a/internal/store/usage.go
+++ b/internal/store/usage.go
@@ -36,7 +36,10 @@ type usageEvent struct {
 // the server's own observation of a read, worth losing before a read is
 // (0029 §3.1).
 type missEvent struct {
-	query     string
+	query string
+	// key groups this asking with the others that meant the same thing
+	// (domain.MissKey, migration 0037). The query stays as typed.
+	key       string
 	actorKind string
 	actorName string
 	at        time.Time
@@ -68,7 +71,7 @@ func (s *Store) RecordEvents(ctx context.Context, event string, actor domain.Act
 // immediately (design doc 0051 §3.2). Same contract as RecordEvents: the
 // row is written by the background flush loop, and the error says only
 // that the buffer was full, never that the search failed.
-func (s *Store) RecordMiss(ctx context.Context, query string, actor domain.Actor) error {
+func (s *Store) RecordMiss(ctx context.Context, query, key string, actor domain.Actor) error {
 	if query == "" {
 		return nil
 	}
@@ -78,7 +81,7 @@ func (s *Store) RecordMiss(ctx context.Context, query string, actor domain.Actor
 	if len(s.missBuf) >= usageBufferMax {
 		return errUsageBufferFull
 	}
-	s.missBuf = append(s.missBuf, missEvent{query, actor.Kind, actor.Name, now})
+	s.missBuf = append(s.missBuf, missEvent{query, key, actor.Kind, actor.Name, now})
 	return nil
 }
 
@@ -178,16 +181,18 @@ func (s *Store) flushMisses(ctx context.Context, batch []missEvent) error {
 		return nil
 	}
 	queries := make([]string, len(batch))
+	keys := make([]string, len(batch))
 	kinds := make([]string, len(batch))
 	names := make([]string, len(batch))
 	ats := make([]time.Time, len(batch))
 	for i, m := range batch {
-		queries[i], kinds[i], names[i], ats[i] = m.query, m.actorKind, m.actorName, m.at
+		queries[i], keys[i] = m.query, m.key
+		kinds[i], names[i], ats[i] = m.actorKind, m.actorName, m.at
 	}
 	_, err := s.pool.Exec(ctx, `
-		INSERT INTO search_miss (query, actor_kind, actor_name, at)
-		SELECT * FROM unnest($1::text[], $2::text[], $3::text[], $4::timestamptz[])`,
-		queries, kinds, names, ats)
+		INSERT INTO search_miss (query, normalized, actor_kind, actor_name, at)
+		SELECT * FROM unnest($1::text[], $2::text[], $3::text[], $4::text[], $5::timestamptz[])`,
+		queries, keys, kinds, names, ats)
 	if err != nil {
 		return fmt.Errorf("writing %d buffered search misses: %w", len(batch), err)
 	}


### PR DESCRIPTION
<!-- Keep PRs small and focused. Link the issue or design doc, if there is one. -->

## What and why

Part of #529 (plan #540) — and it comes with a finding that changes the rest of that issue, below.

The miss list is the one signal that says *what to write next*, and it is ten rows long (`missQueryLimit`). It grouped on the exact bytes somebody typed, so `Revenue by channel`, `revenue by channel` and `revenue by channel?` took three of those ten slots, and the count beside each understated how much anyone actually wanted the answer.

The key moves off the bytes. `domain.MissKey` folds what two askings have to share to be one question — compatibility normalization, case, inner whitespace, punctuation at either end — and `search_miss` keeps it beside the query, which stays exactly as typed. **The list still shows somebody's own words**, in the wording of the most recent asking; it groups by what they meant. 0031 kept the query as asked because it is provenance, and that is untouched.

Punctuation *inside* the query is left alone deliberately: `q3` and `q/3` are not obviously the same thing, and a key that folds too much merges gaps that wanted separate answers.

Existing rows are keyed by their own text rather than backfilled. Doing it properly would mean a second implementation of `MissKey` in SQL — the duplication migration 0036's CJK class needed a whole test to keep honest — and misses are pruned at 180 days, so old rows group as they always did until they age out.

## The rest of #529 is blocked by the REST freeze

Worth knowing before planning further. Most of what #529 asks for is **a new number in `GET /api/v1/stats`**: dropped-observation counts, `report_outcome` coverage, loop throughput. Every one of those adds a property to the `Stats` schema, and `TestFrozenWireHasNotMoved` fails on it:

```
+ components/schemas/Stats.dropped required=true type=object
+ components/schemas/Stats.dropped.events required=true type=integer
```

0064 §11 is unambiguous — *凍結を破ってよい唯一の理由はセキュリティ上の欠陥である* — and the freeze fingerprints response properties, not just addresses. There is no way round it either: the CLI and the web UI are both REST clients (0067 §2), so neither can show a number REST does not return, and stats is not on MCP.

I built the dropped-observation counter (a `usage_drop` table written by the next flush that reaches the database, so the loss outlives the instance that had it) and **reverted it** when the freeze said no, rather than regenerate the golden and call an additive field a security fix. That is your call, not mine, and I have left three options on #529: keep the freeze and defer those items to a major version; treat additive response fields as compatible and break it with a record; or amend the freeze's rule so response properties are outside its fingerprint. Until then, the items of #529 that change *values* rather than *shape* — this one, the feed orderings — are the ones that can move.

## Checks

CI runs the same script; make it pass locally first (CONTRIBUTING.md has the
context, including the store integration test and the fuzz targets).

- [x] `scripts/check` is clean — `core` with `--db` (all packages green) and `lint` 0 issues. `govulncheck` cannot reach vuln.go.dev from this sandbox, so that step is unverified here and left to CI
- [x] Behavior changes come with tests — `TestMissesGroupByMeaningIntegration` asks one question five ways (case, trailing `?`, doubled spacing, full-width) and pins that it becomes one row counted five times, shown in the most recent wording. Its words are nonsense on purpose: the test database is shared, and a question made of real words finds somebody else's concepts and stops being a miss

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — none changed. `misses.queries`
      keeps its shape; what moved is which strings fill it
- [x] The change lands on every surface it belongs on — the stats read is one
      implementation behind REST, the CLI and the web UI, so all three get it
- [x] `api/openapi.frozen.txt` is untouched — deliberately, see above
- [x] Widens a surface? No — no operation, tool, command, or variable is added;
      `docs/surface.md` is unchanged

## Design docs

- [x] Alters an accepted decision? It does not. 0051 §3.1 decided the query is
      kept as it was asked, and it still is — this adds a grouping key beside
      it, which is the internal shape of a read. This box is not applicable
- [x] Commit messages and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BATZn1qmJosokMG8HGxRi8

---
_Generated by [Claude Code](https://claude.ai/code/session_01BATZn1qmJosokMG8HGxRi8)_