### PR TITLE
Declare code on the 13 error responses that were carrying it silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,28 @@ last entry.
 
 ### Fixed
 
+- **Thirteen error responses were missing the `code` the entry below
+  already claimed every one of them carries.** `api/openapi.yaml`
+  declared `code`'s enum on `components/responses/Error` alone;
+  `searchConcepts`'s 400, `reviewConcept`'s 400 and 409, six of
+  `getBundlePath`/`putBundlePath`/`deleteBundlePath`'s own 404/409/412,
+  and the shared `Forbidden` response wrote `properties: {error}` with
+  no `code` at all. That is exactly where the conditions 0083 exists to
+  separate live: the three sharing 409 (`already_exists`/`not_deleted`/
+  `no_rejection`), the two sharing 412 (a stale `If-Match` versus an
+  occupied path under `If-None-Match: *`), and 403's
+  `forbidden`/`read_only` split — a developer embedding the REST API
+  (C6) had the same prose-matching problem 0083 was written to close,
+  on the very statuses it names.
+  `TestErrorCodesMatchTheContract` only read the shared `Error` schema
+  and could not see any of them. Fixed by declaring `code` at all
+  thirteen sites — narrowed to the codes each one can actually answer,
+  several carrying two — and a new `TestEveryErrorResponseDeclaresACode`
+  that finds an error envelope by shape (any JSON body carrying `error`)
+  instead of by which component wrote it, so an inline schema cannot go
+  quiet again
+  ([#601](https://github.com/na0fu3y/ochakai/issues/601)).
+
 - **A generated REST client works, and the contract was what stopped it.**
   `/api/v1/bundle/{path}` declared its `path` parameter on `get` only —
   `put` and `delete` did not — so the contract said three different

--- a/api/openapi.frozen.txt
+++ b/api/openapi.frozen.txt
@@ -25,15 +25,18 @@ DELETE /api/v1/bundle/{path} response 401 ref=Unauthorized
 DELETE /api/v1/bundle/{path} response 403 ref=Forbidden
 DELETE /api/v1/bundle/{path} response 404
 DELETE /api/v1/bundle/{path} response 404 content application/json type=object
+DELETE /api/v1/bundle/{path} response 404 content application/json.code required=true type=string enum=["not_found"]
 DELETE /api/v1/bundle/{path} response 404 content application/json.error required=true type=string
 DELETE /api/v1/bundle/{path} response 404 header Ochakai-Read-Only ref=ReadOnly
 DELETE /api/v1/bundle/{path} response 405 ref=Error
 DELETE /api/v1/bundle/{path} response 409
 DELETE /api/v1/bundle/{path} response 409 content application/json type=object
+DELETE /api/v1/bundle/{path} response 409 content application/json.code required=true type=string enum=["invalid" "not_deleted"]
 DELETE /api/v1/bundle/{path} response 409 content application/json.error required=true type=string
 DELETE /api/v1/bundle/{path} response 409 header Ochakai-Read-Only ref=ReadOnly
 DELETE /api/v1/bundle/{path} response 412
 DELETE /api/v1/bundle/{path} response 412 content application/json type=object
+DELETE /api/v1/bundle/{path} response 412 content application/json.code required=true type=string enum=["precondition_failed"]
 DELETE /api/v1/bundle/{path} response 412 content application/json.error required=true type=string
 DELETE /api/v1/bundle/{path} response 412 header Ochakai-Read-Only ref=ReadOnly
 DELETE /api/v1/bundle/{path} response 500 ref=Error
@@ -69,16 +72,19 @@ GET /api/v1/bundle/{path} response 401 ref=Unauthorized
 GET /api/v1/bundle/{path} response 403 ref=Forbidden
 GET /api/v1/bundle/{path} response 404
 GET /api/v1/bundle/{path} response 404 content application/json type=object
+GET /api/v1/bundle/{path} response 404 content application/json.code required=true type=string enum=["not_found"]
 GET /api/v1/bundle/{path} response 404 content application/json.error required=true type=string
 GET /api/v1/bundle/{path} response 404 header Ochakai-Read-Only ref=ReadOnly
 GET /api/v1/bundle/{path} response 405 ref=Error
 GET /api/v1/bundle/{path} response 409
 GET /api/v1/bundle/{path} response 409 content application/json type=object
+GET /api/v1/bundle/{path} response 409 content application/json.code required=true type=string enum=["invalid"]
 GET /api/v1/bundle/{path} response 409 content application/json.error required=true type=string
 GET /api/v1/bundle/{path} response 409 header Ochakai-Read-Only ref=ReadOnly
 GET /api/v1/bundle/{path} response 500 ref=Error
 GET /api/v1/bundle/{path} response 501
 GET /api/v1/bundle/{path} response 501 content application/json type=object
+GET /api/v1/bundle/{path} response 501 content application/json.code required=true type=string enum=["unsupported"]
 GET /api/v1/bundle/{path} response 501 content application/json.error required=true type=string
 GET /api/v1/bundle/{path} response 501 header Ochakai-Read-Only ref=ReadOnly
 GET /api/v1/context
@@ -139,6 +145,7 @@ GET /api/v1/search response 200 content application/json.hits[] ref=SearchHit
 GET /api/v1/search response 200 header Ochakai-Read-Only ref=ReadOnly
 GET /api/v1/search response 400
 GET /api/v1/search response 400 content application/json type=object
+GET /api/v1/search response 400 content application/json.code required=true type=string enum=["invalid"]
 GET /api/v1/search response 400 content application/json.error required=true type=string
 GET /api/v1/search response 400 header Ochakai-Read-Only ref=ReadOnly
 GET /api/v1/search response 401 ref=Unauthorized
@@ -221,6 +228,7 @@ POST /api/v1/review/{id} response 200 header ETag ref=ETag
 POST /api/v1/review/{id} response 200 header Ochakai-Read-Only ref=ReadOnly
 POST /api/v1/review/{id} response 400
 POST /api/v1/review/{id} response 400 content application/json type=object
+POST /api/v1/review/{id} response 400 content application/json.code required=true type=string enum=["invalid"]
 POST /api/v1/review/{id} response 400 content application/json.error required=true type=string
 POST /api/v1/review/{id} response 400 header Ochakai-Read-Only ref=ReadOnly
 POST /api/v1/review/{id} response 401 ref=Unauthorized
@@ -229,6 +237,7 @@ POST /api/v1/review/{id} response 404 ref=Error
 POST /api/v1/review/{id} response 405 ref=Error
 POST /api/v1/review/{id} response 409
 POST /api/v1/review/{id} response 409 content application/json type=object
+POST /api/v1/review/{id} response 409 content application/json.code required=true type=string enum=["no_rejection"]
 POST /api/v1/review/{id} response 409 content application/json.error required=true type=string
 POST /api/v1/review/{id} response 409 header Ochakai-Read-Only ref=ReadOnly
 POST /api/v1/review/{id} response 413 ref=Error
@@ -284,15 +293,18 @@ PUT /api/v1/bundle/{path} response 401 ref=Unauthorized
 PUT /api/v1/bundle/{path} response 403 ref=Forbidden
 PUT /api/v1/bundle/{path} response 404
 PUT /api/v1/bundle/{path} response 404 content application/json type=object
+PUT /api/v1/bundle/{path} response 404 content application/json.code required=true type=string enum=["not_found"]
 PUT /api/v1/bundle/{path} response 404 content application/json.error required=true type=string
 PUT /api/v1/bundle/{path} response 404 header Ochakai-Read-Only ref=ReadOnly
 PUT /api/v1/bundle/{path} response 405 ref=Error
 PUT /api/v1/bundle/{path} response 409
 PUT /api/v1/bundle/{path} response 409 content application/json type=object
+PUT /api/v1/bundle/{path} response 409 content application/json.code required=true type=string enum=["already_exists" "invalid"]
 PUT /api/v1/bundle/{path} response 409 content application/json.error required=true type=string
 PUT /api/v1/bundle/{path} response 409 header Ochakai-Read-Only ref=ReadOnly
 PUT /api/v1/bundle/{path} response 412
 PUT /api/v1/bundle/{path} response 412 content application/json type=object
+PUT /api/v1/bundle/{path} response 412 content application/json.code required=true type=string enum=["already_exists" "precondition_failed"]
 PUT /api/v1/bundle/{path} response 412 content application/json.error required=true type=string
 PUT /api/v1/bundle/{path} response 412 header Ochakai-Read-Only ref=ReadOnly
 PUT /api/v1/bundle/{path} response 413 ref=Error
@@ -328,6 +340,7 @@ components/responses/Error content application/json.error required=true type=str
 components/responses/Error header Ochakai-Read-Only ref=ReadOnly
 components/responses/Forbidden
 components/responses/Forbidden content application/json type=object
+components/responses/Forbidden content application/json.code required=true type=string enum=["forbidden" "read_only"]
 components/responses/Forbidden content application/json.error required=true type=string
 components/responses/Forbidden header Ochakai-Read-Only ref=ReadOnly
 components/responses/Unauthorized

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -460,7 +460,8 @@ paths:
                 type: object
                 properties:
                   error: { type: string }
-                required: [error]
+                  code: { type: string, enum: [invalid] }
+                required: [error, code]
               examples:
                 queryAndSortTogether:
                   summary: q and sort are mutually exclusive
@@ -811,7 +812,8 @@ paths:
                 type: object
                 properties:
                   error: { type: string }
-                required: [error]
+                  code: { type: string, enum: [unsupported] }
+                required: [error, code]
               example:
                 error: "files are not supported without GCS: set OCHAKAI_GCS_BUCKET (design doc 0013)"
         "409":
@@ -840,7 +842,8 @@ paths:
                 type: object
                 properties:
                   error: { type: string }
-                required: [error]
+                  code: { type: string, enum: [invalid] }
+                required: [error, code]
               example:
                 error: >
                   index.md is generated from the bundle, not stored in it
@@ -856,7 +859,8 @@ paths:
                 type: object
                 properties:
                   error: { type: string }
-                required: [error]
+                  code: { type: string, enum: [not_found] }
+                required: [error, code]
               example:
                 error: no object at this path
         "405": { $ref: "#/components/responses/Error" }
@@ -1009,13 +1013,16 @@ paths:
                 type: object
                 properties:
                   error: { type: string }
-                required: [error]
+                  code: { type: string, enum: [not_found] }
+                required: [error, code]
         "412":
           description: >
             An If-Match or If-None-Match "*" precondition failed — the
             concept changed since it was read, or (design doc 0064,
             matching RFC 9110) the path was already occupied when
-            If-None-Match "*" asked for a create only.
+            If-None-Match "*" asked for a create only. The code says
+            which: `precondition_failed` for a stale `If-Match`,
+            `already_exists` for the occupied path (design doc 0083).
           headers:
             Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
           content:
@@ -1024,7 +1031,8 @@ paths:
                 type: object
                 properties:
                   error: { type: string }
-                required: [error]
+                  code: { type: string, enum: [already_exists, precondition_failed] }
+                required: [error, code]
         "413": { $ref: "#/components/responses/Error" }
         "415": { $ref: "#/components/responses/Error" }
         "501": { $ref: "#/components/responses/Error" }
@@ -1033,7 +1041,9 @@ paths:
             A generated file is not one anybody writes — and an address
             already taken by the other kind of object is not free: a
             file PUT to a path where a live concept sits (or a concept
-            PUT to a path a file holds) answers 409 naming which.
+            PUT to a path a file holds) answers 409 naming which. The
+            code says which: `invalid` for the reserved name,
+            `already_exists` for the occupied address.
           headers:
             Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
           content:
@@ -1042,7 +1052,8 @@ paths:
                 type: object
                 properties:
                   error: { type: string }
-                required: [error]
+                  code: { type: string, enum: [already_exists, invalid] }
+                required: [error, code]
               example:
                 error: index.md is generated from the bundle, not stored in it (design doc 0046 §§3.7-3.8)
         "405": { $ref: "#/components/responses/Error" }
@@ -1113,9 +1124,14 @@ paths:
                 type: object
                 properties:
                   error: { type: string }
-                required: [error]
+                  code: { type: string, enum: [not_found] }
+                required: [error, code]
         "409":
-          description: A generated file is not one anybody deletes.
+          description: >
+            Two conditions, and the code says which: a generated file is
+            not one anybody deletes (`invalid`), or `purge=true` named a
+            concept that is still live — destruction takes the two steps
+            design doc 0031 requires, delete before purge (`not_deleted`).
           headers:
             Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
           content:
@@ -1124,7 +1140,8 @@ paths:
                 type: object
                 properties:
                   error: { type: string }
-                required: [error]
+                  code: { type: string, enum: [invalid, not_deleted] }
+                required: [error, code]
         "412":
           description: >
             If-Match named a version the concept no longer has (design doc
@@ -1137,7 +1154,8 @@ paths:
                 type: object
                 properties:
                   error: { type: string }
-                required: [error]
+                  code: { type: string, enum: [precondition_failed] }
+                required: [error, code]
         "405": { $ref: "#/components/responses/Error" }
         "500": { $ref: "#/components/responses/Error" }
   /api/v1/context:
@@ -1785,7 +1803,8 @@ paths:
                 type: object
                 properties:
                   error: { type: string }
-                required: [error]
+                  code: { type: string, enum: [invalid] }
+                required: [error, code]
               examples:
                 unknownRuling:
                   summary: A ruling outside the vocabulary
@@ -1810,7 +1829,8 @@ paths:
                 type: object
                 properties:
                   error: { type: string }
-                required: [error]
+                  code: { type: string, enum: [no_rejection] }
+                required: [error, code]
               example:
                 error: knowledge carries no rejection to withdraw
         "413": { $ref: "#/components/responses/Error" }
@@ -2397,7 +2417,8 @@ components:
         rather than silently downgrading to the caller's own identity).
         The second reaches every operation, since the header is honored
         on every call; the first only the writes. Same JSON envelope as
-        every other error here.
+        every other error here; the code says which — `read_only` for
+        the deployment posture, `forbidden` for the delegation refusal.
       headers:
         Ochakai-Read-Only: { $ref: "#/components/headers/ReadOnly" }
       content:
@@ -2406,7 +2427,8 @@ components:
             type: object
             properties:
               error: { type: string }
-            required: [error]
+              code: { type: string, enum: [forbidden, read_only] }
+            required: [error, code]
           examples:
             readOnly:
               summary: A write against a read-only deployment

--- a/cmd/ochakai/surface_test.go
+++ b/cmd/ochakai/surface_test.go
@@ -1421,3 +1421,62 @@ func TestErrorCodesMatchTheContract(t *testing.T) {
 			declared, codes)
 	}
 }
