### PR TITLE
Finish the two verification residuals: example bodies missing their required code, and positioning still pre-0086

### DIFF
--- a/.claude/skills/design-doc/SKILL.md
+++ b/.claude/skills/design-doc/SKILL.md
@@ -49,8 +49,9 @@ Two decisions to check any proposal against first:
 
 - **No LLM inside, no SQL execution** (0081). Interpretation and
   execution belong to the client agent.
-- **Google Cloud only, secret-zero** (0065, 0003). Cloud Run IAM + Cloud
-  SQL IAM; no tokens, no passwords.
+- **Secret-zero** (0065, 0003). Cloud Run IAM + Cloud SQL IAM on Google
+  Cloud, in-process OIDC verification off it (0086); no tokens, no
+  passwords.
 
 ## Steps
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,8 +2,9 @@
 
 ochakai is a knowledge store for data-analysis agents. Two decisions
 frame everything: no LLM inside and no SQL execution (0081), and
-Google Cloud only with zero secrets — Cloud Run IAM + Cloud SQL IAM,
-never tokens or passwords (0065, 0003).
+zero secrets — Cloud Run IAM + Cloud SQL IAM on Google Cloud,
+in-process OIDC verification off it (0086), never tokens or passwords
+(0065, 0003).
 
 ## Design docs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -744,8 +744,10 @@ Two decisions worth knowing before proposing features:
 - **No LLM inside, no SQL execution.** ochakai stores and serves
   knowledge; interpretation and execution belong to the client agent
   (0081).
-- **Google Cloud only, secret-zero.** Auth is Cloud Run IAM + Cloud SQL
-  IAM; features must not introduce tokens or passwords (0065, 0003).
+- **Secret-zero.** Auth is Cloud Run IAM + Cloud SQL IAM on Google
+  Cloud, or in-process verification against an OIDC issuer's published
+  keys off it (0086); features must not introduce tokens or passwords
+  (0065, 0003).
 
 ## Translating a manual page
 

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ ochakai loses, and says who should pick something else.
 
 - **Google Cloud**, recommended: Cloud Run IAM and Cloud SQL IAM are how
   ochakai holds no secret of its own without any configuration. Off
-  Google Cloud, naming your own OpenID Connect issuer
+  Google Cloud, naming your own OpenID Connect (OIDC) issuer
   ([0086](docs/design/0086-a-second-way-to-say-who-is-calling.md)) is a
   second, supported authentication path — ochakai verifies the bearer
   token itself against the issuer's published keys, which introduces no

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -106,7 +106,7 @@ it.
   "a second authentication path" until 2026-08, when
   [0086](docs/design/0086-a-second-way-to-say-who-is-calling.md) found one
   that costs secret-zero nothing: a deployment can name its own OpenID
