### PR TITLE
Log one structured line per request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,27 @@ last entry.
 
 ### Added
 
+- **Every request now logs one structured line.** `/health` was the whole
+  observability surface, so "search got slow" had no answer short of
+  attaching to Cloud SQL by hand and "what is failing" had none at all.
+  Each `/api/v1` and `/mcp` request writes a `request` line when its
+  response ends, carrying the method, the **route pattern** the mux
+  matched, the status, `duration_ms`, the bytes written, the actor's kind
+  and — on a failure — the error `code`. A log-based metric can be built
+  from it, which is why this is not a `/metrics` endpoint: the platform
+  the product already requires is the one that aggregates, and REST stays
+  the only address space ([0067 §1](docs/design/0067-four-faces-and-what-they-decline.md)).
+  Two things are deliberately absent, and both are the same rule: the
+  route rather than the path, because a bundle path is a concept's
+  address and the log is not a second copy of the knowledge base's shape;
+  and the actor's kind rather than their name, because who wrote what is
+  provenance and lives on the concept
+  ([0065](docs/design/0065-identity-and-provenance.md)). Still no
+  telemetry — nothing is reported anywhere, the line goes to this
+  deployment's own stdout. No new endpoint, environment variable or wire
+  field; [the operating guide](docs/guides/operating.md) says how to read
+  it.
+
 - **A search hit now says why it matched.** `snippet` carries the passage
   of the body where the query's own words land, cut to about 140
   characters and marked with … where it was cut. Title and description

