### PR TITLE
Give English speakers one page into a Japanese manual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,24 @@ last entry.
 
 ### Added
 
+- **One page of the manual is in English** ([docs/en.md](docs/en.md)).
+  The manual is Japanese by decision — condition C8 — and the front door
+  and the contract are the seven pages that stay English, which left an
+  evaluator who reads neither Japanese nor Go at a wall on step two: the
+  pitch was in their language and everything needed to run it was not.
+  This is not a translation and there is still no mirrored page, because
+  two texts saying the same thing go out of step and nobody can tell
+  which half is stale. It is the page that makes the Japanese ones
+  usable: what each holds, in what order to read them, and the handful of
+  names — the environment variables, the four postures of
+  `OCHAKAI_MODE`, the two shapes of an MCP connection, the absence of
+  authorization — that you cannot find by skimming a page you cannot
+  skim. Machine translation handles prose well; what it cannot tell you
+  is which page to open. The environment-variable list is the one
+  duplicate, and it is checked against the build rather than trusted
+  (`cmd/ochakai/surface_test.go`). `DOC` 25 → 26 and `DOC-LINES`
+  5,900 → 6,000.
+
 - **`ochakai seed` fills an empty base without ochakai touching a
   warehouse.** A new deployment starts empty, and catalog products solve
   that with connectors that crawl the warehouse — which ochakai does not

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ SQL](deploy/terraform/README.md) (Japanese) for about $10/month, or Docker
 and nothing else locally.
 
 [Quick start](#quick-start) · [Why ochakai](#why-ochakai) ·
-[Requirements](#requirements) · [All docs](docs/README.md) (Japanese) ·
+[Requirements](#requirements) · [All docs](docs/README.md) (Japanese;
+[one page in English](docs/en.md)) ·
 [REST API](api/openapi.yaml) · [Changelog](CHANGELOG.md)
 
 ![The draft review queue: concepts agents wrote back, waiting for a human
@@ -260,6 +261,11 @@ in the version you are running.
   [Golden query canary](docs/guides/golden-query-canary.md) (Japanese)
 - **Building on it** — [REST API](api/openapi.yaml) ·
   [Examples](examples) (Japanese) · [All docs](docs/README.md) (Japanese)
+- **Reading it in English** — [docs/en.md](docs/en.md): what each Japanese
+  page holds, in what order to read them, and the names you would
+  otherwise have to hunt for inside a page you cannot skim. The manual is
+  Japanese by decision (condition C8), and this is the way in rather than
+  a translation of it
 - **Deciding** — [The surface](docs/surface.md), the eight conditions
   ochakai exists to satisfy and everything counted against them, and
   [docs/design](docs/design/README.md), the numbered decision records

--- a/cmd/ochakai/surface_test.go
+++ b/cmd/ochakai/surface_test.go
@@ -612,6 +612,39 @@ func TestSurfaceDocCountsEnvironmentVariables(t *testing.T) {
 		names = append(names, name)
 	}
 	compareSurface(t, "ENV", names)
+	englishPageNamesEveryEnvVar(t, names)
+}
+
+// docs/en.md repeats the environment variables, which is the one place
+// the no-mirrors rule is bent: an English speaker cannot skim a Japanese
+// page for a name they do not yet know to look for, and the names are
+// the part machine translation renders least usefully. A repeated list
+// is exactly what goes stale, so it is checked rather than trusted —
+// which is how this repo pays for a duplicate anywhere (design doc
+// 0035). The meanings stay in configuration.md, unrepeated.
+func englishPageNamesEveryEnvVar(t *testing.T, names []string) {
+	t.Helper()
+	const page = "../../docs/en.md"
+	content, err := os.ReadFile(page)
+	if err != nil {
+		t.Fatalf("read %s: %v", page, err)
+	}
+	listed := map[string]bool{}
+	for _, line := range strings.Split(string(content), "\n") {
+		if m := surfaceItemRe.FindStringSubmatch(line); m != nil {
+			listed[m[1]] = true
+		}
+	}
+	for _, name := range names {
+		if !listed[name] {
+			t.Errorf("%s does not name %s: an English reader is sent to configuration.md "+
+				"for the meaning, so the list of names has to be complete", page, name)
+		}
+		delete(listed, name)
+	}
+	for name := range listed {
+		t.Errorf("%s names %s, which nothing reads any more", page, name)
+	}
 }
 
 // testSupportPkg is the one package under internal that ships with the

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,10 @@
 まずは [README](../README.md) を読む — ochakai とは何か、クイックスタート、
 そして何をしないか。README はわざと短くしてあり、詳しい説明はここにある。
 
+**English speakers: [docs/en.md](en.md)** — one page that says what each
+Japanese page holds, in what order to read them, and the names you would
+otherwise have to hunt for. Not a translation; a way in.
+
 **このマニュアルは日本語である**(C8、[surface.md](surface.md))。英語で
 残るのは玄関と契約だけで、それは決定である — [README](../README.md)
 (使うかどうかを決める場所であり、その読者は国際的である)、

--- a/docs/en.md
+++ b/docs/en.md
@@ -1,0 +1,98 @@
+# The manual, for English speakers
+
+**The manual is in Japanese, and that is a decision** rather than a
+backlog item: condition C8 in [surface.md](surface.md) says ochakai
+should be one of the best choices available to a Japanese-speaking
+reader, and a manual in their language is most of what that means.
+Seven pages stay in English — the front door and the contract — and
+[docs/README.md](README.md) lists them.
+
+No page has a translated twin. Two texts saying the same thing go out of
+step, and nobody can tell which half is stale
+([CONTRIBUTING.md](../CONTRIBUTING.md), *Translating a manual page*).
+
+**So this page is not a translation.** It is the one page an English
+speaker needs in order to use the Japanese ones: what each contains, in
+what order to read them, and the handful of names you would otherwise
+have to find inside a page you cannot skim. Machine translation handles
+the prose from there, and it handles it well — what it cannot give you is
+which page to open.
+
+## Read in this order
+
+**Deciding whether to adopt it.** [README](../README.md) (English) says
+what ochakai is and what it refuses. Then
+[docs/positioning.md](positioning.md): the answer to "why not use X?",
+one neighbour at a time — warehouse-native semantic layers, catalogs,
+agent memory layers, RAG over your own documents, the verified-query
+store inside an AI-analyst product, Palantir-style ontologies, graph-DB
+ontology platforms, and a markdown vault with an MCP server. It ends with
+**where ochakai loses** and who should pick something else, which is the
+section worth reading first if you are evaluating.
+
+**Running it.** [docs/configuration.md](configuration.md) is every
+setting and what it does. [deploy/terraform](../deploy/terraform) is the
+recommended path — thirteen steps to a Cloud Run + Cloud SQL deployment
+for about $10 a month; [deploy/cloudrun](../deploy/cloudrun) is the
+gcloud reference it was built from, and stays the source of truth where
+the two disagree. [docs/guides/operating.md](guides/operating.md) covers
+backups, monitoring, hardening, the team web UI and upgrades.
+
+**Using it.** [docs/loop.md](loop.md) walks recall → write-back → ruling
+→ outcome in four prompts. [docs/cli.md](cli.md) (English, generated from
+the binary's own help) is the command reference.
+[docs/guides/mcp-clients.md](guides/mcp-clients.md) is how each MCP
+client is pointed at a deployment.
+[docs/architecture.md](architecture.md) is the reference side: what a
+concept is, types, ids as addresses, links derived from the body.
+
+**Building on it.** [api/openapi.yaml](../api/openapi.yaml) (English) is
+the contract, frozen at `/api/v1`.
+[docs/guides/rest-integration.md](guides/rest-integration.md) is what an
+application embedding it needs.
+
+## The names you would otherwise have to hunt for
+
+**Environment variables.** Meanings are in
+[configuration.md](configuration.md); this is the list, so you know what
+to look up.
+
+- `OCHAKAI_DATABASE_URL`
+- `OCHAKAI_DB_IAM_AUTH`
+- `OCHAKAI_DELEGATING_CALLERS`
+- `OCHAKAI_EMBEDDINGS`
+- `OCHAKAI_GCS_BUCKET`
+- `OCHAKAI_IAP_AUDIENCE`
+- `OCHAKAI_MODE`
+- `OCHAKAI_PRODUCER`
+- `OCHAKAI_RECORD_MISSES`
+- `OCHAKAI_URL`
+- `PORT`
+
+**`OCHAKAI_MODE` is the access posture, and there are four.** Unset is
+the normal one: private, writable, Cloud Run IAM decides who reaches it.
+`read-only` serves the base and refuses every write. `public` is the
+posture the demo runs in — reachable without a Google account, read-only,
+and reading no identity at all. `dev` turns authentication off and makes
+every caller `human:anonymous`; it is for a laptop, never for a
+deployment.
+
+**There is no authorization.** Whoever can reach a deployment can read
+and write everything; identity is recorded as provenance, and trust is
+judged from provenance by whoever reads the concept. If you need
+per-concept permissions, this is the wrong tool — said plainly here
+because it is a disqualifying requirement for some teams and it is not
+going to change.
+
+**Connecting an MCP client** takes one of two forms, whichever client it
+is: a URL for clients that speak HTTP MCP, or the `ochakai mcp-stdio`
+bridge for those that cannot. The guide's table names the config file and
+the key each client spells the URL with.
+
+## Contributing in English
+
+Design records are Japanese, and every one carries an English abstract in
+[docs/design/README.en.md](design/README.en.md) — a reading aid, not the
+authority. Propose in whichever language you think in and say so in the
+pull request; [CONTRIBUTING.md](../CONTRIBUTING.md) is in English and
+describes the checks.

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -83,8 +83,8 @@ ochakai を使う人が払うのは実装の行数ではなく**表面**であ�
 - FLAG: 29
 - ENV: 11
 - VOCAB: 46
-- DOC: 25
-- DOC-LINES: 5900
+- DOC: 26
+- DOC-LINES: 6000
 - DOC-LINES-SLACK: 100
 
 `-LINES` と `-BYTES` で終わる行だけは、一覧ではなく**量**に天井を置いて
@@ -601,7 +601,7 @@ MCP ツール 5 本を改名したが、本数は 8 のままで、**変わっ�
 - `type.Reference`
 - `type.Skill`
 
-## DOC (25)
+## DOC (26)
 
 九つ目の次元は**読まされる文書**である。上の八つが数えているのは利用者が
 **使うもの** — 呼べる操作、渡す語、覚えるコマンド、設定する変数 — で
@@ -754,6 +754,20 @@ Neo4j の発信で広く流通しているのに、[positioning](positioning.md)
 を持つ md は保存されるものであって説明ではない(下の箇条)ので
 `kb/bundle` は数えず、入口の一枚 [kb/README.md](../kb/README.md) だけが出る。
 
+**DOC 25 → 26、5,900 → 6,000 は英語話者のための一枚である
+([docs/en.md](en.md))。** マニュアルが日本語であることは C8 の決定で、
+対訳を置かない規則もそのままである — このページは訳ではなく、
+**日本語のページを使うための一枚**である: どのページに何があり、どの順で
+読み、そして「読めないページの中を探さないと分からない名前」は何か。
+機械翻訳は散文をよく訳すが、どのページを開くべきかは教えてくれない。
+
+環境変数の一覧だけは重複する。ここが対訳禁止を曲げる唯一の場所で、
+**知らない名前を日本語のページから拾うことはできない**からである。
+重複は古びるので、`cmd/ochakai/surface_test.go` が en.md の一覧と実物を
+突き合わせる — この repo が重複に払う代金はいつもこれである
+([0035](design/0035-verifiability.md))。意味は
+[configuration.md](configuration.md) にあり、そちらは重複していない。
+
 **5,800 → 5,900 は、二つの到達経路と一つの計器である。**
 [0084](design/0084-a-hit-says-why-it-matched.md) と
 [0085](design/0085-the-empty-base-and-what-fills-it.md) が節を足し、
@@ -833,6 +847,7 @@ PR も自分の tree では正しく、落ちたのは合流点だった。100 �
 - `docs/architecture.md`
 - `docs/compatibility.md`
 - `docs/configuration.md`
+- `docs/en.md`
 - `docs/faq.md`
 - `docs/guides/git-review.md`
 - `docs/guides/golden-query-canary.md`


### PR DESCRIPTION
## What and why

IMPROVEMENT_PLAN.md の #7、選択肢③(英語話者向けに要約 1 枚)。

**詰まる場所。** マニュアルが日本語なのは C8 の決定で、英語で残るのは玄関と契約の 7 ページ。結果として評価が**ステップ 2 で止まる** — 売り文句は英語なのに、実際に動かすのに要るもの(設定・デプロイ・ポジショニング・MCP 接続)はすべて日本語である。監査でも最も費用対効果が高い項目として挙がっていた。

**[docs/en.md](docs/en.md) は翻訳ではない。** 対訳を置かない規則もそのまま — 同じことを言う二本のテキストは、どちらが古いか誰にも分からなくなる。これは**日本語のページを使うための一枚**である:

- どのページに何があり、どの順で読むか(評価する人 / 動かす人 / 使う人 / 組み込む人の四つの導線)
- **読めないページの中を探さないと分からない名前**: 環境変数の一覧、`OCHAKAI_MODE` の四つの姿勢、MCP 接続の二つの形、そして**認可が無いこと**(一部のチームには失格要件であり、変わらないので正面から書いた)

機械翻訳は散文をよく訳す。訳してくれないのは「どのページを開くべきか」で、そこだけを埋める設計にした。

**重複は環境変数の一覧だけで、そこが対訳禁止を曲げる唯一の場所である** — まだ知らない名前を、読めない文字のページから拾うことはできない。重複は古びるので `cmd/ochakai/surface_test.go` が実物と突き合わせる(名前を一つ落として実際に落ちることを確認済み)。**意味は configuration.md にあり、そちらは重複していない。**

三つの問い: (1) 非日本語話者の評価者が、動かす手順に到達できずに脱落していた。(2) 既存の面では回避できない — 7 つの英語ページはどれも「何であるか」と「契約」で、「どう動かすか」を持っていない。(3) 畳めるものは無いので理由を書いた: 買っているのは C8 を保ったままの到達経路で、代金はページ 1 枚と、機械が照合する一覧 1 つ。

## Checks

- [x] `scripts/check --db core` と `scripts/check lint` はローカルで緑(PostgreSQL 16.13。CI は pgvector/pg17。`vuln` は egress ポリシーで検証不能)
- [x] Behavior changes come with tests — `englishPageNamesEveryEnvVar`(en.md の一覧が実物と一致する。多くても少なくても落ちる)。他は文書のみ

## Surfaces and contract

- [x] コードの面は一つも動いていない(REST / MCP / CLI / ENV いずれも不変)
- [x] `docs/surface.md` を更新: **DOC 25 → 26、DOC-LINES 5,900 → 6,000**(どちらも天井を上げる決定として、理由の段落を添えた)
- [x] `api/openapi.yaml` と `api/openapi.frozen.txt` は未変更
- [x] README と docs/README.md の両方から新しいページを指した

## Design docs

- [x] 採択済みの決定は変えていない。C8(マニュアルは日本語)も対訳禁止も**そのまま**で、その規則の下で英語話者が到達できる経路を一本足しただけである。番号は取らない — 利用者が観測する挙動・ワイヤ・保存形は動いていない
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_014Mfkjj6NfFFTx1KszwJG3y)_