### PR TITLE
Draw the footnotes the product tells writers to use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -314,6 +314,30 @@ last entry.
 
 ### Fixed
 
+- **The bundled UI drew footnotes as characters, on a bundle it ships
+  with.** `sources[].id` exists so a footnote in a concept's body can
+  cite one of its sources — `docs/architecture.md` says so, and
+  `examples/demo`'s own `metrics/revenue` is written that way — so the
+  first concept most readers open showed `systems.[^rev-policy]` in the
+  prose and the definition line as a stray paragraph. The server
+  recommended a notation its own web UI turned into litter. Footnotes
+  render as footnotes now: a numbered marker, a list at the foot in the
+  order the prose refers to them, and a link back. A reference nothing
+  defines is left as the writer's text, the way an unresolvable link
+  already is, and a definition nothing refers to puts no number in the
+  margin.
+
+  Three more constructs came with it, because a renderer that drops what
+  a writer wrote is the same defect each time: **headings below h3**,
+  **block quotes**, and **nested lists** — which were flattened, so a
+  runbook's sub-steps read as steps.
+
+- **Following a footnote left the concept.** The router treated every
+  hash as a route, so `#fn-…` — an anchor inside the document being read
+  — resolved to no route and landed the reader on the home page. Routes
+  begin `#/`; anything else is the browser's to scroll to
+  ([#536](https://github.com/na0fu3y/ochakai/issues/536)).
+
 - **Deleting a file at a bundle path left its vector behind, still
   ranking the concept that showed it.** `DELETE` on a bundle path
   removed the object and its bytes but nothing dropped the embedding, so

--- a/internal/webui/jstest/markdown.test.js
+++ b/internal/webui/jstest/markdown.test.js
@@ -97,13 +97,75 @@ test('a description draws no bundle links', () => {
   assert.match(descHTML('[x](/metrics/revenue.md)'), /\[x\]\(\/metrics\/revenue\.md\)/);
 });
 
-// What it does not draw. Written down because the page invites authors
-// to write markdown and these are the notations that come back as
-// characters — the renderer's replacement is issue #536's second half,
-// and this is the list it has to satisfy.
+test('headings go to six levels', () => {
+  assert.equal(md('#### 四段目'), '<h4>四段目</h4>');
+  assert.equal(md('###### 六段目'), '<h6>六段目</h6>');
+  // Seven is not a heading in markdown either.
+  assert.doesNotMatch(md('####### 七'), /<h7>|<h6>/);
+});
+
+test('a block quote is a quote', () => {
+  assert.equal(md('> 引用'), '<blockquote><p>引用</p></blockquote>');
+  // Consecutive lines are one quoted paragraph, as they are in prose.
+  assert.equal(md('> 一行目\n> 二行目'), '<blockquote><p>一行目 二行目</p></blockquote>');
+  assert.equal(md('> 引用\n\nあと'), '<blockquote><p>引用</p></blockquote><p>あと</p>');
+  // The quote's own contents are still markdown, and still escaped.
+  assert.match(md('> **強い** <b>'), /<strong>強い<\/strong> &lt;b&gt;/);
+});
+
+test('a nested list is a tree, not two lists in a row', () => {
+  // The child list opens inside the item above it, so the markup says
+  // what the writer said: these steps are under that step.
+  assert.equal(md('- a\n  - b'), '<ul><li>a<ul><li>b</li></ul></li></ul>');
+  assert.equal(md('- a\n  - b\n- c'), '<ul><li>a<ul><li>b</li></ul></li><li>c</li></ul>');
+  assert.equal(md('1. a\n   - b'), '<ol><li>a<ul><li>b</li></ul></li></ol>');
+  // Three deep, and back out in one step.
+  assert.equal(md('- a\n  - b\n    - c\n- d'),
+    '<ul><li>a<ul><li>b<ul><li>c</li></ul></li></ul></li><li>d</li></ul>');
+});
+
+// The notation the product tells writers to use. `sources[].id` exists
+// so a footnote in the body can cite one of the concept's sources, and
+// examples/demo is written that way — so this was the one gap where the
+// server recommended something the bundled UI drew as characters.
+test('a footnote is a footnote', () => {
+  const html = md('主張。[^src]\n\n[^src]: 出典の名前');
+  assert.match(html, /<sup class="fnref"><a id="fnref-src" href="#fn-src">1<\/a><\/sup>/);
+  assert.match(html, /<section class="footnotes"><ol><li id="fn-src">出典の名前/);
+  assert.match(html, /<a class="fnback" href="#fnref-src"/);
+  // The definition line is not also drawn where it stands.
+  assert.doesNotMatch(html, /<p>\[\^src\]/);
+  assert.doesNotMatch(html, /\[\^src\]<\/p>/);
+});
+
+test('footnotes are numbered in the order the prose refers to them', () => {
+  const html = md('一[^b] 二[^a]\n\n[^a]: あ\n[^b]: い');
+  assert.match(html, /href="#fn-b">1</);
+  assert.match(html, /href="#fn-a">2</);
+  assert.match(html, /<li id="fn-b">い .*<li id="fn-a">あ /);
+});
+
+test('a footnote nothing defines stays the writer\'s text', () => {
+  // The same rule the link and image notations follow: what cannot be
+  // resolved is left as it was written, not drawn as a broken marker.
+  assert.equal(md('主張。[^missing]'), '<p>主張。[^missing]</p>');
+  // And a definition nothing refers to puts no number in the margin.
+  assert.equal(md('本文。\n\n[^unused]: 誰も参照しない'), '<p>本文。</p>');
+});
+
+test('a footnote label cannot escape its own anchor', () => {
+  // The label reaches an id and an href, so it is slugified rather than
+  // trusted — the body is somebody else's text.
+  const html = md('x[^a"b]\n\n[^a"b]: 出典');
+  assert.doesNotMatch(html, /id="fn-a"b"/);
+  assert.match(html, /id="fn-a-*b"|id="fn-a-quot-b"/);
+});
+
+// What it still does not draw, so the next person does not have to
+// discover it in a document somebody wrote.
 test('the notations this renderer does not know stay as text', () => {
-  assert.doesNotMatch(md('#### 四段目'), /<h4>/);           // h4 and deeper
-  assert.doesNotMatch(md('> 引用'), /<blockquote>/);         // block quotes
-  assert.doesNotMatch(md('脚注[^1]\n\n[^1]: 注'), /<sup>/);  // footnotes
-  assert.doesNotMatch(md('- a\n  - b'), /<ul><li>a<\/li><ul>/); // nested lists
+  assert.doesNotMatch(md('term\n: definition'), /<dl>/);      // definition lists
+  assert.doesNotMatch(md('- [ ] todo'), /<input/);             // task lists
+  assert.doesNotMatch(md('~~gone~~'), /<del>/);                // strikethrough
+  assert.doesNotMatch(md('---'), /<hr/);                       // thematic breaks
 });

--- a/internal/webui/jstest/smoke.mjs
+++ b/internal/webui/jstest/smoke.mjs
@@ -211,6 +211,22 @@ try {
   await check('a concept renders', await waitFor(`${textOf('#view')}.includes('Revenue')`), shown);
   await check('its body renders as markdown', await waitFor(`${countOf('#view .md *')} > 0`), shown);
 
+  // examples/demo's metrics/revenue cites a source with a footnote, which
+  // is the notation `sources[].id` exists for. Two things have to be
+  // true: it is drawn as a footnote, and following the marker stays on
+  // the concept — the router owns "#/" routes, and an in-page anchor is
+  // not one.
+  await check('a footnote is drawn as a footnote',
+    await waitFor(`${countOf('#view .md:not(.desc) .fnref a')} > 0`), shown);
+  await evalJS(`document.querySelector('#view .md:not(.desc) .fnref a').click()`);
+  // Asserted on something only the detail view draws. "the text still
+  // says Revenue" is not that: the home page lists the concept too, so
+  // the first version of this check passed against a build with the
+  // router guard removed.
+  await check('following a footnote marker stays on the concept',
+    await waitFor(`location.hash.startsWith('#fn-')
+      && !!document.querySelector('#view .md:not(.desc) .footnotes')`), shown);
+
   await go('#/review');
   await check('the review queue renders', await waitFor(`${textOf('#view')}.length > 100`), shown);
 

--- a/internal/webui/static/app.css
+++ b/internal/webui/static/app.css
@@ -311,10 +311,35 @@ table.kv td.k { color: var(--muted); width: 11rem; white-space: nowrap; }
 .tile .lbl { color: var(--muted); font-size: .82rem; }
 
 /* ---- markdown body ---- */
-.md h1, .md h2, .md h3 { line-height: 1.3; margin: 1.1em 0 .4em; }
+.md h1, .md h2, .md h3, .md h4, .md h5, .md h6 { line-height: 1.3; margin: 1.1em 0 .4em; }
 .md h1 { font-size: 1.3rem; } .md h2 { font-size: 1.15rem; } .md h3 { font-size: 1rem; }
+/* h4 and below stop growing and start leaning on weight and colour:
+   past the third level a document is showing structure, not shouting. */
+.md h4, .md h5, .md h6 { font-size: .95rem; color: var(--muted); }
 .md p { margin: .5em 0; }
 .md ul, .md ol { margin: .4em 0; padding-left: 1.5em; }
+/* A nested list sits inside its item, so it needs no margin of its own
+   above — the item already provided one. */
+.md li > ul, .md li > ol { margin: .15em 0; }
+.md blockquote {
+  margin: .6em 0; padding: .1em 0 .1em .9em;
+  border-left: 3px solid var(--border); color: var(--muted);
+}
+/* The footnote marker is a link the size of a marker, not of the prose
+   around it, and the foot of the document is set apart from the body it
+   annotates. */
+.md .fnref { font-size: .75em; line-height: 0; }
+.md .fnref a { text-decoration: none; padding: 0 .1em; }
+.md .footnotes {
+  margin-top: 1.4em; padding-top: .6em;
+  border-top: 1px solid var(--border); font-size: .9rem; color: var(--muted);
+}
+.md .footnotes ol { margin: 0; }
+.md .footnotes li { margin: .2em 0; }
+.md .fnback { text-decoration: none; }
+/* The target of a jump gets a moment of colour, so a reader who followed
+   a marker can see where they landed. */
+.md .footnotes li:target, .md .fnref a:target { background: var(--accent-weak); }
 .md img { max-width: 100%; border: 1px solid var(--border); border-radius: 8px; display: block; margin: .6rem 0; }
 .md table { border-collapse: collapse; margin: .6em 0; max-width: 100%; }
 .md th, .md td { border: 1px solid var(--border); padding: .35rem .6rem; }

--- a/internal/webui/static/js/markdown.js
+++ b/internal/webui/static/js/markdown.js
@@ -11,7 +11,43 @@ import { esc } from './escape.js';
 // text (design doc 0024) — returning a route or null.
 export function md(src, resolveFile, resolveEntry) {
   const lines = String(src ?? '').split('\n');
-  let out = '', inCode = false, inList = null, para = [];
+  let out = '', inCode = false, para = [], quote = [];
+  // Open lists, outermost first, each with the indentation that opened
+  // it. A list is a stack rather than a flag because a runbook writes
+  // steps under steps, and a renderer that flattened them changed what
+  // the writer said.
+  const lists = [];
+  // Footnote definitions, keyed by the label that refers to them, found
+  // in a pass before any line is drawn — a reference may come before its
+  // definition, and in practice always does.
+  //
+  // This notation is not decoration here. `sources[].id` exists so that a
+  // footnote in the body can cite one of the concept's sources
+  // (docs/architecture.md; the id keys the document's own footnotes,
+  // api/openapi.yaml on `cites`), and examples/demo's own metrics/revenue
+  // is written that way — so the bundle every reader imports first was
+  // being drawn with `[^rev-policy]` sitting in the prose as characters.
+  const notes = new Map();
+  const cited = [];
+  for (const line of lines) {
+    const def = line.match(/^\[\^([^\]\s]+)\]:\s*(.*)$/);
+    // Keyed by the escaped label, because the reference is matched
+    // against text that has already been escaped: a label carrying a
+    // quote would otherwise be one string here and another there, and
+    // the footnote would quietly stop resolving.
+    if (def) notes.set(esc(def[1]), def[2]);
+  }
+  // The anchor is the writer's own label rather than the number beside
+  // it: two renders on one page (a description and a body) would
+  // otherwise both claim #fn-1, and a label is what the writer can see
+  // in the URL.
+  const anchor = id => id.replace(/[^A-Za-z0-9_-]+/g, '-');
+  const footnote = (m, id) => {
+    if (!notes.has(id)) return m; // undefined: the writer's text, unchanged
+    if (!cited.includes(id)) cited.push(id);
+    return `<sup class="fnref"><a id="fnref-${anchor(id)}" href="#fn-${anchor(id)}">` +
+      `${cited.indexOf(id) + 1}</a></sup>`;
+  };
   const img = (m, alt, ref) => {
     const url = /^https?:/.test(ref) ? ref : resolveFile && resolveFile(ref);
     return url ? `<img src="${url}" alt="${alt}" loading="lazy">` : m;
@@ -35,14 +71,22 @@ export function md(src, resolveFile, resolveEntry) {
   // as a link here is exactly what became an edge there.
   const outsideCode = (html, fn) =>
     html.split(/(<code>[\s\S]*?<\/code>)/).map((part, i) => i % 2 ? part : fn(part)).join('');
+  // The footnote pass runs before the link pass: `[^x]` carries no
+  // parentheses, so the link notation never matches it, but reading the
+  // two in the other order would leave the choice to an accident.
   const inline = s => outsideCode(esc(s).replace(/`([^`]+)`/g, '<code>$1</code>'), t => t
     .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
     .replace(/(^|\W)\*([^*\n]+)\*(?=\W|$)/g, '$1<em>$2</em>')
+    .replace(/\[\^([^\]\s]+)\]/g, footnote)
     .replace(/!\[([^\]]*)\]\(([^)\s]+)\)/g, img)
     .replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, link)
     );
   const flushPara = () => { if (para.length) { out += '<p>' + inline(para.join(' ')) + '</p>'; para = []; } };
-  const flushList = () => { if (inList) { out += `</${inList}>`; inList = null; } };
+  const flushQuote = () => {
+    if (quote.length) { out += '<blockquote><p>' + inline(quote.join(' ')) + '</p></blockquote>'; quote = []; }
+  };
+  // Every open <li> is still open, so closing a level closes both.
+  const flushList = () => { while (lists.length) out += `</li></${lists.pop().tag}>`; };
   // GFM table: a header row followed by a `|---|---|` delimiter row (with
   // optional `:` alignment markers), then body rows until a blank line.
   // Requiring a delimiter with at least two columns keeps a lone `---`
@@ -72,7 +116,7 @@ export function md(src, resolveFile, resolveEntry) {
     }
     if (inCode) { out += esc(line) + '\n'; continue; }
     if (line.includes('|') && i + 1 < lines.length && isTableSep(lines[i + 1])) {
-      flushPara(); flushList();
+      flushPara(); flushQuote(); flushList();
       const aligns = splitRow(lines[i + 1]).map(a => {
         const left = a.startsWith(':'), right = a.endsWith(':');
         return left && right ? 'center' : right ? 'right' : left ? 'left' : '';
@@ -86,21 +130,66 @@ export function md(src, resolveFile, resolveEntry) {
       i--;
       continue;
     }
-    const h = line.match(/^(#{1,3})\s+(.*)/);
-    if (h) { flushPara(); flushList(); out += `<h${h[1].length}>${inline(h[2])}</h${h[1].length}>`; continue; }
-    const li = line.match(/^\s*([-*]|\d+\.)\s+(.*)/);
+    // A definition line was read before the loop started and is not
+    // drawn where it stands: it belongs at the foot, with the others.
+    if (/^\[\^([^\]\s]+)\]:/.test(line)) { flushPara(); flushQuote(); flushList(); continue; }
+    // Six levels, because a document that reaches h4 is a document
+    // somebody wrote that way, and drawing it as a paragraph loses the
+    // structure rather than simplifying it.
+    const h = line.match(/^(#{1,6})\s+(.*)/);
+    if (h) {
+      flushPara(); flushQuote(); flushList();
+      out += `<h${h[1].length}>${inline(h[2])}</h${h[1].length}>`;
+      continue;
+    }
+    const q = line.match(/^>\s?(.*)/);
+    if (q) {
+      flushPara(); flushList();
+      if (q[1].trim()) quote.push(q[1].trim());
+      else flushQuote();
+      continue;
+    }
+    flushQuote();
+    const li = line.match(/^([ \t]*)([-*]|\d+\.)\s+(.*)/);
     if (li) {
       flushPara();
-      const want = /^\d/.test(li[1]) ? 'ol' : 'ul';
-      if (inList !== want) { flushList(); out += `<${want}>`; inList = want; }
-      out += '<li>' + inline(li[2]) + '</li>';
+      const indent = li[1].replace(/\t/g, '  ').length;
+      const want = /^\d/.test(li[2]) ? 'ol' : 'ul';
+      // Deeper levels close first, each taking its open <li> with it.
+      while (lists.length && lists[lists.length - 1].indent > indent) {
+        out += `</li></${lists.pop().tag}>`;
+      }
+      const top = lists[lists.length - 1];
+      if (!top || indent > top.indent) {
+        // A nested list opens inside the item above it, which is still
+        // open — that is what makes the markup a tree rather than two
+        // lists in a row.
+        out += `<${want}>`;
+        lists.push({ tag: want, indent });
+      } else {
+        out += '</li>';
+        if (top.tag !== want) {
+          out += `</${top.tag}><${want}>`;
+          lists[lists.length - 1] = { tag: want, indent };
+        }
+      }
+      out += `<li>${inline(li[3])}`;
       continue;
     }
     if (!line.trim()) { flushPara(); flushList(); continue; }
     para.push(line.trim());
   }
   if (inCode) out += '</code></pre>';
-  flushPara(); flushList();
+  flushPara(); flushQuote(); flushList();
+  // The foot, in the order the body referred to them. A definition
+  // nothing referred to is left out: it names no claim, and printing it
+  // would put a number in the margin that the prose never uses.
+  if (cited.length) {
+    out += '<section class="footnotes"><ol>' + cited.map(id =>
+      `<li id="fn-${anchor(id)}">${inline(notes.get(id))} ` +
+      `<a class="fnback" href="#fnref-${anchor(id)}" title="本文に戻る">↩</a></li>`).join('') +
+      '</ol></section>';
+  }
   return out;
 }
 

--- a/internal/webui/static/js/router.js
+++ b/internal/webui/static/js/router.js
@@ -17,15 +17,22 @@ export let unsaved = null; // () => boolean
 window.addEventListener('beforeunload', e => { if (unsaved && unsaved()) e.preventDefault(); });
 
 export function route() {
+  // Every route this page has begins "#/". A hash that does not is an
+  // anchor within the document being shown — a footnote marker jumping
+  // to the foot of a body, and back — so it is the browser's to handle
+  // and not a navigation at all. Without this the reader who clicked a
+  // footnote landed on the home page, which is worse than the marker
+  // not being a link.
+  const hash = location.hash;
+  if (hash && !hash.startsWith('#/')) return;
   if (unsaved && unsaved() && !confirm('保存していない変更を捨てますか?')) {
     // Put the URL back; replaceState does not re-fire hashchange.
     history.replaceState(null, '', route._current || '#/');
     return;
   }
   unsaved = null;
-  route._current = location.hash || '#/';
-  const hash = location.hash.replace(/^#\/?/, '');
-  const [head, ...rest] = hash.split('/');
+  route._current = hash || '#/';
+  const [head, ...rest] = hash.replace(/^#\/?/, '').split('/');
   document.querySelectorAll('#topnav a').forEach(a => a.classList.remove('active'));
   const mark = r => { const a = document.querySelector(`#topnav a[data-route="${r}"]`); if (a) a.classList.add('active'); };
   if (head === 'k' && rest.length >= 1) {


### PR DESCRIPTION
#536 の二つ目。**ライブラリの同梱はしていません** — 理由は下に。

## What and why

`sources[].id` exists so that a footnote in a concept's body can cite one of its sources. `docs/architecture.md` says it in as many words —「一つに `id` を与えれば、本文中の markdown の脚注がその一つの主張の出典を示せる」— `api/openapi.yaml` repeats it on `cites`, and **`examples/demo`'s own `metrics/revenue` is written that way**:

```markdown
  settlement date, so the last two days of a month land differently in the two
  systems.[^rev-policy]
…
[^rev-policy]: Revenue Recognition Policy (FY2026)
```

Rendered in the bundled UI, against a live instance with the demo bundle imported:

```
sup elements: 0
footnote section: 0
literal "[^" at: 788
context: …land differently in the two systems.[^rev-policy]The verified way to compute…
```

**The first concept most readers open, in the bundle the quick start imports, showed the server recommending a notation its own web UI turned into litter.** That is the contradiction #536 names, and it is exact.

After:

```
sup elements: 1
footnote section: 1
literal "[^" at: -1
```

A numbered marker, a list at the foot in the order the prose refers to them, a link back. A reference nothing defines stays the writer's text — the rule unresolvable links already follow — and a definition nothing refers to puts no number in the margin. Labels are keyed by their **escaped** form, so a label carrying a quote resolves on both sides rather than silently on neither.

Three more constructs came with it, because it is the same defect each time — a renderer dropping what a writer wrote: **headings below h3**, **block quotes**, and **nested lists**, which were flattened so a runbook's sub-steps read as steps. Nested lists open *inside* the item above them, so the markup is the tree the writer meant rather than two lists in a row.

## The library is declined, and the reason is the footnotes

#536 asked for「markdown は自前実装をやめ、監査可能な小型ライブラリを同梱」. I did not, on three grounds:

1. **Footnotes are not CommonMark.** `marked` needs an extension, `markdown-it` needs a plugin — so the library route would be *two* vendored dependencies to fix the one thing the product actually promises. It does not solve the stated problem on its own.
2. **Design doc 0092 §2 already declined that supply chain** for the test runner. A vendored copy is the same third-party code with worse update ergonomics than npm: no lockfile, no advisory feed, and nobody re-reads it on bump.
3. **The premise is out of date.** #536 describes the renderer as「h1–h3 と平坦リストだけ」. It already does GFM tables with alignment, fenced code, code spans, emphasis, images and links. What was missing is exactly what this adds — 109 lines changed, not a rewrite.

If you would rather have the library anyway, say so and I will do it; I would want it recorded as a decision rather than left as an unstated deviation.

## A second bug, found before shipping

The footnote marker links to `#fn-…`. The router treated **every** hash as a route, so an in-page anchor resolved to no route and **landed the reader on the home page** — worse than the marker not being a link. Routes begin `#/`; anything else is the browser's to scroll to.

Worth saying how the check for it went, because the first one was wrong: it asserted the page still said "Revenue" after the click — and **the home page lists that concept too**, so it passed against a build with the router guard removed. It asserts on the footnote section now, which only the detail view draws, and I verified it both ways:

```
--- without the guard (must FAIL):
FAIL following a footnote marker stays on the concept

--- with the guard (must pass):
ok   following a footnote marker stays on the concept
```

## Checks

- [x] `scripts/check` is clean — add `--db` when the change touches the store

  `scripts/check core ui lint` green against a local PostgreSQL (store and service integration tests ran). `scripts/check vuln` is unverifiable here — the proxy refuses `vuln.go.dev`; that is the network policy, not a finding.

- [x] Behavior changes come with tests

  The renderer tests go from 20 to 27 assertions covering the four new constructs, including footnote numbering by first reference, the undefined-reference and unreferenced-definition cases, and a label that tries to escape its own anchor. The test that used to *document* the gaps now documents the ones that remain (definition lists, task lists, strikethrough, thematic breaks). The browser smoke gains two checks against `examples/demo`'s real footnote.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, `internal/apiclient` — untouched
- [x] The change lands on every surface it belongs on — the web UI is the only surface that renders markdown; the CLI and MCP hand over the document as written
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens a surface? No. `docs/surface.md` is unchanged — nothing to call, no new word, and no manual page enumerates supported markdown

## Design docs

- [x] Alters an accepted decision? No. It makes the UI do what `docs/architecture.md` already says the product does, which is a defect fix rather than a decision; the refusal to vendor a library rests on 0092 §2, which already carries it. The reasoning is here rather than in a new record, per CLAUDE.md's rule for changes that decide nothing new — tell me if you would rather it were numbered.
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01BATZn1qmJosokMG8HGxRi8)_