--- a/cmd/ochakai/main.go
+++ b/cmd/ochakai/main.go
@@ -280,7 +280,12 @@ For the web UI, run the bundled proxy on your machine:
 then open http://127.0.0.1:8098. See also: ochakai --help
 `, version)
 	})
-	mux.Handle("/mcp", httpauth.Middleware(cfg, mcpserver.Handler(svc, version)))
+	// /mcp gets the same line as /api/v1 (internal/restapi/requestlog.go).
+	// Its whole surface is one address, so the route is that address; a
+	// deployment whose agents talk MCP would otherwise have a request log
+	// covering the half of its traffic it reads least.
+	mux.Handle("/mcp", restapi.RequestLog(log, "/mcp",
+		httpauth.Middleware(cfg, mcpserver.Handler(svc, version))))
 	mux.Handle("/api/v1/", restapi.AnnounceReadOnly(svc, httpauth.Middleware(cfg, restapi.Handler(svc))))
 
 	log.Info("ochakai listening", "addr", cfg.Addr, "version", version,

--- a/docs/guides/operating.md
+++ b/docs/guides/operating.md
@@ -132,6 +132,42 @@ provenance はそれが起きるのを見ていたインスタンスに属する
 ときにだけ成功する。`ochakai whoami` はシェルから同じことをしつつ、
 サーバーがどの identity を見ているかも表示する。
 
+### リクエストログ
+
+**リクエストは一本ずつ一行になる。** `/api/v1` と `/mcp` のすべての
+リクエストが、応答が終わった時点で `request` という一行を出す:
+
+```
+"request" method=GET route="GET /api/v1/search" status=200 duration_ms=34 bytes=1820 actor=process
+"request" method=PUT route="GET /api/v1/bundle/{path...}" status=409 duration_ms=7 bytes=96 actor=human code=already_exists
+```
+
+- **`route` はパスではなく、mux が一致させたパターンである。**
+  バンドルのパスは concept の住所、つまり利用者のナレッジそのものなので、
+  ログに出せばナレッジベースの形を一行ずつ第二の場所に写すことになる。
+  出るのは「何が呼ばれたか」であって「何に対して呼ばれたか」ではない。
+- **`actor` は kind だけである**(`human` / `process`)。誰が書いたかは
+  provenance であり concept の上に住む(設計ドキュメント
+  [0065](../design/0065-identity-and-provenance.md))。ログはその第二の
+  コピーではない。運用者が率として読むのは人か処理かの別である。
+- **`code`** は失敗のときだけ付く。ステータスが言えない半分がこれで、
+  409 は三つの条件が共有している(設計ドキュメント
+  [0083](../design/0083-an-error-carries-a-code.md))。
+
+**これはテレメトリではない。** 送信先はこのデプロイの stdout で、
+Cloud Run ではこのプロジェクトの Cloud Logging である。そこから先は
+ログベースの指標にできる — ochakai が `/metrics` を生やさず、二つ目の
+アドレス空間もスクレイプ対象も持たずに済むのはそのためである
+(すべては `/api/v1` に載るか、どこにも載らない、設計ドキュメント
+[0067](../design/0067-four-faces-and-what-they-decline.md) §1)。組む
+価値があるのは次の三つである。
+
+| 指標 | クエリの骨子 |
+|---|---|
+| レイテンシ | `jsonPayload.message="request"` の `duration_ms` を分布で。`route` で分けると、遅いのが検索なのか export なのかが出る |
+| エラー率 | 同じ行の `status>=500`。`4xx` は呼び出し元の問題なので、率で見るなら `code` で分ける |
+| 劣化 | `query embedding failed` の件数(下の表)。検索が lexical に落ちている時間である |
+
 ### ログ
 
 すべては `slog` を通した JSON なので、Cloud Logging は手を加えずに

--- a/internal/restapi/requestlog.go
+++ b/internal/restapi/requestlog.go
@@ -1,0 +1,115 @@
+package restapi
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/na0fu3y/ochakai/internal/httpauth"
+)
+
+// One line per request, so an operator has something to read.
+//
+// Until this existed the whole observability surface was /health: a
+// deployment could say it was alive and nothing else. "Search got slow"
+// had no answer short of attaching to Cloud SQL by hand, "what is
+// failing" had none at all, and the counts the loop keeps
+// (design doc 0069) are about the knowledge rather than the service
+// holding it.
+//
+// This is not telemetry. Nothing is reported anywhere — the line goes to
+// stdout, which on Cloud Run is the deployment's own log in the
+// deployment's own project (README, "what it refuses"). What it buys
+// there is that a log-based metric can be built from it without ochakai
+// growing a metrics endpoint, a second address space, or a scrape
+// target: the platform the product already requires is the one that
+// aggregates.
+//
+// **The route, not the path.** A bundle path is a concept's address and
+// therefore the user's knowledge — logging it would copy the knowledge
+// base's shape into a second place, one line at a time. The pattern the
+// mux matched ("GET /api/v1/bundle/{path...}") says what was called
+// without saying what was called on.
+func requestLog(log *slog.Logger, route func(*http.Request) string, next http.Handler) http.Handler {
+	if log == nil {
+		// A Service assembled without one is a legitimate construction —
+		// several tests build the smallest thing that serves — and a
+		// missing logger must not be the reason a request panics.
+		log = slog.Default()
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		rec := &loggingWriter{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(rec, r)
+		// Milliseconds because a request that takes a whole one is
+		// already interesting here, and rounding hides nothing an
+		// operator would act on.
+		attrs := []any{
+			"method", r.Method,
+			"route", route(r),
+			"status", rec.status,
+			"duration_ms", time.Since(start).Milliseconds(),
+			"bytes", rec.bytes,
+			// The kind, not the name: who reached a deployment is
+			// provenance and lives on the concepts they wrote (design doc
+			// 0065), and a request log is not a second, unasked-for copy
+			// of it. Whether the caller was a person or a process is what
+			// an operator reads a rate by.
+			"actor", httpauth.Actor(r.Context()).Kind,
+		}
+		if rec.code != "" {
+			// The condition, not the sentence: "409 already_exists" is a
+			// rate somebody can watch, and the prose beside it moves
+			// between releases (design doc 0083).
+			attrs = append(attrs, "code", rec.code)
+		}
+		log.Info("request", attrs...)
+	})
+}
+
+// RequestLog wraps one handler that is not behind a mux — /mcp, whose
+// whole surface is a single address — with the same line.
+func RequestLog(log *slog.Logger, route string, next http.Handler) http.Handler {
+	return requestLog(log, func(*http.Request) string { return route }, next)
+}
+
+// loggingWriter remembers what the response turned out to be. It also
+// receives the error code from writeErrorBody, which is the one thing
+// about a failure the wire carries and the status does not.
+type loggingWriter struct {
+	http.ResponseWriter
+	status  int
+	bytes   int
+	code    string
+	written bool
+}
+
+func (w *loggingWriter) WriteHeader(status int) {
+	if !w.written {
+		w.status, w.written = status, true
+	}
+	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *loggingWriter) Write(b []byte) (int, error) {
+	w.written = true
+	n, err := w.ResponseWriter.Write(b)
+	w.bytes += n
+	return n, err
+}
+
+// Flush keeps a streaming response streaming: an export writes a gzip of
+// the whole bundle through this wrapper, and swallowing Flush would hold
+// it in the buffer until the end.
+func (w *loggingWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// codeRecorder is what writeErrorBody looks for: the machine-readable
+// condition, handed to whatever is recording this response rather than
+// put on the wire a second time.
+type codeRecorder interface{ recordCode(string) }
+
+func (w *loggingWriter) recordCode(code string) { w.code = code }

--- a/internal/restapi/requestlog_test.go
+++ b/internal/restapi/requestlog_test.go
@@ -1,0 +1,130 @@
+package restapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/na0fu3y/ochakai/internal/domain"
+	"github.com/na0fu3y/ochakai/internal/httpauth"
+)
+
+// logLines decodes what a handler wrote to its logger.
+func logLines(t *testing.T, buf *bytes.Buffer) []map[string]any {
+	t.Helper()
+	var out []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			t.Fatalf("log line is not JSON: %q", line)
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+func TestRequestLogRecordsTheRouteNotThePath(t *testing.T) {
+	buf := &bytes.Buffer{}
+	log := slog.New(slog.NewJSONHandler(buf, nil))
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/bundle/{path...}", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("body"))
+	})
+	h := requestLog(log, func(r *http.Request) string {
+		_, pattern := mux.Handler(r)
+		return pattern
+	}, mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/bundle/metrics/quarterly-revenue.md", nil)
+	req = req.WithContext(httpauth.WithActor(context.Background(),
+		domain.Actor{Kind: domain.ActorProcess, Name: "analysis_agent/gemini"}))
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	lines := logLines(t, buf)
+	if len(lines) != 1 {
+		t.Fatalf("logged %d lines, want one per request", len(lines))
+	}
+	line := lines[0]
+	if line["route"] != "GET /api/v1/bundle/{path...}" {
+		t.Errorf("route = %v, want the pattern the mux matched", line["route"])
+	}
+	// The knowledge is the user's, and a log is not a second place to keep
+	// a copy of what it is called.
+	if raw := buf.String(); strings.Contains(raw, "quarterly-revenue") {
+		t.Errorf("the log carries a concept id:\n%s", raw)
+	}
+	// Nor is it a second copy of who wrote what: the kind is a rate, the
+	// name is provenance and lives on the concept.
+	if raw := buf.String(); strings.Contains(raw, "gemini") {
+		t.Errorf("the log carries an actor name:\n%s", raw)
+	}
+	if line["actor"] != string(domain.ActorProcess) {
+		t.Errorf("actor = %v, want the kind", line["actor"])
+	}
+	if line["status"] != float64(http.StatusOK) || line["bytes"] != float64(4) {
+		t.Errorf("status/bytes = %v/%v, want 200/4", line["status"], line["bytes"])
+	}
+	if _, ok := line["duration_ms"]; !ok {
+		t.Error("no duration_ms: answering \"search got slow\" is why this line exists")
+	}
+	if _, ok := line["code"]; ok {
+		t.Errorf("a success carries code %v; there is no condition to name", line["code"])
+	}
+}
+
+// A failure logs the condition beside the status, because that is the
+// half a status cannot say: three conditions answer 409 (design doc
+// 0083), and an operator watching a rate wants to know which one moved.
+func TestRequestLogRecordsTheErrorCode(t *testing.T) {
+	buf := &bytes.Buffer{}
+	log := slog.New(slog.NewJSONHandler(buf, nil))
+
+	h := requestLog(log, func(*http.Request) string { return "PUT /api/v1/bundle/{path...}" },
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			writeErrorBody(w, http.StatusConflict, domain.CodeAlreadyExists, "taken")
+		}))
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPut, "/api/v1/bundle/x.md", nil))
+
+	lines := logLines(t, buf)
+	if len(lines) != 1 {
+		t.Fatalf("logged %d lines, want one", len(lines))
+	}
+	if lines[0]["status"] != float64(http.StatusConflict) {
+		t.Errorf("status = %v, want 409", lines[0]["status"])
+	}
+	if lines[0]["code"] != domain.CodeAlreadyExists {
+		t.Errorf("code = %v, want %q", lines[0]["code"], domain.CodeAlreadyExists)
+	}
+}
+
+// An export streams a gzip of the whole bundle, so the wrapper has to
+// stay a Flusher: holding a stream in a buffer until the end is the way
+// a request log breaks the one response that cannot wait.
+func TestRequestLogKeepsAStreamStreaming(t *testing.T) {
+	log := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
+	flushed := false
+	h := requestLog(log, func(*http.Request) string { return "GET /api/v1/bundle/{path...}" },
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			f, ok := w.(http.Flusher)
+			if !ok {
+				t.Error("the wrapped writer is not a Flusher")
+				return
+			}
+			_, _ = w.Write([]byte("chunk"))
+			f.Flush()
+			flushed = true
+		}))
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/api/v1/bundle/", nil))
+	if !flushed {
+		t.Error("the handler could not flush through the request log")
+	}
+}

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -967,7 +967,15 @@ func Handler(svc *service.Service) http.Handler {
 		writeJSON(w, http.StatusOK, res)
 	})
 
-	return AnnounceReadOnly(svc, stdlibDefaultsAsJSON(mux))
+	// The log sits inside AnnounceReadOnly and outside the mux: it needs
+	// the pattern the mux matched, which ServeMux.Handler answers without
+	// serving anything, and it should see the status every layer below it
+	// produced.
+	logged := requestLog(svc.Log, func(r *http.Request) string {
+		_, pattern := mux.Handler(r)
+		return pattern
+	}, stdlibDefaultsAsJSON(mux))
+	return AnnounceReadOnly(svc, logged)
 }
 
 // stdlibDefaultsAsJSON rewrites the two responses net/http's ServeMux
@@ -1684,6 +1692,12 @@ func writeError(w http.ResponseWriter, err error) {
 // sentence for a person, a code for a client (design doc 0082 leaves a
 // response-only addition outside the freeze).
 func writeErrorBody(w http.ResponseWriter, status int, code, msg string) {
+	// The request log wants the condition, and the wire already carries
+	// it; handing it over here keeps the log from having to read the body
+	// back (requestlog.go).
+	if rec, ok := w.(codeRecorder); ok {
+		rec.recordCode(code)
+	}
 	writeJSON(w, status, map[string]string{"error": msg, "code": code})
 }
 


### PR DESCRIPTION
## What and why

IMPROVEMENT_PLAN.md の #17。

**詰まる場所。** 観測性の面は `/health` だけで、それが答えるのは「プロセスが応答しているか」に尽きる。「検索が遅くなった」の診断手段は Cloud SQL への手作業アタッチしかなく、「何が失敗しているか」には手段が無かった。ループが持つ数([0069](``docs/design/0069-the-loop-and-what-measures-it.md))はナレッジについてのものであって、それを持つサービスについてのものではない。``

**足したもの。** `/api/v1` と `/mcp` のすべてのリクエストが、応答が終わった時点で一行を書く: method、mux が一致させた **route パターン**、status、`duration_ms`、bytes、actor の kind、そして失敗のときだけ error `code`。

```
"request" method=GET route="GET /api/v1/search" status=200 duration_ms=34 bytes=1820 actor=process
"request" method=PUT route="GET /api/v1/bundle/{path...}" status=409 duration_ms=7 bytes=96 actor=human code=already_exists
```

**なぜ `/metrics` ではないか。** [0067 §1](docs/design/0067-four-faces-and-what-they-decline.md) は「すべては `/api/v1` に載るか、どこにも載らない」と決めている。ログベースの指標なら、製品が既に要求しているプラットフォームがそのまま集計してくれるので、二つ目のアドレス空間もスクレイプ対象も要らない。**これはテレメトリではない** — 送信先はこのデプロイ自身の stdout である。

**二つの意図的な欠落は、同じ規則の二度の適用である。**

- **パスではなく route。** バンドルのパスは concept の住所、つまり利用者のナレッジそのものなので、出せばナレッジベースの形を一行ずつ第二の場所に写すことになる。
- **名前ではなく actor の kind。** 誰が書いたかは provenance であり concept の上に住む([0065](docs/design/0065-identity-and-provenance.md))。運用者が率として読むのは人か処理かの別である。

三つの問い: (1) 運用者が「遅い」「壊れている」を診断する手段を持っていなかった。(2) 既存の面では回避できない — `/health` は無条件に `ok` を返し、`stats` はナレッジを数えるものである。(3) 畳めるものは無いが、**エンドポイント・環境変数・ワイヤのフィールドはいずれも増えていない**。

## Checks

- [x] `scripts/check --db core` と `scripts/check lint` はローカルで緑(PostgreSQL 16.13 に対して。CI は pgvector/pg17。`vuln` は egress ポリシーで検証不能)
- [x] Behavior changes come with tests — `TestRequestLogRecordsTheRouteNotThePath`(パターンが出ること、**concept の id と actor の名前がログに現れないこと**を明示的に確かめる)、`TestRequestLogRecordsTheErrorCode`、`TestRequestLogKeepsAStreamStreaming`(export は gzip を流すので、ラッパーが Flusher を保つことを固定する)
- [x] `svc.Log` を持たない Service で組んだテストが panic しないよう nil ガードを入れた(既存の二つのテストがその構成だった)

## Surfaces and contract

- [x] 面は一つも動いていない — 新しいエンドポイント・パラメータ・フラグ・環境変数・語彙はゼロ。`docs/surface.md` の数はどれも不変
- [x] `api/openapi.yaml` と `api/openapi.frozen.txt` は未変更(ワイヤに何も足していない — error code はレスポンスから読むのではなく、`writeErrorBody` が記録側に手渡している)
- [x] 面ごとの着地: サーバーの挙動なので **REST と MCP の両方**に等しく効く。CLI と Web UI はクライアントなので対象外

## Design docs

- [x] 採択済みの決定は変えていない。ワイヤも保存形も identity も不変で、`/metrics` を作らない判断は 0067 §1 の既定に従っただけである。読み方は[運用ガイド](docs/guides/operating.md)の「リクエストログ」節に書いた(`DOC-LINES` は天井 5,800 の内側のまま)
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_014Mfkjj6NfFFTx1KszwJG3y)_