### PR TITLE
Lift the concepts a compound question names, not just what it covers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -555,6 +555,32 @@ last entry.
   No migration, no reindex, no reembed: both terms are expressions on rows
   the scan already reads, and the candidate set is unchanged (a Japanese
   keyword scan measured about 4% slower on 5,000 entries).
+- **A compound question now finds the concepts it names.** 「EC事業の
+  アクティブ会員の継続率を計算して」 is the name of nothing, so the rule
+  above never fired for it, and coverage decided instead: the score is the
+  fraction of the query's fragments an entry contains, a weekly memo that
+  co-mentions every term covers them all, and each definition covers only
+  its own third. Measured on a seeded corpus, the pack `get_context`
+  returned for a question chaining three 社内用語 was five meeting memos
+  and none of the three definitions. The name rule now reads the query's
+  *terms* — the maximal runs of letters and digits between the hiragana,
+  so EC事業, アクティブ会員, 継続率 and 計算 fall out of the example with
+  no morphological analyzer — and a concept named by any of them outranks
+  the prose that merely says all the words, in the store's ranking and
+  through fusion both.
+
+  A run counts as a term only when it carries a Han or Katakana
+  character, and that line was measured, not reasoned: scripts written
+  with spaces make every word of a question a run — why, is, down — and
+  a question saying revenue is not a lookup of the concept called
+  revenue. Granting those the lift cost the golden set six points of
+  lexical MRR (0.92 to 0.86), questions losing their answers to the
+  definitions of their own words, so search in spaced scripts is
+  unchanged. The stated cost: a purely latin name (SaaS), an all-digit
+  one (2026), or one with hiragana inside it (売り上げ) is lifted only
+  when the query is the name whole — the reach the rule already had.
+  Same candidate set, no migration; the golden set reads the same
+  lexical 0.92 as before, and fused 0.90 against 0.89.
 - **The write faces now say what each recommended type holds**, one line
   per type, instead of handing over nine spellings and nothing to tell
   them apart: `put_concept`'s description and `ochakai put -h` both render

--- a/internal/service/search.go
+++ b/internal/service/search.go
@@ -116,20 +116,26 @@ const rrfK = 60
 // compare against something.
 const verifiedBoost = 1.0/(rrfK+1) - 1.0/(rrfK+2)
 
-// namedBy reports whether the query is what the concept is called, rather
-// than something it mentions. Either name answers, as in the store's
-// scorer: the title, or the id's last segment (design doc 0022).
+// namedBy reports whether one of names — the query, and the terms of it
+// (store.QueryTerms) — is what the concept is called, rather than
+// something it mentions. Either name answers, as in the store's scorer:
+// the title, or the id's last segment (design doc 0022).
 //
 // The comparison is the store's, repeated here rather than carried: a hit
 // arrives with both fields on it, and a flag would be a new thing to keep
 // in sync across three lists that come from three queries.
