### PR TITLE
Remove the dead (id,name) attachment API and unwire orphaned helpers

### DIFF
--- a/internal/domain/fuzz_test.go
+++ b/internal/domain/fuzz_test.go
@@ -111,8 +111,8 @@ func FuzzLinksFromBody(f *testing.F) {
 				t.Errorf("duplicate link %+v", l)
 			}
 			seen[l] = true
-			// DisplayText is what every surface renders; an edge with no
-			// readable name is a dead entry in a "linked from" list.
+			// An edge with no readable name would be a dead entry in a
+			// "linked from" list, were a surface to render one.
 			if l.DisplayText() == "" {
 				t.Errorf("link %+v renders as nothing", l)
 			}

--- a/internal/domain/knowledge.go
+++ b/internal/domain/knowledge.go
@@ -444,8 +444,6 @@ func ValidOutcome(o string) bool {
 // ruling behind at all.
 var Rulings = []string{"verified", "rejected", "withdrawn"}
 
-func ValidRuling(r string) bool { return slices.Contains(Rulings, r) }
-
 // Changes are the values a revision's Change carries — what the product
 // calls each kind of write in an entry's history. They are the verb form
 // of what happened; a ruling posted as "withdrawn" is recorded here as
@@ -688,7 +686,9 @@ type Link struct {
 
 // DisplayText returns how the link should read: its anchor text when the
 // body gave one, else the target's last segment — the same "filename is
-// the name" fallback titles use (design doc 0022).
+// the name" fallback titles use (design doc 0022). No surface calls this
+// yet; it exists so a derived link is never rendered as nothing (see the
+// fuzz invariant in fuzz_test.go).
 func (l Link) DisplayText() string {
 	if l.Text != "" {
 		return l.Text

--- a/internal/okf/file.go
+++ b/internal/okf/file.go
@@ -72,7 +72,7 @@ func resolveFiles(files map[string][]byte, concepts []*domain.Knowledge) (atts [
 		if seen[k] == nil {
 			seen[k] = map[string]bool{}
 		}
-		if seen[k][name] || !domain.ValidFileName(name) || len(data) > domain.MaxFileSize || len(data) == 0 {
+		if seen[k][name] || domain.ValidateFile(name, len(data)) != nil {
 			return
 		}
 		if _, err := domain.DetectFileMediaType(data); err != nil {

--- a/internal/service/attachment.go
+++ b/internal/service/attachment.go
@@ -101,10 +101,10 @@ func (s *Service) FillFiles(ctx context.Context, ks []*domain.Knowledge) error {
 	return nil
 }
 
-// PutFile writes a file at a bundle path (design doc 0046 §§3.2, 3.5).
-// It is Attach's counterpart for an object that belongs to no entry: a
-// producer's seed data in a shared directory, a diagram two entries
-// show, a markdown file carrying no type and so not a concept.
+// PutFile writes a file at a bundle path (design doc 0046 §§3.2, 3.5),
+// for an object that belongs to no entry: a producer's seed data in a
+// shared directory, a diagram two entries show, a markdown file carrying
+// no type and so not a concept.
 //
 // Attribution is not asked for and not recorded. Whether an entry is
 // shown by this file is a question its body answers (§3.3), so a file

--- a/internal/store/attachment.go
+++ b/internal/store/attachment.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"slices"
 	"strings"
 	"time"
 
@@ -76,103 +75,6 @@ func scanFile(row pgx.CollectableRow) (domain.File, error) {
 	return asFile(path, mediaType, size, hash, by, at), nil
 }
 
-// filePath is where a file with this name, written against this entry,
-// lives: the path it names when the entry's own body points there, and
-// the canonical <id>/<name> otherwise.
-//
-// The body is what decides, because the body is what attributes the file
-// (design doc 0046 §3.3). A caller naming a path the entry says nothing
-// about would otherwise write a file nothing points at — an orphan the
-// moment it lands, and one no export would put back where it was asked
-// for. Under the entry's own namespace it needs no mention: the path
-// says whose it is.
-func filePath(k *domain.Knowledge, name, at string) string {
-	canonical := k.ID + "/" + name
-	if at == "" || at == canonical {
-		return canonical
-	}
-	if slices.Contains(domain.FilesFromBody(k.ID, k.Body), at) {
-		return at
-	}
-	return canonical
-}
-
-// PutAttachment stores data as an attachment of a live entry, replacing
-// any attachment of the same name. mediaType must already be validated
-// (domain.DetectFileMediaType). Attach and detach count as changes
-// to the entry: updated_at is bumped and a revision (with the attachment
-// list in the snapshot) is recorded.
-func (s *Store) PutAttachment(ctx context.Context, id, name, mediaType, at string, data []byte, actor domain.Actor) (*domain.File, error) {
-	sum := sha256.Sum256(data)
-	att := &domain.File{
-		Name:      name,
-		MediaType: mediaType,
-		Size:      int64(len(data)),
-		SHA256:    hex.EncodeToString(sum[:]),
-		Path:      at,
-		CreatedBy: actor,
-		CreatedAt: time.Now().UTC(),
-	}
-	if s.blobs == nil {
-		return nil, ErrNoBlobStore
-	}
-	err := s.withTx(ctx, func(tx pgx.Tx) error {
-		// The upload happens under the writers' shared lock (sweep.go):
-		// create-only and content-addressed, a DB failure afterwards
-		// leaves only an unreferenced object — which the sweep may
-		// reclaim, but never between this Put and the commit that names
-		// its hash.
-		if err := lockBlobsShared(ctx, tx); err != nil {
-			return err
-		}
-		if err := s.blobs.Put(ctx, att.SHA256, mediaType, data); err != nil {
-			return err
-		}
-		k, err := s.Get(ctx, id)
-		if err != nil {
-			return err
-		}
-		path := filePath(k, name, at)
-		// The caller asked for a name and may have asked for a path; what
-		// it gets back is the address the file actually took, because the
-		// vector and every later read are keyed by it.
-		att.Path = path
-		// The blob row is metadata only now — the object row carries the
-		// media type and size a read answers with — but it stays the
-		// registry of which content exists, and a revision names bytes by
-		// hash alone.
-		if _, err := tx.Exec(ctx, `INSERT INTO blob (sha256, media_type, size)
-			VALUES ($1, $2, $3) ON CONFLICT (sha256) DO NOTHING`,
-			att.SHA256, att.MediaType, att.Size); err != nil {
-			return err
-		}
-		if _, err := tx.Exec(ctx, `INSERT INTO object
-			(path, type, title, body, blob_hash, size, media_type,
-			 created_by_kind, created_by_name, updated_by_kind, updated_by_name,
-			 created_at, updated_at, content_changed_at)
-			VALUES ($1,'','','',$2,$3,$4,$5,$6,$5,$6,$7,$7,$7)
-			ON CONFLICT (path) DO UPDATE SET
-				blob_hash=EXCLUDED.blob_hash, size=EXCLUDED.size, media_type=EXCLUDED.media_type,
-				updated_by_kind=EXCLUDED.updated_by_kind, updated_by_name=EXCLUDED.updated_by_name,
-				updated_at=EXCLUDED.updated_at
-			WHERE object.id IS NULL`,
-			path, att.SHA256, att.Size, att.MediaType, actor.Kind, actor.Name, att.CreatedAt); err != nil {
-			return err
-		}
-		// A replaced file's vector describes the old bytes; drop it here
-		// and let the service re-embed after commit (design doc 0020).
-		if err := execTolerateMissingTable(ctx, tx,
-			`DELETE FROM attachment_embedding WHERE path=$1`, path); err != nil {
-			return err
-		}
-		return s.touchAndRevise(ctx, tx, k, "add_file", actor)
-	})
-	if err != nil {
-		return nil, err
-	}
-	return att, nil
-}
-
 // ErrNoBlobStore is the backstop for attachment operations on an
 // instance without a blob store; the service layer checks first and
 // wraps the condition in a client-facing error (design doc 0013).
@@ -183,23 +85,6 @@ func (s *Store) PutAttachment(ctx context.Context, id, name, mediaType, at strin
 // (ExportSnapshot.FileMeta). So the sentinel travels, and writeError
 // gives it the 501 the other paths get.
 var ErrNoBlobStore = errors.New("files are not supported without GCS: set OCHAKAI_GCS_BUCKET (design doc 0075 §1)")
-
-// GetAttachment returns one attachment with its bytes. Attachments of
-// soft-deleted entries are gone with the entry.
-func (s *Store) GetAttachment(ctx context.Context, id, name string) (*domain.File, []byte, error) {
-	att, err := s.GetAttachmentMeta(ctx, id, name)
-	if err != nil {
-		return nil, nil, err
-	}
-	if s.blobs == nil {
-		return nil, nil, ErrNoBlobStore
-	}
-	data, err := s.blobs.Get(ctx, att.SHA256)
-	if err != nil {
-		return nil, nil, err
-	}
-	return att, data, nil
-}
 
 // ListAttachments returns the metadata (no bytes) of the files a live
 // entry is shown by, in name order.
@@ -241,70 +126,6 @@ func (s *Store) ListAttachmentsBatch(ctx context.Context, ids []string) (map[str
 	return out, rows.Err()
 }
 
-// GetAttachmentMeta returns one file's metadata without touching the
-// blob store — enough to answer a conditional GET (the ETag is the
-// content hash) before deciding whether the bytes are needed.
-//
-// The name is the last segment of a path, so a file the entry shows from
-// elsewhere in the bundle answers to its filename here, which is the
-// name every surface has always called it by.
-func (s *Store) GetAttachmentMeta(ctx context.Context, id, name string) (*domain.File, error) {
-	rows, err := s.pool.Query(ctx, `SELECT `+fileCols+`
-		FROM object k JOIN object f ON `+attributedTo+`
-		WHERE k.id=$1 AND k.deleted_at IS NULL
-		  AND substr(f.path, length(f.path) - length($2)) = '/' || $2
-		ORDER BY f.path LIMIT 1`, id, name)
-	if err != nil {
-		return nil, err
-	}
-	att, err := pgx.CollectExactlyOneRow(rows, scanFile)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, ErrNotFound
-	}
-	if err != nil {
-		return nil, err
-	}
-	return &att, nil
-}
-
-// DeleteAttachment removes the entry→blob mapping. The blob itself is
-// not touched here: content-addressed bytes are shared, so whether they
-// can go is a global question — SweepBlobs (sweep.go) answers it, and
-// the service runs it after this commit.
-func (s *Store) DeleteAttachment(ctx context.Context, id, name string, actor domain.Actor) error {
-	return s.withTx(ctx, func(tx pgx.Tx) error {
-		k, err := s.Get(ctx, id)
-		if err != nil {
-			return err
-		}
-		att, err := s.GetAttachmentMeta(ctx, id, name)
-		if err != nil {
-			return err
-		}
-		path := filePath(k, att.Name, att.Path)
-		tag, err := tx.Exec(ctx, `DELETE FROM object WHERE path=$1 AND id IS NULL`, path)
-		if err != nil {
-			return err
-		}
-		if tag.RowsAffected() == 0 {
-			return ErrNotFound
-		}
-		if err := execTolerateMissingTable(ctx, tx,
-			`DELETE FROM attachment_embedding WHERE path=$1`, path); err != nil {
-			return err
-		}
-		return s.touchAndRevise(ctx, tx, k, "remove_file", actor)
-	})
-}
-
-// ExportAttachment is one attachment with its owner and bytes, as the
-// OKF exporter consumes it.
-type ExportAttachment struct {
-	ID   string
-	Att  domain.File
-	Data []byte
-}
-
 // AttachmentBytes returns the content-addressed bytes behind an
 // attachment. Paired with ExportSnapshot.FileMeta for streaming
 // export.
@@ -313,47 +134,6 @@ func (s *Store) AttachmentBytes(ctx context.Context, sha256 string) ([]byte, err
 		return nil, ErrNoBlobStore
 	}
 	return s.blobs.Get(ctx, sha256)
-}
-
-// touchAndRevise bumps the entry's updated_at and records a revision
-// whose snapshot includes the attachment list after the change —
-// attach/detach are changes to the entry, and every change is kept.
-func (s *Store) touchAndRevise(ctx context.Context, tx pgx.Tx, k *domain.Knowledge, change string, actor domain.Actor) error {
-	// NowStored, like every other write path: time.Now()'s nanoseconds do
-	// not survive the round trip through timestamptz, so the revision
-	// snapshot would carry a version the stored row never had (design
-	// doc 0030).
-	k.UpdatedAt = NowStored()
-	// deleted_at IS NULL, as on every other write: the entry was read
-	// outside this transaction, so a delete can land in the window, and
-	// an attachment plus its revision planted on a tombstone would
-	// resurface whenever someone revived the entry.
-	tag, err := tx.Exec(ctx,
-		`UPDATE object SET updated_at=$2 WHERE id=$1 AND deleted_at IS NULL`, k.ID, k.UpdatedAt)
-	if err != nil {
-		return err
-	}
-	if tag.RowsAffected() == 0 {
-		return ErrNotFound
-	}
-	atts, err := listAttachmentsTx(ctx, tx, k.ID)
-	if err != nil {
-		return err
-	}
-	k.Files = atts
-	return s.addRevision(ctx, tx, k, change, actor)
-}
-
-// listAttachmentsTx reads the file list inside the writing transaction,
-// so the revision snapshot sees the change it records.
-func listAttachmentsTx(ctx context.Context, tx pgx.Tx, id string) ([]domain.File, error) {
-	rows, err := tx.Query(ctx, `SELECT `+fileCols+`
-		FROM object k JOIN object f ON `+attributedTo+`
-		WHERE k.id=$1 ORDER BY f.path`, id)
-	if err != nil {
-		return nil, err
-	}
-	return pgx.CollectRows(rows, scanFile)
 }
 
 // PutFile writes a file object at a bundle path, replacing whatever file

--- a/internal/store/attachment_search_integration_test.go
+++ b/internal/store/attachment_search_integration_test.go
@@ -93,7 +93,7 @@ func TestIntegrationAttachmentSearch(t *testing.T) {
 		_ = s.SoftDelete(ctx, a.ID, actor, nil)
 		_ = s.SoftDelete(ctx, b.ID, actor, nil)
 	}()
-	if _, err := s.PutAttachment(ctx, a.ID, "sales-seeds.txt", "text/plain", "", []byte("region,amount\n"), actor); err != nil {
+	if _, _, err := s.PutFile(ctx, a.ID+"/sales-seeds.txt", "text/plain", []byte("region,amount\n"), actor); err != nil {
 		t.Fatal(err)
 	}
 
@@ -112,10 +112,10 @@ func TestIntegrationAttachmentSearch(t *testing.T) {
 
 	// Vector: an entry with several attachments surfaces once, scored by
 	// its best match; a worse-matching entry ranks below.
-	if _, err := s.PutAttachment(ctx, a.ID, "notes.txt", "text/plain", "", []byte("misc notes"), actor); err != nil {
+	if _, _, err := s.PutFile(ctx, a.ID+"/notes.txt", "text/plain", []byte("misc notes"), actor); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := s.PutAttachment(ctx, b.ID, "other.txt", "text/plain", "", []byte("other"), actor); err != nil {
+	if _, _, err := s.PutFile(ctx, b.ID+"/other.txt", "text/plain", []byte("other"), actor); err != nil {
 		t.Fatal(err)
 	}
 	for _, e := range []struct {
@@ -155,7 +155,7 @@ func TestIntegrationAttachmentSearch(t *testing.T) {
 
 	// Replacing an attachment invalidates its vector: the row is dropped
 	// in the same transaction, re-embedding is the writer's follow-up.
-	if _, err := s.PutAttachment(ctx, a.ID, "sales-seeds.txt", "text/plain", "", []byte("region,amount,updated\n"), actor); err != nil {
+	if _, _, err := s.PutFile(ctx, a.ID+"/sales-seeds.txt", "text/plain", []byte("region,amount,updated\n"), actor); err != nil {
 		t.Fatal(err)
 	}
 	if n := countEmbeddings(a.ID + "/sales-seeds.txt"); n != 0 {
@@ -166,7 +166,7 @@ func TestIntegrationAttachmentSearch(t *testing.T) {
 	if err := s.UpsertFileEmbedding(ctx, a.ID+"/sales-seeds.txt", "test-model", []float32{1, 0, 0, 0}); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.DeleteAttachment(ctx, a.ID, "sales-seeds.txt", actor); err != nil {
+	if err := s.DeleteFile(ctx, a.ID+"/sales-seeds.txt", actor); err != nil {
 		t.Fatal(err)
 	}
 	if n := countEmbeddings(a.ID + "/sales-seeds.txt"); n != 0 {

--- a/internal/store/blob_integration_test.go
+++ b/internal/store/blob_integration_test.go
@@ -2,10 +2,8 @@ package store
 
 import (
 	"context"
-	"errors"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/na0fu3y/ochakai/internal/domain"
 	"github.com/na0fu3y/ochakai/internal/testdb"
@@ -76,14 +74,14 @@ func TestIntegrationBlobStoreOnly(t *testing.T) {
 
 	// Attach → the bytes live in the blob store, metadata in the blob row.
 	png := append([]byte("\x89PNG\r\n\x1a\n"), []byte("gcs only bytes")...)
-	att, err := s.PutAttachment(ctx, k.ID, "chart.png", "image/png", "", png, actor)
+	att, _, err := s.PutFile(ctx, k.ID+"/chart.png", "image/png", png, actor)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if _, ok := fake.m[att.SHA256]; !ok {
 		t.Error("attach should upload to the blob store")
 	}
-	if _, data, err := s.GetAttachment(ctx, k.ID, "chart.png"); err != nil || string(data) != string(png) {
+	if _, data, err := s.GetFile(ctx, k.ID+"/chart.png"); err != nil || string(data) != string(png) {
 		t.Errorf("attachment did not round-trip: %v", err)
 	}
 
@@ -122,113 +120,12 @@ func TestIntegrationBlobStoreOnly(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer bare.Close()
-	if _, err := bare.PutAttachment(ctx, k.ID, "other.png", "image/png", "", png, actor); err == nil ||
+	if _, _, err := bare.PutFile(ctx, k.ID+"/other.png", "image/png", png, actor); err == nil ||
 		!strings.Contains(err.Error(), "OCHAKAI_GCS_BUCKET") {
 		t.Errorf("attach without a blob store = %v, want config hint", err)
 	}
-	if _, _, err := bare.GetAttachment(ctx, k.ID, "chart.png"); err == nil ||
+	if _, _, err := bare.GetFile(ctx, k.ID+"/chart.png"); err == nil ||
 		!strings.Contains(err.Error(), "OCHAKAI_GCS_BUCKET") {
 		t.Errorf("read without a blob store = %v, want config hint", err)
-	}
-}
-
-// An attach and a delete can be in flight together: PutAttachment reads
-// the entry outside its transaction, so a delete can commit in the window
-// between that read and the write. The attach must lose. Before the guard
-// it wrote the attachment and an "attach" revision onto the tombstone,
-// where they sat invisible until someone revived the entry and got back a
-// file they never attached to the entry they were reviving.
-func TestIntegrationAttachRacingDeleteLoses(t *testing.T) {
-	dbURL := testdb.URL(t)
-	lockLiveAttachments(t, dbURL) // a live file, on a blob fake only this test can read
-	ctx := context.Background()
-	s, err := New(ctx, dbURL, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer s.Close()
-	if err := s.Migrate(ctx, 0); err != nil {
-		t.Fatal(err)
-	}
-	s.UseBlobStore(newFakeBlobStore())
-	actor := domain.Actor{Kind: "human", Name: "test"}
-
-	id := testdb.Unique(t, "it-attach-race-")
-	defer func() {
-		_, _ = s.pool.Exec(ctx, `DELETE FROM attachment WHERE knowledge_id = $1`, id)
-		for _, table := range []string{"knowledge_revision", "object"} {
-			_, _ = s.pool.Exec(ctx, `DELETE FROM `+table+` WHERE id = $1`, id)
-		}
-	}()
-	if err := s.Create(ctx, &domain.Knowledge{
-		Type: domain.TypeTerms, ID: id, Title: id, Status: domain.StatusDraft, CreatedBy: actor,
-	}, false); err != nil {
-		t.Fatal(err)
-	}
-
-	// A delete that has not committed yet: PutAttachment's own read runs
-	// on another connection and still sees a live entry, which is the
-	// window the guard closes.
-	del, err := s.pool.Begin(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = del.Rollback(ctx) }()
-	if _, err := del.Exec(ctx,
-		`UPDATE object SET deleted_at = now(), updated_at = now() WHERE id = $1`, id); err != nil {
-		t.Fatal(err)
-	}
-
-	attached := make(chan error, 1)
-	go func() {
-		png := append([]byte("\x89PNG\r\n\x1a\n"), []byte("racing bytes")...)
-		_, err := s.PutAttachment(ctx, id, "chart.png", "image/png", "", png, actor)
-		attached <- err
-	}()
-
-	// Wait for the attach to reach the entry row and block on the delete.
-	deadline := time.Now().Add(10 * time.Second)
-	for {
-		var waiting int
-		if err := s.pool.QueryRow(ctx,
-			`SELECT count(*) FROM pg_stat_activity
-			  WHERE wait_event_type = 'Lock'
-			    AND (query LIKE '%object%' OR query LIKE '%knowledge%')`).Scan(&waiting); err != nil {
-			t.Fatal(err)
-		}
-		if waiting > 0 {
-			break
-		}
-		select {
-		case err := <-attached:
-			t.Fatalf("attach finished without blocking: %v", err)
-		default:
-		}
-		if time.Now().After(deadline) {
-			t.Fatal("attach never blocked on the delete")
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	if err := del.Commit(ctx); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := <-attached; !errors.Is(err, ErrNotFound) {
-		t.Fatalf("attach racing a delete: got %v, want ErrNotFound", err)
-	}
-	var atts, revs int
-	if err := s.pool.QueryRow(ctx,
-		`SELECT count(*) FROM attachment WHERE knowledge_id = $1`, id).Scan(&atts); err != nil {
-		t.Fatal(err)
-	}
-	if atts != 0 {
-		t.Errorf("refused attach left %d attachment rows on the tombstone", atts)
-	}
-	if err := s.pool.QueryRow(ctx,
-		`SELECT count(*) FROM knowledge_revision WHERE id = $1 AND change = 'add_file'`, id).Scan(&revs); err != nil {
-		t.Fatal(err)
-	}
-	if revs != 0 {
-		t.Errorf("refused attach left %d attach revisions", revs)
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -596,19 +596,6 @@ func (s *Store) GetTombstone(ctx context.Context, id string) (*domain.Knowledge,
 	return s.getOne(ctx, id, true)
 }
 
-// ListLinkingToDocs returns live entries whose links point at id, most
-// recently updated first, with their documents. It is the context pack's
-// reverse edge: a pack delivers its companions as documents, and a
-// companion read without one would come back rendered while the entries
-// beside it came back as written (design doc 0046 §2.2).
-//
-// The reverse lookup a caller can ask for is the LinksTo filter instead
-// — a row there is a projection, and the document would be paid for and
-// dropped.
-func (s *Store) ListLinkingToDocs(ctx context.Context, id string, limit int) ([]domain.Knowledge, error) {
-	return s.listLinkingTo(ctx, id, limit, knowledgeSelectDoc, scanKnowledgeDoc)
-}
-
 // StatementCount reports how many times a statement has taken a
 // connection from the pool since the store opened — one per query, and
 // one per transaction however many statements it runs.
@@ -650,9 +637,17 @@ func (s *Store) GetManyDocs(ctx context.Context, ids []string) (map[string]*doma
 	return out, nil
 }
 
-// LinkersByTargetDocs answers ListLinkingToDocs for several ids at once,
-// grouped by the id linked at and each group ordered and capped exactly
-// as the single-id form is.
+// LinkersByTargetDocs returns, for several ids at once, the live entries
+// whose links point at each one, most recently updated first, with their
+// documents — the context pack's reverse edge: a pack delivers its
+// companions as documents, and a companion read without one would come
+// back rendered while the entries beside it came back as written (design
+// doc 0046 §2.2). Grouped by the id linked at, each group ordered and
+// capped as a single-id lookup would be.
+//
+// The reverse lookup a caller can ask for directly is the LinksTo filter
+// instead — a row there is a projection, and the document would be paid
+// for and dropped.
 //
 // The lateral join is what makes it the same answer rather than a
 // cheaper approximation: a union ordered globally would let one id's
@@ -701,21 +696,6 @@ func scanKnowledgeDocForTarget(row pgx.CollectableRow) (targetedKnowledge, error
 		return t, err
 	}
 	return t, finish()
-}
-
-func (s *Store) listLinkingTo(ctx context.Context, id string, limit int, cols string,
-	scan func(pgx.CollectableRow) (domain.Knowledge, error),
-) ([]domain.Knowledge, error) {
-	rows, err := s.pool.Query(ctx,
-		`SELECT `+cols+` FROM object
-		 WHERE deleted_at IS NULL AND links @> $1
-		 ORDER BY updated_at DESC LIMIT $2`,
-		fmt.Sprintf(`[{"target": %q}]`, id),
-		limit)
-	if err != nil {
-		return nil, err
-	}
-	return pgx.CollectRows(rows, scan)
 }
 
 // Create inserts a new entry. A live entry with the same id is
@@ -1090,8 +1070,8 @@ func (s *Store) SoftDelete(ctx context.Context, id string, actor domain.Actor, i
 // single call erases history, and the entry stays recoverable (Create
 // revives it) right up until someone deliberately asks for it to be gone.
 //
-// Attachment bytes are not touched here, as DeleteAttachment does not
-// touch them: blobs are content-addressed and shared between entries, so
+// Attachment bytes are not touched here, as DeleteFile does not touch
+// them: blobs are content-addressed and shared between entries, so
 // reclaiming them cannot be a side effect of one purge. SweepBlobs
 // (sweep.go) is the global answer, and the service runs it after this
 // commit — the bytes' erasure is part of what a purge promises (design

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -728,7 +728,7 @@ func TestIntegrationMove(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if _, err := s.PutAttachment(ctx, "it-move-src/metric", "chart.png", "image/png", "", []byte("png"), actor); err != nil {
+	if _, _, err := s.PutFile(ctx, "it-move-src/metric/chart.png", "image/png", []byte("png"), actor); err != nil {
 		t.Fatal(err)
 	}
 	if err := s.UpsertEmbedding(ctx, "it-move-src/metric", "test-model", []float32{1, 0, 0, 0}, false); err != nil {
@@ -846,8 +846,8 @@ func TestIntegrationMove(t *testing.T) {
 
 	// Leave no live attachment behind: its bytes exist only in this
 	// test's fake blob store, and export scans every live attachment.
-	if err := s.DeleteAttachment(ctx, "it-move-dst/metric", "chart.png", actor); err != nil {
-		t.Fatalf("cleanup DeleteAttachment: %v", err)
+	if err := s.DeleteFile(ctx, "it-move-dst/metric/chart.png", actor); err != nil {
+		t.Fatalf("cleanup DeleteFile: %v", err)
 	}
 }
 
@@ -955,8 +955,8 @@ func TestIntegrationCreateRevivesSoftDeleted(t *testing.T) {
 	}
 }
 
-// Attachments (design doc 0008): content-addressed blobs, replace-by-name,
-// revisions on attach/detach, and disappearance with the soft-deleted entry.
+// Attachments (design doc 0008): content-addressed blobs, replace-by-path,
+// and disappearance from the entry's listing with the soft-deleted entry.
 func TestIntegrationAttachments(t *testing.T) {
 	dbURL := testdb.URL(t)
 	lockLiveAttachments(t, dbURL)
@@ -1002,26 +1002,27 @@ func TestIntegrationAttachments(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	path := k.ID + "/weekly.png"
 	png := append([]byte("\x89PNG\r\n\x1a\n"), []byte("fake image bytes")...)
-	att, err := s.PutAttachment(ctx, k.ID, "weekly.png", "image/png", "", png, actor)
+	att, _, err := s.PutFile(ctx, path, "image/png", png, actor)
 	if err != nil {
-		t.Fatalf("PutAttachment: %v", err)
+		t.Fatalf("PutFile: %v", err)
 	}
 	if att.Size != int64(len(png)) || att.SHA256 == "" {
 		t.Errorf("attachment metadata wrong: %+v", att)
 	}
 
-	got, data, err := s.GetAttachment(ctx, k.ID, "weekly.png")
+	got, data, err := s.GetFile(ctx, path)
 	if err != nil {
-		t.Fatalf("GetAttachment: %v", err)
+		t.Fatalf("GetFile: %v", err)
 	}
 	if string(data) != string(png) || got.MediaType != "image/png" {
 		t.Errorf("bytes did not round-trip: %+v", got)
 	}
 
-	// Replace by name: same entry, same name, new bytes.
+	// Replace by path: same entry, same path, new bytes.
 	png2 := append([]byte("\x89PNG\r\n\x1a\n"), []byte("updated bytes")...)
-	if _, err := s.PutAttachment(ctx, k.ID, "weekly.png", "image/png", "", png2, actor); err != nil {
+	if _, _, err := s.PutFile(ctx, path, "image/png", png2, actor); err != nil {
 		t.Fatal(err)
 	}
 	list, err := s.ListAttachments(ctx, k.ID)
@@ -1043,38 +1044,24 @@ func TestIntegrationAttachments(t *testing.T) {
 		t.Errorf("blob count = %d, want 2", blobs)
 	}
 
-	// Attach/detach are revisions on the entry.
-	if err := s.DeleteAttachment(ctx, k.ID, "weekly.png", actor); err != nil {
-		t.Fatalf("DeleteAttachment: %v", err)
+	if err := s.DeleteFile(ctx, path, actor); err != nil {
+		t.Fatalf("DeleteFile: %v", err)
 	}
-	var changes []string
-	rows, err := s.pool.Query(ctx,
-		`SELECT change FROM knowledge_revision WHERE id=$1 ORDER BY rev`, k.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer rows.Close()
-	for rows.Next() {
-		var c string
-		if err := rows.Scan(&c); err != nil {
-			t.Fatal(err)
-		}
-		changes = append(changes, c)
-	}
-	want := []string{"create", "add_file", "add_file", "remove_file"}
-	if len(changes) != len(want) {
-		t.Fatalf("revisions = %v, want %v", changes, want)
+	if list, err := s.ListAttachments(ctx, k.ID); err != nil || len(list) != 0 {
+		t.Errorf("attachments after delete = %+v, %v, want none", list, err)
 	}
 
-	// Attachments of soft-deleted entries are unreachable.
-	if _, err := s.PutAttachment(ctx, k.ID, "weekly.png", "image/png", "", png, actor); err != nil {
+	// Attachments of soft-deleted entries drop out of the entry's listing,
+	// even though the file object itself is untouched (0046 §3.3: it is
+	// the entry's namespace that stops claiming it).
+	if _, _, err := s.PutFile(ctx, path, "image/png", png, actor); err != nil {
 		t.Fatal(err)
 	}
 	if err := s.SoftDelete(ctx, k.ID, actor, nil); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := s.GetAttachment(ctx, k.ID, "weekly.png"); !errors.Is(err, ErrNotFound) {
-		t.Errorf("attachment of a deleted entry = %v, want ErrNotFound", err)
+	if list, err := s.ListAttachments(ctx, k.ID); err != nil || len(list) != 0 {
+		t.Errorf("attachments of a deleted entry = %+v, %v, want none", list, err)
 	}
 }
 
@@ -1237,7 +1224,7 @@ func TestIntegrationSearchTextFollowsAttachmentsAndMoves(t *testing.T) {
 		}
 	}
 
-	if _, err := s.PutAttachment(ctx, id, "seeds.txt", "text/plain", "", []byte("x"), actor); err != nil {
+	if _, _, err := s.PutFile(ctx, id+"/seeds.txt", "text/plain", []byte("x"), actor); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(searchText(id), "seeds.txt") {
@@ -1255,7 +1242,7 @@ func TestIntegrationSearchTextFollowsAttachmentsAndMoves(t *testing.T) {
 		t.Errorf("move dropped the attachment name from search_text: %q", after)
 	}
 
-	if err := s.DeleteAttachment(ctx, moved, "seeds.txt", actor); err != nil {
+	if err := s.DeleteFile(ctx, moved+"/seeds.txt", actor); err != nil {
 		t.Fatal(err)
 	}
 	if strings.Contains(searchText(moved), "seeds.txt") {
@@ -3066,11 +3053,10 @@ func TestIntegrationFilesAreObjectsAttributedByPathOrBody(t *testing.T) {
 	if err := s.Create(ctx, k, false); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := s.PutAttachment(ctx, id, "chart.png", "image/png", "", []byte("png"), actor); err != nil {
+	if _, _, err := s.PutFile(ctx, id+"/chart.png", "image/png", []byte("png"), actor); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := s.PutAttachment(ctx, id, "orders.csv", "text/plain",
-		base+"/seeds/orders.csv", []byte("a,b\n"), actor); err != nil {
+	if _, _, err := s.PutFile(ctx, base+"/seeds/orders.csv", "text/plain", []byte("a,b\n"), actor); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3130,7 +3116,7 @@ func TestIntegrationFilesAreObjectsAttributedByPathOrBody(t *testing.T) {
 	}
 
 	// Detaching takes the object with it, and the entry stops naming it.
-	if err := s.DeleteAttachment(ctx, id, "orders.csv", actor); err != nil {
+	if err := s.DeleteFile(ctx, base+"/seeds/orders.csv", actor); err != nil {
 		t.Fatal(err)
 	}
 	if err := s.pool.QueryRow(ctx,
@@ -3290,7 +3276,7 @@ func TestIntegrationAFileReportsItsPath(t *testing.T) {
 	if err := s.Create(ctx, k, false); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := s.PutAttachment(ctx, id, "chart.png", "image/png", "", []byte("png"), actor); err != nil {
+	if _, _, err := s.PutFile(ctx, id+"/chart.png", "image/png", []byte("png"), actor); err != nil {
 		t.Fatal(err)
 	}
 	if _, _, err := s.PutFile(ctx, base+"/seeds/orders.csv", "text/plain", []byte("a,b\n"), actor); err != nil {

--- a/internal/store/sweep.go
+++ b/internal/store/sweep.go
@@ -27,13 +27,13 @@ import (
 // the file bytes in the bucket forever.
 
 // blobLockID keys the advisory lock the sweep and the file writers
-// share. The race it closes: PutFile and PutAttachment upload bytes
-// create-only and read "already there" as success, so a sweep running
-// between that upload and the commit of the row referencing it would
-// erase bytes a row is about to name. Writers therefore hold the lock
-// shared (they can run beside each other) for the span from upload to
-// commit, and the sweep holds it exclusive. The value is arbitrary and
-// only has to be one thing in one place.
+// share. The race it closes: PutFile uploads bytes create-only and
+// reads "already there" as success, so a sweep running between that
+// upload and the commit of the row referencing it would erase bytes a
+// row is about to name. Writers therefore hold the lock shared (they
+// can run beside each other) for the span from upload to commit, and
+// the sweep holds it exclusive. The value is arbitrary and only has to
+// be one thing in one place.
 const blobLockID int64 = 0xb10b // "blob", squinting
 
 // lockBlobsShared marks tx as a writer the sweep must not run beside.

--- a/internal/store/sweep_integration_test.go
+++ b/internal/store/sweep_integration_test.go
@@ -57,7 +57,7 @@ func TestIntegrationSweepBlobs(t *testing.T) {
 	sum := sha256.Sum256(data)
 	sha := hex.EncodeToString(sum[:])
 	for _, k := range []*domain.Knowledge{a, b} {
-		if _, err := s.PutAttachment(ctx, k.ID, "seed.txt", "text/plain", "", data, actor); err != nil {
+		if _, _, err := s.PutFile(ctx, k.ID+"/seed.txt", "text/plain", data, actor); err != nil {
 			t.Fatal(err)
 		}
 	}


### PR DESCRIPTION
Closes #606.

## Summary

- Deletes the (id, name) attachment API on `internal/store`
  (`PutAttachment`/`GetAttachment`/`GetAttachmentMeta`/`DeleteAttachment`,
  `ExportAttachment`, and the private helpers `touchAndRevise`,
  `listAttachmentsTx`, `filePath`) — reachable only from `_test.go`
  since 0075/migration 0029 moved file addressing to bundle paths and
  the codebase moved onto `PutFile`/`GetFile`/`GetFileMeta`/`DeleteFile`.
- Migrates the store integration tests onto the path-based API.
- Clears the orphaned domain helpers the issue flagged, judged per item
  (see the commit message for the full reasoning): `ValidRuling`
  deleted, `ValidateFile` wired into `okf/file.go`'s `attach()` in
  place of its hand-rolled equivalent, `BuiltinType` and
  `Link.DisplayText` kept (real callers/invariants, and `DisplayText`'s
  false doc comment is now fixed), `store.ListLinkingToDocs` and its
  private `listLinkingTo` helper deleted (superseded by
  `LinkersByTargetDocs` and the `LinksTo` filter), and a stale
  `service.PutFile` doc comment ("Attach's counterpart" — `Service.Attach`
  doesn't exist) fixed.

## A real behavior gap this surfaced

Attach/detach used to bump the *owning entry's* `updated_at` and record
an *entry* revision (`touchAndRevise`, only reachable through the
now-deleted `PutAttachment`/`DeleteAttachment`). `PutFile`/`DeleteFile`
never did this — they only ever touched the file's own revision. That
gap was already live in production before this PR; removing the dead
code just stops testing a guarantee nothing has offered since the 0075
migration. Two tests couldn't be ported as-is because of this:

- `TestIntegrationAttachRacingDeleteLoses` guarded a race specific to
  `PutAttachment` reading the owning entry before writing. `PutFile`
  never reads the owning entry, so there's nothing left to race.
  Removed.
- `TestIntegrationAttachments`'s revision-count assertions tested the
  same entry-revision bump. Replaced with assertions against
  `ListAttachments` (dedup on replace-by-path, disappearance from the
  entry's listing on delete and on the owning entry's soft-delete),
  which still holds today.

## No design doc

Nothing here is observable from outside the process (0048) — this is
internal Go API only; REST/CLI/MCP/web-UI surface is unchanged.

## Test plan

- [x] `scripts/check --db` (core, ui, lint, vuln) — all green.