### PR TITLE
positioning: answer the OSS Palantir-alternative category

### DIFF
--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -32,6 +32,7 @@ semantic layer は revenue = `SUM(price)` だと教えてくれる。100 とい�
 | 自分の文書に対する RAG | 他の理由で書かれた文書からの断片 | 単位としてのレビュー済みの主張、provenance、著者の向き | 両立 |
 | AI アナリスト製品に内蔵された検証済みクエリストア(Cortex Analyst の VQR、Genie) | 問い + 検証済み SQL、一つのベンダーのチャットの中で | 他のクライアント、出口 | 重なる、そしてロックインする |
 | FDE 型オントロジー([Palantir Foundry Ontology](https://www.palantir.com/docs/foundry/ontology/overview)) | 組織のデジタルツイン — オブジェクトとリンク、Action と write-back、ライブデータへの接続、プラットフォーム内のガバナンス | 出口(オントロジーはプラットフォームのもの)、FDE 無しの立ち上げ、テナントごとの安価なセルフホスト | 約束は同じ、買い方を拒む — 下記参照 |
+| OSS の「Palantir 代替」([semantica](https://github.com/semantica-agi/semantica)) | 数十ソースの取り込みと自動抽出、ポリグロットなグラフ・ベクトルストア、OWL/SHACL、PROV-O、エージェントの決定の因果記録、セルフホスト | 人の裁定が中核であること(decision の記録は verify ではない)、secret-zero、単一形式の往復、キュレーションが買う小ささ | 約束の語彙は重なる、軸が違う — 下記参照 |
 | グラフ DB ネイティブのオントロジー基盤([NebulaGraph](https://nebula-graph.io/posts/ontology-and-graph-databases-enterprise-ai-from-theory-to-production-reality)、Neo4j + GraphRAG) | 型システムと書き込み時のスキーマ強制、型間のリレーション制約、数十億ノードへのスケール、多段トラバーサルとグラフアルゴリズム | 検証のループが中核であること(あちらでは成熟モデルの最終段)、markdown での出口、キュレーションされた規模が買う単純さ | 規模が前提から違う — 下記参照 |
 | **MCP サーバー付きの markdown vault(Obsidian、Logseq、ノートの git リポジトリ)** | markdown + frontmatter、リンク、ローカルな所有、エージェントが読めること | 生きた状態としての検証、ループ、複数書き手の identity、一台のマシンを越える到達 | 両立 — 下記参照 |
 
@@ -132,7 +133,38 @@ Action の実行基盤が要る、オペレーショナルな write-back が要�
 kinetic の三つ目の要素 — 誰が実行してよいかの Role — や concept 単位の
 権限が要る([0065](design/0065-identity-and-provenance.md) §1)、
 Google Cloud の外で動かす([0003](design/0003-gcp-only.md)) — どれか
-一つでも真なら、FDE 型を買う理由はまだそこにある。
+一つでも真なら、FDE 型を買う理由はまだそこにある。買い方だけを外した
+OSS が同じ約束を名乗る場合は、この節の答えが効かないので次の節が扱う。
+
+### OSS の「Palantir 代替」
+
+*約束の語彙は重なる、軸が違う。* このカテゴリ(代表は
+[semantica](https://github.com/semantica-agi/semantica)、自称 "The Open
+Source Palantir for AI Agents")は上の節の二つの支払いを両方とも外して
+くる — OSS でセルフホスト、FDE の代わりに取り込みと自動抽出のパイプ
+ラインが意味を書き起こす。だから「買い方を拒む」はここでは答えに
+ならず、残る違いは軸そのものである: **あちらは収集し、こちらは検証する。**
+
+あちらは数十ソースを取り込み、プロセス内の ML(NER・関係抽出)で
+グラフを機械が建て、衝突検出や SHACL で後から統治する。ochakai は
+コネクタも取り込みも持たない
+([0081](design/0081-what-ochakai-is-and-what-it-refuses-to-hold.md) §1)。
+どちらも「中核に LLM 不要」を名乗るが意味が逆で、あちらは抽出まで機械が
+やるための ML を中に持ち、こちらは LLM(エージェント)が外にいる前提で
+抽出の実装を一行も持たない — 読む・割る・書き起こすのはエージェントの
+仕事で、ochakai は draft を受けて人の裁定を待つ。あちらの Decision
+Intelligence が記録するのはエージェントの決定の因果であり、C7 の中核で
+ある人の verify / reject と trust tier に相当する段は、グラフ DB 節と
+同じく成熟の先にある。姿勢も同じ向きに割れる: ポリグロットなストレージ
+と環境変数に並ぶ資格情報に対して、Google Cloud 一択の secret-zero
+(C2)と OKF 一枚の往復(C3)である。
+
+なお表面を数字で比べるなら、MCP だけは本数で語らないこと — ツール数は
+あちらが多いのに、実測の常駐バイトはツールが書き方を教えるこちらの方が
+重い([0076](design/0076-two-tools-leave-mcp.md) が「代金は本数ではなく
+バイト」と言った当のトレードオフである)。断片化した生データから
+統治されたグラフを機械で建てたいならあちらを使う。人が確かめた少数の
+ナレッジをエージェントに小さな契約で配りたいなら、それがこの枠である。
 
 ### グラフ DB ネイティブのオントロジー基盤
 


### PR DESCRIPTION
<!-- Keep PRs small and focused. Link the issue or design doc, if there is one. -->

## What and why

One neighbor-table row and a short section in `docs/positioning.md`, plus a one-sentence hand-off from the FDE-ontology section.

The FDE section's answer — *same promise, refuse the buying model* — does not reach an OSS, self-hosted product that drops both of that section's payments (the platform and the FDE), and that category now has a visible representative: [semantica](https://github.com/semantica-agi/semantica) (3.4k stars, trending, a machine-translated Japanese README), self-described as "The Open Source Palantir for AI Agents". A C8 evaluator who finds it dead-ends in the current table: the Palantir row's verdict doesn't apply, and the graph-DB row's ("you don't need a dedicated engine") only half applies, since semantica doesn't claim you do.

Same shape as #542: the section is written from decisions already made, not from the neighbor's feature list, so it should age with ochakai rather than with semantica's release cadence — collection versus curation (0081 §1), what "no LLM in the core" means on each side (in-process ML versus the agent being the extractor), agent decision-causality records versus the human ruling at the core of C7, and polyglot storage with credentials in env versus secret-zero (C2) with one round-tripping format (C3). The MCP sentence deliberately says to compare in bytes, not tool count: measured, semantica's 17 tools (7,771 B, no instructions) are lighter than our teaching six (11,850 B), which is 0076's bytes-not-count call confirmed from the other direction — a count-based comparison loses that point, so the page doesn't make one.

Background: the comparison measurements and the kb extraction experiment behind this are in #580 (`kb/bundle/insights/mcp-bytes-not-tool-count.md`).

## Checks

CI runs the same script; make it pass locally first (CONTRIBUTING.md has the
context, including the store integration test and the fuzz targets).

- [x] `scripts/check` is clean — `core` and `lint` ran green locally (cloud session: `vuln` unverifiable here, Docker cannot run; no Go changes so the store tests are unaffected)
- [x] Behavior changes come with tests — no behavior changes; prose only

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — untouched
- [x] The change lands on every surface it belongs on — not applicable, no surface is touched
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens a surface? No — `DOC` stays 26 (no new page) and `DOC-LINES` stays inside its 6,500 ceiling (+33 lines, no boundary crossed), so `docs/surface.md` needs no change and `surface_test.go` agrees

## Design docs

- [x] Alters an accepted decision? It does not — positioning is the landscape page, kept current outside the records by its own closing section; this box is not applicable
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7stZ1LihbFxWaXf8KtnrJ)_