### PR TITLE
Count what the loop lost, beside what it kept

### DIFF
--- a/api/openapi.frozen.txt
+++ b/api/openapi.frozen.txt
@@ -422,6 +422,9 @@ components/schemas/Stats.concepts.status.* type=integer
 components/schemas/Stats.concepts.total required=true type=integer
 components/schemas/Stats.concepts.trust required=true type=object
 components/schemas/Stats.concepts.trust.* type=integer
+components/schemas/Stats.dropped required=true type=object
+components/schemas/Stats.dropped.events required=true type=integer
+components/schemas/Stats.dropped.misses required=true type=integer
 components/schemas/Stats.misses required=true type=object
 components/schemas/Stats.misses.count required=true type=integer
 components/schemas/Stats.misses.queries required=true type=array

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2851,7 +2851,32 @@ components:
                   last_at: { type: string, format: date-time }
                 required: [query, count, last_at]
           required: [recording, count, queries]
-      required: [at, window_days, concepts, queues, review, outcomes, misses]
+        dropped:
+          type: object
+          description: >
+            Flow: observations the loop made and then lost inside the
+            window — the footnote every other number here depends on.
+            Usage is best-effort by decision (design doc 0029 §3.1): it
+            buffers in memory, refuses events past a cap rather than
+            growing without bound, and loses a batch whose write fails
+            instead of keeping a retry queue. On Cloud Run an instance is
+            killed on scale-to-zero and on every rollout, so this is not
+            an exotic number.
+
+
+            Zero is what makes the rest trustworthy: with anything else
+            here, the counts above undercount by at least that much.
+            Unscoped by `prefix`, for the reason misses are — a dropped
+            batch is a number, and the ids that were in it are gone.
+          properties:
+            events:
+              type: integer
+              description: Search hits, fetches and outcome reports lost together.
+            misses:
+              type: integer
+              description: Unanswered questions lost the same two ways.
+          required: [events, misses]
+      required: [at, window_days, concepts, queues, review, outcomes, misses, dropped]
     QueueCounts:
       type: object
       description: >

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -709,6 +709,11 @@ func cmdStats(ctx context.Context, args []string) error {
 	fmt.Printf("window_days\t%d\ncreated\t%d\nverifications\t%d\nworked\t%d\nfailed\t%d\n",
 		st.WindowDays, st.Concepts.Created, st.Review.Verifications,
 		st.Outcomes.Worked, st.Outcomes.Failed)
+	// Printed even at zero, for the reason the queue counts are: a number
+	// that appears only when something is wrong cannot be told from one
+	// nobody reported. Zero is what says the rest of these are whole.
+	fmt.Printf("dropped_events\t%d\ndropped_misses\t%d\n",
+		st.Dropped.Events, st.Dropped.Misses)
 	if !st.Misses.Recording {
 		// Not zero — unknown. A deployment that keeps no questions must
 		// not read as one that was asked none.

--- a/internal/domain/stats.go
+++ b/internal/domain/stats.go
@@ -40,6 +40,26 @@ type Stats struct {
 	Review   StatsReview   `json:"review"`
 	Outcomes StatsOutcomes `json:"outcomes"`
 	Misses   StatsMisses   `json:"misses"`
+	// Dropped is what the loop observed and then lost inside the window
+	// — the footnote every other number here depends on. Usage is
+	// best-effort by decision (design doc 0029 §3.1): it buffers in
+	// memory, refuses events past a cap rather than growing without
+	// bound, and loses a batch whose write fails instead of keeping a
+	// retry queue. That the loss showed only in a log line was the gap:
+	// a curator reading how often a concept was fetched could not tell 4
+	// from 40. Zero here is what makes the rest trustworthy.
+	Dropped StatsDropped `json:"dropped"`
+}
+
+// StatsDropped counts the observations that never reached the database
+// in the window. Unscoped by prefix, for the reason misses are: a
+// dropped batch is a number, and the ids that were in it are gone.
+type StatsDropped struct {
+	// Events is search hits, fetches and outcome reports together —
+	// refused by the buffer, or lost with a failed flush.
+	Events int64 `json:"events"`
+	// Misses is unanswered questions lost the same two ways.
+	Misses int64 `json:"misses"`
 }
 
 // StatsConcepts is what the base is made of (state), plus how much of it

--- a/internal/service/stats_integration_test.go
+++ b/internal/service/stats_integration_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"strings"
@@ -234,5 +235,48 @@ func TestMissesGroupByMeaningIntegration(t *testing.T) {
 	// and the most recent asking is the one a reader is shown.
 	if rows[0].Query != askings[len(askings)-1] {
 		t.Errorf("the row reads %q, want the most recent asking %q", rows[0].Query, askings[len(askings)-1])
+	}
+}
+
+// TestDroppedObservationsReachTheStatsIntegration pins the honest
+// footnote (migration 0038): usage is best-effort, and the loss now
+// shows up beside the numbers it damaged instead of only in a log line.
+//
+// The buffer is filled past its cap rather than a failing database
+// simulated, because that is the drop a deployment actually meets — an
+// instance holding more than it can write. The other one, a flush whose
+// statement fails, is counted on the same path.
+func TestDroppedObservationsReachTheStatsIntegration(t *testing.T) {
+	ctx := context.Background()
+	svc := newIntegrationService(t, ctx)
+	since := time.Now().Add(-time.Hour)
+
+	before, err := svc.Store.Stats(ctx, since, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// One call bigger than the whole buffer: refused entire, and counted.
+	const dropped = 20001
+	run := uid(t, "dropit")
+	ids := make([]string, dropped)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("%s/%d", run, i)
+	}
+	if err := svc.Store.RecordEvents(ctx, domain.EventSearchHit,
+		domain.Actor{Kind: domain.ActorHuman, Name: "test"}, ids); err == nil {
+		t.Fatal("a batch larger than the buffer was accepted; nothing was dropped to count")
+	}
+	// The count reaches the database with the next flush that works.
+	if err := svc.Store.FlushUsage(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := svc.Store.Stats(ctx, since, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := got.Dropped.Events - before.Dropped.Events; n != dropped {
+		t.Errorf("stats report %d dropped events, want %d: what the loop lost has to be "+
+			"readable beside what it kept", n, dropped)
 	}
 }

--- a/internal/store/migrations/0038_the_loop_counts_what_it_lost.sql
+++ b/internal/store/migrations/0038_the_loop_counts_what_it_lost.sql
@@ -1,0 +1,35 @@
+-- What the loop threw away, beside what it kept.
+--
+-- Usage is best-effort by decision (design doc 0029 §3.1): events buffer
+-- in memory, the buffer is capped so a stalled database cannot grow it
+-- without bound, and a flush that fails loses its batch rather than
+-- spending memory on a retry queue. That decision also asked for the
+-- loss to be visible — and it was, in a log line, which is the one place
+-- nobody is looking while reading the numbers the loss damaged.
+--
+-- On Cloud Run the loss is not exotic: an instance is killed on
+-- scale-to-zero and on every revision rollout, and whatever it was
+-- holding goes with it. So a curator reading "this concept was fetched
+-- 4 times" had no way to tell whether it was 4 or 40. The number stays
+-- best-effort; what changes is that it stops being silently so.
+--
+-- Rows, not a counter, because every other flow number in the stats is
+-- windowed by `since` and this one has to be comparable with them: a
+-- thousand events lost last quarter says nothing about the month being
+-- read. A row is written by the next flush that succeeds, which is how
+-- the count outlives the instance that dropped it — and why a drop never
+-- followed by a successful flush is itself lost. That last case is the
+-- process dying between the two, and nothing short of the retry queue
+-- 0029 refused would catch it.
+--
+-- Not scoped by prefix, for the reason misses are not (0051 §3.7): a
+-- dropped batch is a number, and the ids that were in it are gone.
+
+CREATE TABLE IF NOT EXISTS usage_drop (
+    seq    bigserial   PRIMARY KEY,
+    at     timestamptz NOT NULL,
+    events bigint      NOT NULL,
+    misses bigint      NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS usage_drop_at ON usage_drop (at DESC);

--- a/internal/store/stats.go
+++ b/internal/store/stats.go
@@ -55,6 +55,9 @@ func (s *Store) Stats(ctx context.Context, since time.Time, prefixes []string) (
 	if err := s.statsMisses(ctx, st, since); err != nil {
 		return nil, err
 	}
+	if err := s.statsDropped(ctx, st, since); err != nil {
+		return nil, err
+	}
 	return st, nil
 }
 
@@ -238,6 +241,19 @@ func (s *Store) statsMisses(ctx context.Context, st *domain.Stats, since time.Ti
 	})
 	if err != nil {
 		return fmt.Errorf("stats: missed queries: %w", err)
+	}
+	return nil
+}
+
+// statsDropped reads what the loop lost in the window (migration 0038).
+// The rows are written by whichever instance recovered from the loss, so
+// this is the deployment's gap rather than one process's.
+func (s *Store) statsDropped(ctx context.Context, st *domain.Stats, since time.Time) error {
+	if err := s.pool.QueryRow(ctx, `
+		SELECT COALESCE(sum(events), 0), COALESCE(sum(misses), 0)
+		FROM usage_drop WHERE at >= $1`, since).
+		Scan(&st.Dropped.Events, &st.Dropped.Misses); err != nil {
+		return fmt.Errorf("stats: dropped observations: %w", err)
 	}
 	return nil
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -88,11 +88,18 @@ type Store struct {
 	// never touches the read path (design doc 0029). usageBuf is
 	// guarded by usageMu; the flush loop stops on flushStop and drains
 	// once more before flushWG releases (see New/Close, usage.go).
-	usageMu   sync.Mutex
-	usageBuf  []usageEvent
-	missBuf   []missEvent
-	flushStop chan struct{}
-	flushWG   sync.WaitGroup
+	// dropped counts what the buffer refused and what a failed flush took
+	// with it, under the same lock. The next flush that reaches the
+	// database writes it to usage_drop and clears it (migration 0038), so
+	// the number outlives the instance that lost the events; until then it
+	// is this process's memory of its own gap.
+	usageMu       sync.Mutex
+	usageBuf      []usageEvent
+	missBuf       []missEvent
+	droppedEvents int64
+	droppedMisses int64
+	flushStop     chan struct{}
+	flushWG       sync.WaitGroup
 }
 
 // UseLogger routes the store's own diagnostics to l — the flush loop's

--- a/internal/store/usage.go
+++ b/internal/store/usage.go
@@ -59,6 +59,7 @@ func (s *Store) RecordEvents(ctx context.Context, event string, actor domain.Act
 	s.usageMu.Lock()
 	defer s.usageMu.Unlock()
 	if len(s.usageBuf)+len(ids) > usageBufferMax {
+		s.droppedEvents += int64(len(ids))
 		return errUsageBufferFull
 	}
 	for _, id := range ids {
@@ -79,6 +80,7 @@ func (s *Store) RecordMiss(ctx context.Context, query, key string, actor domain.
 	s.usageMu.Lock()
 	defer s.usageMu.Unlock()
 	if len(s.missBuf) >= usageBufferMax {
+		s.droppedMisses++
 		return errUsageBufferFull
 	}
 	s.missBuf = append(s.missBuf, missEvent{query, key, actor.Kind, actor.Name, now})
@@ -129,7 +131,10 @@ func (s *Store) usageFlushLoop() {
 // queue: usage is best-effort, and design doc 0029 §3.1 chose that
 // deliberately over spending memory on a stalled database. What the
 // decision also asked for is that the loss be visible — the error says
-// how many events went with it, and the flush loop logs it.
+// how many events went with it, and the flush loop logs it. How much was
+// lost altogether is counted too, and written to usage_drop by the next
+// flush that reaches the database (migration 0038), so it reaches the
+// stats beside the numbers it damaged rather than only a log line.
 func (s *Store) FlushUsage(ctx context.Context) error {
 	s.usageMu.Lock()
 	batch, misses := s.usageBuf, s.missBuf
@@ -140,7 +145,11 @@ func (s *Store) FlushUsage(ctx context.Context) error {
 	// with no aggregate to maintain, and a batch of events failing is no
 	// reason to drop the questions that came with it.
 	missErr := s.flushMisses(ctx, misses)
+	if missErr != nil {
+		s.countDropped(0, int64(len(misses)))
+	}
 	if len(batch) == 0 {
+		s.recordDrops(ctx)
 		return missErr
 	}
 
@@ -167,10 +176,47 @@ func (s *Store) FlushUsage(ctx context.Context) error {
 			last_at = GREATEST(knowledge_usage.last_at, EXCLUDED.last_at)`,
 		ids, events, kinds, names, ats)
 	if err != nil {
+		s.countDropped(int64(len(batch)), 0)
+		s.recordDrops(ctx)
 		return fmt.Errorf("writing %d buffered usage events: %w", len(batch), err)
 	}
+	s.recordDrops(ctx)
 	s.maybePruneEvents(ctx)
 	return missErr
+}
+
+// countDropped remembers observations that never reached the database.
+func (s *Store) countDropped(events, misses int64) {
+	if events == 0 && misses == 0 {
+		return
+	}
+	s.usageMu.Lock()
+	defer s.usageMu.Unlock()
+	s.droppedEvents += events
+	s.droppedMisses += misses
+}
+
+// recordDrops writes what this process has lost so far and clears it,
+// leaving the count where every instance's stats can read it.
+//
+// Taken and put back rather than read and cleared: if this insert is the
+// statement that fails — the same stalled database that caused the drop
+// — the count has to survive for the next attempt, or the fix would lose
+// exactly the numbers it exists to keep. What is dropped between here
+// and the process dying goes with it, which is the retry queue design
+// doc 0029 refused, and the honest edge of this.
+func (s *Store) recordDrops(ctx context.Context) {
+	s.usageMu.Lock()
+	events, misses := s.droppedEvents, s.droppedMisses
+	s.droppedEvents, s.droppedMisses = 0, 0
+	s.usageMu.Unlock()
+	if events == 0 && misses == 0 {
+		return
+	}
+	if _, err := s.pool.Exec(ctx,
+		`INSERT INTO usage_drop (at, events, misses) VALUES (now(), $1, $2)`, events, misses); err != nil {
+		s.countDropped(events, misses)
+	}
 }
 
 // flushMisses writes one search_miss row per buffered miss. Same bargain
@@ -241,6 +287,8 @@ func (s *Store) maybePruneEvents(ctx context.Context) {
 	_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_event WHERE at < now() - $1::interval`,
 		eventRetention.String())
 	_, _ = s.pool.Exec(ctx, `DELETE FROM search_miss WHERE at < now() - $1::interval`,
+		eventRetention.String())
+	_, _ = s.pool.Exec(ctx, `DELETE FROM usage_drop WHERE at < now() - $1::interval`,
 		eventRetention.String())
 }
 

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -2107,6 +2107,10 @@ async function loadLoopStats() {
   const trust = s.concepts?.trust || {};
   const confirmed = (trust['human-reviewed'] || 0) + (trust['machine-confirmed'] || 0);
   const gaps = s.misses?.recording ? (s.misses.queries || []) : [];
+  // Shown only when it happened. The tiles above are the always-there
+  // numbers; this is a fault in the measurement behind them, and a
+  // permanent "0 lost" line would be one more thing to read past.
+  const dropped = (s.dropped?.events ?? 0) + (s.dropped?.misses ?? 0);
   out.innerHTML = `
     <div class="stat-tiles" style="max-width:52rem;margin:.2rem 0 1rem">
       <div class="tile"><div class="num">${s.concepts?.total ?? 0}</div><div class="lbl">concepts</div></div>
@@ -2114,7 +2118,12 @@ async function loadLoopStats() {
       <div class="tile"><div class="num">${s.review?.verifications ?? 0}</div><div class="lbl">verified in ${s.window_days} days</div></div>
       <div class="tile"><div class="num">${s.misses?.recording ? (s.misses.count ?? 0) : '–'}</div>
         <div class="lbl">searches that found nothing</div></div>
-    </div>` + (gaps.length ? `
+    </div>` + (dropped ? `
+    <p style="max-width:48rem;margin:0 0 1.2rem;color:var(--muted);font-size:.9rem">
+      ${dropped} observation${dropped === 1 ? '' : 's'} were recorded and then lost in these
+      ${s.window_days} days, so the numbers above undercount by at least that much. Usage is
+      buffered in memory and written in batches; an instance that went away took what it was
+      holding with it.</p>` : '') + (gaps.length ? `
     <details style="max-width:48rem;margin:0 0 1.2rem">
       <summary style="cursor:pointer;color:var(--muted)">Asked for, not found — what to write next</summary>
       <p style="color:var(--muted);font-size:.9rem;margin:.5rem 0">Searches from the last ${s.window_days} days


### PR DESCRIPTION
<!-- Keep PRs small and focused. Link the issue or design doc, if there is one. -->

## What and why

Part of #529 (plan #540), and **the first addition to land under 0082**.

Usage is best-effort by decision (0029 §3.1): events buffer in memory, the buffer is capped so a stalled database cannot grow it without bound, and a flush that fails loses its batch rather than spending memory on a retry queue. The decision asked for the loss to be visible — and it was, in a log line, which is the one place nobody is looking while reading the numbers the loss damaged. **A curator reading "this concept was fetched 4 times" could not tell 4 from 40.**

On Cloud Run the loss is routine, not exotic: an instance is killed on scale-to-zero and on every revision rollout, and whatever it was holding goes with it.

So the drops are counted, and **the next flush that reaches the database writes them to `usage_drop`** (migration 0038) — which is how the number outlives the instance that lost the events. Rows rather than a counter, because every other flow number in the stats is windowed by `since` and this one has to be comparable with them: a thousand events lost last quarter says nothing about the month being read.

The count is taken from memory and put back if its own insert fails — the same stalled database that caused the drop would otherwise lose the record of it too. What is dropped between a flush and the process dying goes with it, which is the retry queue 0029 refused and the honest edge of this; the record says so.

### The nature of the change is unchanged

Usage stays best-effort. Nothing retries, nothing grows without bound, no read path gets slower. **Zero is what makes the rest of the stats trustworthy** — the numbers were always approximate, and now they say when they are.

### On the three faces

- **REST** — `stats.dropped.{events,misses}`.
- **CLI** — `dropped_events` / `dropped_misses`, printed **even at zero**, for the reason the queue counts are: a number that appears only when something is wrong cannot be told from one nobody reported.
- **Web UI** — shown **only when it happened**. The tiles beside it are the always-there numbers; this is a fault in the measurement behind them, and a permanent "0 lost" line is one more thing to read past on every visit.
- **MCP** — no. Stats is not on that surface (0076), and this is the human half of the loop.

### 0082 in practice

This is the addition 0082 was written for, and it went exactly as that record says it should. The freeze test failed, in its own words:

```
the frozen REST wire grew:

  + components/schemas/Stats.dropped required=true type=object
  + components/schemas/Stats.dropped.events required=true type=integer
  + components/schemas/Stats.dropped.misses required=true type=integer

Adding a property to a response-only schema is outside the freeze (design
doc 0082) … It still has to show in a diff, so regenerate the golden in the
same PR and say in the description what the addition is for
```

Three added lines in the golden, no line moved or removed, and `Stats` is a schema no `requestBody` reaches.

## Checks

CI runs the same script; make it pass locally first (CONTRIBUTING.md has the
context, including the store integration test and the fuzz targets).

- [x] `scripts/check` is clean — `core` with `--db` (all packages green) and `lint` 0 issues. `govulncheck` cannot reach vuln.go.dev from this sandbox, so that step is unverified here and left to CI
- [x] Behavior changes come with tests — `TestDroppedObservationsReachTheStatsIntegration` fills the buffer past its cap (the drop a deployment actually meets — an instance holding more than it can write), flushes, and asserts the stats moved by exactly what was refused

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — the schema, the domain type and
      the CLI/web UI renderings are in this PR; `apiclient` decodes
      `domain.Stats` directly, so it follows
- [x] The change lands on every surface it belongs on — REST, CLI, web UI;
      deliberately not MCP, per above
- [x] `api/openapi.frozen.txt` is regenerated: **three lines added, none moved
      or removed**, under 0082. Read the diff — that is the point of the rule
- [x] Widens a surface? No — `docs/surface.md` is unchanged. No operation,
      tool, command, parameter, header or variable is added; a response field
      is none of the nine counted dimensions

## Design docs

- [x] Alters an accepted decision? It does not — 0029 §3.1's bargain is
      untouched (still best-effort, still no retry queue), and this delivers
      the visibility that decision asked for. 0082 is what makes the wire
      change legitimate and it is already on `main`. This box is not applicable
- [x] Commit messages and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BATZn1qmJosokMG8HGxRi8

---
_Generated by [Claude Code](https://claude.ai/code/session_01BATZn1qmJosokMG8HGxRi8)_