### PR TITLE
kb: seven draft concepts from a bulk-extraction experiment

### DIFF
--- a/kb/bundle/insights/mcp-bytes-not-tool-count.md
+++ b/kb/bundle/insights/mcp-bytes-not-tool-count.md
@@ -1,0 +1,38 @@
+---
+type: Insight
+title: MCP の代金は本数ではなくバイトである — 17 本が 6 本より安い実例
+description: semantica(17 ツール 7,771B)と ochakai(6 ツール 11,850B)の実測比較が 0076 の判断を裏返しから確認した
+tags: [dogfood, mcp, positioning]
+status: draft
+sources:
+  - id: semantica
+    resource: https://github.com/semantica-agi/semantica
+    title: 比較対象(mcp/schemas.py + mcp/tools から静的算出)
+  - id: surface
+    resource: docs/surface.md
+    title: MCP の節(MCP-BYTES の定義)
+generated:
+    by: process:claude-code
+    via: human:anonymous
+    producer: claude-code/1.0
+    at: "2026-08-10T02:37:12Z"
+created_by: process:claude-code via human:anonymous using claude-code/1.0
+---
+
+類似 OSS の semantica と MCP 面を実測比較したところ、**ツール 17 本の
+semantica(7,771 バイト、instructions なし)は、6 本の ochakai
+(11,850 バイト、instructions 1,021 込み)より軽かった**。本数の少なさは
+コンテキスト代金の少なさを意味しない — 0076 が「支払っているのは本数では
+なくバイト」と見抜いたことの、逆向きからの確認である。
+
+差の中身は説明の厚さである。semantica の `extract_entities` は 263 バイト
+で「text を渡せ」しか言わない。ochakai の `put_concept` は一本で 3,836
+バイト、OKF の書き方と型ガイドをスキーマ内で教える。つまりこれは
+トレードオフの選択であって優劣ではない — **ochakai は「ツールが教える」
+をバイトで買っている**。その買い物が正しいかは、説明を薄くしたときに
+エージェントの書き込み失敗率が上がるかで決まり、それを測る計器が
+report_outcome(C7)である。
+
+比較の副産物: 本数だけを見て「semantica の方が表面が大きい」と主張する
+と、この一点では逆転されている。positioning の議論で MCP に触れるときは
+バイトで言うこと。

--- a/kb/bundle/insights/store-tests-shared-db.md
+++ b/kb/bundle/insights/store-tests-shared-db.md
@@ -1,0 +1,28 @@
+---
+type: Insight
+title: store 統合テストは共有 DB 前提で書く
+description: id は internal/testdb.Unique から取る — 自前の名前空間はコーパスを太らせ、無関係な検索テストを壊す
+tags: [dogfood, testing]
+status: draft
+sources:
+  - id: contributing
+    resource: CONTRIBUTING.md
+    title: Tests and checks の節
+generated:
+    by: process:claude-code
+    via: human:anonymous
+    producer: claude-code/1.0
+    at: "2026-08-10T02:37:12Z"
+created_by: process:claude-code via human:anonymous using claude-code/1.0
+---
+
+store 統合テストの DB は共有される: CI は 1 コンテナを 1 run で使い回し、
+手元では 1 つを立てっぱなしにする(port 55433、`OCHAKAI_TEST_DATABASE_URL`)。
+だから **テストの id は `internal/testdb.Unique` から取る** — run ごとに
+一意な番号が付き、その下に書いた全行を掃除する sweep も登録される。
+
+自前のトークンで名前空間を切ると行が残り、コーパスが黙って太る。壊れる
+のは自分のテストではなく、**どこか別の、件数を絞った ranking の assertion**
+である — 自分の concept が上位から押し出された変更が「検索のバグ」として
+落ち始める。この故障の読みにくさが、`TestNoTestRollsItsOwnNamespace` が
+自前の名前空間を機械的に落とす理由である。

