### PR TITLE
Name the MCP trust filter in the plural, like its four siblings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,6 +289,27 @@ last entry.
 
 ### Changed
 
+- **BREAKING (MCP): the `trust` filter on `search_concepts` and
+  `get_context` is now `trusts`.** This surface takes its filters as
+  arrays of values, and the other four say so in their name — `types`,
+  `statuses`, `tags`, `prefixes` — while this one alone was singular. It
+  is the same rule with one spelling broken, so no capability, argument
+  or response changed, and the descriptions now say "several are OR-ed"
+  the way `prefixes` already did instead of REST's "repeat to OR". REST's
+  `trust=` and the CLI's `--trust` are unchanged: those are repeatable
+  singular parameters, aligned there with `type` / `status` / `tag` /
+  `prefix`. OKF is untouched — SPEC §5.3's trust is a tier derived from
+  `verified` rather than a frontmatter key, and the `trust` a response
+  carries (one concept, one tier) keeps its singular name and its three
+  values. A client still sending `trust` fails the call rather than
+  silently searching unfiltered — the tool schemas are
+  `additionalProperties: false`, so the rename surfaces the same way an
+  unknown REST query parameter does (design doc 0064 §2). Check any MCP
+  caller that pinned a tier: design doc 0088's one-release window is for
+  tool and command *names*, and it says so — arguments, flags and output
+  shapes are outside it (§2), so this takes effect on the release that
+  carries it.
+
 - **The bundled web UI is in Japanese.** The manual has been Japanese
   since the C8 translation, and the interface it describes was not: the
   reader the product is aimed at was reading a Japanese page about an

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -347,6 +347,16 @@ Web UI に、いずれもそのまま残る(CLI が完全性の面であると�
 であって、能力も引数も応答も変わらない。応答の JSON キーも
 `attachment` から `file` に変わっている。
 
+6 本のまま、`search_concepts` と `get_context` の `trust` を `trusts` に
+改めた。この面のフィルタは値の配列で、`types` / `statuses` / `tags` /
+`prefixes` は複数形を名乗っていたのに**この一つだけが単数だった** —
+同じ規則の中で綴りが割れていただけで、能力も応答も変わらない。REST の
+`trust=` と CLI の `--trust` は繰り返す単数のパラメータで、そちらでは
+`type` / `status` / `tag` / `prefix` と揃っているので動かさない。
+**OKF も動かない**: SPEC §5.3 の trust は `verified` から導出される段で
+あって frontmatter のキーではなく、応答が運ぶ `trust`(段は一つなので
+単数)も三つの段の綴りもそのままである。
+
 ## CLI (25)
 
 - `ochakai browse`

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -235,7 +235,7 @@ func newServer(svc *service.Service, version string, retired []RetiredToolName) 
 		f := store.Filter{
 			Types: domain.ToTypes(in.Types), Statuses: domain.ToStatuses(in.Statuses),
 			Tags: in.Tags, Source: in.Source, Prefixes: in.Prefixes,
-			Trust: domain.ToTrusts(in.Trust), Rejected: in.Rejected,
+			Trust: domain.ToTrusts(in.Trusts), Rejected: in.Rejected,
 		}
 		page, err := svc.SearchOrList(ctx, in.Query, in.Sort, in.Cursor, f, in.Limit)
 		if err != nil {
@@ -263,7 +263,7 @@ func newServer(svc *service.Service, version string, retired []RetiredToolName) 
 			Query: in.Query,
 			Filter: store.Filter{
 				Types: domain.ToTypes(in.Types), Statuses: domain.ToStatuses(in.Statuses), Tags: in.Tags,
-				Prefixes: in.Prefixes, Trust: domain.ToTrusts(in.Trust),
+				Prefixes: in.Prefixes, Trust: domain.ToTrusts(in.Trusts),
 			},
 			Limit: in.Limit, Budget: budget,
 		})
