### PR TITLE
Make the README one staircase, and say it is good at Japanese

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,24 @@ last entry.
 
 ### Added
 
+- **The README is one staircase, and it says the product is good at
+  Japanese.** The quick start ran demo → your own server → an agent, but
+  the rungs were unlabelled and production was not one of them, so a
+  reader still had to work out which entrance was theirs; it is three
+  named steps now (sixty seconds, ten minutes, for real), and the last
+  one carries Cloud Run and Cloud SQL instead of leaving them to a link
+  in the intro. Filling a base with your own tables leads with `ochakai
+  seed` — shipped for exactly that and named nowhere on the front page —
+  and the ten-minute rung uses the CLI the first rung installed rather
+  than reaching into the container. **The word "Japanese" appeared in
+  this README only as a warning label on documentation links**, never as
+  something the product does, so a Japanese-speaking evaluator learned
+  only that the manual might be unreadable to them. There is a *Why*
+  bullet now: no tokenizer extension to install (which managed Postgres
+  would not allow anyway), 売上 answered from an index rather than a
+  scan, latin words stemmed, nothing to configure
+  ([#527](https://github.com/na0fu3y/ochakai/issues/527)).
+
 - **A renamed MCP tool or CLI command keeps answering for one release**
   ([0088](docs/design/0088-a-retired-name-answers-for-one-release.md)).
   The policy used to be that there was no deprecation window for

--- a/README.md
+++ b/README.md
@@ -16,9 +16,8 @@ humans and agents together, and served to Claude Code and every other
 data agent over [MCP](https://modelcontextprotocol.io), REST, a CLI, and
 a bundled web UI. More at [ochak.ai](https://ochak.ai).
 
-One Go binary and Postgres: [Terraform stands up Cloud Run + Cloud
-SQL](deploy/terraform/README.md) (Japanese) for about $10/month, or Docker
-and nothing else locally.
+One Go binary and Postgres — Docker and nothing else locally, Cloud Run
+and Cloud SQL when it is real.
 
 [Quick start](#quick-start) · [Why ochakai](#why-ochakai) ·
 [Requirements](#requirements) · [All docs](docs/README.md) (Japanese;
@@ -29,6 +28,11 @@ and nothing else locally.
 to verify or reject them](docs/images/webui-review.png)
 
 ## Quick start
+
+Three steps, in order, and nothing to choose between: read somebody
+else's knowledge, then hold your own, then run it for a team.
+
+### Sixty seconds: the public demo
 
 A public demo already holds the knowledge base below. It reads no
 identity and writes nothing, which is what makes it safe to leave open
@@ -44,7 +48,7 @@ ochakai context "why is revenue down?"
 It is also the one deployment where plain curl works — nothing to sign:
 `curl 'https://demo.ochak.ai/api/v1/search?q=revenue'`.
 
-### What that one call is worth
+#### What that one call is worth
 
 `ochakai context` is the read an agent makes before a data question: it
 returns the concepts that bear on it in full and names the rest. Here is
@@ -86,7 +90,10 @@ people wrote and verified, with the provenance still attached; the reading
 is your agent's job ([design doc
 0081](docs/design/0081-what-ochakai-is-and-what-it-refuses-to-hold.md) §6).
 
-To hold knowledge of your own, run a server:
+### Ten minutes: a base of your own
+
+The demo above is somebody else's knowledge, and it refuses every write.
+A server of your own is one command, and everything after it writes:
 
 ```sh
 git clone https://github.com/na0fu3y/ochakai && cd ochakai
@@ -97,20 +104,46 @@ This runs with `OCHAKAI_MODE=dev`: authentication is off and every
 request acts as `human:anonymous` — never do this on a deployment
 ([every mode](docs/configuration.md#environment-variables) (Japanese)).
 
-Load the demo knowledge base — [ten concepts](examples/demo) about one
-invented retail domain, linked to each other, some of them drafts — and
-search it. Everything goes through the API, so plain curl works too:
+Point the same CLI at it and load the demo knowledge base — [ten
+concepts](examples/demo) about one invented retail domain, linked to each
+other, some of them drafts. Everything goes through the API, so plain
+curl reaches it too:
 
 ```sh
-docker compose -f deploy/compose.yaml exec ochakai /ochakai import /examples/demo
+ochakai use http://localhost:8080
+ochakai import examples/demo
 curl 'http://localhost:8080/api/v1/search?q=revenue'
 ```
 
-That shop is invented. To fill a base with *your* tables, project a
-BigQuery dataset in: [examples/bigquery-catalog](examples/bigquery-catalog)
-(Japanese) carries the day-one procedure, the job that runs it, and the attester that
-says whether a run counted — outside the server, under your own service
-account, because ochakai has no connectors.
+That shop is invented. Your own tables go in the same way, and ochakai
+never touches the warehouse to get them — you run the schema query with
+your own client and your own identity, and pipe the rows in:
+
+```sh
+bq query --format=json --nouse_legacy_sql \
+  'SELECT table_schema, table_name, column_name, data_type, is_nullable, description
+     FROM `your-project.your_dataset.INFORMATION_SCHEMA.COLUMNS`
+    ORDER BY ordinal_position' \
+  | ochakai seed - | ochakai import -
+```
+
+Every concept lands as a **draft**, because a projected schema is a
+skeleton somebody still has to say something about — which is what the
+review queue is for. When the projection wants to be a job that reruns,
+[examples/bigquery-catalog](examples/bigquery-catalog) (Japanese) carries
+the day-one procedure, the job, and the attester that says whether a run
+counted.
+
+### For real: Cloud Run and Cloud SQL
+
+The same binary, about $10/month, and no secret anywhere — Cloud Run IAM
+decides who reaches it, Cloud SQL IAM authenticates the service, and
+there is nothing to issue or rotate. [Terraform stands the whole thing
+up](deploy/terraform/README.md) (Japanese), or
+[the gcloud commands it runs](deploy/cloudrun/README.md) (Japanese) if
+you would rather see them one at a time. Your knowledge keeps going the
+other way too: `ochakai export` hands back the whole base as an OKF
+bundle, which is markdown you can commit.
 
 ## Connect an agent
 
@@ -118,13 +151,13 @@ For Claude Code — and anything else with a shell (headless agents, CI) —
 the recommended interface is the bundled CLI, a thin client of the same
 REST API: tool schemas don't occupy the agent's context, output composes
 with pipes, and it resolves Google ID tokens itself, so no proxy process
-is needed against Cloud Run. Take a
-[release archive](https://github.com/na0fu3y/ochakai/releases), or:
+is needed against Cloud Run. The quick start already installed it (a
+[release archive](https://github.com/na0fu3y/ochakai/releases) is the
+other way), and it is pointed at your own server; the rest of what it
+does:
 
 ```sh
-go install github.com/na0fu3y/ochakai/cmd/ochakai@latest
-
-ochakai use http://localhost:8080   # Cloud Run: ochakai use https://your-service.run.app
+ochakai use https://your-service.run.app   # or back to http://localhost:8080
 ochakai whoami                      # which server, as whom, reachable?
 ochakai context "why is revenue down?"  # the one-call read before a data question
 ochakai search "revenue" --type Metric --trust human-reviewed
@@ -166,6 +199,17 @@ for what they still don't do:
   tribal knowledge that never fits in a semantic-model YAML and today
   travels by Slack. Your agent gets it in the same search that returns
   the metric definition.
+- **Japanese search works with nothing installed and nothing tuned.**
+  PostgreSQL does not tokenize Japanese, so a knowledge base written in
+  it usually means installing a tokenizer extension and configuring it —
+  which managed Postgres, Cloud SQL included, will not let you do.
+  ochakai cuts Japanese runs into the two-character windows the language
+  actually spells its terms in, stores them as lexemes, and looks a query
+  up in the same index: 売上 is an index lookup, not a scan of the
+  corpus. Latin words stem on the way, so `revenues` finds `revenue`.
+  There is no setting for any of this, and semantic search sits beside it
+  by default on Google Cloud ([design doc
+  0080](docs/design/0080-search-and-how-a-deployment-embeds.md)).
 - **A write-back loop with a memory.** Agents write learnings back as
   drafts and a human promotes them, with provenance on every concept and
   every change kept as a revision. Proposals that don't make it are kept


### PR DESCRIPTION
## What and why

#527(計画 #540、Phase 0)。四項目のうち**二つを実装、一つは既に済んでいた、一つは断ります**。

### いちばん大きかったのは、issue に書かれていないほうでした

**この README に "Japanese" という語は、ドキュメントリンクの警告ラベルとしてしか現れていませんでした。**

```
[All docs](docs/README.md) (Japanese; ...)
[every mode](docs/configuration.md#environment-variables) (Japanese)
[connecting an MCP client](docs/guides/mcp-clients.md) (Japanese)
...
```

**製品ができることとしては一度も出てきません。** 日本語話者の評価者 —— つまり C8 そのもの —— が表玄関から得る情報は「マニュアルが読めないかもしれない」だけでした。

migration 0036 がこれを本当に良くしたのに、どこもそう言っていない。*Why* に一項目足しました:

- トークナイザ拡張を入れる必要が無い(そしてマネージド Postgres は入れさせてくれない)
- **売上 は索引で引く**、走査ではなく
- ラテン文字は語幹化される(`revenues` が `revenue` に当たる)
- 設定項目はゼロ、そして Google Cloud では意味的検索が既定で隣に立つ

### 一本の階段にする

既に demo → 自分のサーバ → エージェント の順にはなっていましたが、**段に名前が無く、本番が段になっていませんでした** — Cloud Run と Cloud SQL は導入段落のリンクの中だけ。自分がどの入口かを読者が判断する必要が残っていました。

```
### Sixty seconds: the public demo
### Ten minutes: a base of your own
### For real: Cloud Run and Cloud SQL
```

導入段落は三段目と重複する分を落としました。

### 経路そのものに欠けていた二つ

1. **10 分の段がコンテナに手を入れていた。** `docker compose exec ochakai /ochakai import /examples/demo` — 一段目でインストールした CLI が `ochakai use` 一行でホストからできることです
2. **自分のテーブルを入れる話が `ochakai seed` を名指していなかった。** #567 でまさにそのために入ったコマンドが、表玄関のどこにも出ていませんでした。日本語の example ページへのリンクだけだった箇所を、コマンドの help が自分で載せているパイプラインに差し替えています

**この経路は dev サーバに対して端から端まで実行して確認しました**: `use` → `import examples/demo` → `curl` → `seed - | import -`(ファイル引数と stdin の両方)。

## 断ること

### ヘッドラインは変えません

監査の指摘は「**verified query store** はもうヘッドラインにできない」で、それは正しいのですが、**この README はそれを使っていません**。今の一文は:

> Semantic layers tell you that revenue = `SUM(price)` — they don't tell you whether 100 is good or bad.

意味論レイヤが残す欠けた半分を、具体的に、一度読めば覚えられる形で言っています。提案されている「エージェントが起草し、人が裁定し、どのエージェントにも配られ、git に持ち出せる、チームの解釈知識」は**性質の四連**で、**リストは文より悪い第一文**です。四つの性質は Why の各項目が既に持っています。

### 既に済んでいたもの

「なぜ `gcloud auth application-default login` が動かないか」の段落は、英語の README に既にあります(*Connect an agent* の中)。

### Why の順序

「差別化 3 点を先頭に」のうち、**git 可搬**(項目 5)と**ループが OSS**(項目 2)は既にあり、欠けていたのは日本語だけでした。先頭の「解釈知識が一級」は差別化そのものなので動かしていません。日本語の項目は二番目に置いています。

## Checks

- [x] `scripts/check core` clean、`scripts/check lint` 0 issues
- [x] **README のコマンドを実際に走らせて確認**(dev サーバ + ローカル Postgres)。`ochakai seed` のパイプラインは CLI の help が載せている例と同じ形です
- [ ] `scripts/check vuln` は proxy が vuln.go.dev を拒否するためこの環境では確認不能(欠陥ではありません)

## Surfaces and contract

- [x] コード変更なし。ドキュメントのみです
- [x] `DOC-LINES` に余裕あり: **6,098 → 6,142**(天井 6,500、下限 6,000)。issue が言う「天井に触るなら同 PR で畳み込みを探す」は**発生していません** — 導入段落の重複 3 行が唯一の畳み込みで、必要だったからではなく三段目と同じことを言っていたからです

## Design docs

- [x] 該当なし。決定は一つも動かしていません
- [x] Commit messages and code comments are in English

## 受け入れ基準

「compose 10 分経路が README の正面にあり、初見の評価者が入口を選ばずに済む」— **満たしています。** 段に名前が付き、順序が宣言され(*Three steps, in order, and nothing to choose between*)、本番が三段目として存在します。

---
_Generated by [Claude Code](https://claude.ai/code/session_01BATZn1qmJosokMG8HGxRi8)_