### PR TITLE
Answer 501 when an archive needs a bucket the deployment has not got

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,19 @@ last entry.
 
 ### Fixed
 
+- **Archiving a bundle that holds files, on a deployment with no bucket,
+  answered `internal error`.** The store refuses that archive on purpose
+  — one that silently omitted the files would be a backup missing what it
+  claims to carry — but the sentinel it raises never became a client
+  error, so the one endpoint that exists to *be* a backup answered 500
+  with the reason left in the server's log. It is 501 `unsupported` now,
+  naming `OCHAKAI_GCS_BUCKET`, which is what design doc 0013 says a
+  missing bucket is and what every path through the service already
+  returned. An operator meets this by removing the bucket from a database
+  that has file rows. `?files=false` asks for the concepts alone and
+  still succeeds. No contract change: the address already declared 501
+  ([#546](https://github.com/na0fu3y/ochakai/issues/546)).
+
 - **The web UI read the error sentence to decide what to offer.** The
   editor decided whether to show *"view the existing concept"* by
   matching `/already exists/` against the message — the half the

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -805,6 +805,12 @@ paths:
             that is not a concept's: at `<id>.md` the answer is the
             concept's own 404, because what was asked about is the
             concept and not the deployment.
+
+            An archive answers 501 for the same reason without a file
+            having been named: the bundle under the requested path holds
+            files, and one that omitted them would be a backup missing
+            what it claims to carry. `?files=false` asks for the concepts
+            alone and succeeds.
           headers:
             Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
           content:

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -1675,6 +1675,16 @@ func writeError(w http.ResponseWriter, err error) {
 		status, code = http.StatusBadRequest, domain.CodeInvalid
 	case errors.As(err, &unsupportedErr):
 		status, code = http.StatusNotImplemented, domain.CodeUnsupported
+	// The same condition arriving from the store rather than the service.
+	// Every other path asks the service, which checks for a blob store
+	// and says so; the archive reads the store directly, because whether
+	// it needs one is a property of what the snapshot contains rather
+	// than of the request. Without this the one endpoint that exists to
+	// be a backup answered "internal error" for a deployment that has
+	// file rows and no bucket — the true reason left in the server's log,
+	// in exactly the case an operator most needs it.
+	case errors.Is(err, store.ErrNoBlobStore):
+		status, code = http.StatusNotImplemented, domain.CodeUnsupported
 	}
 	if status == http.StatusInternalServerError {
 		// Every status above is a message a caller is meant to read; this

--- a/internal/restapi/restapi_integration_test.go
+++ b/internal/restapi/restapi_integration_test.go
@@ -60,6 +60,42 @@ func lockLiveAttachments(t *testing.T) {
 	t.Cleanup(func() { _ = conn.Close(ctx) }) // closing the session releases the lock
 }
 
+// The lock above is a convention until something checks it, and a
+// convention is what issue #546 was: one archive test out of five did not
+// take it, and that one flaked twice in two days on a CI run where
+// another package happened to be holding a live file. The failure was
+// unreadable from here — `gzip: invalid header`, because the archive had
+// answered with an error envelope whose first byte is `{`.
+//
+// So the rule is read back off the source: a test that asks for an
+// archive scans every file the snapshot contains, and every file's bytes
+// resolve against some other package's in-memory fake.
+func TestEveryArchiveTestSerializesAgainstLiveFiles(t *testing.T) {
+	src, err := os.ReadFile("restapi_integration_test.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Function bodies, split on the column-0 brace that ends each one.
+	// Crude, and enough: this file's functions are all top-level.
+	bodies := strings.Split(string(src), "\nfunc ")
+	checked := 0
+	for _, body := range bodies[1:] {
+		name, _, _ := strings.Cut(body, "(")
+		if name == "getArchive" || !strings.Contains(body, "getArchive(t,") {
+			continue
+		}
+		checked++
+		if !strings.Contains(body, "lockLiveAttachments(t)") {
+			t.Errorf("%s asks for an archive without lockLiveAttachments(t): "+
+				"a file another package holds resolves against a blob fake this "+
+				"server cannot read, and the archive fails on it (#546)", name)
+		}
+	}
+	if checked < 4 {
+		t.Errorf("only %d archive tests found; the guard stopped matching them", checked)
+	}
+}
+
 // newIntegrationService is a Service over a real, migrated PostgreSQL,
 // skipping the test without OCHAKAI_TEST_DATABASE_URL.
 //
@@ -2288,6 +2324,7 @@ func TestRESTIntegrationIndexListsTheFilesInADirectory(t *testing.T) {
 // bound, so a reader extracting the bundle and a reader calling the
 // endpoint are not reading two different histories.
 func TestRESTIntegrationTheArchiveCarriesTheHistory(t *testing.T) {
+	lockLiveAttachments(t) // it archives the root, so it scans every live file
 	srv, _ := newIntegrationServer(t)
 
 	typ := testdb.Unique(t, "restlog")
@@ -2478,6 +2515,94 @@ func TestRESTIntegrationHistoryIsAtTheObjectAndTheDirectory(t *testing.T) {
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusNotFound {
 		t.Errorf("history of an object that never existed = %d, want 404", resp.StatusCode)
+	}
+}
+
+// A bundle holding files cannot be archived by a deployment with no blob
+// store, and the archive says which of the two it is.
+//
+// The store decided this deliberately — an archive that silently omitted
+// the files would be a backup missing half of what it claims to hold
+// (ExportSnapshot.FileMeta) — but the sentinel it raised reached the wire
+// as `{"code":"internal","error":"internal error"}`. Design doc 0013's
+// answer for a missing bucket is 501, and every path that goes through
+// the service gives it; this one reads the store directly, because
+// whether it needs a bucket is a property of what the snapshot contains
+// rather than of the request.
+//
+// An operator meets this by removing OCHAKAI_GCS_BUCKET from a database
+// that has file rows, and meets it at the endpoint that exists to be
+// their backup. Issue #546 found it as a CI flake: a test archiving the
+// root while another package held a live file, failing on `gzip: invalid
+// header` — an error envelope where the gzip magic should be.
+func TestRESTIntegrationArchivingFilesWithoutABucketIs501(t *testing.T) {
+	lockLiveAttachments(t)
+	// The file is written through a server that has somewhere to put the
+	// bytes, which is how the row comes to exist at all.
+	writer, ws := newIntegrationServer(t)
+	ws.UseBlobStore(memBlobStore{})
+	typ := testdb.Unique(t, "restnobucket")
+	id := typ + "/owner"
+	removeEntries(t, writer, id)
+	resp := putDoc(t, writer.URL, id, docFrom(t, map[string]any{
+		"type": typ, "id": id, "title": "Owner"}), true)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create status = %d", resp.StatusCode)
+	}
+	file := id + "/chart.png"
+	req, err := http.NewRequest(http.MethodPut, writer.URL+"/api/v1/bundle/"+file,
+		bytes.NewReader(append([]byte("\x89PNG\r\n\x1a\n"), make([]byte, 16)...)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp, err = http.DefaultClient.Do(req); err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	t.Cleanup(func() {
+		rq, _ := http.NewRequest(http.MethodDelete, writer.URL+"/api/v1/bundle/"+file, nil)
+		if rr, err := http.DefaultClient.Do(rq); err == nil {
+			rr.Body.Close()
+		}
+	})
+
+	// And read back by one that has nowhere to get them from.
+	blobless, _ := newIntegrationServer(t)
+	arch, err := getArchive(t, blobless.URL+"/api/v1/bundle/", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer arch.Body.Close()
+	if arch.StatusCode != http.StatusNotImplemented {
+		body, _ := io.ReadAll(arch.Body)
+		t.Fatalf("archive over a file with no bucket = %d, want 501: %s", arch.StatusCode, body)
+	}
+	var refused struct {
+		Code  string `json:"code"`
+		Error string `json:"error"`
+	}
+	if err := json.NewDecoder(arch.Body).Decode(&refused); err != nil {
+		t.Fatal(err)
+	}
+	if refused.Code != domain.CodeUnsupported {
+		t.Errorf("code = %q, want %q", refused.Code, domain.CodeUnsupported)
+	}
+	// And it names the bucket, rather than the "internal error" the
+	// generic 500 branch hands back on purpose.
+	if !strings.Contains(refused.Error, "OCHAKAI_GCS_BUCKET") {
+		t.Errorf("the refusal does not name the setting that fixes it: %q", refused.Error)
+	}
+
+	// ?files=false asks for the concepts alone, which needs no bucket.
+	plain, err := getArchive(t, blobless.URL+"/api/v1/bundle/", "files=false")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer plain.Body.Close()
+	if plain.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(plain.Body)
+		t.Errorf("archive without files = %d, want 200: %s", plain.StatusCode, body)
 	}
 }
 

--- a/internal/store/attachment.go
+++ b/internal/store/attachment.go
@@ -21,7 +21,7 @@ import (
 // store (GCS): attaching the same file twice stores it once, and a
 // revision can name any historical content by hash. Blobs are never
 // deleted, so the bucket only grows. Without a configured blob store,
-// files are unsupported — writes fail with errNoBlobStore.
+// files are unsupported — writes fail with ErrNoBlobStore.
 //
 // Which entry a file belongs to is derived rather than recorded (0046
 // §3.3): it is the entry whose <id>/ namespace the file sits directly
@@ -114,7 +114,7 @@ func (s *Store) PutAttachment(ctx context.Context, id, name, mediaType, at strin
 		CreatedAt: time.Now().UTC(),
 	}
 	if s.blobs == nil {
-		return nil, errNoBlobStore
+		return nil, ErrNoBlobStore
 	}
 	err := s.withTx(ctx, func(tx pgx.Tx) error {
 		// The upload happens under the writers' shared lock (sweep.go):
@@ -169,10 +169,16 @@ func (s *Store) PutAttachment(ctx context.Context, id, name, mediaType, at strin
 	return att, nil
 }
 
-// errNoBlobStore is the backstop for attachment operations on an
+// ErrNoBlobStore is the backstop for attachment operations on an
 // instance without a blob store; the service layer checks first and
 // wraps the condition in a client-facing error (design doc 0013).
-var errNoBlobStore = errors.New("files are not supported without GCS: set OCHAKAI_GCS_BUCKET (design doc 0075 §1)")
+//
+// Exported because one caller cannot check first: the archive reads the
+// store directly, and whether it needs a blob store is not a property of
+// the request but of what the snapshot turned out to contain
+// (ExportSnapshot.FileMeta). So the sentinel travels, and writeError
+// gives it the 501 the other paths get.
+var ErrNoBlobStore = errors.New("files are not supported without GCS: set OCHAKAI_GCS_BUCKET (design doc 0075 §1)")
 
 // GetAttachment returns one attachment with its bytes. Attachments of
 // soft-deleted entries are gone with the entry.
@@ -182,7 +188,7 @@ func (s *Store) GetAttachment(ctx context.Context, id, name string) (*domain.Fil
 		return nil, nil, err
 	}
 	if s.blobs == nil {
-		return nil, nil, errNoBlobStore
+		return nil, nil, ErrNoBlobStore
 	}
 	data, err := s.blobs.Get(ctx, att.SHA256)
 	if err != nil {
@@ -300,7 +306,7 @@ type ExportAttachment struct {
 // export.
 func (s *Store) AttachmentBytes(ctx context.Context, sha256 string) ([]byte, error) {
 	if s.blobs == nil {
-		return nil, errNoBlobStore
+		return nil, ErrNoBlobStore
 	}
 	return s.blobs.Get(ctx, sha256)
 }
@@ -357,7 +363,7 @@ func listAttachmentsTx(ctx context.Context, tx pgx.Tx, id string) ([]domain.File
 // the entry there means PUT on the entry.
 func (s *Store) PutFile(ctx context.Context, p, mediaType string, data []byte, actor domain.Actor) (att *domain.File, created bool, err error) {
 	if s.blobs == nil {
-		return nil, false, errNoBlobStore
+		return nil, false, ErrNoBlobStore
 	}
 	sum := sha256.Sum256(data)
 	hash := hex.EncodeToString(sum[:])
@@ -427,7 +433,7 @@ func (s *Store) GetFile(ctx context.Context, p string) (*domain.File, []byte, er
 		return nil, nil, err
 	}
 	if s.blobs == nil {
-		return nil, nil, errNoBlobStore
+		return nil, nil, ErrNoBlobStore
 	}
 	data, err := s.blobs.Get(ctx, att.SHA256)
 	if err != nil {

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -135,7 +135,7 @@ func (e *ExportSnapshot) FileMeta(ctx context.Context, prefix string) ([]domain.
 		return nil, err
 	}
 	if len(atts) > 0 && e.store.blobs == nil {
-		return nil, errNoBlobStore
+		return nil, ErrNoBlobStore
 	}
 	return atts, nil
 }


### PR DESCRIPTION
## What and why

#546。**flaky を追ったら製品の欠陥が出てきた** ので、直したのはそちらが主です。

### 追跡

CI ログ([run 31162194324](https://github.com/na0fu3y/ochakai/actions/runs/31162194324))を読み直しました。

**issue が挙げていた二つ目の手掛かりは死にました。** `connection reset` と `pq: password authentication failed for user "ochakai" at 10.0.0.5:5432` は `restapi_test.go` の `writeError` ユニットテストの**フィクスチャ**です(:34 と :54)。失敗の一秒後に同じバイナリが出力しています。そもそも `pq:` は lib/pq で、ochakai は pgx しか使っていません。

本当の手掛かりは、FAIL の直前の行でした:

```
08:34:38 ERROR unhandled REST error error="files are not supported without GCS: set OCHAKAI_GCS_BUCKET"
--- FAIL: TestRESTIntegrationTheArchiveCarriesTheHistory (0.27s)
    restapi_integration_test.go:2298: gzip: invalid header
```

再現しました。片方のサーバに live なファイルを持たせ、blob store の無いもう一方に**バンドル全体**のアーカイブを要求します:

```
archive status=500 len=45 first bytes="{\"code\":" gzip magic=false
```

**gzip ヘッダが不正なのは、本体が `{` で始まっていたから**です。

### 製品側の欠陥 — 500 であるべきでないもの

`ExportSnapshot.FileMeta` は、ファイルを持つバンドルを blob store 無しでアーカイブすることを**意図的に**拒否します — 黙って落としたアーカイブは、carry すると称しているものが欠けたバックアップだからです。ところが上げるのは裸の sentinel で、`writeError` はストアのエラーをどれも知っているのにこれだけ知りませんでした。

結果、**バックアップであることが存在理由の唯一のエンドポイントが、500 `internal error` を返し、本当の理由はサーバのログにだけ残る**。運用者がこれに出会うのは、ファイル行を持つデータベースから `OCHAKAI_GCS_BUCKET` を外したときで、まさに理由を一番知りたい場面です。

[0013](docs/design/0013-attachments.md) が bucket 不在に与える答えは 501 で、service を通る経路は全部そう返しています。アーカイブがストアを直接読むのは、**bucket が要るかどうかがリクエストの性質ではなくスナップショットの中身の性質**だからです。なので sentinel を export し、`writeError` が既に写像しているストアエラーの隣に置きました。

- `?files=false` は concept だけを求めるので、bucket 無しでも 200 のままです
- **契約は動きません** — このアドレスは既に 501 を宣言済み(`api/openapi.frozen.txt` untouched)。散文にファイルを名指さない場合の一文を足しただけです

### flake 側 — 抜けていたロック

アーカイブを要求するテストは 5 本あり、**4 本が `lockLiveAttachments` を取り、1 本が取っていませんでした。** その 1 本が二日で二回落ちたものです。ロック自身のコメントが「whole-KB scan は取れ」と書いています(別パッケージの in-memory blob fake に対してバイトが解決するので、他人の live file が whole-KB scan を壊す)。

規約は**ソースから読み返す**ようにしました(0035: 規約を信じるのではなく外から不変条件を読む)。次の一本が忘れられません。

なお **issue の一つ目の症状は既に main で直っています**(`log.md` の JSON/markdown 比較が root ではなく自分の接頭辞に限定済み)。この PR は残っていた二つ目だけを扱います。

## Checks

- [x] `scripts/check core --db` clean、`scripts/check lint` 0 issues
- [x] Behavior changes come with tests:
  - `TestRESTIntegrationArchivingFilesWithoutABucketIs501` — `writeError` の分岐を外すと `= 500, want 501: {"code":"internal","error":"internal error"}` で落ちることを確認済み
  - `TestEveryArchiveTestSerializesAgainstLiveFiles` — ロックを外すと該当テスト名を挙げて落ちることを確認済み
- [ ] `scripts/check vuln` は proxy が vuln.go.dev を拒否するためこの環境では確認不能(欠陥ではありません)

## Surfaces and contract

- [x] `api/openapi.frozen.txt` untouched。501 はこのアドレスで宣言済みで、実装が契約に追いついただけです
- [x] `internal/restapi` / `internal/apiclient` / `internal/mcpserver` — 面は増減せず、`code: unsupported` も既存の語彙
- [x] `docs/surface.md` 変更なし

## Design docs

- [x] 該当なし。0013 が既に決めていることを、決めた通りに返すようにする変更です
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01BATZn1qmJosokMG8HGxRi8)_