### PR TITLE
Walk the loop from a cold base, not only from the demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,10 +129,15 @@ bq query --format=json --nouse_legacy_sql \
 
 Every concept lands as a **draft**, because a projected schema is a
 skeleton somebody still has to say something about — which is what the
-review queue is for. When the projection wants to be a job that reruns,
-[examples/bigquery-catalog](examples/bigquery-catalog) (Japanese) carries
-the day-one procedure, the job, and the attester that says whether a run
-counted.
+review queue is for, and [the loop from a cold
+base](docs/loop.md#cold-start) (Japanese) is that first sitting: which
+drafts to read first, and why not all of them.
+
+The warehouse also knows *what people keep asking*, which a schema does
+not: [examples/bigquery-catalog](examples/bigquery-catalog) (Japanese)
+turns repeated queries from your job history into drafts, and carries the
+day-one procedure, the job that reruns it, and the attester that says
+whether a run counted.
 
 ### For real: Cloud Run and Cloud SQL
 

--- a/docs/loop.md
+++ b/docs/loop.md
@@ -3,7 +3,8 @@
 エージェントが下書きし、人が検証し、その後どうなったかを測る。この
 ページはそのループを端から端まで一周する — クイックスタートで入れた
 [デモバンドル](../examples/demo)には、どの段でも何かが返ってくるだけの
-中身がある。
+中身がある。**自分のテーブルから始めた人**は、その入口が
+[§空のベースから始めるとき](#cold-start)にある。
 
 ## 四つのプロンプト
 
@@ -73,6 +74,51 @@ reject を待っている concept](images/webui-review.png)
 `ochakai serve-ui` はチームで共有するサービスとして配る — サーバーと
 同じコンテナイメージに `--args=serve-ui` を渡すだけである
 ([運用ガイド](guides/operating.md#the-team-web-ui))。
+
+<a id="cold-start"></a>
+
+## 空のベースから始めるとき
+
+デモではなく自分の倉庫から始めるなら、ループの一周目は**書き戻し**では
+なく**投影**で埋まる。入口は二つあり、どちらも ochakai が倉庫に触らない
+形をしている — クエリを撃つのはあなたの identity である。
+
+```sh
+# 何が在るか。テーブルとカラムが concept になる。
+bq query --format=json --nouse_legacy_sql \
+  'SELECT table_schema, table_name, column_name, data_type, is_nullable, description
+     FROM `your-project.your_dataset.INFORMATION_SCHEMA.COLUMNS`
+    ORDER BY ordinal_position' | ochakai seed - | ochakai import -
+
+# 何が既に訊かれているか。5 回以上撃たれたクエリが concept になる。
+#   examples/bigquery-catalog の draft-from-query-history(手順はそちら)
+```
+
+**どちらも全件 draft で着地する。** 投影されたスキーマはまだナレッジでは
+なく骨格であり、5 回撃たれたクエリは「大事だ」の証拠であって「正しい」の
+証拠ではない。ナレッジになるのは、**そのカラムが何を意味するかを誰かが
+言った瞬間**である — それがこのページの残りの部分がやっていることである。
+
+一周目のキューはこう読む:
+
+```sh
+ochakai stats                        # drafts が何件あるか
+ochakai list usage --status draft    # 需要の多い順(直近 90 日)
+```
+
+**初日はここが全部 0 である。** 投影された concept はまだ誰にも読まれて
+いないので、順番が意味を持つのは二周目からである — エージェントを一度
+走らせたあとにもう一度この一覧を見ると、**あなたのチームが実際に触れて
+いる十件が上に来る**。裁定する順番はそれが決める。直近の窓で並ぶことは
+[0090](design/0090-a-queue-ranks-on-what-happened-lately.md) の決定で、
+「昔たくさん読まれた」ではなく「いま読まれている」を上に置くためである。
+
+骨格のまま残った concept は誰の邪魔もしない — 検索では verified が上に
+来るので、**裁定しないことの代償は静かである**。全部を読み切ろうとしない
+こと自体が、このキューの使い方である。
+
+そのあとは上の四つのプロンプトが、デモではなくあなたのテーブルに対して
+そのまま働く。**書き戻しは二周目から**である。
 
 <a id="feeds"></a>
 


### PR DESCRIPTION
Closes #537.

## What and why

The three boxes, checked against what is actually in the tree:

- **The catalog projection in the README staircase** — mostly there already: *Ten minutes* carries `bq query … | ochakai seed - | ochakai import -` and says every concept lands as a draft. What was **missing is the second projection**: the job history, which answers *what anybody is asking* — the half a schema cannot answer for. It shipped in `examples/bigquery-catalog` and never reached the way in. Added.
- **A client-side drafting job from query history** — landed earlier (`draft-from-query-history`, no LLM in it: each draft carries an empty *"the question this answers"* heading, which is where the user's own agent goes).
- **One continuous guide from drafted to queued** — this PR. The two halves were documented in two pages that pointed at each other's middle: the catalog README ends at *"…and then a human rules in the review queue"*, and `docs/loop.md` **began after that**, opening with *"the demo bundle has enough in it that every stage answers with something"*. Somebody who arrived from their own warehouse landed on a page about an invented shop.

`docs/loop.md` gains the entry it was missing (`#cold-start`): both projections in one place, what lands (all of it drafts — a projected schema is a skeleton, and a query run forty times is evidence that it matters and not that it is right), and how to read the queue on the first sitting.

**The honest part is the day-one ranking.** I ran the walk end to end against a running server rather than describing it from the code:

```
$ ochakai seed cols.json | ochakai import -
created ochakai://tables/shopx/customers
created ochakai://tables/shopx/orders
imported 2 concepts (2 created, …)

$ ochakai stats | grep drafts
drafts  5   ochakai list usage --status draft

$ ochakai list usage --status draft
5  metrics/repeat-purchase-rate     draft
5  queries/sales/revenue-by-channel draft
7  metrics/huge-revenue             draft
0  tables/shopx/customers           draft   ← projected just now
0  tables/shopx/orders              draft   ← projected just now
```

**On day one the demand column is all zeroes**, because nothing has been read yet. The order only starts meaning something after an agent has run once — and then the ten your team actually touches rise to the top, which is the order to rule in. The page says that rather than implying a ranking that is not there yet, and says the other half too: leaving a skeleton unruled is quiet, because verified concepts rank above it in search. Not reading the whole queue is how the queue is meant to be used.

### The three questions

- **Who got stuck**: the reader who followed the README into their own warehouse and then had no page to continue on — the loop guide assumed the demo, and the catalog example handed off to a section that started somewhere else.
- **Does an existing surface cover it**: two pages covered the ends and neither covered the seam. Fixed by extending the page whose subject it already is, not by adding one.
- **What is folded away**: nothing, and nothing is added either — no new page (`DOC` stays 26), no new command, no new flag. The manual stays under its line cap with room to spare.

Condition served: **C4** (no forward-deployed engineer — day one is where that promise is tested) and **C8**.

## Checks

- [x] `scripts/check core ui lint` clean
- [x] Behavior changes come with tests — no behavior changed; the documented walk was executed against a live server instead, including the cleanup of the two probe concepts afterwards

`scripts/check vuln` could not run here: the environment's proxy refuses vuln.go.dev. Unverified rather than passing; CI runs it.

## Surfaces and contract

- [x] Nothing on the wire moved; `api/openapi.frozen.txt` untouched
- [x] No surface widens — `docs/surface.md` is unchanged, `DOC` stays at 26, and the manual is under `DOC-LINES` with slack to spare
- [x] The English front door and the Japanese manual keep their split: the README gains two sentences and the walk itself is Japanese, where the manual lives

## Design docs

- [x] Alters an accepted decision? No — documentation of decisions already recorded (0090's recent window is cited where it explains the ordering)
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01BATZn1qmJosokMG8HGxRi8)_