-  Connect issuer and verify bearer tokens itself, against the issuer's
+  Connect (OIDC) issuer and verify bearer tokens itself, against the issuer's
   published public keys, with nothing to issue or rotate there either. The
   goal was always secret-zero
   ([0065](docs/design/0065-identity-and-provenance.md),

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -467,18 +467,22 @@ paths:
                   summary: q and sort are mutually exclusive
                   value:
                     error: sort=usage lists concepts; it cannot be combined with a search query (q)
+                    code: invalid
                 noQuery:
                   summary: Neither q nor sort was given
                   value:
                     error: search needs a query; use sort=verified_at|usage|failed|stale_after to list concepts without one, or source=URI to list what cites a resource
+                    code: invalid
                 cursorOnSearch:
                   summary: A ranking has no next page
                   value:
                     error: "a search is bounded by limit and has no next page: its ranking is a fused window, not an order to resume from — narrow it with filters, or walk a listing with sort=verified_at|usage|failed|stale_after"
+                    code: invalid
                 cursorFromAnotherListing:
                   summary: The cursor belongs to a different order
                   value:
                     error: cursor belongs to the usage listing; it cannot resume the failed one
+                    code: invalid
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
         "405": { $ref: "#/components/responses/Error" }
@@ -816,6 +820,7 @@ paths:
                 required: [error, code]
               example:
                 error: "files are not supported without GCS: set OCHAKAI_GCS_BUCKET (design doc 0013)"
+                code: unsupported
         "409":
           description: >
             The path was read as a thing it is not. A reserved name was
@@ -849,6 +854,7 @@ paths:
                   index.md is generated from the bundle, not stored in it
                   (design doc 0046 §§3.7-3.8), so there is no subtree here
                   to archive; ask the directory it sits in
+                code: invalid
         "404":
           description: No object at this path.
           headers:
@@ -863,6 +869,7 @@ paths:
                 required: [error, code]
               example:
                 error: no object at this path
+                code: not_found
         "405": { $ref: "#/components/responses/Error" }
         "500": { $ref: "#/components/responses/Error" }
     put:
@@ -1056,6 +1063,7 @@ paths:
                 required: [error, code]
               example:
                 error: index.md is generated from the bundle, not stored in it (design doc 0046 §§3.7-3.8)
+                code: invalid
         "405": { $ref: "#/components/responses/Error" }
         "500": { $ref: "#/components/responses/Error" }
     delete:
@@ -1810,10 +1818,12 @@ paths:
                   summary: A ruling outside the vocabulary
                   value:
                     error: 'ruling must be one of verified, rejected, withdrawn, not "approved"'
+                    code: invalid
                 noteOnVerification:
                   summary: A note belongs to a rejection
                   value:
                     error: 'a verification carries no note: "verified" says the concept is right as it stands, and anything to say about it belongs in the concept. Use ruling=rejected to record a reason'
+                    code: invalid
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
         "404": { $ref: "#/components/responses/Error" }
@@ -1833,6 +1843,7 @@ paths:
                 required: [error, code]
               example:
                 error: knowledge carries no rejection to withdraw
+                code: no_rejection
         "413": { $ref: "#/components/responses/Error" }
         "405": { $ref: "#/components/responses/Error" }
         "500": { $ref: "#/components/responses/Error" }
@@ -2434,10 +2445,12 @@ components:
               summary: A write against a read-only deployment
               value:
                 error: "this ochakai is read-only: it serves knowledge but does not change it"
+                code: read_only
             notADelegator:
               summary: Ochakai-On-Behalf-Of from a caller not permitted to delegate
               value:
                 error: "auth: Ochakai-On-Behalf-Of: app@example.iam.gserviceaccount.com is not permitted to act on behalf of others (add it to OCHAKAI_DELEGATING_CALLERS)"
+                code: forbidden
   schemas:
     Type:
       type: string

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -282,10 +282,14 @@ vault が持たないのは、ファイル形式でないすべてである:
 - **インフラ。** vault を立てるのはただである。ochakai は Google Cloud
   プロジェクトと Postgres を要る — 月 $10 ほどだが、ゼロではないし、
   5 分でもない。
-- **Google Cloud のみ。** C2 の secret-zero という性質は Cloud Run IAM
-  と Cloud SQL IAM で買われており、他所で本番を動かすサポートされた方法
-  は無い([0003](design/0003-gcp-only.md))。多くのチームにとってこれは
-  失格要件であり、そしてそれは欠落ではなく決定である。
+- **Google Cloud 推奨、外は認証だけ。** C2 の secret-zero という性質は
+  Cloud Run IAM と Cloud SQL IAM で無設定に買われている
+  ([0003](design/0003-gcp-only.md))。外で動かす道は認証には開いた —
+  OIDC 発行者を名指せば ochakai が公開鍵で自分で検証し、secret は
+  増えない([0086](design/0086-a-second-way-to-say-who-is-calling.md))
+  — が、埋め込みは Vertex AI か無いかで検索は lexical のみになり、
+  データベースの資格情報は運用者の仕事に戻る。失格要件が一つ消えた
+  だけで、Google Cloud の外が快適になったわけではない。
 - **認可が無い。** デプロイに到達できる者は、すべてを読み書きできる
   ([0065](design/0065-identity-and-provenance.md) §1)。concept ごとの
   権限が要るなら、これは間違った道具である。


### PR DESCRIPTION
## What and why

The post-merge verification of #613–#624 found two residuals worth fixing before the release; this closes both. (The third finding — 26 bytes of MCP-BYTES headroom — is deliberately left for the next schema-touching change.)

**1. The thirteen error examples violated the schemas #614 tightened** (`api/openapi.yaml`). #614 made `code` required beside `error` on the inline error responses, and their `example`/`examples` bodies still carried only the sentence — every one of them stopped satisfying the schema printed beside it. No test validates examples against schemas so CI stayed green, but a spec linter flags them all, and an example is the part of a contract somebody copies. Each gains the code its response declares and its site actually sends (`invalid`, `unsupported`, `not_found`, `no_rejection`, `read_only`, `forbidden`). Examples are prose to the frozen fingerprint, so no golden moves.

**2. `docs/positioning.md` still argued the position #617 retracted.** The README now states the OIDC path (0086); the Japanese positioning page the manual's index links still said 「他所で本番を動かすサポートされた方法は無い」, so the two front doors contradicted each other. The bullet now tells the honest post-0086 trade: secret-zero is configuration-free on Google Cloud, the way out exists for authentication alone with no secret introduced, and off Google Cloud search is lexical-only with database credentials back on the operator — one disqualifier removed, not comfort gained. The contributor-facing shorthand moves with it (CLAUDE.md, CONTRIBUTING's design-principles bullet, the design-doc skill): the invariant to hold proposals against is **secret-zero**, with two verification paths under it. README and ROADMAP also spell the acronym **OIDC** once beside the full name, so the term an operator searches for lands (issue #603's own acceptance grep).

## Checks

- [x] `scripts/check core lint` is clean; the store-dependent tests are untouched by this diff (docs and contract examples only) and CI runs them against pgvector/pg17
- [x] No behavior changes — no new tests owed

## Surfaces and contract

- [x] `api/openapi.yaml` changes are example bodies only; `internal/restapi`, `internal/mcpserver`, `internal/apiclient` are untouched and stay in sync
- [x] Nothing lands on or leaves any surface; docs pages keep their language (positioning stays Japanese, front door stays English)
- [x] `api/openapi.frozen.txt` is untouched — examples are deliberately outside the fingerprint
- [x] No surface widens; `docs/surface.md` counts are unmoved (DOC-LINES stays under its ceiling with positioning's +4)

## Design docs

- [x] No decision changes — both fixes finish the paper trail of already-recorded decisions (0083's `code`, 0086's second path)
- [x] Commit messages and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRNu5r95mLSh8dY5XXoGwT

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRNu5r95mLSh8dY5XXoGwT)_