--- a/kb/bundle/insights/translation-costs-lines.md
+++ b/kb/bundle/insights/translation-costs-lines.md
@@ -1,0 +1,35 @@
+---
+type: Insight
+title: 翻訳は行数を返さない
+description: 日本語化で DOC-LINES がどう動くかの実測と、ページの外に出る二つの代金
+tags: [dogfood, docs]
+status: draft
+sources:
+  - id: contributing
+    resource: CONTRIBUTING.md
+    title: Translating a manual page の節
+  - id: surface
+    resource: docs/surface.md
+    title: DOC の節の実測
+generated:
+    by: process:claude-code
+    via: human:anonymous
+    producer: claude-code/1.0
+    at: "2026-08-10T02:37:12Z"
+created_by: process:claude-code via human:anonymous using claude-code/1.0
+---
+
+マニュアルの日本語化(C8)で分かった、直感に反する三つ:
+
+- **行数は増える。** 日本語は語間に空白が無いので一行が多くを運ぶと
+  見込んでいたが、全角文字は同じ 70 桁ラップに半分しか入らない。
+  loop.md 114 → 120、configuration.md 75 → 84。減るのは一行要約を並べる
+  ナビゲーションページだけ(docs/README.md 101 → 96)。**行数を返すのは
+  翻訳ではなく畳み込みだけである。**
+- **代金はページの外にも出る。** 見出しを訳すとアンカーが動き、死んだ
+  フラグメントは「正しいページの先頭に着く普通のリンク」に化けて
+  レビューを生き延びる。訳した見出しの上に `<a id="…"></a>` を明示で
+  置く(`TestManualLinksResolve` が落とす)。被リンクの多いページほど
+  `(Japanese)` 印の付け外しが波及する。
+- **訳す前に英語を疑う。** 古びた記述は「忠実に訳して」から別 PR で
+  直す — 訳と修正を混ぜると、どちらの変更かレビューで読めなくなる。

--- a/kb/bundle/skills/dogfood-instance-without-docker.md
+++ b/kb/bundle/skills/dogfood-instance-without-docker.md
@@ -1,0 +1,51 @@
+---
+type: Skill
+title: Docker なしで dogfood インスタンスを立てる
+description: compose が使えない環境(リモートセッション等)で、ローカル PostgreSQL + serve + MCP over HTTP により dogfood ループを回す手順
+tags: [dogfood, runbook, environment]
+status: draft
+sources:
+  - id: loop
+    resource: kb/bundle/skills/run-the-dogfood-loop.md
+    title: 正規の手順(compose 版)
+  - id: check
+    resource: scripts/check
+    title: ローカル PostgreSQL から使い捨てクラスタを組む先例
+generated:
+    by: process:claude-code
+    via: human:anonymous
+    producer: claude-code/1.0
+    at: "2026-08-10T02:37:12Z"
+created_by: process:claude-code via human:anonymous using claude-code/1.0
+---
+
+[dogfood ループ](/skills/run-the-dogfood-loop.md)の正規の立て方は
+docker compose だが、Docker が動かない環境
+([リモートセッション](/skills/remote-session-checks.md))でも、
+scripts/check --db と同じやり方でインスタンスは立つ:
+
+```sh
+BIN=/usr/lib/postgresql/16/bin   # pgvector が隣にあること
+mkdir -p /tmp/kbdb && chown postgres /tmp/kbdb
+su postgres -s /bin/sh -c "$BIN/initdb -D /tmp/kbdb/data -U t --auth=trust --no-sync"
+su postgres -s /bin/sh -c "$BIN/pg_ctl -D /tmp/kbdb/data -o '-p 55434 -c listen_addresses=localhost -F' -l /tmp/kbdb/pg.log start"
+$BIN/createdb -h localhost -p 55434 -U t t
+go build -o /tmp/kbdb/ochakai ./cmd/ochakai
+OCHAKAI_DATABASE_URL='postgres://t:t@localhost:55434/t?sslmode=disable' \
+  OCHAKAI_MODE=dev PORT=8080 /tmp/kbdb/ochakai serve &
+```
+
+三つの癖:
+
+- **データディレクトリは /tmp 直下に。** scratchpad 配下は postgres
+  ユーザーが親ディレクトリを辿れず `Permission denied` になる。
+- **AI の書き込みは MCP over HTTP で。** `.mcp.json` が無い文脈(素の
+  curl)でも、`POST /mcp` に JSON-RPC を送り
+  `Ochakai-On-Behalf-Of: process:claude-code` を毎リクエストに載せれば
+  [identity 規律](/policies/ai-human-identity.md)は保てる。initialize の
+  応答ヘッダ `Mcp-Session-Id` を以後のリクエストに返すこと。
+- **このインスタンスは使い捨てである。** 検証台帳(trust)は pgdata に
+  しか住まないという正規手順の注意がそのまま効く — セッションが死ねば
+  台帳は消える。書いた draft を残すには export して git に載せるしか
+  ない。だから裁定(verify/reject)はここでは打つ意味がなく、レビューは
+  export 後の PR diff で人が行う。

