### PR TITLE
Measure how close a base's concepts sit before proposing to dedupe them

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,6 +141,28 @@ would have drawn is simply blank. A missing browser or an unreachable UI
 is a skip locally and a failure under `OCHAKAI_SMOKE_REQUIRED=1`, which
 is how CI runs it: a skip there would be a green run that tested nothing.
 
+### Measuring before proposing
+
+`scripts/duplicate-distances.sql` is the shape a measurement takes here:
+read-only SQL, no surface, run against a base somebody actually curates.
+
+```sh
+psql "$OCHAKAI_DATABASE_URL" -f scripts/duplicate-distances.sql
+```
+
+It answers one question — how close the concepts in a base sit to each
+other — because the feature it is upstream of ("return one of the
+near-duplicates, not five") cannot be specified without a number nobody
+can name from an armchair. A histogram with a bump near zero, separated
+from the rest, is a threshold; one smooth slope is the finding that
+there is not one, and that finding is worth as much as the feature.
+
+The pattern generalizes, and it is the order the records follow: the
+count that shows a problem exists ships before the mechanism that
+answers it (design doc 0089 §4). A script like this is not a surface —
+nobody has to learn it, no endpoint answers it — so it is cheap to write
+and cheap to delete once it has been read.
+
 ## Working with Claude Code
 
 The repository checks in a `.claude/settings.json` with **hooks only**.

--- a/scripts/duplicate-distances.sql
+++ b/scripts/duplicate-distances.sql
@@ -1,0 +1,139 @@
+-- How close the concepts in a base sit to each other, as a distribution
+-- and as the pairs behind it.
+--
+--     psql "$OCHAKAI_DATABASE_URL" -f scripts/duplicate-distances.sql
+--
+-- Read-only: it takes no locks a reader does not, writes nothing, and
+-- adds nothing to any surface. Run it on a base you actually curate — a
+-- demo bundle has too few concepts to have a distribution.
+--
+-- WHY THIS EXISTS. "Return one of the near-duplicates instead of five"
+-- sounds like a feature until someone has to name the distance at which
+-- two concepts stop being two concepts. Nobody can name it from an
+-- armchair: on one base 0.12 is a paraphrase, on another it is two
+-- metrics that share a domain. So the number comes first, and the
+-- mechanism — a queue a human rules on, never a silent filter at search
+-- time — comes only if the number says there is a boundary to draw.
+--
+-- WHAT TO LOOK FOR, in this order:
+--
+--   1. Does the histogram have a bump near zero, separated from the
+--      rest? A single smooth slope means "duplicate" and "related" are
+--      the same thing here, and no threshold can tell them apart. That
+--      is a finding: it says do not build the queue.
+--   2. Read the pairs. The distance where you stop saying "these are the
+--      same knowledge" and start saying "these belong near each other"
+--      is the only definition of the threshold that means anything.
+--   3. Compare the two ends. If the closest pair in the base is at 0.3,
+--      there is nothing to clean up and the queue would open empty.
+--
+-- It measures concepts only. File vectors are keyed by path and answer a
+-- different question (design doc 0091).
+
+\pset border 2
+\timing off
+\set ON_ERROR_STOP on
+
+-- A base with no vectors is an ordinary deployment, not a failure: the
+-- lexical half of search works without them (design doc 0080 §5). Say so
+-- once and stop, rather than letting every query below repeat it.
+SELECT to_regclass('knowledge_embedding') IS NULL AS absent \gset
+\if :absent
+\echo 'This base has no vectors — semantic search was never configured here'
+\echo '(OCHAKAI_EMBEDDINGS; design doc 0080 §1). Nothing to measure.'
+\quit
+\endif
+
+-- Every embedded live concept, under the model the base actually uses.
+-- A base mid-reembed holds two models at once and comparing across them
+-- is meaningless — vectors from different models live in different
+-- spaces (design doc 0080 §3) — so the busiest one wins and the count
+-- below says how many were left out.
+CREATE TEMPORARY VIEW embedded AS
+SELECT e.id, e.embedding, k.title, k.type
+  FROM knowledge_embedding e
+  JOIN object k ON k.id = e.id
+ WHERE k.deleted_at IS NULL
+   AND e.model = (SELECT model FROM knowledge_embedding
+                  GROUP BY model ORDER BY count(*) DESC LIMIT 1);
+
+-- Two concepts is the arithmetic minimum; fifty is where a histogram
+-- starts being a shape rather than a handful of bars. Below that the
+-- pairs are still worth reading and the distribution is not.
+SELECT (SELECT count(*) FROM embedded) < 2 AS too_few,
+       (SELECT count(*) FROM embedded) < 50 AS small \gset
+\if :too_few
+\echo 'Fewer than two embedded concepts. Nothing to compare.'
+\quit
+\endif
+\if :small
+\echo 'NOTE: under 50 concepts. Read the pairs; the histogram is too few'
+\echo 'bars to be a shape, and a threshold read off it would be noise.'
+\echo ''
+\endif
+
+\echo '== what is being measured'
+SELECT (SELECT count(*) FROM embedded)                        AS concepts,
+       (SELECT count(*) FROM knowledge_embedding)             AS vectors_all_models,
+       (SELECT model FROM knowledge_embedding
+         GROUP BY model ORDER BY count(*) DESC LIMIT 1)       AS model;
+
+-- Each concept's nearest neighbour. Cosine distance, which is what
+-- search ranks on: 0 is the same direction, 1 is unrelated, 2 is
+-- opposite.
+CREATE TEMPORARY VIEW nearest AS
+SELECT a.id AS a_id, a.title AS a_title, a.type AS a_type,
+       n.id AS b_id, n.title AS b_title, n.type AS b_type,
+       n.dist
+  FROM embedded a
+ CROSS JOIN LATERAL (
+   SELECT b.id, b.title, b.type, a.embedding <=> b.embedding AS dist
+     FROM embedded b
+    WHERE b.id <> a.id
+    ORDER BY a.embedding <=> b.embedding
+    LIMIT 1
+ ) n;
+
+\echo ''
+\echo '== nearest-neighbour distance, as a shape'
+\echo '   a bump near zero that is separated from the rest is a threshold;'
+\echo '   one smooth slope is the finding that there is not one'
+-- Empty buckets are printed, not skipped: the gap between a cluster of
+-- paraphrases and the rest of the base is the whole signal, and a gap
+-- that shows as missing rows is one a reader has to notice rather than
+-- see.
+WITH b AS (SELECT generate_series(1, 20) * 0.05 AS bucket),
+     n AS (SELECT width_bucket(dist, 0, 1, 20) * 0.05 AS bucket FROM nearest)
+SELECT b.bucket AS "under", count(n.bucket) AS concepts,
+       repeat('#', (count(n.bucket) * 50
+              / greatest(max(count(n.bucket)) OVER (), 1))::int) AS shape
+  FROM b LEFT JOIN n ON n.bucket = b.bucket
+ GROUP BY b.bucket
+ ORDER BY b.bucket;
+
+\echo ''
+\echo '== how many concepts have a neighbour closer than …'
+\echo '   the queue this would feed is this many rows deep'
+SELECT t AS "under",
+       (SELECT count(*) FROM nearest WHERE dist < t) AS concepts,
+       round(100.0 * (SELECT count(*) FROM nearest WHERE dist < t)
+             / greatest((SELECT count(*) FROM nearest), 1), 1) AS "%"
+  FROM unnest(ARRAY[0.02, 0.05, 0.10, 0.15, 0.20, 0.30]) AS t;
+
+\echo ''
+\echo '== the closest 40 pairs — this is the part to read'
+\echo '   somewhere in this list they stop being the same knowledge;'
+\echo '   that line is the threshold, and nothing else is'
+SELECT round(dist::numeric, 4) AS dist,
+       least(a_id, b_id)    AS concept_a,
+       greatest(a_id, b_id) AS concept_b,
+       CASE WHEN a_type = b_type THEN a_type::text
+            ELSE a_type || ' / ' || b_type END AS types,
+       left(CASE WHEN a_id < b_id THEN a_title ELSE b_title END, 40) AS title_a,
+       left(CASE WHEN a_id < b_id THEN b_title ELSE a_title END, 40) AS title_b
+  FROM (SELECT DISTINCT ON (least(a_id, b_id), greatest(a_id, b_id))
+               a_id, b_id, a_title, b_title, a_type, b_type, dist
+          FROM nearest
+         ORDER BY least(a_id, b_id), greatest(a_id, b_id), dist) p
+ ORDER BY dist
+ LIMIT 40;


### PR DESCRIPTION
重複掃除キューの前段です。**この PR は機構を足しません** — 数を出す道具だけです。

## What and why

"Return one of the near-duplicates instead of five" cannot be specified without naming **the distance at which two concepts stop being two concepts**. Nobody can name it from an armchair: on one base 0.12 is a paraphrase, on another it is two metrics that share a domain.

So the number comes first. `scripts/duplicate-distances.sql` is read-only SQL — no Go, no binary, no endpoint, no flag — run against a base somebody actually curates:

```sh
psql "$OCHAKAI_DATABASE_URL" -f scripts/duplicate-distances.sql
```

It prints three things:

1. the nearest-neighbour distance distribution as a histogram;
2. how deep the queue would be at six candidate thresholds;
3. **the forty closest pairs**, which is the part that decides anything — the line where a reader stops saying *"these are the same knowledge"* and starts saying *"these belong near each other"* is the only definition of the threshold that means something.

**A histogram with a bump near zero, separated from the rest, is a threshold. One smooth slope is the finding that there is not one** — and that finding is worth as much as the feature would have been, because it says don't build the queue.

## I cannot give you the number, and here is why

The corpora in this repository are 10 concepts (`kb/`) and 19 (`examples/`) — too few to have a distribution — and this sandbox can reach no embedding provider, so it holds no vectors to measure. **The reading has to come from a base with real curation on it.** Saying so is the point of this PR rather than a limitation of it; a threshold I produced here would be a guess wearing a number's clothes.

## The instrument is validated, even though the reading is not

An instrument gets checked before its reading is trusted. I seeded a synthetic base with a planted structure — 6 paraphrase pairs at ~0.03, 8 related-but-distinct pairs, 40 unrelated concepts — and it separates all three:

```
| under | concepts |                       shape                        |
|  0.05 |       12 | ################################################## |   ← the 6 planted pairs
|  0.10 |        0 |                                                    |
|  0.15 |        0 |                                                    |   ← the gap
|  0.20 |        2 | ########                                           |
|  0.25 |        6 | #########################                          |   ← related
...
|  0.50 |       11 | #############################################      |   ← unrelated
```

```
|  dist  |    concept_a    |    concept_b    | title_a | title_b              |
| 0.0242 | metrics/base-05 | metrics/dup-05  | base 5  | paraphrase of base 5 |
| 0.0257 | metrics/base-01 | metrics/dup-01  | base 1  | paraphrase of base 1 |
…
| 0.1721 | metrics/base-11 | metrics/rel-01  | base 11 | related to base 11   |
```

Empty buckets are printed rather than skipped, because **the gap is the whole signal** and a gap that shows as missing rows is one a reader has to notice rather than see. (That was a fix during validation; so was the histogram's column alias, which was invalid SQL and errored on first run.)

## What it does when there is nothing to measure

- **No vectors** — an ordinary lexical-only deployment (0080 §5), not a failure. One sentence and `\quit`, instead of the cascade of `relation "embedded" does not exist` it produced before I guarded it.
- **Fewer than two concepts** — stops.
- **Fewer than fifty** — runs, but says the histogram is too few bars to be a shape and a threshold read off it would be noise.

## What happens next

If the reading shows a separated bump: a **fourth review queue**, a human rules on each pair, one documented constant — the shape `RecentUsageDays = 90` already has. Never a silent filter at search time: hiding duplicates covers rather than fixes, and picks a winner nobody chose. That was recorded as declined in design doc 0093 §4 when the same idea came up under #533.

If it shows one slope: nothing gets built, and the script has earned its keep.

## Checks

- [x] `scripts/check` is clean — add `--db` when the change touches the store

  `scripts/check core ui lint` green against a local PostgreSQL (store and service integration tests ran). `scripts/check vuln` is unverifiable here — the proxy refuses `vuln.go.dev`; that is the network policy, not a finding. The SQL itself was exercised against three databases: the synthetic one above, a base with no embedding tables, and a five-concept base.

- [x] Behavior changes come with tests

  There is no behavior to test — no Go changed, and the product is byte-identical. The script's own correctness is what the synthetic base above establishes.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, `internal/apiclient` — untouched
- [x] The change lands on every surface it belongs on — none. A repository script is not a surface: nothing to call, nothing to learn, nothing that answers over the wire
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens a surface? No. `docs/surface.md` is unchanged

## Design docs

- [x] Alters an accepted decision? No — it decides nothing. The decision it is upstream of is recorded as *declined* in [0093](https://github.com/na0fu3y/ochakai/blob/main/docs/design/0093-the-budget-governs-the-whole-response.md) §4, and stays declined until there is a number. CONTRIBUTING gains a short section naming this as the shape a measurement takes here, and the order the records already follow: the count that shows a problem exists ships before the mechanism that answers it (0089 §4).
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01BATZn1qmJosokMG8HGxRi8)_