@@ -474,8 +474,8 @@ type searchIn struct {
 	// rejects an empty search, the handler rejects the combination).
 	Query    string   `json:"query,omitempty" jsonschema:"search text; required unless sort is set"`
 	Types    []string `json:"types,omitempty" jsonschema:"filter by type, case-insensitive: Metric, Attested Computation, Skill, Insight, Policy, Glossary Term, BigQuery Dataset, BigQuery Table, Reference, or any custom type"`
-	Statuses []string `json:"statuses,omitempty" jsonschema:"filter by lifecycle status: draft, stable, deprecated — confirmation is a separate question, ask it with trust"`
-	Trust    []string `json:"trust,omitempty" jsonschema:"filter by who confirmed it: unverified, machine-confirmed, human-reviewed (OKF SPEC §5.3); repeat to OR, omit to not ask. Independent of status"`
+	Statuses []string `json:"statuses,omitempty" jsonschema:"filter by lifecycle status: draft, stable, deprecated — confirmation is a separate question, ask it with trusts"`
+	Trusts   []string `json:"trusts,omitempty" jsonschema:"filter by who confirmed it: unverified, machine-confirmed, human-reviewed (OKF SPEC §5.3); several are OR-ed, omit to not ask. Independent of status"`
 	Rejected *bool    `json:"rejected,omitempty" jsonschema:"true to list only concepts a human turned down — how you check whether a proposal was already rejected. Omit and they stay out"`
 	Tags     []string `json:"tags,omitempty" jsonschema:"filter by tag"`
 	Source   string   `json:"source,omitempty" jsonschema:"only concepts citing this resource, matched exactly against sources[].resource — \"this material changed, what derives from it?\". A filter: it combines with query or sort"`
@@ -504,8 +504,8 @@ type searchOut struct {
 type contextIn struct {
 	Query    string   `json:"query" jsonschema:"the data question to gather context for"`
 	Types    []string `json:"types,omitempty" jsonschema:"filter by type, case-insensitive: Metric, Attested Computation, Skill, Insight, Policy, Glossary Term, BigQuery Dataset, BigQuery Table, Reference, or any custom type"`
-	Statuses []string `json:"statuses,omitempty" jsonschema:"filter by lifecycle status: draft, stable, deprecated — confirmation is a separate question, ask it with trust"`
-	Trust    []string `json:"trust,omitempty" jsonschema:"filter by who confirmed it: unverified, machine-confirmed, human-reviewed; repeat to OR, omit to not ask. Independent of status"`
+	Statuses []string `json:"statuses,omitempty" jsonschema:"filter by lifecycle status: draft, stable, deprecated — confirmation is a separate question, ask it with trusts"`
+	Trusts   []string `json:"trusts,omitempty" jsonschema:"filter by who confirmed it: unverified, machine-confirmed, human-reviewed; several are OR-ed, omit to not ask. Independent of status"`
 	Tags     []string `json:"tags,omitempty" jsonschema:"filter by tag"`
 	Prefixes []string `json:"prefixes,omitempty" jsonschema:"only concepts under these paths, e.g. [\"teams/growth\", \"company\"] — an id is a path, so this scopes to a subtree; several are OR-ed. It scopes the search, not the link expansion: a concept in scope still arrives with the term it cites outside"`
 	Limit    int      `json:"limit,omitempty" jsonschema:"max primary concepts: default 5, max 20 (out-of-range falls back to the default); linked companions share a 2x total cap"`

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"slices"
 	"strings"
 	"testing"
 
@@ -141,6 +142,70 @@ func TestFMIsNotOnTheToolSchemas(t *testing.T) {
 		if _, ok := schema.Properties["fm"]; ok {
 			t.Errorf("%s exposes fm: a frontmatter filter is REST and CLI vocabulary, "+
 				"and its schema costs every agent that connects (design doc 0058 §2.2)", tool.Name)
+		}
+	}
+}
+
+// TestArrayFiltersAreNamedInThePlural pins the one naming rule this
+// surface has that REST and the CLI do not. A filter here is a JSON array
+// of values to OR, so its name says so; REST and the CLI spell the same
+// filters singular (type, status, tag, prefix, trust) because they repeat
+// a parameter instead. trust was the one that broke it — it stood beside
+// types, statuses, tags and prefixes as an array and called itself
+// singular, which no number in docs/surface.md moved, since field names
+// are counted by no dimension.
+//
+// The assertion is the exact set rather than "ends in s": status ends in
+// one and is singular, so the cheap heuristic would wave through the
+// regression this exists to catch.
+func TestArrayFiltersAreNamedInThePlural(t *testing.T) {
+	want := map[string][]string{
+		"search_concepts": {"prefixes", "statuses", "tags", "trusts", "types"},
+		"get_context":     {"prefixes", "statuses", "tags", "trusts", "types"},
+	}
+	cs := connect(t)
+	res, err := cs.ListTools(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	seen := map[string]bool{}
+	for _, tool := range res.Tools {
+		expect, ok := want[tool.Name]
+		if !ok {
+			continue
+		}
+		seen[tool.Name] = true
+		raw, err := json.Marshal(tool.InputSchema)
+		if err != nil {
+			t.Fatalf("marshal %s schema: %v", tool.Name, err)
+		}
+		// "type" is a string or a list of them, so it is read loosely: a
+		// property that can be an array at all is one whose value the
+		// caller writes as a list.
+		var schema struct {
+			Properties map[string]struct {
+				Type json.RawMessage `json:"type"`
+			} `json:"properties"`
+		}
+		if err := json.Unmarshal(raw, &schema); err != nil {
+			t.Fatalf("unmarshal %s schema: %v", tool.Name, err)
+		}
+		var got []string
+		for name, prop := range schema.Properties {
+			if strings.Contains(string(prop.Type), `"array"`) {
+				got = append(got, name)
+			}
+		}
+		slices.Sort(got)
+		if !slices.Equal(got, expect) {
+			t.Errorf("%s takes arrays %v, want %v — a filter this surface reads as a "+
+				"list of values is named in the plural, the way types/statuses/tags/prefixes are",
+				tool.Name, got, expect)
+		}
+	}
+	for name := range want {
+		if !seen[name] {
+			t.Errorf("%s is not offered: this check now guards less than it says", name)
 		}
 	}
 }


### PR DESCRIPTION
## What and why

`search_concepts` and `get_context` take their filters as arrays of
values, and four of the five say so in their name — `types`, `statuses`,
`tags`, `prefixes`. `trust` stood beside them holding a `[]string` and
called itself singular. **One spelling broken inside a rule the surface
already follows**, so nothing else moves: same capability, same
arguments, same responses. A caller now sends `trusts: ["human-reviewed"]`.

Found while auditing how consistent REST / CLI / MCP actually are. Most
of what looked inconsistent turned out to be deliberate and documented
(0067 §1, 0068 §1–2). This was the one that was not: it is not a decision
anybody recorded, and **no dimension in `docs/surface.md` counts field
names**, so it moved no number and nobody saw it.

**No surface is added or widened.** MCP stays at 6 tools; REST, PARAM,
FLAG, CLI, ENV, VOCAB, DOC unchanged. `MCP-BYTES` moves 11,836 → 11,850,
well inside its 500-byte slack, so no ceiling moves.

### OKF is untouched — checked against the spec

The one real risk here was drifting from OKF, so, from
[SPEC.md](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md):

- **§5.3's trust is derived, not stored.** Consumers derive the tier from
  `verified`; there is no `trust` frontmatter key to contradict. The
  three values (`unverified`, `machine-confirmed`, `human-reviewed`) are
  unchanged.
- **The `trust` a *response* carries stays singular.** `domain.View`,
  `SearchHit` and `ContextRank` each carry one concept's one tier, and
  that is the spelling of §5.3's derived tier. Input-plural /
  output-singular is already the pattern here — `types` filters, `type`
  comes back.
- **OKF's own keys are not involved.** `type`, `status`, `tags` keep
  their spec spellings wherever ochakai stores or returns them.

### Also corrected, same drift

`trust`'s description said "repeat to OR" — REST and CLI language for a
repeatable parameter, where `prefixes` already said "several are OR-ed".
The `statuses` description pointed at the filter by name, so it points at
the new one.

### REST and the CLI are deliberately unchanged

`?trust=` and `--trust` repeat a singular parameter, which is exactly
what `type` / `status` / `tag` / `prefix` do there. The consistent
spelling genuinely differs per surface, which is 0067 §1 (each face has
its own idiom) rather than a drift to chase everywhere.

### Compatibility

**BREAKING for MCP clients** that pinned a tier. A client still sending
`trust` fails the call rather than silently searching unfiltered — the
tool schemas are `additionalProperties: false`, verified by calling one —
so it surfaces the way an unknown REST query parameter does (0064 §2).

**0088's one-release window does not cover this, and says so.** It landed
while this PR was open, so I checked: §2 draws the line at *names* —
"対象は名前だけである。引数・フラグ・出力の形は含まない" — and
`RetiredToolNames` maps an old *tool* name to a new one, with no way to
spell an argument rename. So there is no window entry to add, and the
CHANGELOG entry (corrected here: it used to cite compatibility.md's
"no grace period", which 0088 replaced) is the notice.

## Checks

- [x] `scripts/check` is clean — no `--db`; nothing touches the store
- [x] Behavior changes come with tests — `TestArrayFiltersAreNamedInThePlural`
      pins **the rule**, not this field: it asserts the exact set of
      array-valued properties on both tools. "Ends in `s`" would have waved
      the regression through, since `status` ends in one and is singular.
      Verified it fails on both tools when the field is renamed back

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi` and `internal/apiclient` are
      untouched by design — see *REST and the CLI* above; only
      `internal/mcpserver` changes
- [x] Lands where it belongs: MCP only. The other surfaces are already
      internally consistent under their own convention
- [x] `api/openapi.frozen.txt` untouched — no REST wire change
- [x] No surface widened. `docs/surface.md`'s MCP section records the
      rename in the same form as the two before it ("8 本のまま、…")

## Design docs

- [ ] Not applicable, and this is the judgement call worth a reviewer's
      eye. **No accepted decision is altered** — no record states how MCP
      filter inputs are spelled; this applies an unstated rule that four
      of five fields already followed. The two prior MCP renames did carry
      numbers, but for what else they decided (0057: `concept` as the word
      across the product; 0064: REST stops at `/api/v1`), and both were
      recorded *in the MCP section* the way this one is. If you read
      "the shape of the wire" in CLAUDE.md as reaching an MCP input name,
      say so and I will write the record
- [x] Commit message and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)
