### PR TITLE
Fix four stale manual index/peripheral counts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -798,13 +798,13 @@ Two pieces of bookkeeping, both easy to forget:
   take the markers off this page's own outbound links** to pages that are
   already Japanese: between two Japanese pages the mark says nothing, and
   the ones left behind are what a reader learns to stop trusting.
-- **`DOC-LINES` usually needs nothing.** The ceiling moves in hundreds
-  (`DOC-LINES-SLACK: 100`), so most pages land inside the block the
-  manual is already in and the number is not touched — which is what
+- **`DOC-LINES` usually needs nothing.** The ceiling moves in fives of
+  hundreds (`DOC-LINES-SLACK: 500`), so most pages land inside the block
+  the manual is already in and the number is not touched — which is what
   keeps nine translations from all conflicting on one line. Run
-  `scripts/check core`; if it fails, round the ceiling to the next
-  hundred and write the paragraph, because crossing a hundred is the
-  moment the manual actually got bigger.
+  `scripts/check core`; if it fails, round the ceiling to the next five
+  hundred and write the paragraph, because crossing that grid line is
+  the moment the manual actually got bigger.
 
   Expect it to grow rather than shrink where it moves at all. Japanese
   puts no spaces between words, so a line was expected to carry more; a

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,8 +27,9 @@ otherwise have to hunt for. Not a translation; a way in.
   AI アナリスト製品に内蔵された検証済みクエリストア、MCP サーバー付きの
   markdown vault。ochakai が劣る場面と、そのとき何を選ぶべきかも含む。
 - [互換性とサポート](compatibility.md) — REST は `/api/v1` で凍結済み。
-  MCP・CLI・保存形式はまだ 0.x のままで不安定、非推奨化の猶予期間も無く、
-  サポートされるのは最新リリースのみ。ochakai の上に何かを組む前に読む。
+  MCP・CLI・保存形式はまだ 0.x のままで不安定、名前の猶予期間は一リリース
+  だけ、サポートされるのは最新リリースのみ。ochakai の上に何かを組む前に
+  読む。
 - [ROADMAP](../ROADMAP.md) — いま取り組んでいること、そして意図して
   断っていること。
 - [CHANGELOG](../CHANGELOG.md) — リリース間で何が変わったか。
@@ -47,7 +48,7 @@ otherwise have to hunt for. Not a translation; a way in.
   `ochakai <command> -h` をそのまま出力したもので、両者が食い違えば
   テストが落ちる。バイナリを持つ前から読め、持った後も古びない。
 - [MCP クライアントを繋ぐ](guides/mcp-clients.md) — エージェントに見える
-  六つのツール、そしてクライアントごとの URL か `mcp-stdio` ブリッジ、
+  七つのツール、そしてクライアントごとの URL か `mcp-stdio` ブリッジ、
   各クライアントが読む設定ファイル。
 - [最初のカタログを作る](../examples/bigquery-catalog) — BigQuery の
   テーブルを concept として取り込む day-one の手順、それを走らせる job、

--- a/docs/en.md
+++ b/docs/en.md
@@ -71,7 +71,7 @@ to look up.
 - `OCHAKAI_URL`
 - `PORT`
 
-**`OCHAKAI_MODE` is the access posture, and there are four.** Unset is
+**`OCHAKAI_MODE` is the access posture, and there are five.** Unset is
 the normal one: private, writable, Cloud Run IAM decides who reaches it.
 `read-only` serves the base and refuses every write. `public` is the
 posture the demo runs in — reachable without a Google account, read-only,


### PR DESCRIPTION
## Summary
- `docs/README.md:30` — "非推奨化の猶予期間も無く" was the last surviving pre-0088 statement; 0088 introduced a one-release name grace window (already reflected correctly in `docs/compatibility.md`).
- `docs/README.md:50` — "六つのツール" → 七つ, after 0096 split out `list_concepts` (`README.md:184`, `docs/surface.md:320`, `docs/guides/mcp-clients.md` were already correct).
- `docs/en.md:74` — opening sentence said "there are four" `OCHAKAI_MODE` postures while the paragraph lists five (sandbox from 0087 was already described, just not counted).
- `CONTRIBUTING.md:801-807` — described `DOC-LINES-SLACK` as 100, but `docs/surface.md` declares 500 (and CONTRIBUTING itself acknowledges the 500-line grid elsewhere at `:674`). A contributor following the old instruction would round to the wrong grid and fail CI.

Fixes #605.

## Test plan
- [x] `scripts/check core` passes