### PR TITLE
Bring README and ROADMAP up to 0086's actual stance on auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,13 +277,15 @@ ochakai loses, and says who should pick something else.
 
 ## Requirements
 
-- **Google Cloud**, for a real deployment: Cloud Run IAM and Cloud SQL
-  IAM are how ochakai holds no secret of its own, and there is no
-  supported way to run it elsewhere. This superseded an earlier "runs
-  anywhere" position, for a reason worth knowing before you adopt:
-  keeping a non-GCP path alive meant keeping a second authentication path
-  alive with it, and that is the one thing secret-zero cannot afford.
-  What is portable is the knowledge, not the runtime.
+- **Google Cloud**, recommended: Cloud Run IAM and Cloud SQL IAM are how
+  ochakai holds no secret of its own without any configuration. Off
+  Google Cloud, naming your own OpenID Connect issuer
+  ([0086](docs/design/0086-a-second-way-to-say-who-is-calling.md)) is a
+  second, supported authentication path — ochakai verifies the bearer
+  token itself against the issuer's published keys, which introduces no
+  secret either, so it costs secret-zero nothing. Embeddings stay Vertex
+  AI or nothing there, so search off Google Cloud is lexical-only. What
+  is portable is the knowledge; a particular runtime is not required.
 - **PostgreSQL 17, able to install `pg_trgm`**. Nothing queries it — the
   lexical index has been a `tsvector` column since the two-character
   windows above replaced trigrams — but the schema replays from its first

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -108,13 +108,18 @@ it.
 - **A chat UI or dashboards.** The bundled web UI is a curation surface, not a
   BI tool: no charts, no query execution, no chat. It feeds your agents rather
   than competing with them.
-- **Secrets, and clouds that would require them.** Cloud Run IAM decides who
-  reaches a deployment and Cloud SQL authenticates the service account, so
-  there is nothing to issue or rotate. Features must not introduce a token or a
-  password, and porting the auth model to another cloud is not a goal — the
-  secret-zero property is exactly the thing that would be lost
+- **Secrets.** Cloud Run IAM decides who reaches a deployment and Cloud SQL
+  authenticates the service account, so there is nothing to issue or rotate by
+  default. Features must not introduce a token or a password. This declined
+  "a second authentication path" until 2026-08, when
+  [0086](docs/design/0086-a-second-way-to-say-who-is-calling.md) found one
+  that costs secret-zero nothing: a deployment can name its own OpenID
+  Connect issuer and verify bearer tokens itself, against the issuer's
+  published public keys, with nothing to issue or rotate there either. The
+  goal was always secret-zero
   ([0065](docs/design/0065-identity-and-provenance.md),
-  [0003](docs/design/0003-gcp-only.md)).
+  [0003](docs/design/0003-gcp-only.md)) — not Google Cloud, and not one
+  authentication path, for their own sake.
 - **Authorization, and a user database.** Whoever can reach a deployment can
   read and write; identity is recorded as provenance, and trust is judged from
   provenance by whoever reads the concept (0065 §1).


### PR DESCRIPTION
Fixes #603

## What and why

0086 revised 0003's "no way to run ochakai off Google Cloud": a
deployment can now name its own OpenID Connect issuer
(`OCHAKAI_OIDC_ISSUER` / `OCHAKAI_OIDC_AUDIENCE`) as a second,
secret-free authentication path — ochakai verifies the bearer token
itself against the issuer's published keys, which introduces no
secret and so costs secret-zero nothing.

README.md's Requirements section and ROADMAP.md's "Considered and
deliberately not doing" section still argued the pre-0086 position
after that release shipped ("there is no supported way to run it
elsewhere", "porting the auth model to another cloud is not a goal"),
contradicting the very feature the release had just shipped.
`docs/configuration.md` and `docs/en.md` already documented 0086
correctly — only the two front-door pages were stale.

This PR rewrites both passages to describe the current state: Cloud
Run IAM + Cloud SQL IAM stay the recommended, no-configuration
default; the OIDC issuer path is a supported second option that costs
secret-zero nothing; ROADMAP's bullet is updated in place (not
deleted) per this repo's convention of saying what changed and when,
rather than erasing the prior position.

`api/openapi.yaml`'s own related inconsistency (info prose says
"ochakai itself verifies nothing") is explicitly out of scope per the
issue — it's a frozen contract file tied to a separate decision about
declaring the 401.

## Checks

- [x] `scripts/check` is clean (docs-only change; no store touched)
- [x] Behavior changes come with tests — N/A, no behavior change

## Surfaces and contract

- [x] N/A — no wire, endpoint, or surface change
- [x] N/A — nothing widened

## Design docs

- [x] N/A — no accepted decision is altered; this brings prose in line
      with 0086, which was already accepted and shipped
- [x] Commit messages and code comments are in English