+
+// TestEveryErrorResponseDeclaresACode guards the gap issue #601 found:
+// TestErrorCodesMatchTheContract above reads only
+// components/responses/Error, so a response written inline with
+// `properties: {error}` and no `code` — one operation's own 409, a
+// shared component like Forbidden — was invisible to it. An error
+// envelope is identified by shape here, not by which component wrote
+// it: any response whose JSON body carries `error` must carry `code`
+// beside it, with a non-empty enum drawn from domain.ErrorCodes (design
+// doc 0083 §2 — the code is repeated even where the status already
+// determines it, so a client never has to ask whether this particular
+// failure has one).
+func TestEveryErrorResponseDeclaresACode(t *testing.T) {
+	doc := readSpecTree(t)
+	valid := map[string]bool{}
+	for _, c := range domain.ErrorCodes {
+		valid[c] = true
+	}
+	checked := 0
+	check := func(loc string, resp map[string]any) {
+		props := wireMap(wireMap(wireMap(wireMap(resp["content"])["application/json"])["schema"])["properties"])
+		if props["error"] == nil {
+			return // not an error envelope
+		}
+		checked++
+		enum, _ := wireMap(props["code"])["enum"].([]any)
+		if len(enum) == 0 {
+			t.Errorf("%s: carries `error` with no `code` enum beside it (design doc 0083)", loc)
+			return
+		}
+		for _, v := range enum {
+			if !valid[wireStr(v)] {
+				t.Errorf("%s: code enum names %q, which is not one of domain.ErrorCodes", loc, wireStr(v))
+			}
+		}
+	}
+
+	for name, node := range wireMap(wireMap(wireMap(doc["components"])["responses"])) {
+		check("components/responses/"+name, wireMap(node))
+	}
+	for path, item := range wireMap(doc["paths"]) {
+		for method, node := range wireMap(item) {
+			if !httpMethods[method] {
+				continue
+			}
+			loc := strings.ToUpper(method) + " " + path
+			for status, respNode := range wireMap(wireMap(node)["responses"]) {
+				resp := wireMap(respNode)
+				if wireStr(resp["$ref"]) != "" {
+					continue // checked once, above, where it is declared
+				}
+				check(loc+" response "+status, resp)
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no error-shaped response found in openapi.yaml: this check now guards nothing")
+	}
+}


### PR DESCRIPTION
## Summary

- `api/openapi.yaml` declared `code`'s enum on `components/responses/Error` alone. Thirteen responses across `searchConcepts`, `getBundlePath`, `putBundlePath`, `deleteBundlePath`, `reviewConcept` and the shared `Forbidden` component wrote `properties: {error}` with no `code` at all — including four of the conditions design doc 0083 exists to separate: the three sharing 409 (`already_exists`/`not_deleted`/`no_rejection`), the two sharing 412 (a stale `If-Match` versus an occupied path under `If-None-Match: *`), and 403's `forbidden`/`read_only` split. `TestErrorCodesMatchTheContract` only reads the shared `Error` schema, so none of the thirteen were visible to it.
- Fixed by declaring `code` at all thirteen sites, narrowed to the codes each response can actually answer (several carry two, matched against `writeError`'s switch in `internal/restapi/restapi.go` and the purge-of-a-live-concept / occupied-address paths it falls through to).
- Added `TestEveryErrorResponseDeclaresACode`, which finds an error envelope by shape — any response whose JSON body carries `error` — instead of by which component wrote it, so an inline schema going quiet again fails the build.
- Regenerated `api/openapi.frozen.txt` (all thirteen additions are to response-only schemas, which design doc 0082 places outside the freeze) and added a CHANGELOG entry.

Fixes #601

## Test plan

- [x] `scripts/check --db core` (gofmt, go vet, `go test -race` including the DB-backed `internal/restapi` integration suite, build)
- [x] `scripts/check ui lint`
- [x] Manually reverted one of the thirteen fixes and confirmed `TestEveryErrorResponseDeclaresACode` catches it
- [x] `TestFrozenWireHasNotMoved`, `TestErrorCodesMatchTheContract`, `TestTheContractStaysUnderItsLineCap` (REST-LINES stays at 3,405 / 3,500, well under the ceiling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)