### PR TITLE
Fix four small leftovers from the release review

### DIFF
--- a/cmd/ochakai/ui_test.go
+++ b/cmd/ochakai/ui_test.go
@@ -75,7 +75,7 @@ func TestTheUIPageCarriesASecurityPolicy(t *testing.T) {
 				}
 			}
 			// The one that would undo the rest. A page with no inline
-			// script has no reason to allow one (design doc 0092).
+			// script has no reason to allow one (design doc 0094).
 			if strings.Contains(csp, "script-src 'self' 'unsafe-inline'") ||
 				strings.Contains(csp, "script-src 'unsafe-inline'") {
 				t.Errorf("script-src allows inline again, which is what the policy is for:\n%s", csp)

--- a/cmd/ochakai/uicommon.go
+++ b/cmd/ochakai/uicommon.go
@@ -66,9 +66,10 @@ func assets(files fs.FS) http.Handler {
 }
 
 // contentSecurityPolicy is what the page is allowed to do. It became
-// writable when the page stopped carrying an inline script (design doc
-// 0092): `script-src 'self'` with nothing inline is the whole point —
-// an injection that reaches the DOM cannot become code.
+// writable when the page stopped carrying an inline script, and design
+// doc 0094 is what decided to write it: `script-src 'self'` with nothing
+// inline is the whole point — an injection that reaches the DOM cannot
+// become code.
 //
 // The page renders a concept's body, which is somebody else's text, and
 // every value it interpolates goes through one escape function. This is

--- a/internal/store/migrate_test.go
+++ b/internal/store/migrate_test.go
@@ -1,6 +1,51 @@
 package store
 
-import "testing"
+import (
+	"regexp"
+	"strconv"
+	"testing"
+)
+
+// migrationNumberGaps records numbers deliberately skipped in
+// internal/store/migrations, so a genuinely missing or duplicated file
+// still fails TestMigrationsAreSequentiallyNumbered instead of passing
+// silently.
+var migrationNumberGaps = map[int]string{
+	6: "0005_outcomes.sql and 0007_blob_external.sql landed in the same commit; 0006 never existed",
+}
+
+// Migrate (migrate.go) applies migrations in filename order without
+// checking that the sequence is contiguous or free of duplicates — a
+// renamed or accidentally reused number would only surface as a subtle
+// ordering bug. This test is the check.
+func TestMigrationsAreSequentiallyNumbered(t *testing.T) {
+	entries, err := migrationFS.ReadDir("migrations")
+	if err != nil {
+		t.Fatal(err)
+	}
+	re := regexp.MustCompile(`^(\d{4})_`)
+	want := 1
+	for _, e := range entries {
+		m := re.FindStringSubmatch(e.Name())
+		if m == nil {
+			t.Fatalf("migration file %q does not start with a four-digit number", e.Name())
+		}
+		n, err := strconv.Atoi(m[1])
+		if err != nil {
+			t.Fatalf("migration file %q: %v", e.Name(), err)
+		}
+		for want < n {
+			if _, ok := migrationNumberGaps[want]; !ok {
+				t.Errorf("migration number %04d is missing and not recorded in migrationNumberGaps", want)
+			}
+			want++
+		}
+		if n != want {
+			t.Errorf("migration file %q duplicates or is out of order for number %04d", e.Name(), n)
+		}
+		want++
+	}
+}
 
 // Migration 0026 rewrites the ochakai:// links out of the bodies that
 // still carry them (design doc 0046 §3.6). It has to read where a bare

--- a/internal/webui/static/js/views/review.js
+++ b/internal/webui/static/js/views/review.js
@@ -55,9 +55,6 @@ export function viewReview() {
 // came back empty — not a dashboard: what a curator can act on this
 // morning, which is what the queues below are for.
 //
-// Failure to load is silent. Stats are a help, and a review queue that
-// refuses to draw because a tally is unavailable would be worse than one
-// with no tally.
 // sparkline draws the review trend: eight weeks of verifications, oldest
 // first (design doc 0095). Inline SVG rather than a chart library — this
 // is a curation surface and not a BI tool (design doc 0067 §1), and one
@@ -91,7 +88,11 @@ export async function loadLoopStats() {
   const out = $('#loop-stats');
   if (!out) return;
   let s;
-  try { s = await api('/api/v1/stats'); } catch (e) { return; }
+  try { s = await api('/api/v1/stats'); } catch (e) {
+    if (out !== $('#loop-stats')) return;
+    out.innerHTML = `<div class="error-banner" role="alert">loop の数字を読み込めませんでした: ${esc(e.message)}</div>`;
+    return;
+  }
   if (out !== $('#loop-stats')) return;
   const trust = s.concepts?.trust || {};
   const confirmed = (trust['human-reviewed'] || 0) + (trust['machine-confirmed'] || 0);

--- a/kb/bundle/skills/webui-screenshots.md
+++ b/kb/bundle/skills/webui-screenshots.md
@@ -23,11 +23,14 @@ docs/images/webui-*.png は examples/demo を実際に serve して撮る。
 - **ライトスキームは強制する。** ヘッドレス Chrome の既定はダーク。
   `Emulation.setEmulatedMedia` で明示する。
 - **ロケールは DevTools プロトコルでしか直らない。** entry ページの日付
-  は `toLocaleDateString()` が ICU の既定ロケールを読む。macOS では
-  `--lang=en-US` も `LANG`/`LC_ALL` も効かず、`navigator.language` が
-  en-US を名乗ったまま日付だけ `2026年7月27日` になる。
-  `Emulation.setLocaleOverride` で上書きし、ページ内で
-  `Intl.DateTimeFormat().resolvedOptions().locale` が `en-US` である
+  は `toLocaleDateString()` が ICU の既定ロケールを読む。Web UI は
+  `lang="ja"` なので、日付も `ja-JP` で揃える — 英語ロケールのまま
+  日本語 UI を撮ると、日付だけ英語という食い違いになる。macOS では
+  `--lang=`、`LANG`/`LC_ALL` のどれも効かず、`navigator.language` が
+  指定した値を名乗ったまま日付だけシステムのロケールで描かれる、という
+  食い違いが撮影機のロケール次第で起きる。`Emulation.setLocaleOverride`
+  で `ja-JP` を明示的に上書きし、ページ内で
+  `Intl.DateTimeFormat().resolvedOptions().locale` が `ja-JP` である
   ことを確かめる。
 - **コミット前に全 PNG を読む。** 落ちたバックエンドは整った「502 Bad
   Gateway」カードとして描画され、一瞥ではコンテンツに見える。ダーク・


### PR DESCRIPTION
Closes #609.

Four small fixes from the release-quality review, each a few lines:

1. **`internal/webui/static/js/views/review.js`** — a failed `/api/v1/stats` fetch silently left the whole loop-stats block (tiles, sparkline, truncated warning) undrawn with no explanation. Now it draws the same `error-banner` the rest of this page's failed loads already use.
2. **`internal/store/migrations/` 0006 gap** — `0005_outcomes.sql` → `0007_blob_external.sql` skips 0006 with no record anywhere, and `Migrate` (`internal/store/migrate.go`) only sorts filenames without checking the sequence. Added `TestMigrationsAreSequentiallyNumbered` in `internal/store/migrate_test.go`, with the 0006 gap recorded and explained in a `migrationNumberGaps` map — a genuinely missing or duplicated number still fails the test.
3. **`cmd/ochakai/uicommon.go` / `cmd/ochakai/ui_test.go`** — both CSP-related comments cited design doc 0092 (module splitting), which only made `script-src 'self'` writable; the actual decision to enforce the policy is 0094. Fixed both citations.
4. **`kb/bundle/skills/webui-screenshots.md`** — the skill forced an `en-US` locale override for screenshot dates, but the Web UI now renders with `lang="ja"` (per the CHANGELOG, the existing README/loop-guide screenshots are English UI pending a reshoot). Following the skill as written would produce a Japanese UI with English dates. Updated it to target `ja-JP`, consistent with the current UI.

Left out of scope, per the issue: `kb/bundle/insights/mcp-bytes-not-tool-count.md`'s stale tool-count numbers — that's a `status: draft` concept meant to be adjudicated through the review queue, not fixed by editing the bundle file directly.

## Test plan

- [x] `scripts/check --db` (gofmt, go vet, go test -race incl. the new migration test, CGO_ENABLED=0 build, node --test, golangci-lint, govulncheck) — all green.