### PR TITLE
Fix MCP tool schema prose that contradicted the implementation

### DIFF
--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -241,9 +241,9 @@ func newServer(svc *service.Service, version string, retired []RetiredToolName) 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "list_concepts",
 		Annotations: readOnly,
-		Description: "Walk a review feed in full, oldest work first. Scores nothing and ranks " +
-			"nothing: pass the cursor from the last page to continue, and no cursor back means " +
-			"the end.\n" +
+		Description: "Walk a review feed in full; each feed's own priority order (below). Scores " +
+			"nothing and ranks nothing: pass the cursor from the last page to continue, and no " +
+			"cursor back means the end.\n" +
 			"- verified_at: by verification age, oldest first — stale verified knowledge.\n" +
 			"- usage: by how often the concept was read — the draft review feed.\n" +
 			"- failed: reported wrong via report_outcome, worst first — the re-verification feed.\n" +
@@ -488,11 +488,13 @@ func parseKnowledgeURI(uri string) (id string, ok bool) {
 }
 
 // The jsonschema tags spell out the numeric contracts (defaults, maxima,
-// out-of-range fallback) that api/openapi.yaml and the CLI help already
+// out-of-range refusal) that api/openapi.yaml and the CLI help already
 // document — MCP agents only see the tool schema.
-// filters are the six every read tool takes, in one embedded struct
-// rather than repeated per tool: they are the same question everywhere,
-// and a schema written twice is a schema that starts differing.
+// filters are the seven fields search_concepts and list_concepts both
+// take, in one embedded struct rather than repeated per tool: they are
+// the same question everywhere, and a schema written twice is a schema
+// that starts differing. get_context has its own contextIn instead,
+// without rejected or source.
 type filters struct {
 	Types    []string `json:"types,omitempty" jsonschema:"filter by type, case-insensitive: Metric, Attested Computation, Skill, Insight, Policy, Glossary Term, BigQuery Dataset, BigQuery Table, Reference, or any custom type"`
 	Statuses []string `json:"statuses,omitempty" jsonschema:"filter by lifecycle status: draft, stable, deprecated — confirmation is a separate question, ask it with trusts"`
@@ -514,7 +516,7 @@ func (f filters) filter() store.Filter {
 type searchIn struct {
 	Query string `json:"query" jsonschema:"the text to search for"`
 	filters
-	Limit int `json:"limit,omitempty" jsonschema:"max results: default 10, max 50 (out-of-range falls back to the default)"`
+	Limit int `json:"limit,omitempty" jsonschema:"max results: default 10, max 50 (out-of-range is an error)"`
 }
 
 // listIn is the same filters with a feed and a position instead of a
@@ -524,7 +526,7 @@ type searchIn struct {
 type listIn struct {
 	Sort string `json:"sort,omitempty" jsonschema:"which feed: verified_at | usage | failed | stale_after (the description says what each is)"`
 	filters
-	Limit  int    `json:"limit,omitempty" jsonschema:"max results per page: default 100, max 1000 (out-of-range falls back to the default)"`
+	Limit  int    `json:"limit,omitempty" jsonschema:"max results per page: default 100, max 1000 (out-of-range is an error)"`
 	Cursor string `json:"cursor,omitempty" jsonschema:"resume: pass back the cursor the last page returned, with the same sort and filters"`
 }
 
@@ -551,7 +553,7 @@ type contextIn struct {
 	Trusts   []string `json:"trusts,omitempty" jsonschema:"filter by who confirmed it: unverified, machine-confirmed, human-reviewed; several are OR-ed, omit to not ask. Independent of status"`
 	Tags     []string `json:"tags,omitempty" jsonschema:"filter by tag"`
 	Prefixes []string `json:"prefixes,omitempty" jsonschema:"only concepts under these paths, e.g. [\"teams/growth\", \"company\"] — an id is a path, so this scopes to a subtree; several are OR-ed. It scopes the search, not the link expansion: a concept in scope still arrives with the term it cites outside"`
-	Limit    int      `json:"limit,omitempty" jsonschema:"max primary concepts: default 5, max 20 (out-of-range falls back to the default); linked companions share a 2x total cap"`
+	Limit    int      `json:"limit,omitempty" jsonschema:"max primary concepts: default 5, max 20 (out-of-range is an error); linked companions share a 2x total cap"`
 	Budget   int      `json:"budget,omitempty" jsonschema:"max bytes of the whole response — hits, outline and concepts together (default 12000). The ranking and the outline always come back, so what this buys is whole concepts. Raise it when you need them, lower it when context is tight"`
 }
 

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -101,10 +101,15 @@ func TestLimitContractsInSchema(t *testing.T) {
 	}
 	// One tool, one pair of numbers: the two contracts used to share a
 	// description, which is the sentence design doc 0096 split apart.
+	// "out-of-range is an error" pins the actual behavior (design doc
+	// 0064): a prior version of this prose said the opposite — that an
+	// out-of-range limit "falls back to the default" — and nothing here
+	// caught it because the check only looked for the numbers, never the
+	// fallback claim itself (issue #600).
 	want := map[string][]string{
-		"search_concepts": {"default 10", "max 50"},
-		"list_concepts":   {"default 100", "max 1000"},
-		"get_context":     {"default 5", "max 20"},
+		"search_concepts": {"default 10", "max 50", "out-of-range is an error"},
+		"list_concepts":   {"default 100", "max 1000", "out-of-range is an error"},
+		"get_context":     {"default 5", "max 20", "out-of-range is an error"},
 	}
 	for _, tool := range res.Tools {
 		substrs, ok := want[tool.Name]
@@ -129,6 +134,10 @@ func TestLimitContractsInSchema(t *testing.T) {
 			if !strings.Contains(desc, s) {
 				t.Errorf("%s limit description %q does not mention %q", tool.Name, desc, s)
 			}
+		}
+		if strings.Contains(desc, "falls back") {
+			t.Errorf("%s limit description %q claims an out-of-range limit falls back to the "+
+				"default; the service refuses it instead (design doc 0064)", tool.Name, desc)
 		}
 	}
 	for name := range want {


### PR DESCRIPTION
## Summary

Three spots in `internal/mcpserver`'s schema prose said the opposite of what the code does — and that prose is what an agent reads instead of the source, so a wrong claim there is load-bearing in a way a stale code comment usually isn't.

- The `limit` jsonschema descriptions on `search_concepts`, `list_concepts` and `get_context` said "out-of-range falls back to the default." The service has refused out-of-range limits with a 400 since design doc 0064 (`internal/service/service.go`'s `checkedLimit`), matching what `api/openapi.yaml` already documents. Changed all three to "out-of-range is an error."
- `list_concepts`' first-line summary claimed every feed is "oldest work first," but of the four feeds only `verified_at` and `stale_after` actually are — `usage` sorts most-read-first and `failed` sorts worst-first. The summary now defers to the per-feed bullets instead of asserting an order two of the four don't have.
- The `filters` struct's internal comment said "the six every read tool takes." It's seven fields (types, statuses, trusts, rejected, tags, source, prefixes — design doc 0096 §2), and `get_context` doesn't embed `filters` at all: it has its own `contextIn` without `rejected` or `source`.

Also strengthened `TestLimitContractsInSchema` per the issue's request: it now pins the corrected "out-of-range is an error" wording and fails if the string "falls back" ever reappears in a limit description, so this can't silently regress.

No tools added, removed, or reshaped — prose and comments only. `MCP-BYTES` moved from 13,433 to 13,474, still under the 13,500 ceiling with room inside the declared 500-byte slack.

Fixes #600.

## Test plan

- [x] `scripts/check` (full suite, including `--race`, `go vet`, `golangci-lint`, `govulncheck`) passes
- [x] `go test ./internal/mcpserver/...` passes, including `TestMCPStaysUnderItsResidentByteCap` and the strengthened `TestLimitContractsInSchema`