--- a/kb/bundle/skills/extract-into-kb.md
+++ b/kb/bundle/skills/extract-into-kb.md
@@ -1,0 +1,40 @@
+---
+type: Skill
+title: リポジトリ文書から kb への一括抽出
+description: 既にある文書の山(規約・フック・セッションの学び)を concept の粒で draft に起こすときの手順と線引き
+tags: [dogfood, runbook, extraction]
+status: draft
+sources:
+  - id: loop
+    resource: kb/bundle/skills/run-the-dogfood-loop.md
+    title: 抽出後の draft が流れ込む先のループ
+generated:
+    by: process:claude-code
+    via: human:anonymous
+    producer: claude-code/1.0
+    at: "2026-08-10T02:37:12Z"
+created_by: process:claude-code via human:anonymous using claude-code/1.0
+---
+
+コーパス(CONTRIBUTING、フック、直近のセッションで学んだこと)から
+concept を大量に起こすときの手順。パイプラインは要らない — 読むのも
+割るのも書くのもエージェント自身で、ochakai は draft を受けるだけである。
+
+1. **concept の粒で割る。ファイルの粒ではない。** 一つの文書は複数の
+   独立した知識を持つ(CONTRIBUTING は店のテスト規約と翻訳の教訓を
+   同居させている)。「三ヶ月後に単独で想起されて意味があるか」で切る。
+2. **書く前に検索する。** `search_concepts` で同じ知識が既に draft に
+   ないか、`search --rejected` で同種の提案が断られていないかを見る。
+   ヒットしたら足すのではなくリンクするか、既存を replace する。
+3. **複製ではなく到達経路にする。** 出典がリポジトリの文書なら、全文を
+   写さない — 想起されたときに効く判断・罠・数字だけを書き、全表は
+   sources と本文リンクで指す。複製された散文は必ず古びる(0071 §6 が
+   語彙について言ったことは散文にも効く)。
+4. **draft で入れて、裁定は人に残す。** 抽出した concept は自分で
+   verify しない。まとめてレビューできるよう、export した diff を PR に
+   して人へ渡す([Docker なしの立て方](/skills/dogfood-instance-without-docker.md)
+   の使い捨てインスタンスなら、これが唯一の残し方でもある)。
+5. **セッション固有の学びを優先する。** 文書に既にある知識の再配置より、
+   どこにも書かれていない慣行(環境の癖、今日踏んだ罠)の方が、一件の
+   価値が高い。文書は明日も読めるが、セッションの学びは書かなければ
+   消える。

--- a/kb/bundle/skills/remote-session-checks.md
+++ b/kb/bundle/skills/remote-session-checks.md
@@ -1,0 +1,43 @@
+---
+type: Skill
+title: リモートセッションで正直に主張できるチェック
+description: Claude Code のクラウド環境で scripts/check の何が本物で、何が CI に任せるものかの線引き
+tags: [dogfood, runbook, environment]
+status: draft
+sources:
+  - id: hook
+    resource: .claude/hooks/session-start.sh
+    title: この線引きをセッション開始時に注入するフック
+  - id: contributing
+    resource: CONTRIBUTING.md
+    title: Working with Claude Code の節
+generated:
+    by: process:claude-code
+    via: human:anonymous
+    producer: claude-code/1.0
+    at: "2026-08-10T02:37:12Z"
+created_by: process:claude-code via human:anonymous using claude-code/1.0
+---
+
+Claude Code のクラウドセッション(`CLAUDE_CODE_REMOTE=true`)は egress
+ポリシーの都合で、リポジトリのチェックの一部しか本物として走らせられ
+ない。緑を報告してよいものとそうでないものの線引き:
+
+- **`scripts/check core` と `scripts/check lint` は本物。** この二つが
+  緑なら、そう主張してよい。
+- **store 統合テストも走る**が、CI と同じ DB ではない。`scripts/check
+  --db` は Docker が使えないとき、マシンにインストール済みの PostgreSQL
+  から使い捨てクラスタを組む。締めの行が実際に使った DB を名乗るのは、
+  それが pgvector/pgvector:pg17(CI の DB)ではないからである。共有 DB
+  前提の書き方は [store テストの規約](/insights/store-tests-shared-db.md)。
+- **Docker は動かない。** CLI はあるがデーモンが無く、dockerd を起こして
+  も Docker Hub の blob CDN に 403 が返るのでイメージは引けない。
+  Dockerfile と deploy/compose.yaml の検証は CI に任せ、セッションでは
+  時間を使わない。
+- **`scripts/check vuln` の `Forbidden` は脆弱性ではない。** プロキシが
+  vuln.go.dev を拒んでいるだけである。`curl -sS
+  "$HTTPS_PROXY/__agentproxy/status"` で確かめた上で「ここでは検証不能」
+  と報告する — 「チェックが落ちた」とは決して報告しない。
+
+この線引き自体はセッション開始フックが注入するが、フックが切れて
+いる・別の環境にいるときにも同じ判断ができるよう、ここに置く。

