### PR TITLE
Reject an empty query in search_concepts instead of silently listing

### DIFF
--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -225,6 +225,16 @@ func newServer(svc *service.Service, version string, retired []RetiredToolName) 
 			"Ranking, so it ends at limit and has no page two: a search that needs more is one " +
 			"that needs narrowing. To walk a whole feed instead, use list_concepts.",
 	}, tool(svc, func(ctx context.Context, _ domain.Actor, in searchIn) (*mcp.CallToolResult, searchOut, error) {
+		// SearchOrList routes an empty query with a source filter to a
+		// listing before it ever checks that search needs a query (0096
+		// §5 put that reverse lookup on list_concepts, which has a cursor
+		// parameter and a listing-sized limit — this schema has neither).
+		// Reject it here so this tool stays one capability, not two
+		// behind one schema (issue #602).
+		if strings.TrimSpace(in.Query) == "" {
+			return nil, searchOut{}, service.Invalidf(
+				"search_concepts needs a query; to list what derives from a source, use list_concepts")
+		}
 		page, err := svc.SearchOrList(ctx, in.Query, "", "", in.filter(), in.Limit)
 		if err != nil {
 			return nil, searchOut{}, err

--- a/internal/mcpserver/mcpserver_integration_test.go
+++ b/internal/mcpserver/mcpserver_integration_test.go
@@ -544,4 +544,31 @@ func TestIntegrationListWalksAFeedAndSearchRefusesTo(t *testing.T) {
 	if !strings.Contains(said, "sort") {
 		t.Errorf("the refusal does not name the argument that does not belong: %q", said)
 	}
+
+	// An empty query with a source filter is the other way this tool
+	// could quietly become a listing: SearchOrList routes that shape to
+	// s.list before it ever checks that a search needs a query (0096
+	// §5 put the reverse lookup on list_concepts, which has a cursor
+	// parameter and a listing-sized limit — this schema has neither).
+	// The handler has to refuse it itself, because no JSON Schema shape
+	// says "query required only when source is empty" (issue #602).
+	res, err = cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "search_concepts", Arguments: map[string]any{"query": "", "source": "https://example.com/doc"},
+	})
+	if err == nil && !res.IsError {
+		t.Fatal("search_concepts with only a source filter answered as a listing instead of refusing")
+	}
+	said = ""
+	if err != nil {
+		said = err.Error()
+	} else {
+		for _, c := range res.Content {
+			if tc, ok := c.(*mcp.TextContent); ok {
+				said += tc.Text
+			}
+		}
+	}
+	if !strings.Contains(said, "list_concepts") {
+		t.Errorf("the refusal does not point at the tool that does this: %q", said)
+	}
 }


### PR DESCRIPTION
## Summary

- `search_concepts`'s handler now refuses a present-but-empty `query`, telling the caller to use `list_concepts` instead — closing the gap where `SearchOrList` routed `query:"" + source:"…"` to a listing before its search-needs-a-query guard ever ran.
- The root cause: a JSON Schema `required` field only checks that the key is present, not that its value is non-empty, so `query:""` slipped past `search_concepts`' schema despite `Query` being a required field with no `omitempty`. `list_concepts` already had an equivalent handler-level guard (`Sort == "" && Source == ""`); `search_concepts` was missing its half.
- REST's `/search` is untouched — its dual capability at `query=""` is the documented, intentional behavior (design doc 0037 §2.3). The MCP tool description text is also untouched (no schema/MCP-BYTES change), only handler behavior.

Fixes #602.

## Test plan

- [x] Added `internal/mcpserver/mcpserver_integration_test.go` coverage: `search_concepts{query:"", source:"…"}` is refused with an error naming `list_concepts`, not answered as a listing.
- [x] `scripts/check --db` (gofmt, go vet, race tests against a live Postgres, golangci-lint, govulncheck) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)