### PR TITLE
Draft golden queries from the warehouse's own job history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ dist/
 # these are per-developer or per-session and are not.
 .claude/settings.local.json
 .claude/worktrees/
+
+# The Python examples ship as source; running one leaves these behind,
+# and a bundle import would try to store them as files.
+__pycache__/
+*.pyc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,23 @@ last entry.
 
 ### Added
 
+- **The cold start has a second half: draft golden queries from the
+  warehouse's own job history.** `ochakai seed` answers *what tables
+  exist*; a base full of columns still does not know what anybody is
+  asking of them — and the warehouse has been writing that down all
+  along. `examples/bigquery-catalog` gains a second job: it reads
+  `INFORMATION_SCHEMA.JOBS` rows as JSON on stdin, groups the runs that
+  differ only in their literals, comments or whitespace, and writes an
+  OKF bundle of drafts on stdout, one per query somebody keeps running.
+  It connects to nothing — you run the query with your own identity and
+  pipe the answer in, the same shape `seed` takes and for the same
+  reason. **There is no LLM in it**: what a query *means* is the one
+  thing a fingerprint cannot produce, so every draft carries an empty
+  "The question this answers" heading, which is where your own agent
+  belongs. Everything lands as a draft, because a query run forty times
+  is evidence that it matters and not evidence that it is right
+  ([#537](https://github.com/na0fu3y/ochakai/issues/537)).
+
 - **A release now carries `ochakai_X.Y.Z.mcpb`, the one-click install for
   Claude Desktop.** Connecting a desktop app meant finding a JSON file
   the app does not show you, writing a `command` that has to be an

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,9 +2,12 @@
 
 - **[demo/](demo)** — 10 concept のナレッジベース丸ごと。コマンド一つで
   import できる。下で説明する。
-- **[bigquery-catalog/](bigquery-catalog)** — BigQuery のテーブルメタデータ
-  を毎日投影するジョブ。Attested Computation として、その Python を隣に置いて
-  出荷している。コネクタによる取り込みがサーバーの外に留まると、こうなる。
+- **[bigquery-catalog/](bigquery-catalog)** — 空のベースを BigQuery から
+  埋める二つのジョブ。テーブルのメタデータを毎日投影するものと、**ジョブ履歴
+  から golden query の draft を起こすもの**(何が既に訊かれているかは、倉庫が
+  自分で記録している)。どちらも Attested Computation として、その Python を
+  隣に置いて出荷している。コネクタによる取り込みがサーバーの外に留まると、
+  こうなる。
 - **[claude-code/](claude-code)** — 想起と書き戻しのループを、Claude Code
   の指示とフックにしたもの。
 - **[golden-query.md](golden-query.md)** — concept 一つだけ。

--- a/examples/bigquery-catalog/README.md
+++ b/examples/bigquery-catalog/README.md
@@ -58,6 +58,7 @@ tar czf - -C examples/bigquery-catalog/bundle --exclude='*.py' . |
 |---|---|---|
 | [`skills/build-the-first-catalog`](bundle/skills/build-the-first-catalog.md) | Skill | **ここから** — day-one の順序: 小さく範囲を決め、住所を確定し、テーブルを投影し、一つ verify し、それからやっと computation を付ける |
 | [`jobs/sync-bigquery-catalog`](bundle/jobs/sync-bigquery-catalog.md) | Attested Computation | `runtime: python`、パラメータ、receipt、そして投影が下すすべての判断 |
+| [`jobs/draft-from-query-history`](bundle/jobs/draft-from-query-history.md) | Attested Computation | **コールドスタートのもう半分** — 何度も撃たれているクエリを golden query の draft として書き戻す |
 | [`skills/run-a-python-job`](bundle/skills/run-a-python-job.md) | Skill | `executor` が指しているもの: どの identity で走らせるか、IAM ロール、receipt のフィールド |
 
 concept と一緒に 2 つのファイルが旅をする。
@@ -94,6 +95,35 @@ concept になっているナレッジベースは、誰も読まない README �
 自分のプロジェクトでジョブを走らせ、receipt がきれいに返ってきてから
 verify すること — それはちょうど、IAM ロールを実際に付与したとおりに
 直したくなる瞬間でもある。
+
+## 何が既に訊かれているか: `draft-from-query-history`
+
+テーブルが入っただけのベースは、**カラム名は答えるが、誰も何を訊いて
+いるかは知らない**。倉庫は自分でそれを記録している — ジョブ履歴である。
+
+`seed` と同じ形で受け取る。あなたが自分の identity でクエリを撃ち、
+答えをパイプで渡す:
+
+```sh
+bq query --format=json --nouse_legacy_sql \
+  'SELECT query, user_email, creation_time, referenced_tables
+     FROM `region-us`.INFORMATION_SCHEMA.JOBS
+    WHERE creation_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 90 DAY)
+      AND job_type = "QUERY" AND state = "DONE" AND error_result IS NULL' |
+  python3 bundle/jobs/draft-from-query-history/draft-from-query-history.py |
+  ochakai import -
+```
+
+リテラルとコメントと空白だけが違う実行は**一つにまとまり**、5 回以上
+撃たれたものが draft として着地する。**LLM は入っていない** — 「この
+クエリは何の問いに答えるのか」だけは書けないので、各 draft は空の見出し
+を持って出てくる。そこを埋めるのはあなたか、**あなたの**エージェントで
+ある。サーバーは決定論のままである。
+
+これで初日の一続きが揃う: `seed` でテーブル、この二つ目で問い、そして
+[レビューキュー](../../docs/loop.md)で人が裁定する。全部 draft で着地
+するのは、**何度も撃たれていることは「大事だ」の証拠であって「正しい」
+の証拠ではない**からである。
 
 ## 何にも触らずに試す
 

--- a/examples/bigquery-catalog/bundle/jobs/draft-from-query-history.md
+++ b/examples/bigquery-catalog/bundle/jobs/draft-from-query-history.md
@@ -1,0 +1,100 @@
+---
+type: Attested Computation
+title: Draft golden queries from job history
+description: Group the queries people keep running and write each one back as a draft for review
+tags: [bigquery, query-history, drafting, python]
+generated: { by: human:na0fu3y, at: 2026-08-10T09:00:00Z }
+status: draft
+runtime: python
+parameters:
+  - { name: prefix, type: string }
+  - { name: min_runs, type: integer }
+  - { name: min_users, type: integer }
+  - { name: limit, type: integer }
+  - { name: project, type: string }
+computation: /jobs/draft-from-query-history/draft-from-query-history.py
+executor:
+  resource: /skills/run-a-python-job.md
+  receipt: [jobs_read, distinct_queries, drafted]
+---
+
+The other half of the cold start. [The catalog
+sync](sync-bigquery-catalog.md) answers *what tables exist*; this answers
+*what people keep asking of them* — and it answers it from the warehouse's
+own record rather than from anybody's memory.
+
+It reads `INFORMATION_SCHEMA.JOBS` rows as JSON on stdin and writes an OKF
+bundle of drafts on stdout, one per query somebody keeps running:
+
+```sh
+bq query --format=json --nouse_legacy_sql \
+  'SELECT query, user_email, creation_time, referenced_tables
+     FROM `region-us`.INFORMATION_SCHEMA.JOBS
+    WHERE creation_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 90 DAY)
+      AND job_type = "QUERY" AND state = "DONE" AND error_result IS NULL' \
+  | python3 draft-from-query-history/draft-from-query-history.py \
+  | ochakai import -
+```
+
+# It connects to nothing
+
+You run the query, with your own client and your own identity, and pipe
+the answer in. That is the same shape `ochakai seed` takes and it is the
+same reason: ochakai holds no warehouse credential, and neither does this
+([0081](../../../../docs/design/0081-what-ochakai-is-and-what-it-refuses-to-hold.md) §1).
+
+It also makes the permission yours to have or not. Seeing anybody else's
+jobs needs `bigquery.jobs.listAll`; without it the history is your own
+queries, and the counts still look plausible — which is worse than no
+counts. Read the first line of the summary before the drafts.
+
+# There is no LLM in it
+
+Grouping is a fingerprint: comments and literals stripped, whitespace
+collapsed, space around punctuation dropped. Two runs of the same question
+against different months land together, and nothing is invented.
+
+**What a query means is the one thing this cannot produce.** So every
+draft carries an empty heading:
+
+```markdown
+## The question this answers
+
+<!-- Nothing here yet, and this script cannot fill it: the history says
+what was run, never why. -->
+```
+
+That is the seam. Fill it yourself, or hand the drafts to your own agent
+— which is where an LLM belongs, on your side of the wire, with your
+knowledge base as the thing it writes *back* to. The server stays
+deterministic either way.
+
+# What lands
+
+One `Attested Computation` per surviving query at
+`queries/from-history/<table>-<hash>`, `status: draft`, carrying the SQL,
+the tables it touched, how often it ran, by how many accounts, and over
+what window. The id is a placeholder built to be unique and readable —
+whoever promotes the draft renames it to whatever the question turns out
+to be about.
+
+Nothing declares its own `generated:`. A document that does imports as a
+*claim*, kept under `received` and answering to no trust tier
+([0075](../../../../docs/design/0075-the-bundle-is-the-address-space.md) §3.1),
+and it would say that on every concept. The instance's own record — it
+observed this import, as you — is truer and quieter; what made them is in
+the tag and the section above.
+
+# What it deliberately drops
+
+- **Anything that is not a `SELECT`.** DDL, DML and scripts are not
+  questions. Judged on the fingerprint, so a query opening with a comment
+  is still a query.
+- **Queries run fewer than `--min-runs` times** (5 by default). A query
+  run once is a question somebody had, not one the team keeps having.
+- **Everything past `--limit`** (50, most-run first). A review queue
+  nobody can finish is one nobody starts — and the counts say which end
+  of the list to raise the limit for.
+
+Every one of those is a threshold, which means every one of them is
+wrong for somebody. They are flags for that reason.

--- a/examples/bigquery-catalog/bundle/jobs/draft-from-query-history/draft-from-query-history.py
+++ b/examples/bigquery-catalog/bundle/jobs/draft-from-query-history/draft-from-query-history.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Draft Golden Query concepts from a warehouse's own job history.
+
+Reads INFORMATION_SCHEMA.JOBS rows as JSON on stdin and writes an OKF
+bundle of `Attested Computation` **drafts** as a tar.gz on stdout, one
+per query somebody keeps running. Pipe it into `ochakai import -`.
+
+    bq query --format=json --nouse_legacy_sql \\
+      'SELECT query, user_email, creation_time, referenced_tables
+         FROM `region-us`.INFORMATION_SCHEMA.JOBS
+        WHERE creation_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 90 DAY)
+          AND job_type = "QUERY" AND state = "DONE" AND error_result IS NULL' \\
+      | ./draft-from-query-history.py --project my-project \\
+      | ochakai import -
+
+**It does not connect to anything.** You run the query, with your own
+client and your own identity, and pipe the answer here — the same shape
+`ochakai seed` takes, and for the same reason: ochakai holds no warehouse
+credential and neither does this (design doc 0081 §1). Seeing anybody
+else's jobs needs bigquery.jobs.listAll; without it the history is your
+own queries, which is worth knowing before you read the counts.
+
+**There is no LLM in here.** Grouping is a deterministic fingerprint —
+comments and literals stripped, whitespace collapsed — so the same two
+queries group and nothing is invented. What a query *means* is the one
+thing this cannot produce, so every draft carries an empty "The question
+this answers" heading, and that is the seam: fill it yourself, or hand
+the drafts to your own agent, which is where an LLM belongs.
+
+Everything lands as a draft. A query somebody ran forty times is evidence
+that it matters, not evidence that it is right — the review queue is
+where that gets decided.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import re
+import sys
+import tarfile
+
+# Literal-ish things a fingerprint should not distinguish. Two queries
+# that differ only in the month they filter on are the same question
+# asked twice, and grouping them is the whole point.
+_COMMENT_LINE = re.compile(r"--[^\n]*")
+_COMMENT_BLOCK = re.compile(r"/\*.*?\*/", re.S)
+_STRING = re.compile(r"'(?:[^']|'')*'")
+_NUMBER = re.compile(r"\b\d+(?:\.\d+)?\b")
+_SPACE = re.compile(r"\s+")
+# Space around punctuation is typing, not meaning: `m , sum(` and `m, sum(`
+# are the same query reformatted, and a fingerprint that told them apart
+# would put the same question in the queue twice.
+_PUNCT_SPACE = re.compile(r"\s*([(),;])\s*")
+# The first table named after FROM or JOIN, for a readable id when the
+# rows carry no referenced_tables.
+_FROM = re.compile(r"\b(?:from|join)\s+`?([A-Za-z0-9_.\-]+)`?", re.I)
+_SLUG_BAD = re.compile(r"[^a-z0-9]+")
+
+
+def fingerprint(sql: str) -> str:
+    """The form two runs of the same query share."""
+    s = _COMMENT_BLOCK.sub(" ", sql)
+    s = _COMMENT_LINE.sub(" ", s)
+    s = _STRING.sub("?", s)
+    s = _NUMBER.sub("?", s)
+    s = _SPACE.sub(" ", s)
+    s = _PUNCT_SPACE.sub(r"\1", s)
+    return s.strip().rstrip(";").lower()
+
+
+def yaml_str(text: str) -> str:
+    """A YAML scalar that survives whatever is in it.
+
+    Quoted always, rather than when it looks risky. A title built from a
+    table name and a count reads fine until the day it holds a colon and
+    a space — and then the whole frontmatter stops parsing, the document
+    is stored as a file rather than a concept, and the only sign is a
+    note nobody reads. Which is exactly how this was found.
+    """
+    return '"' + text.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def slug(text: str) -> str:
+    return _SLUG_BAD.sub("-", text.lower()).strip("-")
+
+
+def table_names(row: dict, sql: str) -> list[str]:
+    """The tables a row touched, as `dataset.table`.
+
+    referenced_tables when the JOBS query selected it — it is the
+    warehouse's own answer and survives a query this script's regex
+    cannot parse. The FROM match is the fallback, and it is a fallback:
+    it sees the first table and nothing else.
+    """
+    refs = row.get("referenced_tables")
+    if isinstance(refs, str):
+        try:
+            refs = json.loads(refs)
+        except json.JSONDecodeError:
+            refs = None
+    out = []
+    for ref in refs or []:
+        if isinstance(ref, dict) and ref.get("table_id"):
+            out.append(f"{ref.get('dataset_id', '')}.{ref['table_id']}".strip("."))
+    if out:
+        return out
+    m = _FROM.search(sql)
+    return [m.group(1).split(".", 1)[-1]] if m else []
+
+
+def rows_from(stream) -> list[dict]:
+    """A JSON array, or one object per line. bq --format=json gives the
+    first; a streaming export gives the second."""
+    text = stream.read().strip()
+    if not text:
+        return []
+    if text.startswith("["):
+        return json.loads(text)
+    return [json.loads(line) for line in text.splitlines() if line.strip()]
+
+
+class Candidate:
+    """One query, and what the history says about it."""
+
+    def __init__(self, sql: str, tables: list[str]):
+        self.sql = sql
+        self.tables = tables
+        self.runs = 0
+        self.users: set[str] = set()
+        self.first: str | None = None
+        self.last: str | None = None
+
+    def observe(self, row: dict, sql: str) -> None:
+        self.runs += 1
+        if row.get("user_email"):
+            self.users.add(row["user_email"])
+        at = (row.get("creation_time") or "")[:10]
+        if at:
+            self.first = min(self.first or at, at)
+            self.last = max(self.last or at, at)
+            # The newest spelling is the one a reader should see: an
+            # older run of the same question may name a column that has
+            # since been dropped.
+            if at == self.last:
+                self.sql = sql
+
+
+def gather(rows: list[dict]) -> dict[str, Candidate]:
+    by_print: dict[str, Candidate] = {}
+    for row in rows:
+        sql = (row.get("query") or "").strip()
+        if not sql:
+            continue
+        # Judged on the fingerprint rather than the raw text: a query
+        # opening with a `-- what this is for` comment is still a query,
+        # and reading the first word of the raw SQL threw those away.
+        fp = fingerprint(sql)
+        if not fp.lstrip("( ").startswith("select"):
+            continue  # DDL, DML and scripts are not questions
+        cand = by_print.get(fp)
+        if cand is None:
+            cand = by_print[fp] = Candidate(sql, table_names(row, sql))
+        if not cand.tables:
+            cand.tables = table_names(row, sql)
+        cand.observe(row, sql)
+    return by_print
+
+
+def document(cand: Candidate, fp: str, args) -> tuple[str, str]:
+    """One draft: its bundle path, and the OKF document."""
+    name = slug(cand.tables[0].split(".")[-1]) if cand.tables else "query"
+    entry_id = f"{args.prefix}/{name}-{hashlib.sha256(fp.encode()).hexdigest()[:6]}"
+    title = f"{name.replace('-', ' ')}: a query run {cand.runs} times"
+    window = ""
+    if cand.first and cand.last:
+        window = f'usage_window: {{ from: "{cand.first}", to: "{cand.last}" }}\n'
+    tags = sorted({slug(t.split(".")[-1]) for t in cand.tables} | {"from-query-history"})
+    # No `generated:` key. A document that declares its own provenance
+    # imports as a *claim* — kept under `received`, answering to no trust
+    # tier, and noted once per concept (design doc 0075 §3.1). The
+    # instance's own record of who wrote these is truer and quieter: it
+    # observed the import. What made them is in the tag, the id prefix
+    # and the section below.
+    # The id is a placeholder. It is built to be unique and readable, not
+    # to be right — whoever promotes this draft renames it to whatever
+    # the question turns out to be about.
+    body = f"""---
+type: Attested Computation
+title: {yaml_str(title)}
+description: {yaml_str("Drafted from job history; nobody has said yet what question it answers")}
+tags: [{", ".join(tags)}]
+{window}status: draft
+runtime: bigquery
+---
+
+## The question this answers
+
+<!-- Nothing here yet, and this script cannot fill it: the history says
+what was run, never why. Write the question a person would ask, then
+promote this out of `{args.prefix}/` to where that question belongs. -->
+
+## What the history says
+
+- Run **{cand.runs} times**{f" by {len(cand.users)} accounts" if cand.users else ""}\
+{f", {cand.first} to {cand.last}" if cand.first else ""}.
+- Tables: {", ".join(f"`{t}`" for t in cand.tables) if cand.tables else "not recorded"}.
+- Grouped with every run whose SQL differs only in its literals, comments
+  or whitespace. The SQL below is the most recent of them.
+
+## Computation
+
+```sql
+{cand.sql}
+```
+"""
+    return f"{entry_id}.md", body
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--prefix", default="queries/from-history",
+                   help="id prefix the drafts are written under (default: %(default)s)")
+    p.add_argument("--min-runs", type=int, default=5,
+                   help="how often a query must have been run to be a candidate "
+                        "(default: %(default)s). A query run once is a question "
+                        "somebody had, not one the team keeps having")
+    p.add_argument("--min-users", type=int, default=1,
+                   help="how many distinct accounts must have run it (default: "
+                        "%(default)s). Raise it to find what more than one person "
+                        "needs; it does nothing unless the rows carry user_email")
+    p.add_argument("--limit", type=int, default=50,
+                   help="most-run first, at most this many (default: %(default)s). "
+                        "A review queue nobody can finish is one nobody starts")
+    p.add_argument("--project", default="", help="named in the drafts' provenance")
+    args = p.parse_args()
+
+    rows = rows_from(sys.stdin)
+    cands = gather(rows)
+    kept = [
+        (fp, c) for fp, c in cands.items()
+        if c.runs >= args.min_runs and max(len(c.users), 1) >= args.min_users
+    ]
+    kept.sort(key=lambda kv: (-kv[1].runs, kv[0]))
+    kept = kept[: args.limit]
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for fp, cand in kept:
+            path, doc = document(cand, fp, args)
+            data = doc.encode()
+            info = tarfile.TarInfo(path)
+            info.size = len(data)
+            info.mtime = 0
+            tar.addfile(info, io.BytesIO(data))
+    sys.stdout.buffer.write(buf.getvalue())
+
+    print(
+        f"read {len(rows)} jobs, {len(cands)} distinct queries, "
+        f"{len(kept)} drafted (>= {args.min_runs} runs); "
+        "pipe into `ochakai import -` and rule on them in the review queue",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What and why

#537(計画 #540、Phase 3)。三項目のうち**一つが残っていた**ので、それを。

### 何が残っていたか

- ✅ **bigquery-catalog を README の階段に組み込む** — #576 で `ochakai seed` が正面に出て、この example の README も day-one を seed に譲る形に既になっていた
- ❌ **クエリ履歴から draft を起草するクライアント側ジョブ** — **未着手**。既存の sync ジョブは履歴を読みますが、それは**テーブルに「何回引かれたか」を注記するため**で、クエリ本文からは何も起こしていませんでした
- 🔶 **一続きのガイド** — 上が入って初めて繋がる

### 直したこと

`seed` は**どんなテーブルがあるか**に答えます。カラムだらけになったベースは、**誰が何を訊いているかをまだ知りません** — そして倉庫はそれをずっと記録しています。

二つ目のジョブが `INFORMATION_SCHEMA.JOBS` の行を JSON で stdin から読み、OKF バンドルの draft を stdout に書きます。

```sh
bq query --format=json --nouse_legacy_sql '...JOBS...' \
  | python3 draft-from-query-history.py \
  | ochakai import -
```

**何にも接続しません。** あなたが自分の identity でクエリを撃ち、答えをパイプで渡す — `seed` と同じ形で、理由も同じです([0081](docs/design/0081-what-ochakai-is-and-what-it-refuses-to-hold.md) §1)。権限もあなたの側に残ります: 他人のジョブを見るには `bigquery.jobs.listAll` が要り、無ければ履歴はあなた自身のクエリだけになって**それでも数字はもっともらしく見える**ので、要約の一行目がそれを言います。

**LLM は入っていません。** グループ化はフィンガープリント(コメントとリテラルを剥がし、空白を畳み、句読点まわりの空白を落とす)なので、違う月に対する同じ問いの実行は一つにまとまり、何も発明されません。

**このスクリプトに書けない唯一のものが「そのクエリが何の問いに答えるか」**です。なので各 draft は空の見出しを持って出てきます:

```markdown
## The question this answers

<!-- Nothing here yet, and this script cannot fill it: the history says
what was run, never why. -->
```

**そこが LLM の座る場所**で、ワイヤのあなた側です。サーバーは決定論のままです。

全部 draft で着地します — **40 回撃たれていることは「大事だ」の証拠であって「正しい」の証拠ではない**からです。

## 動かして分かった三つ

**推論ではなく、動いているサーバに対して作りました。** そうでなければ見つからなかったものが三つ:

1. **先頭の `-- comment` が本物の SELECT を DDL に見せていた** — ガードが fingerprint ではなく生テキストの先頭語を読んでいたため
2. **`m ,` と `m,` が別物になっていた** — 同じクエリがキューに二度並ぶ
3. **生成したタイトルに `": "` が入ると frontmatter 全体が壊れる** — 文書は **concept ではなく file として import され**、手がかりは誰も読まない note 一行だけでした。**これが一番怖い壊れ方**なので、書き出すスカラーは全部クォートするようにしています

最後に、`generated:` は**書きません**。自分の provenance を宣言した文書は claim として `received` に入り、concept ごとに note が出ます([0075](docs/design/0075-the-bundle-is-the-address-space.md) §3.1)。インスタンス自身の記録(import を観測した)のほうが真であり静かで、何が作ったかはタグと本文が言っています。

## 確認したこと

合成した履歴 JSON → draft → `ochakai import -` → **レビューキューに並ぶ**ところまで、ローカルのサーバで通しました:

```
read 5 jobs, 2 distinct queries, 1 drafted (>= 3 runs)
created ochakai://queries/from-history/orders-415710
imported 1 concepts (1 created, ..., 0 notes)

$ ochakai list usage --status draft
0  ochakai://queries/from-history/orders-415710  draft  orders: a query run 3 times — ...

$ curl .../stats → drafts in queue: 1
```

バンドル全体(`--exclude='*.py'` 版、README が案内している形)の import も 4 concept で通ります。

## Checks

- [x] `scripts/check core` clean、`scripts/check lint` 0 issues
- [x] **example なので Go のテストは増えません。** 代わりに上の end-to-end を実際に走らせています
- [ ] `scripts/check vuln` は proxy が vuln.go.dev を拒否するためこの環境では確認不能(欠陥ではありません)

`.gitignore` に `__pycache__/` を足しました — Python の example を走らせると残り、バンドルの import がそれをファイルとして書こうとして落ちます(実際に落ちました)。

## Surfaces and contract

- [x] **製品のコードは一行も変わりません。** example のバンドルが 1 concept + 1 ファイル増えるだけです
- [x] `docs/surface.md` 変更なし。DOC-LINES に余裕あり(README 2 本に節と行を追加)

## Design docs

- [x] 該当なし。決定は一つも動かず、[0081](docs/design/0081-what-ochakai-is-and-what-it-refuses-to-hold.md) §1(コネクタを持たない)と 0085(空のベースを何が埋めるか)を**そのまま守る形の例**です
- [x] Commit messages and code comments are in English

## 受け入れ基準

「新規ユーザーが自分の BigQuery データセットから、レビュー待ちの draft 群まで 1 セッションで到達できる」— **満たしています**: `seed` でテーブル、このジョブで問い、どちらも draft、そして [docs/loop.md](docs/loop.md) が裁定を引き受けます。

---
_Generated by [Claude Code](https://claude.ai/code/session_01BATZn1qmJosokMG8HGxRi8)_