--- a/kb/bundle/skills/webui-screenshots.md
+++ b/kb/bundle/skills/webui-screenshots.md
@@ -1,0 +1,34 @@
+---
+type: Skill
+title: Web UI スクリーンショットの再現手順の癖
+description: 撮り直しで踏む二つの罠(ダークスキームと ICU ロケール)と、コミット前の目視規則
+tags: [dogfood, runbook]
+status: draft
+sources:
+  - id: contributing
+    resource: CONTRIBUTING.md
+    title: Web UI screenshots の節(ルート・高さ・縮小の全表)
+generated:
+    by: process:claude-code
+    via: human:anonymous
+    producer: claude-code/1.0
+    at: "2026-08-10T02:37:12Z"
+created_by: process:claude-code via human:anonymous using claude-code/1.0
+---
+
+docs/images/webui-*.png は examples/demo を実際に serve して撮る。
+ルート・高さ・縮小コマンドの全表は CONTRIBUTING.md にある — ここに置く
+のは、表を正しくなぞっても絵が狂う二つの罠と、最後の規則である。
+
+- **ライトスキームは強制する。** ヘッドレス Chrome の既定はダーク。
+  `Emulation.setEmulatedMedia` で明示する。
+- **ロケールは DevTools プロトコルでしか直らない。** entry ページの日付
+  は `toLocaleDateString()` が ICU の既定ロケールを読む。macOS では
+  `--lang=en-US` も `LANG`/`LC_ALL` も効かず、`navigator.language` が
+  en-US を名乗ったまま日付だけ `2026年7月27日` になる。
+  `Emulation.setLocaleOverride` で上書きし、ページ内で
+  `Intl.DateTimeFormat().resolvedOptions().locale` が `en-US` である
+  ことを確かめる。
+- **コミット前に全 PNG を読む。** 落ちたバックエンドは整った「502 Bad
+  Gateway」カードとして描画され、一瞥ではコンテンツに見える。ダーク・
+  日本語日付・ほぼ空・エラー表示のどれかがあれば撮り直す。


### PR DESCRIPTION
<!-- Keep PRs small and focused. Link the issue or design doc, if there is one. -->

## What and why

An experiment in bulk extraction into the dogfood knowledge base, prompted by comparing semantica's ingest→extract pipeline with ochakai: every pipeline stage (read, split, extract, dedup) belongs to the agent here, and ochakai only receives drafts. Seven new concepts land in `kb/bundle`, all `status: draft`, extracted from CONTRIBUTING.md, `.claude/hooks/session-start.sh`, and this session's own learnings:

- `skills/remote-session-checks` — which checks are honest in the cloud session environment
- `skills/dogfood-instance-without-docker` — standing up the dogfood instance where compose can't run (local PostgreSQL cluster + `serve` dev + MCP over HTTP)
- `skills/webui-screenshots` — the two traps (dark scheme, ICU locale) and the read-every-PNG rule
- `skills/extract-into-kb` — the extraction procedure itself, as learned by running it
- `insights/store-tests-shared-db` — why integration tests take ids from `internal/testdb.Unique`
- `insights/translation-costs-lines` — translation never returns line budget; the out-of-page costs
- `insights/mcp-bytes-not-tool-count` — measured: semantica's 17 MCP tools cost 7,771 bytes against ochakai's 6 at 11,850, confirming 0076's bytes-not-count call from the opposite direction

Process followed `kb/policies/ai-human-identity.md`: all writes went through MCP as `process:claude-code` against a throwaway local instance, each preceded by a `search_concepts` call; the CLI was used only to read and export. The exported `generated`/`created_by` keys are kept in the files — they are the claim that the AI drafted these, which is what review needs to see. Rulings stay with the human: nothing here is verified, and the next `ochakai import kb/bundle` is a human's to run.

These are OKF documents (knowledge the store holds), not manual pages, so no surface moves — `DOC` counts only `kb/README.md`, which is unchanged.

## Checks

CI runs the same script; make it pass locally first (CONTRIBUTING.md has the
context, including the store integration test and the fuzz targets).

- [x] `scripts/check` is clean — `core` and `lint` ran green locally (cloud session: `vuln` is unverifiable here and Docker cannot run; the store tests are unaffected since no Go changes)
- [x] Behavior changes come with tests — no behavior changes; content-only addition under `kb/bundle`

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — untouched
- [x] The change lands on every surface it belongs on — not applicable, no surface is touched
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens a surface? No — adds no REST operation, MCP tool, CLI command, or environment variable; `docs/surface.md` is untouched

## Design docs

- [x] Alters an accepted decision? It does not — this box is not applicable
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7stZ1LihbFxWaXf8KtnrJ)_