### PR TITLE
Pin the MCP write-back loop, and say to link what a draft replaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,18 @@ last entry.
 
 ### Changed
 
+- **`put_concept` now tells an agent to link the concept its draft would
+  replace.** The instruction was already there — a verified concept that
+  is wrong gets `report_outcome failed`, or a better draft at a different
+  id for a human to promote — but nothing joined it to the sentence about
+  links, so the relationship that makes a replacement reviewable was left
+  to chance. A body link is how any relationship is written here
+  ([0074 §2](docs/design/0074-the-document-and-the-vocabulary-that-asks-it.md)),
+  and it is two-way, so the reviewer reaching either concept sees the
+  other. No tool, no argument, no ceiling moved: the MCP schema budget
+  goes 11,733 → 11,812 bytes against its 12,000.
+
+
 - **Search ties are broken by verification recency instead of by
   whatever the scan produced.** A short question leaves several concepts
   holding exactly the same score — five of them, for the README's own

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -307,7 +307,8 @@ func newServer(svc *service.Service, version string) *mcp.Server {
 			"confirming and rejecting are not on this surface.\n" +
 			"A concept a human has ruled on — verified, rejected, deprecated — cannot be " +
 			"replaced here: if a verified concept is wrong, report_outcome failed, otherwise put " +
-			"a better draft at a different id and let a human promote it. An id whose concept " +
+			"a better draft at a different id, linking the concept it would replace from its " +
+			"body so the reviewer sees both, and let a human promote it. An id whose concept " +
 			"was deleted can be reused, which revives it as your draft — unless a human had " +
 			"ruled on it (verified, rejected, or deprecated), and then this surface refuses too. " +
 			"Search rejected=true first so you do not re-propose what was already turned down.\n" +

--- a/internal/mcpserver/mcpserver_integration_test.go
+++ b/internal/mcpserver/mcpserver_integration_test.go
@@ -2,6 +2,7 @@ package mcpserver
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -242,5 +243,175 @@ func TestIntegrationPutKnowledgeCreatesThenReplaces(t *testing.T) {
 		if !strings.Contains(said, want) {
 			t.Errorf("the refusal does not mention %q: %s", want, said)
 		}
+	}
+}
+
+// The write-back loop's second half, walked from the six tools alone.
+//
+// The claim this pins is that an MCP-only agent — a hosted client with no
+// shell, which the README calls the primary case for this surface — can
+// carry out the instruction put_concept's own description gives it: when
+// a verified concept is wrong, "put a better draft at a different id and
+// let a human promote it". That instruction is worth only as much as the
+// agent's ability to see what became of the draft, and nothing had
+// checked that it can.
+//
+// Three things are needed and all three are already here: the draft can
+// name what it would replace (a body link, which is how relationships are
+// written at all — design doc 0074 §2), the agent can see the human's
+// ruling on its own draft (get_concept carries the verification ledger),
+// and it can find out that a proposal was already turned down before
+// spending a write on it (rejected=true). What it cannot do is rule —
+// verify, reject, delete — and that is design doc 0076's decision rather
+// than a gap.
+func TestIntegrationMCPAgentSeesTheRulingOnItsDraft(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := t.Context()
+	s, err := store.New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{InsecureDev: true}
+	svc := &service.Service{Store: s, Config: cfg, Log: slog.New(slog.NewTextHandler(os.Stderr, nil))}
+	srv := httptest.NewServer(httpauth.Middleware(cfg, Handler(svc, "test")))
+	defer srv.Close()
+	cs, err := mcp.NewClient(&mcp.Implementation{Name: "host", Version: "0"}, nil).
+		Connect(ctx, &mcp.StreamableClientTransport{Endpoint: srv.URL}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cs.Close()
+
+	human := domain.Actor{Kind: domain.ActorHuman, Name: "reviewer"}
+	run := testdb.Unique(t, "mcploop")
+	original, replacement := run+"/metrics/revenue", run+"/metrics/revenue-net"
+	defer func() {
+		for _, id := range []string{original, replacement} {
+			_ = svc.Delete(context.Background(), id, human, nil)
+		}
+	}()
+
+	// A verified concept, as a human left it.
+	if _, _, _, err := svc.Put(ctx, &domain.Knowledge{
+		Type: domain.TypeMetrics, ID: original, Title: "mcp loop " + original,
+		Status: domain.StatusStable, Body: "受注合計。", CreatedBy: human,
+	}, human, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.Verify(ctx, original, human); err != nil {
+		t.Fatal(err)
+	}
+
+	call := func(t *testing.T, name string, args map[string]any) *mcp.CallToolResult {
+		t.Helper()
+		res, err := cs.CallTool(ctx, &mcp.CallToolParams{Name: name, Arguments: args})
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		if res.IsError {
+			t.Fatalf("%s failed: %+v", name, res.Content)
+		}
+		return res
+	}
+	conceptOf := func(t *testing.T, res *mcp.CallToolResult) domain.View {
+		t.Helper()
+		var out knowledgeOut
+		raw, err := json.Marshal(res.StructuredContent)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := json.Unmarshal(raw, &out); err != nil {
+			t.Fatal(err)
+		}
+		return out.Knowledge
+	}
+
+	// The agent drafts the replacement, naming what it would replace with
+	// an ordinary body link. No field carries the relationship: links are
+	// written in prose, and the surrounding sentence says what kind it is.
+	call(t, "put_concept", map[string]any{
+		"id": replacement,
+		"document": "---\ntype: Metric\ntitle: mcp loop " + replacement + "\nstatus: draft\n---\n\n" +
+			"[" + original + "](/" + original + ".md) の置き換え案: 返品を除いた受注合計。\n",
+	})
+
+	// Before the ruling: the agent's own draft reads back as unverified,
+	// which is how it knows nothing has happened yet.
+	drafted := conceptOf(t, call(t, "get_concept", map[string]any{"id": replacement}))
+	if drafted.Summary.Trust != domain.TrustUnverified {
+		t.Errorf("a fresh draft reads as trust %q, want %q", drafted.Summary.Trust, domain.TrustUnverified)
+	}
+	if len(drafted.Observed.Verified) != 0 {
+		t.Errorf("a fresh draft carries %d verifications", len(drafted.Observed.Verified))
+	}
+
+	// The link is two-way, so the human reviewing the draft reaches the
+	// concept it would replace and the concept names its challenger.
+	// Asked here the way the human surfaces ask it: the backlink listing
+	// is REST, CLI and the web UI, and is deliberately not an MCP tool
+	// (design doc 0067 §5.1) — the ruling belongs to the person, and so
+	// does the question "what is waiting to replace this?".
+	back, err := svc.SearchOrList(ctx, "", "", "", store.Filter{LinksTo: original}, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, h := range back.Hits {
+		if h.ID == replacement {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("the draft's body link did not make it findable from %s", original)
+	}
+
+	// The human rules. Confirming is not on this surface (design doc
+	// 0076) — that is the point of the split, not a missing tool.
+	if _, err := svc.Verify(ctx, replacement, human); err != nil {
+		t.Fatal(err)
+	}
+
+	// And the agent sees it: same tool, same id, the ledger now naming
+	// who confirmed it and when.
+	promoted := conceptOf(t, call(t, "get_concept", map[string]any{"id": replacement}))
+	if promoted.Summary.Trust != domain.TrustHuman {
+		t.Errorf("after a human confirmed it the draft reads as trust %q, want %q",
+			promoted.Summary.Trust, domain.TrustHuman)
+	}
+	last := promoted.Observed.LastVerified()
+	if last == nil || last.By.Name != human.Name {
+		t.Fatalf("the promotion is not visible in the ledger: %+v", promoted.Observed.Verified)
+	}
+
+	// And the memory of no: a rejected proposal is findable before the
+	// agent spends a write re-proposing it.
+	if _, err := svc.Reject(ctx, replacement, "duplicate of the original", human); err != nil {
+		t.Fatal(err)
+	}
+	var rejected searchOut
+	raw, err := json.Marshal(call(t, "search_concepts", map[string]any{
+		"query": "mcp loop", "rejected": true, "prefixes": []string{run},
+	}).StructuredContent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(raw, &rejected); err != nil {
+		t.Fatal(err)
+	}
+	seen := false
+	for _, h := range rejected.Hits {
+		if h.ID == replacement {
+			seen = true
+		}
+	}
+	if !seen {
+		t.Errorf("a rejected proposal is not findable with rejected=true: %+v", rejected.Hits)
 	}
 }


### PR DESCRIPTION
## What and why

IMPROVEMENT_PLAN.md の #13。計画は `put_concept` に `supersedes` を足すことを提案していた — 監査が「MCP だけのエージェントは、ツール自身が指示する書き戻しの後半を実行できない」と報告したためである。**足す前に三つの問い(特に二つ目「既存の面で回避できるか」)を確かめたところ、報告の大部分が誤りだった。** そこでツールではなく、それを言えるテストを足す。

六本のツールだけでループを歩くと、必要な三つはいずれも既にある:

- **draft が何を置き換えるかを名指す** — 本文のリンク。ここでは関係はそもそもそう書く([0074 §2](``docs/design/0074-the-document-and-the-vocabulary-that-asks-it.md))。しかも双方向なので、どちらから来たレビュアーにも相手が見える。``
- **人の裁定を自分の draft の上で見る** — `get_concept` が検証台帳を運ぶ。draft は `unverified` で読め、人が確かめた後は `human-reviewed` と誰がいつ確かめたかが同じ呼び出しで返る。
- **却下済みを再提案しない** — `rejected=true`。

**できないことは二つで、どちらも決定済みである。** 裁定(verify / reject / delete)は [0076](docs/design/0076-two-tools-leave-mcp.md) がこの面から降ろしたもので、backlinks は [0067 §5.1](docs/design/0067-four-faces-and-what-they-decline.md) が意図して載せていない。「何がこれを置き換えようとしているか」を問うのは、裁定する人の側の問いである。

**本当に足りなかったのは一文だった。** `put_concept` は「verified な concept が間違っていたら report_outcome failed、そうでなければ別 id に良い draft を置いて人の昇格を待て」と言い、別の場所で「リンクは本文に書く」と言い、**その二つを繋いでいなかった** — 置き換え案をレビュー可能にするリンクが、運任せになっていた。その一文を足した。

三つの問い: (1) 詰まったのは監査の想定だったが、検証したら既存の面で回避できていた。(2) 回避できるので**足さない** — ツールも引数も増えていない。(3) 畳めるものは無いが、増えたのも一文だけである。

## Checks

- [x] `scripts/check --db core` と `scripts/check lint` はローカルで緑(PostgreSQL 16.13 に対して。CI は pgvector/pg17。`vuln` は egress ポリシーで検証不能)
- [x] Behavior changes come with tests — `TestIntegrationMCPAgentSeesTheRulingOnItsDraft` が実際の MCP クライアントでループを歩く: draft を書く(元 concept を本文リンクで名指す)→ 双方向リンクが人の面の backlink 一覧に出る → 人が verify → 同じ `get_concept` で trust と台帳が変わって見える → reject 後は `rejected=true` で見つかる。挙動そのものの変更は文言のみ

## Surfaces and contract

- [x] 面は一つも動いていない — MCP は 6 ツールのまま、引数も増えていない。REST/CLI/Web UI は無変更
- [x] MCP スキーマのバイト予算は 11,733 → 11,812(天井 12,000、`MCP-BYTES` は動かさない)
- [x] `api/openapi.frozen.txt` は未変更
- [x] `docs/surface.md` の数はどれも動かない

## Design docs

- [x] 採択済みの決定は変えていない。むしろ 0076(裁定は MCP に載せない)と 0067 §5.1(backlinks は載せない)が現行のまま正しいことを確認し、その二つを理由として PR に書いている
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_014Mfkjj6NfFFTx1KszwJG3y)_