### PR TITLE
Read the error code in the web UI, not the sentence beside it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,19 @@ last entry.
 
 ### Fixed
 
+- **The web UI read the error sentence to decide what to offer.** The
+  editor decided whether to show *"view the existing concept"* by
+  matching `/already exists/` against the message — the half the
+  compatibility policy says may be reworded in any release, and which
+  the server has since rewritten twice, most recently to name what holds
+  the id and what to do about it. The condition has been a code on the
+  wire since 0.20.0's error envelope; ochakai's own client was the one
+  integrator still not reading it, which is the case that made the code
+  worth having. `api()` now carries `code` up to its callers, and a test
+  reads the page back: every code a branch names has to be one the
+  product can actually say, and the shapes prose-matching returns in fail
+  the build ([#534](https://github.com/na0fu3y/ochakai/issues/534)).
+
 - **A purge now erases the file bytes too.** Purge destroyed every row
   keyed by a concept's id and left the bytes behind its files in the
   bucket forever — the store said so in a comment and told the operator

--- a/internal/webui/index.html
+++ b/internal/webui/index.html
@@ -810,12 +810,23 @@ async function api(path, opts = {}) {
   // write affordances; a button that can only ever 403 is a lie.
   setReadOnly(res.headers.get('Ochakai-Read-Only') === 'true');
   if (!res.ok) {
-    let msg = res.status + ' ' + res.statusText;
+    // Two halves, and the page must not confuse them: `error` is a
+    // sentence for a person and may be reworded in any release
+    // (docs/compatibility.md), `code` is the part to branch on. Anything
+    // here that decides what to *do* reads err.code; err.message is only
+    // ever shown.
+    let msg = res.status + ' ' + res.statusText, code = '';
     try {
       const text = await res.text();
-      try { msg = JSON.parse(text).error || text; } catch { msg = text || msg; }
+      try {
+        const body = JSON.parse(text);
+        msg = body.error || text;
+        code = body.code || '';
+      } catch { msg = text || msg; }
     } catch { /* keep status text */ }
-    throw new Error(msg);
+    const err = new Error(msg);
+    err.code = code;
+    throw err;
   }
   return res.status === 204 ? null : res.json();
 }
@@ -2421,7 +2432,13 @@ async function viewEditor(id, prefix = '') {
       location.hash = '#/k/' + idPath((saved && saved.id) || entryId);
       if (editing) route(); // hash may be unchanged; re-render
     } catch (e) {
-      const dupLink = !editing && /already exists/.test(e.message)
+      // The id is taken. This asked the sentence for as long as there
+      // was nothing else to ask — and the sentence it matched is one the
+      // server rewrote twice since, once to name what holds the id and
+      // what to do about it. The condition arrives as a code now, on a
+      // 412 rather than a 409 because the page writes with If-None-Match
+      // and that is a precondition failing (design doc 0083).
+      const dupLink = !editing && e.code === 'already_exists'
         ? ` — <a href="#/k/${idPath(entryId)}">view the existing ${esc(entryId)}</a> (edit it, or pick another ID)`
         : '';
       errBox.innerHTML = `<div class="error-banner">${editing ? 'Save' : 'Create'} failed: ${esc(e.message)}${dupLink}</div>`;

--- a/internal/webui/webui_test.go
+++ b/internal/webui/webui_test.go
@@ -458,3 +458,55 @@ func TestLoopStatsDistinguishNotRecordedFromZero(t *testing.T) {
 		t.Errorf("the loop strip draws misses without asking whether they are recorded:\n%s", body)
 	}
 }
+
+// The page must branch on the error code, never on the sentence beside
+// it. The compatibility policy says the sentence may be reworded in any
+// release, and this page proved the point: it decided whether to offer
+// "view the existing concept" by matching /already exists/, against a
+// message the server has since rewritten twice — once to name what holds
+// the id and what to do about it.
+//
+// Two invariants, and they fail for different reasons. The first is that
+// api() hands the code up at all: an error object that drops it leaves
+// prose as the only thing to read, which is how the regex got there. The
+// second is that every code the page names is one the product can
+// actually say — a branch on a code with a typo in it is a branch that
+// never runs, and nothing else would notice.
+func TestThePageBranchesOnErrorCodesRatherThanProse(t *testing.T) {
+	page := string(Index)
+
+	body := section(t, page, "async function api(", "\n}")
+	if !strings.Contains(body, "err.code = code") {
+		t.Errorf("api() no longer carries the error code up to its caller:\n%s", body)
+	}
+
+	// Reading a code the product cannot say is a branch that never runs.
+	codes := 0
+	for _, i := range indexesOf(page, ".code === '") {
+		rest := page[i+len(".code === '"):]
+		end := strings.IndexByte(rest, '\'')
+		if end < 0 {
+			t.Fatalf("unterminated code literal at offset %d", i)
+		}
+		codes++
+		if got := rest[:end]; !domain.ValidErrorCode(got) {
+			t.Errorf("the page branches on error code %q, which is not one of %v",
+				got, domain.ErrorCodes)
+		}
+	}
+	if codes == 0 {
+		t.Error("no branch reads an error code; the page went back to reading prose")
+	}
+
+	// The shapes prose-matching comes back in.
+	for _, gone := range []string{
+		".test(e.message)", ".test(err.message)",
+		"e.message.includes(", "err.message.includes(",
+		"e.message.match(", "err.message.match(",
+	} {
+		if strings.Contains(page, gone) {
+			t.Errorf("the page decides something by matching an error sentence (%s); "+
+				"the sentence may be reworded in any release, the code may not", gone)
+		}
+	}
+}


### PR DESCRIPTION
## What and why

#534(計画 #540)。ただし **issue の四項目のうち一つだけを実装し、三つは測って断る**提案です。断る根拠を下に全部書いてあります。

### 実装するもの — ochakai 自身のクライアントが散文を読んでいた

エディタは「既存の concept を見る」リンクを出すかどうかを、**エラー文の `/already exists/` 正規表現**で決めていました(`index.html`)。その文は互換性ポリシーが *いつでも書き換えてよい* と宣言している側で、実際にサーバは二回書き換えています — 直近では「何がその id を持っていて、どうすればよいか」を名指すように。

条件は 0.20.0 のエラー封筒以降 **`code` としてワイヤに載っています**。読んでいなかった最後の統合者が ochakai 自身でした。原因ははっきりしていて、`api()` が `code` を捨てていたので、呼び出し側が届く場所に散文しか無かったからです。

- `api()` が `err.code` を運ぶ
- 分岐は `e.code === 'already_exists'`(412 です — ページは If-None-Match で書くので、これは precondition の失敗。[0083](docs/design/0083-two-preconditions-one-status.md))

ガードはページを読み返します(0035: 規約を信じるのではなく外から不変条件を読む)。理由の違う二つ:

1. `api()` が code を上げていること — 上げなければ散文が唯一の手掛かりに戻り、それが正規表現の生まれた経緯です
2. **ページが名指す code が、製品の言える code であること** — 綴りを間違えた分岐は決して走らない分岐で、他の何もそれに気付きません

散文マッチが戻ってくる形(`.test(e.message)`、`e.message.includes(` など)もビルドを落とします。

## 断る三つと、その根拠

### `field` を足さない

`code: invalid` が約 60 条件を一つにまとめているのは事実です。ただ `field` の消費者は**入力欄をハイライトするフォーム UI** で、ochakai にそれは無く(エディタは生の markdown テキストエリア一枚)、REST 統合者は今のところ想像上の存在です。MCP 側の消費者はエージェントで、`field` より散文のほうが直接行動に移せます。「実際に詰まった一件」が書けないので、既定の答えの no を採ります。書けるようになったときに足すべきものです。

### 文言を短くしない / docs の恒久 URL に置き換えない

issue は「時に 280 字の段落」と書いていますが、**測ると最長 194 字、中央値 67.5 字、200 字超はゼロ**(`Invalidf`/`Unsupportedf` の 62 箇所)。前提が成り立ちません。

長いものは中身も見ました — 上位はどれも「代わりに何をすればよいか」を言っている文です。そして主な読み手は MCP のエージェントで、**ツール呼び出しの最中に URL を取りに行けません**。埋め込みの散文を参照に替えるのは、その読み手にとって明確な劣化です([0069](docs/design/0069-the-loop-and-what-measures-it.md) が get_context のヒントを残した理由と同じ)。

### CLI のエラーを日本語にしない

issue の背景は「C8 を掲げる製品で、エラーだけが恒久に英語散文になっている」ですが、**CLI は全部が英語**です — ヘルプも、生成される `docs/cli.md` も。エラーだけが例外なのではありません。

そして日本語化には (a) ロケール面(環境変数かフラグか `LANG` 自動判定)と (b) 第二のメッセージカタログが要ります。(b) は CONTRIBUTING.md が翻訳ミラーを断った理由そのもの — **どちらの半分が古びたか誰にも分からない**。

C8 に対する答えは、むしろ `code` のほうです: **統合者が自分の言語で描ける**。ochakai が日本語を持つのではなく。

言語戦略そのものは #538 の項目なので、この判断はそこで扱われるべきものだと思います。

## 受け入れ基準に対して

- 「統合する側が文字列マッチせずにエラー分岐を書ける」— **満たしています**。ochakai 自身の Web UI が実例で、テストがそれを保つようになりました
- 「CLI が日本語でエラーを説明できる」— **満たしません**。上記の理由で提案を断ります

## Checks

- [x] `scripts/check core --db` clean(store は PostgreSQL 16.13、CI の pg17 ではありません)、`scripts/check lint` 0 issues
- [x] Behavior changes come with tests — `TestThePageBranchesOnErrorCodesRatherThanProse`。変更を戻すと三つの assertion が全部落ちることを確認済み
- [ ] `scripts/check vuln` は proxy が vuln.go.dev を拒否するためこの環境では確認不能(欠陥ではありません)

## Surfaces and contract

- [x] `api/openapi.yaml` / `internal/restapi` / `internal/mcpserver` / `internal/apiclient` — 変更なし。`code` は既に四面で同期済みで、この PR はそれを**使っていなかった一箇所**を直すだけです
- [x] `api/openapi.frozen.txt` untouched
- [x] `docs/surface.md` 変更なし。表面は増減せず、VOCAB の `code` 語彙も動きません

## Design docs

- [x] 該当なし。0083 も互換性ポリシーも動かさず、既に決まっていることをクライアント側が守るようになるだけです
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01BATZn1qmJosokMG8HGxRi8)_