-func namedBy(h domain.SearchHit, query string) bool {
-	name := h.ID
-	if i := strings.LastIndexByte(name, '/'); i >= 0 {
-		name = name[i+1:]
+func namedBy(h domain.SearchHit, names []string) bool {
+	seg := h.ID
+	if i := strings.LastIndexByte(seg, '/'); i >= 0 {
+		seg = seg[i+1:]
 	}
-	return strings.EqualFold(domain.Normalize(h.Title), query) ||
-		strings.EqualFold(domain.Normalize(name), query)
+	title, seg := domain.Normalize(h.Title), domain.Normalize(seg)
+	for _, name := range names {
+		if strings.EqualFold(title, name) || strings.EqualFold(seg, name) {
+			return true
+		}
+	}
+	return false
 }
 
 // sameTime compares two optional verification times, absent included.
@@ -142,7 +148,8 @@ func sameTime(a, b *time.Time) bool {
 
 // rrfFuse merges ranked lists with reciprocal rank fusion, adding one rank
 // position for verified concepts so certified knowledge wins the ties it
-// is in, and keeping a concept the query names ahead of the rest.
+// is in, and keeping a concept the query — or a term of it — names ahead
+// of the rest.
 //
 // Fusion is where a name would otherwise be lost. The store ranks an
 // exact name first by a margin no other term can close, but RRF reads
@@ -177,13 +184,14 @@ func rrfFuse(query string, limit int, primary []domain.SearchHit, others ...[]do
 		lexical float64 // the store's score, or zero if this list missed it
 		named   bool
 	}
+	names := append([]string{query}, store.QueryTerms(query)...)
 	byKey := map[string]*entry{}
 	for li, list := range append([][]domain.SearchHit{primary}, others...) {
 		for rank, hit := range list {
 			key := hit.ID
 			e, ok := byKey[key]
 			if !ok {
-				e = &entry{hit: hit, named: namedBy(hit, query)}
+				e = &entry{hit: hit, named: namedBy(hit, names)}
 				byKey[key] = e
 			}
 			if li == 0 {

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -152,6 +152,33 @@ func TestRRFFuseKeepsTheNamedConceptFirst(t *testing.T) {
 	}
 }
 
+// A compound question is the name of nothing, but it names things: the
+// terms between its hiragana. The concepts those terms name must stay
+// ahead of the prose that merely says all the question's words — which
+// places in every list, so rank arithmetic alone would put it first.
+func TestRRFFuseKeepsTermNamedConceptsFirst(t *testing.T) {
+	keizoku := hit("metrics/keizoku", domain.StatusStable)
+	keizoku.Title = "継続率"
+	kaiin := hit("metrics/アクティブ会員", domain.StatusStable) // named by filename
+	report := verifiedHit("reports/monthly")
+	report.Title = "月次レビュー"
+
+	// The report places in all three lists and is verified besides; each
+	// definition surfaces in the lexical list alone.
+	out := rrfFuse("アクティブ会員の継続率を計算して", 10,
+		[]domain.SearchHit{report, keizoku, kaiin},
+		[]domain.SearchHit{report},
+		[]domain.SearchHit{report})
+	if len(out) != 3 || out[2].ID != report.ID {
+		ids := make([]string, len(out))
+		for i, h := range out {
+			ids[i] = h.ID
+		}
+		t.Errorf("fused ranking = %v, want the two term-named definitions ahead of %s",
+			ids, report.ID)
+	}
+}
+
 // RRF reads rank and throws the score away, which is what lets it merge
 // lists whose numbers share no scale — and which is why a fused list
 // arrives full of exact ties: placing second and fifth in the opposite

--- a/internal/store/filter_test.go
+++ b/internal/store/filter_test.go
@@ -239,6 +239,59 @@ func TestQueryFragments(t *testing.T) {
 	}
 }
 
+// A compound question is the name of nothing, but it names things: the
+// terms between the hiragana are what a concept could be called, and the
+// name rule reads them so the definitions a question asks for outrank the
+// prose that merely says all its words.
+func TestQueryTerms(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		query string
+		want  []string
+	}{
+		{"compound japanese question", "EC事業のアクティブ会員の継続率を計算して",
+			[]string{"EC事業", "アクティブ会員", "継続率", "計算"}},
+		{"single term is itself", "売上", []string{"売上"}},
+		// Scripts with spaces make every word of a question a run — and a
+		// question saying revenue is not a lookup of the concept called
+		// revenue, which the golden set measured (six points of MRR). No
+		// content character, no term; the whole-query rule still serves
+		// the exact lookup.
+		{"english questions carry no terms", "why is revenue down?", nil},
+		{"a latin name needs the whole query", "SaaS", nil},
+		{"spaces split like particles", "継続率 アクティブ会員",
+			[]string{"継続率", "アクティブ会員"}},
+		// A year in a question is not a name; a digit inside a word is
+		// part of one.
+		{"all-digit runs are not terms", "2026の売上", []string{"売上"}},
+		{"digits inside a term stay", "3Q売上の内訳", []string{"3Q売上", "内訳"}},
+		// The reach of the extraction, stated as a limit: a name spelled
+		// with hiragana in it is cut at each hiragana and cannot be
+		// extracted whole. Only the whole query names such a concept.
+		{"hiragana-bearing names fall apart", "売り上げの推移",
+			[]string{"売", "上", "推移"}},
+		{"repeated terms collapse", "売上と売上", []string{"売上"}},
+		{"hiragana only", "ください", nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := QueryTerms(tc.query)
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("QueryTerms(%q) = %q, want %q", tc.query, got, tc.want)
+			}
+		})
+	}
+
+	// The cap that keeps a pasted paragraph from becoming hundreds of
+	// ILIKE probes, as in queryFragments.
+	var long strings.Builder
+	for i := range 100 {
+		fmt.Fprintf(&long, "用語%d ", i)
+	}
+	if got := QueryTerms(long.String()); len(got) != maxQueryFragments {
+		t.Errorf("long query produced %d terms, want the cap of %d", len(got), maxQueryFragments)
+	}
+}
+
 // The HNSW index scan runs before the WHERE clause, so ef_search is a
 // ceiling on what a vector search can return: at pgvector's default of 40
 // a search for 100 rows could not fill its limit even unfiltered.

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -136,6 +136,62 @@ func contentWindows(runes []rune) []string {
 	return all
 }
 
+// QueryTerms extracts the terms of a query — the names a compound
+// question might call concepts by. A term is a maximal run of letters
+// and digits that are not hiragana, kept only when it contains a content
+// character (contentChar — Han or Katakana): hiragana spells the grammar
+// between content words (の, を, して), so 「EC事業のアクティブ会員の
+// 継続率を計算して」 carries the terms EC事業, アクティブ会員, 継続率
+// and 計算, with no morphological analyzer. Exported because the name
+// rule reads it in two places — this store's scorer and the service's
+// fusion sort key — and they must agree on what a query names.
+//
+// The content-character condition is where the extraction stops being
+// trustworthy, and it was measured, not reasoned: scripts written with
+// spaces make every word of a question a run — why, is, down — and a
+// question saying revenue is not a lookup of the concept called revenue.
+// Granting those the name rule cost the golden set six points of lexical
+// MRR (0.92 to 0.86), the questions losing their answers to the
+// definitions of their own words. In the scripts without spaces the
+// grammar is excluded by construction, so a term is a word somebody
+// chose to write in the name-bearing scripts. The cost is that a purely
+// latin name (SaaS) or an all-digit one (2026) is lifted only when the
+// query is the name whole — the reach the rule had before terms existed
+// — and a name with hiragana inside it (売り上げ) likewise.
+func QueryTerms(query string) []string {
+	runes := []rune(query)
+	var terms []string
+	seen := map[string]bool{}
+	start, hasContent := -1, false
+	flush := func(end int) {
+		if start < 0 {
+			return
+		}
+		t := string(runes[start:end])
+		start = -1
+		key := strings.ToLower(t)
+		if !hasContent || seen[key] || len(terms) >= maxQueryFragments {
+			return
+		}
+		seen[key] = true
+		terms = append(terms, t)
+	}
+	for i, r := range runes {
+		if (unicode.IsLetter(r) || unicode.IsDigit(r)) && !unicode.Is(unicode.Hiragana, r) {
+			if start < 0 {
+				start, hasContent = i, false
+			}
+			if contentChar(r) {
+				hasContent = true
+			}
+			continue
+		}
+		flush(i)
+	}
+	flush(len(runes))
+	return terms
+}
+
 // scriptRuns splits a token wherever it crosses between a space-less
 // script (Han, kana) and anything else, so "PL科目" becomes "PL" and
 // "科目".
@@ -245,11 +301,16 @@ const (
 //     weighted the same way, so it works for the question get_context is
 //     built for and not only for a keyword: "なぜ売上が下がっているのか"
 //     lifts the concept named 売上 without the question matching it whole.
-//   - A name that *is* the query outranks every entry that merely
-//     contains it. The bonus is 1.0 against a ceiling of 1.85 for
-//     everything else, so this is a rule rather than a nudge: asking for
-//     売上 puts 売上 first. Either name serves — the deep-linked filename
-//     is a name a person chose as much as the title is.
+//   - A name that *is* the query — or is a term of it (QueryTerms) —
+//     outranks every entry that merely contains it. The bonus is 1.0
+//     against a ceiling of 1.85 for everything else, so this is a rule
+//     rather than a nudge: asking for 売上 puts 売上 first, and asking
+//     「EC事業の継続率を計算して」 puts the definitions of EC事業 and
+//     継続率 above the reports that say all its words — a compound
+//     question is the name of nothing, so coverage alone handed its
+//     answer to whichever prose co-mentioned the most terms. Either name
+//     serves — the deep-linked filename is a name a person chose as much
+//     as the title is.
 //
 // Both terms read expressions on the row the candidate scan already has,
 // and a name match implies a search_tsv match (title and id are both
@@ -275,8 +336,21 @@ func (s *Store) SearchLexical(ctx context.Context, query string, f Filter, limit
 	wholeParam := len(args)
 	// The same escaped query with no wildcards around it: ILIKE without a
 	// pattern is case-insensitive equality, which is the exact-name test.
+	// Beside the whole query, each of its terms: a compound question
+	// (「EC事業の継続率を計算して」) is the name of nothing, but it names
+	// EC事業 and 継続率, and the definitions it asks for must not lose to
+	// the reports that merely say all its words (QueryTerms).
 	args = append(args, escapeLike(query))
-	nameParam := len(args)
+	nameTests := []string{fmt.Sprintf(
+		"k.title ILIKE $%[1]d OR "+filenameText+" ILIKE $%[1]d", len(args))}
+	for _, term := range QueryTerms(query) {
+		if strings.EqualFold(term, query) {
+			continue // the whole-query test above already asks this
+		}
+		args = append(args, escapeLike(term))
+		nameTests = append(nameTests, fmt.Sprintf(
+			"k.title ILIKE $%[1]d OR "+filenameText+" ILIKE $%[1]d", len(args)))
+	}
 	frags := queryFragments(query)
 	var hit, weight, weighted, named, weights, tests []string
 	for i, frag := range frags {
@@ -345,8 +419,7 @@ func (s *Store) SearchLexical(ctx context.Context, query string, f Filter, limit
 				SELECT c.*, %[4]s FROM (
 					SELECT k.id, %[5]s, count(*) OVER () AS total,
 						CASE WHEN k.search_text ILIKE $%[6]d THEN 0.3 ELSE 0 END AS whole,
-						CASE WHEN k.title ILIKE $%[7]d
-							OR `+filenameText+` ILIKE $%[7]d
+						CASE WHEN %[7]s
 							THEN 1 ELSE 0 END AS named,
 						(SELECT max(v.at) FROM knowledge_verification v
 							WHERE v.id = k.id) AS last_verified
@@ -361,7 +434,8 @@ func (s *Store) SearchLexical(ctx context.Context, query string, f Filter, limit
 		ORDER BY scored.score DESC, scored.last_verified DESC NULLS LAST, k.id`,
 		strings.Join(weighted, " + "), strings.Join(named, " + "),
 		strings.Join(weights, " + "),
-		strings.Join(weight, ", "), strings.Join(hit, ", "), wholeParam, nameParam,
+		strings.Join(weight, ", "), strings.Join(hit, ", "), wholeParam,
+		strings.Join(nameTests, " OR "),
 		strings.Join(tests, " || "), where, limit)
 	rows, err := s.pool.Query(ctx, q, args...)
 	if err != nil {

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -1879,6 +1879,90 @@ func TestIntegrationLexicalSearchRanksTheNamedConceptFirst(t *testing.T) {
 	}
 }
 
+// A compound question — 社内用語 chained by の, the input the recall hook
+// actually feeds get_context — used to hand the whole ranking to whichever
+// prose co-mentioned the most of its terms: the score is fragment
+// coverage, a meeting memo saying all three terms covers everything, and
+// each term's definition covers only its own third. The name rule now
+// reads the query's terms (QueryTerms), so the definitions a question
+// names outrank the prose that merely says its words.
+func TestIntegrationLexicalSearchLiftsWhatACompoundQueryNames(t *testing.T) {
+	dbURL := os.Getenv("OCHAKAI_TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("OCHAKAI_TEST_DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	s, err := New(ctx, dbURL, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(s.Close)
+	if err := s.Migrate(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+	actor := domain.Actor{Kind: "human", Name: "test"}
+
+	run := testdb.Unique(t, "it-compound-")
+	mine := Filter{Tags: []string{run}}
+	// The three names a compound question chains: one by title, one by
+	// filename, one mixed-script (design doc 0022 for the two names).
+	ecJigyo, kaiin, keizoku := run+"/EC事業", run+"/アクティブ会員", run+"/keizoku"
+	definitions := []string{ecJigyo, kaiin, keizoku}
+	ids := append([]string{}, definitions...)
+	for i := range 6 {
+		ids = append(ids, fmt.Sprintf("%s/memo-%d", run, i))
+	}
+	t.Cleanup(func() {
+		for _, id := range ids {
+			_, _ = s.pool.Exec(ctx, `DELETE FROM object WHERE id = $1`, id)
+			_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_revision WHERE id = $1`, id)
+		}
+	})
+	create := func(id, title, body string) {
+		t.Helper()
+		if err := s.Create(ctx, &domain.Knowledge{
+			Type: domain.TypeInsights, ID: id, Title: title, Tags: []string{run},
+			Status: domain.StatusDraft, CreatedBy: actor, Body: body,
+		}, false); err != nil {
+			t.Fatalf("create %s: %v", id, err)
+		}
+	}
+	// Worst-first, as above: the memos say every term the question asks
+	// for — and 計算, which no definition says — so coverage alone scores
+	// them near 1.0 and each definition near a third of that.
+	for i := range 6 {
+		create(fmt.Sprintf("%s/memo-%d", run, i), fmt.Sprintf("週次定例メモ %d", i),
+			"EC事業のアクティブ会員は微増、継続率は目標圏内で推移。"+
+				"アクティブ会員の獲得施策は継続、EC事業の継続率が下がったら見直す。"+
+				"来週も同じ枠で計算して報告する。")
+	}
+	create(keizoku, "継続率", "前月アクティブだった会員のうち当月もアクティブである会員の割合。")
+	create(kaiin, "", "集計日から30日以内にログインした会員と定義する。")
+	create(ecJigyo, "", "自社ECサイト経由の受注だけを集計するセグメント。")
+
+	hits, err := s.SearchLexical(ctx, "EC事業のアクティブ会員の継続率を計算して", mine, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rank := func(id string) int {
+		for i, h := range hits {
+			if h.ID == id {
+				return i
+			}
+		}
+		return -1
+	}
+	for _, def := range definitions {
+		for i := range 6 {
+			memo := fmt.Sprintf("%s/memo-%d", run, i)
+			if d, m := rank(def), rank(memo); d < 0 || (m >= 0 && m < d) {
+				t.Errorf("SearchLexical(compound) ranked %s (co-mentions every term) "+
+					"above %s (named by one)", memo, def)
+			}
+		}
+	}
+}
+
 // Verify is the exit from both review feeds (design doc 0025 §6). It
 // stamps a fresh verified_at even when the entry is already verified —
 // which Update cannot do — and an entry whose last failure report predates


### PR DESCRIPTION
## Summary

- `get_context`'s ranking is fragment coverage plus a name-exact-match bonus. A compound question chaining several terms — 「EC事業のアクティブ会員の継続率を計算して」, the shape the recall hook and MCP guidance actually feed it — is the name of nothing, so the bonus never fired, and coverage handed the top of the ranking to whichever prose co-mentioned the most terms rather than to any of their definitions.
- Reproduced on a seeded local corpus: 3 term-definition concepts + 6 prose documents that each mention all three terms. Before this change, `get_context` returned 5 prose documents and 0 definitions for the compound question; the definitions ranked 7th–9th.
- Fix: `store.QueryTerms` extracts the terms of a query — maximal runs of letters/digits, kept only when they contain a Han or Katakana character — and the existing name rule (both the store's SQL scorer and the service's `rrfFuse` sort key) now also fires per-term, not just for the whole query.
- The Han/Katakana restriction was measured, not assumed: extending the rule to every space-separated word (an earlier draft) cost the search-eval golden set 6 points of lexical MRR (0.92 → 0.86), because English question words like "revenue" got force-promoted to a name lookup. Restricting to scripts without spaces (which exclude hiragana's grammar particles by construction) leaves English search untouched; golden set now reads lexical 0.92 (unchanged) / fused 0.90 (up from 0.89).
- No migration, no reindex, no reembed — terms are extracted from the query string only, and the SQL candidate set is unchanged.

## Test plan

- [x] New unit test `TestQueryTerms` (`internal/store/filter_test.go`) covering compound Japanese questions, English questions (no terms — space-separated scripts are excluded), all-digit runs, hiragana-bearing names, and the fragment cap.
- [x] New unit test `TestRRFFuseKeepsTermNamedConceptsFirst` (`internal/service/service_test.go`) — fused ranking puts term-named definitions ahead of prose that merely co-mentions every term.
- [x] New integration test `TestIntegrationLexicalSearchLiftsWhatACompoundQueryNames` (`internal/store/store_integration_test.go`) — reproduces the original failure against a real Postgres instance and asserts each definition outranks the memos that only mention it.
- [x] `scripts/check --db` green (lint, govulncheck, all packages including store/service integration tests against a throwaway pgvector/pg17 container).
- [x] `TestSearchEvalIntegration` (36-question golden set): lexical MRR 0.92 (unchanged from baseline), fused MRR 0.90 (up from 0.89 baseline).
- [x] Manually verified end-to-end against a locally built image + compose instance: reseeded the reproduction corpus, confirmed `get_context` for the compound question now returns the three definitions ranked 1st–3rd (scores 1.19–1.62) ahead of the prose documents (0.84–0.91).

🤖 Generated with [Claude Code](https://claude.com/claude-code)