### PR TITLE
Finish the web UI's Japanese: the toasts, the tiles, and the dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,8 +192,8 @@ last entry.
   carries it too**, at `knowledge.plan`, and that surface has no headers
   at all: an agent writing knowledge back had no way to tell a
   replacement from a write that changed nothing without reading the
-  concept again. The bundled web UI stops saying *Saved.* after a write
-  that stored nothing.
+  concept again. The bundled web UI stops saying *保存しました。* after a
+  write that stored nothing.
 
   **The headers stay.** Removing them is not available: design doc 0082
   §2 puts header names inside the frozen address space, so that half is
@@ -696,13 +696,25 @@ last entry.
   reader the product is aimed at was reading a Japanese page about an
   English screen. The pages are translated — the navigation, the forms,
   the banners, the empty states, the feed explanations, the placeholders
-  and the titles — and the page declares `lang="ja"`. **What is left is
-  named rather than implied**: the toast every action answers with, the
-  stat-tile labels on the usage and review views, `load more`, and the
-  editor's two buttons are still English, so the screen a reader meets
-  is Japanese and the screen that answers them is not yet. Finishing
-  that is its own change, because the words an action says back are the
-  ones worth a maintainer's eye rather than a bulk pass.
+  and the titles — and the page declares `lang="ja"`.
+
+  **The words the page says back are translated too**, in a second pass
+  rather than the same bulk one, because a toast is read at the moment
+  somebody is deciding whether their write landed: every action toast
+  and confirmation (saving, verifying, rejecting, moving, deleting,
+  attaching), every failure banner, the stat-tile labels on the usage
+  and review views, `load more`, the editor's two buttons, the
+  provenance line that says who created and confirmed a concept, and
+  the relative dates (今日 / 昨日 / N 日前). With them went two the
+  page was contradicting itself over: the search bar's three filter
+  chips, which said `verification age`, `reported wrong` and `stale`
+  while the feed banner above them told the reader to uncheck
+  検証の古さ, 間違いと報告された and 期限切れ — and the review page's
+  stale toggle, named in Japanese prose and drawn in English. What
+  stays in Latin script is the contract's own vocabulary, because it is
+  what the API answers and what the page filters on: the lifecycle
+  values (`draft`, `stable`, `deprecated`), the trust tiers, the
+  rulings, the OKF type names, and `concept` itself.
 
   Nothing else moved: no
   route, no id, no `data-` marker, no API call, and the tests that pin

--- a/internal/webui/jstest/format.test.js
+++ b/internal/webui/jstest/format.test.js
@@ -42,7 +42,9 @@ test('an actor never loses who it was acting through', () => {
   assert.equal(actorStr({ kind: 'human', name: 'a@b' }), '👤 a@b');
   assert.equal(actorStr({ kind: 'process', name: 'sa@p' }), '🤖 sa@p');
   assert.equal(actorStr({ kind: 'process', name: 'sa@p', via: 'a@b', producer: 'claude/1' }),
-    '🤖 sa@p via a@b using claude/1');
+    '🤖 sa@p(a@b 経由・claude/1 使用)');
+  assert.equal(actorStr({ kind: 'process', name: 'sa@p', via: 'a@b' }), '🤖 sa@p(a@b 経由)');
+  assert.equal(actorStr({ kind: 'process', name: 'sa@p', producer: 'claude/1' }), '🤖 sa@p(claude/1 使用)');
   assert.equal(actorStr(null), '');
   assert.equal(actorStr({ kind: 'human' }), '');
 });
@@ -59,9 +61,9 @@ test('trust defaults to unverified, and the newest verification wins', () => {
 
 test('an age reads as a person would say it', () => {
   assert.equal(fmtAge(null), '');
-  assert.equal(fmtAge(0), 'today');
-  assert.equal(fmtAge(1), 'yesterday');
-  assert.equal(fmtAge(9), '9 days ago');
+  assert.equal(fmtAge(0), '今日');
+  assert.equal(fmtAge(1), '昨日');
+  assert.equal(fmtAge(9), '9 日前');
   assert.equal(daysSince(null), null);
   assert.equal(daysSince('not a date'), null);
   assert.equal(daysSince(new Date(Date.now() - 3 * 86400000).toISOString()), 3);

--- a/internal/webui/static/index.html
+++ b/internal/webui/static/index.html
@@ -29,7 +29,7 @@
 </head>
 <body>
 <header class="topbar">
-  <button id="side-toggle" title="Show / hide the knowledge tree" aria-label="サイドバーの開閉">☰</button>
+  <button id="side-toggle" title="ナレッジのツリーの開閉" aria-label="サイドバーの開閉">☰</button>
   <a class="brand" href="#/">🍵 ochakai</a>
   <nav class="topnav" id="topnav" aria-label="主なページ">
     <a href="#/search" data-route="search">検索</a>

--- a/internal/webui/static/js/actions.js
+++ b/internal/webui/static/js/actions.js
@@ -17,7 +17,7 @@ export async function moveEntry(from, to) {
   if (!to || to === from) return false;
   try {
     const moved = await api('/api/v1/move', { method: 'POST', body: { from, to } });
-    toast(`Moved to ${moved.id}.`);
+    toast(`${moved.id} へ移動しました。`);
     refreshTree();
     // If the moved entry is on screen, follow it to its new address.
     const m = location.hash.match(/^#\/(?:k|edit)\/(.+)$/);
@@ -26,7 +26,7 @@ export async function moveEntry(from, to) {
     }
     return true;
   } catch (e) {
-    toast('Move failed: ' + e.message);
+    toast('移動に失敗しました: ' + e.message);
     return false;
   }
 }
@@ -88,7 +88,7 @@ export async function moveEntry(from, to) {
     dragId = null;
     const to = prefix + from.split('/').pop();
     if (to === from) return; // dropped on its own directory
-    if (confirm(`Move ${from} → ${to}?\nこの concept を指している参照は書き換えられ、履歴も付いていきます。`)) {
+    if (confirm(`${from} → ${to} へ移動しますか?\nこの concept を指している参照は書き換えられ、履歴も付いていきます。`)) {
       moveEntry(from, to);
     }
   });

--- a/internal/webui/static/js/api.js
+++ b/internal/webui/static/js/api.js
@@ -52,7 +52,7 @@ export async function downloadBundle(e) {
   e.preventDefault();
   const res = await fetch(BASE + '/api/v1/bundle/', { headers: { Accept: 'application/gzip' } });
   if (!res.ok) {
-    toast('Export failed: ' + res.status);
+    toast('書き出しに失敗しました: ' + res.status);
     return;
   }
   const url = URL.createObjectURL(await res.blob());

--- a/internal/webui/static/js/cards.js
+++ b/internal/webui/static/js/cards.js
@@ -48,12 +48,11 @@ export function hitCard(h) {
 
 export function dirCard(prefix, d) {
   const href = dirHash(prefix + d.name);
-  const noun = d.count === 1 ? 'concept' : 'concepts';
   return `<article class="card" data-href="${href}">
     <div class="head">
       <span class="type-ico">📁</span>
       <a class="title mono" href="${href}">${esc(d.name)}/</a>
-      <span class="count">${d.count} ${noun}</span>
+      <span class="count">concept ${d.count} 件</span>
     </div>
   </article>`;
 }

--- a/internal/webui/static/js/format.js
+++ b/internal/webui/static/js/format.js
@@ -20,8 +20,9 @@ export function fmtDate(s) {
 // doc 0052).
 export function actorStr(a) {
   if (!a || !a.name) return '';
+  const notes = [a.via ? a.via + ' 経由' : '', a.producer ? a.producer + ' 使用' : ''].filter(Boolean);
   return (a.kind === 'human' ? '👤 ' : '🤖 ') + a.name +
-    (a.via ? ' via ' + a.via : '') + (a.producer ? ' using ' + a.producer : '');
+    (notes.length ? '(' + notes.join('・') + ')' : '');
 }
 // The ledgers a read carries beside the document (design doc 0043
 // §§3.2-3.3). Verification is plural and stored oldest-first, so the
@@ -44,9 +45,9 @@ export function daysSince(s) {
 }
 export function fmtAge(days) {
   if (days === null) return '';
-  if (days <= 0) return 'today';
-  if (days === 1) return 'yesterday';
-  return days + ' days ago';
+  if (days <= 0) return '今日';
+  if (days === 1) return '昨日';
+  return days + ' 日前';
 }
 export function fmtSize(n) {
   if (!n && n !== 0) return '';

--- a/internal/webui/static/js/queues.js
+++ b/internal/webui/static/js/queues.js
@@ -26,7 +26,7 @@ export async function refreshQueues() {
   const total = waiting ? waiting.drafts + waiting.failed + waiting.stale_after : 0;
   badge.textContent = total;
   badge.hidden = !total;
-  badge.title = total ? `${total} waiting: ${waiting.drafts} drafts, ${waiting.failed} reported wrong, ${waiting.stale_after} past their expiry` : '';
+  badge.title = total ? `${total} 件が待っています: draft ${waiting.drafts}、間違いと報告された ${waiting.failed}、期限切れ ${waiting.stale_after}` : '';
   const strip = $('#queue-strip');
   if (strip) strip.innerHTML = queueStrip();
 }
@@ -38,9 +38,9 @@ export async function refreshQueues() {
 export function queueStrip() {
   if (!waiting) return '';
   return [
-    ['#/review', waiting.drafts, waiting.drafts === 1 ? 'draft' : 'drafts'],
-    ['#/search/reported-wrong', waiting.failed, 'reported wrong'],
-    ['#/search/stale', waiting.stale_after, 'past expiry'],
+    ['#/review', waiting.drafts, 'draft'],
+    ['#/search/reported-wrong', waiting.failed, '間違いと報告された'],
+    ['#/search/stale', waiting.stale_after, '期限切れ'],
   ].map(([href, n, label]) =>
-    `<a class="badge${n ? ' draft' : ''}" href="${href}">${n} ${label}</a>`).join(' ');
+    `<a class="badge${n ? ' draft' : ''}" href="${href}">${label} ${n}</a>`).join(' ');
 }

--- a/internal/webui/static/js/tree.js
+++ b/internal/webui/static/js/tree.js
@@ -41,7 +41,7 @@ export async function refreshTree() {
     else if (dm) revealInTree(dm[1].split('/').map(decodeURIComponent).join('/').replace(/\/*$/, '/'));
     else markTreeSelection();
   } catch (e) {
-    tree.innerHTML = `<div class="error-banner" role="alert">Tree failed: ${esc(e.message)}</div>`;
+    tree.innerHTML = `<div class="error-banner" role="alert">ツリーを読み込めませんでした: ${esc(e.message)}</div>`;
   }
 }
 $('#tree-refresh').addEventListener('click', refreshTree);
@@ -107,13 +107,13 @@ export function loadNode(d) {
       const body = levelHTML(res, prefix);
       const note = res.truncated
         ? `<div class="truncation-note">この階層の先頭 1000 concept を表示 — これだけ広いディレクトリは
-           better split into subdirectories.</div>` : '';
+           サブディレクトリに分けたほうがよいでしょう。</div>` : '';
       box.innerHTML = (body + note) || '<div class="empty">空です。</div>';
       wireNodes(box);
       markTreeSelection();
     } catch (e) {
       d._load = null; // reopen retries
-      box.innerHTML = `<div class="error-banner" role="alert">Load failed: ${esc(e.message)}</div>`;
+      box.innerHTML = `<div class="error-banner" role="alert">読み込みに失敗しました: ${esc(e.message)}</div>`;
     }
   })();
   return d._load;

--- a/internal/webui/static/js/views/detail.js
+++ b/internal/webui/static/js/views/detail.js
@@ -26,6 +26,18 @@ export function resourceHTML(ref) {
 
 export const windowText = w => w && (w.from || w.to) ? `${w.from || '…'} → ${w.to || '…'}` : '';
 
+// The tab bar's labels, in one place because the failure message names
+// the tab it could not load and would otherwise spell it a second way.
+export const TAB_LABELS = {
+  overview: '概要',
+  document: 'ドキュメント',
+  links: 'リンク',
+  files: 'ファイル',
+  linked: 'ここを指しているもの',
+  usage: '利用',
+  history: '履歴',
+};
+
 // The material an entry derives from (OKF SPEC §5.1). ochakai shows the
 // signals as the writer recorded them and scores nothing: §5.1 leaves
 // weighing them to whoever is reading.
@@ -55,18 +67,18 @@ export async function viewDetail(id) {
   })();
 
   const prov = [
-    observed.created_by && observed.created_by.name ? `created by ${actorStr(observed.created_by)} ${fmtDate(entry.created_at)}` : `created ${fmtDate(entry.created_at)}`,
+    observed.created_by && observed.created_by.name ? `${fmtDate(entry.created_at)} に ${actorStr(observed.created_by)} が作成` : `${fmtDate(entry.created_at)} に作成`,
     lastVerification(observed)
-      ? `verified by ${actorStr(lastVerification(observed).by)} ${fmtDate(lastVerification(observed).at)}`
-        + ((observed.verified || []).length > 1 ? ` (${observed.verified.length} verifications)` : '')
+      ? `${fmtDate(lastVerification(observed).at)} に ${actorStr(lastVerification(observed).by)} が検証`
+        + ((observed.verified || []).length > 1 ? `(検証 ${observed.verified.length} 件)` : '')
       : '',
-    observed.rejection ? `rejected by ${actorStr(observed.rejection.by)} ${fmtDate(observed.rejection.at)}` : '',
+    observed.rejection ? `${fmtDate(observed.rejection.at)} に ${actorStr(observed.rejection.by)} が却下` : '',
     // updated_by is OKF's generated.by: who the content stands by now,
     // which is not always who created it (design doc 0036 §3.3).
     entry.updated_at && entry.updated_at !== entry.created_at
       ? ((observed.generated || {}).by && observed.generated.by.name
-          ? `updated by ${actorStr(observed.generated.by)} ${fmtDate(entry.updated_at)}`
-          : `updated ${fmtDate(entry.updated_at)}`)
+          ? `${fmtDate(entry.updated_at)} に ${actorStr(observed.generated.by)} が更新`
+          : `${fmtDate(entry.updated_at)} に更新`)
       : '',
   ].filter(Boolean).join(' · ');
 
@@ -74,8 +86,8 @@ export async function viewDetail(id) {
   // is wrong (OKF SPEC §5.5) — the comparison is a plain date one.
   const staleNote = entry.stale_after
     ? (entry.stale_after <= new Date().toISOString().slice(0, 10)
-        ? `<div class="status-note">Stale since ${esc(entry.stale_after)} — due for a re-check.</div>`
-        : `<div class="provenance">stale after ${esc(entry.stale_after)}</div>`)
+        ? `<div class="status-note">${esc(entry.stale_after)} から期限切れです — 確かめ直す頃合いです。</div>`
+        : `<div class="provenance">${esc(entry.stale_after)} まで(stale_after)</div>`)
     : '';
 
   const tags = (entry.tags || []).map(t => `<span class="tag">${esc(t)}</span>`).join(' ');
@@ -114,7 +126,7 @@ export async function viewDetail(id) {
     </div>
     <div class="provenance">${esc(prov)}</div>
     ${observed.rejection && observed.rejection.note
-      ? `<div class="status-note">Rejected: ${esc(observed.rejection.note)}</div>` : ''}
+      ? `<div class="status-note">却下の理由: ${esc(observed.rejection.note)}</div>` : ''}
     <div id="move-panel" style="display:none;margin-top:.7rem">
       <div class="toolbar" style="margin-bottom:0">
         <input type="text" id="move-to" class="mono" list="move-dirs" value="${esc(entry.id)}"
@@ -130,13 +142,13 @@ export async function viewDetail(id) {
     ${staleNote}
     ${entry.resource ? `<div class="provenance">resource: ${resourceHTML(entry.resource)}</div>` : ''}
     <div class="tabs" id="tabs">
-      <button data-tab="overview" class="active">概要</button>
-      <button data-tab="document">ドキュメント</button>
-      <button data-tab="links">Links${entry.links && entry.links.length ? ' (' + entry.links.length + ')' : ''}</button>
-      <button data-tab="files">Files${atts.length ? ' (' + atts.length + ')' : ''}</button>
-      <button data-tab="linked">ここを指しているもの</button>
-      <button data-tab="usage">利用</button>
-      <button data-tab="history">履歴</button>
+      <button data-tab="overview" class="active">${TAB_LABELS.overview}</button>
+      <button data-tab="document">${TAB_LABELS.document}</button>
+      <button data-tab="links">${TAB_LABELS.links}${entry.links && entry.links.length ? ' (' + entry.links.length + ')' : ''}</button>
+      <button data-tab="files">${TAB_LABELS.files}${atts.length ? ' (' + atts.length + ')' : ''}</button>
+      <button data-tab="linked">${TAB_LABELS.linked}</button>
+      <button data-tab="usage">${TAB_LABELS.usage}</button>
+      <button data-tab="history">${TAB_LABELS.history}</button>
     </div>
     <div id="tab-body"></div>`;
 
@@ -230,7 +242,7 @@ export async function viewDetail(id) {
           <div class="att-meta">
             <span class="mono">${esc(a.name)}</span>
             <span class="meta">${esc(a.media_type || '')} · ${fmtSize(a.size)}${a.created_by && a.created_by.name ? ' · ' + esc(actorStr(a.created_by)) : ''}${a.created_at ? ' · ' + esc(fmtDate(a.created_at)) : ''}</span>
-            <span class="meta">body reference: <code>${ref}</code></span>
+            <span class="meta">本文からの参照: <code>${ref}</code></span>
             <button class="btn small danger write-only" data-remove-file="${esc(a.path)}" data-name="${esc(a.name)}">外す</button>
           </div>
         </div>`;
@@ -243,8 +255,9 @@ export async function viewDetail(id) {
           <span class="provenance" id="att-chosen" style="margin:0"></span>
           <button class="btn small primary" id="att-upload">ファイルを追加</button>
         </div>
-        <p class="provenance write-only">Any file, max 5 MiB each. Reference a file from the
-        body (<code>![alt](${esc(lastSeg)}/name.png)</code> or <code>[name](${esc(lastSeg)}/name.txt)</code>) so it is findable and survives OKF export.</p>`;
+        <p class="provenance write-only">形式は問わず、1 ファイル 5 MiB まで。本文から参照しておくと
+        (<code>![alt](${esc(lastSeg)}/name.png)</code> または <code>[name](${esc(lastSeg)}/name.txt)</code>)、
+        見つけられるようになり、OKF export でも残ります。</p>`;
     },
     linked: () => '<div class="empty">…</div>',
     usage: () => '<div class="empty">…</div>',
@@ -264,18 +277,18 @@ export async function viewDetail(id) {
         for (const f of files) {
           await api(attPath(canonicalPath(f.name)), { method: 'PUT', raw: f });
         }
-        toast(files.length > 1 ? `Added ${files.length} files.` : 'Added.');
+        toast(files.length > 1 ? `${files.length} 件のファイルを追加しました。` : 'ファイルを追加しました。');
         viewDetail(entry.id);
       } catch (e) { toast('ファイルの追加に失敗しました: ' + e.message); }
     });
     body.querySelectorAll('[data-remove-file]').forEach(b => b.addEventListener('click', async () => {
       const path = b.dataset.removeFile;
-      if (!confirm(`Remove ${b.dataset.name}? 変更はリビジョンとして残ります。`)) return;
+      if (!confirm(`${b.dataset.name} を外しますか?変更はリビジョンとして残ります。`)) return;
       try {
         await api(attPath(path), { method: 'DELETE' });
-        toast('Removed.');
+        toast('外しました。');
         viewDetail(entry.id);
-      } catch (e) { toast('Remove failed: ' + e.message); }
+      } catch (e) { toast('外せませんでした: ' + e.message); }
     }));
   }
 
@@ -287,12 +300,12 @@ export async function viewDetail(id) {
       const u = await api('/api/v1/usage/' + idPath(entry.id));
       return () => `
         <div class="stat-tiles">
-          <div class="tile"><div class="num">${u.search_hits ?? 0}</div><div class="lbl">search hits</div></div>
-          <div class="tile"><div class="num">${u.fetches ?? 0}</div><div class="lbl">fetches</div></div>
-          <div class="tile"><div class="num">${u.worked ?? 0}</div><div class="lbl">worked</div></div>
-          <div class="tile"><div class="num">${u.failed ?? 0}</div><div class="lbl">failed</div></div>
+          <div class="tile"><div class="num">${u.search_hits ?? 0}</div><div class="lbl">検索ヒット</div></div>
+          <div class="tile"><div class="num">${u.fetches ?? 0}</div><div class="lbl">取得</div></div>
+          <div class="tile"><div class="num">${u.worked ?? 0}</div><div class="lbl">うまくいった</div></div>
+          <div class="tile"><div class="num">${u.failed ?? 0}</div><div class="lbl">失敗</div></div>
         </div>
-        <p class="provenance">${u.last_used_at ? 'last used ' + esc(fmtDate(u.last_used_at)) : 'never used'}</p>`;
+        <p class="provenance">${u.last_used_at ? '最後に使われたのは ' + esc(fmtDate(u.last_used_at)) : 'まだ使われていません'}</p>`;
     },
     linked: async () => {
       const { hits: entries = [] } = await api('/api/v1/search?links_to=' + encodeURIComponent(entry.id) + '&limit=100');
@@ -310,12 +323,12 @@ export async function viewDetail(id) {
           <td class="k mono">#${r.rev}</td>
           <td>
             <div><strong>${esc(r.change)}</strong> · ${esc(actorStr(r.changed_by))} · ${esc(fmtDate(r.changed_at))}</div>
-            <details><summary style="cursor:pointer;color:var(--muted);font-size:.84rem">document</summary>
+            <details><summary style="cursor:pointer;color:var(--muted);font-size:.84rem">ドキュメント</summary>
               <pre>${esc(r.document || '')}</pre></details>
           </td>
         </tr>`).join('');
       return () => `
-        <p class="provenance" style="margin:0 0 .8rem">Every change, newest first — who made it and the concept as of that change.</p>
+        <p class="provenance" style="margin:0 0 .8rem">すべての変更を新しい順に — 誰が変えたのかと、そのときの concept です。</p>
         <table class="kv">${rows}</table>`;
     },
   };
@@ -330,7 +343,7 @@ export async function viewDetail(id) {
         if (document.querySelector('#tabs button.active')?.dataset.tab === name) body.innerHTML = tabs[name]();
       } catch (e) {
         if (document.querySelector('#tabs button.active')?.dataset.tab === name) {
-          body.innerHTML = `<div class="error-banner" role="alert">Could not load ${esc(name)}: ${esc(e.message)}</div>`;
+          body.innerHTML = `<div class="error-banner" role="alert">${esc(TAB_LABELS[name] || name)} を読み込めませんでした: ${esc(e.message)}</div>`;
         }
       }
     }
@@ -348,12 +361,12 @@ export async function viewDetail(id) {
     const status = statusPick.value;
     try {
       if (await applyStatus(entry.id, status)) {
-        toast(`Marked ${status}.`);
+        toast(`${status} にしました。`);
         refreshTree(); // the tree shows status badges
         viewDetail(entry.id);
         return;
       }
-    } catch (e) { toast('Failed: ' + e.message); }
+    } catch (e) { toast('失敗しました: ' + e.message); }
     statusPick.value = entry.status;
   });
   // The Move panel: a destination input seeded with the current path,
@@ -364,9 +377,9 @@ export async function viewDetail(id) {
     closeMenu();
     try {
       await verifyEntry(entry.id);
-      toast(isVerified(entry) ? 'Re-verified.' : 'Verified.');
+      toast(isVerified(entry) ? '再検証しました。' : '検証しました。');
       viewDetail(entry.id);
-    } catch (e) { toast('Failed: ' + e.message); }
+    } catch (e) { toast('失敗しました: ' + e.message); }
   });
   $('#act-reject')?.addEventListener('click', async () => {
     closeMenu();
@@ -374,19 +387,19 @@ export async function viewDetail(id) {
     if (note === null) return;
     try {
       await rejectEntry(entry.id, note);
-      toast('Rejected.');
+      toast('却下しました。');
       refreshTree(); // the tree hides rejected entries
       viewDetail(entry.id);
-    } catch (e) { toast('Failed: ' + e.message); }
+    } catch (e) { toast('失敗しました: ' + e.message); }
   });
   $('#act-withdraw')?.addEventListener('click', async () => {
     closeMenu();
     try {
       await liftRejection(entry.id);
-      toast('Rejection withdrawn.');
+      toast('却下を取り下げました。');
       refreshTree();
       viewDetail(entry.id);
-    } catch (e) { toast('Failed: ' + e.message); }
+    } catch (e) { toast('失敗しました: ' + e.message); }
   });
   $('#act-move').addEventListener('click', () => {
     closeMenu();
@@ -402,12 +415,12 @@ export async function viewDetail(id) {
   });
   $('#act-delete').addEventListener('click', async () => {
     closeMenu();
-    if (!confirm(`Soft-delete ${entry.id}? リビジョンの履歴は残ります。`)) return;
+    if (!confirm(`${entry.id} を削除しますか?リビジョンの履歴は残ります。`)) return;
     try {
       await api(conceptURL(entry.id), { method: 'DELETE' });
-      toast('Deleted.');
+      toast('削除しました。');
       refreshTree();
       location.hash = '#/';
-    } catch (e) { toast('Failed: ' + e.message); }
+    } catch (e) { toast('失敗しました: ' + e.message); }
   });
 }

--- a/internal/webui/static/js/views/dir.js
+++ b/internal/webui/static/js/views/dir.js
@@ -22,11 +22,11 @@ export async function loadDirIndex(container, prefix, emptyText) {
     const files = (res.files || []).map(fileCard).join('');
     const note = res.truncated
       ? `<div class="truncation-note">この階層の先頭 1000 concept を表示 — これだけ広いディレクトリは
-         better split into subdirectories.</div>` : '';
+         サブディレクトリに分けたほうがよいでしょう。</div>` : '';
     container.innerHTML = (dirs + concepts + files + note) || `<div class="empty">${emptyText}</div>`;
   } catch (e) {
     if (!container.isConnected) return;
-    container.innerHTML = `<div class="error-banner" role="alert">Browse failed: ${esc(e.message)}</div>`;
+    container.innerHTML = `<div class="error-banner" role="alert">一覧を読み込めませんでした: ${esc(e.message)}</div>`;
   }
 }
 
@@ -43,10 +43,10 @@ export function viewDir(rawPrefix) {
       <span class="grow"></span>
       ${clean ? `<a class="btn small" href="#/search/in/${idPath(clean)}"
         title="${esc(prefix)} の下だけを検索">🔍 ここを検索</a>` : ''}
-      <a class="btn small write-only" href="${newHref}" title="Create a concept in ${esc(prefix) || 'the root'}">＋ ここに concept を作る</a>
+      <a class="btn small write-only" href="${newHref}" title="${prefix ? esc(prefix) + ' に' : 'ルートに'} concept を作る">＋ ここに concept を作る</a>
     </div>
     <div id="dir-index"><div class="empty">…</div></div>`;
-  loadDirIndex($('#dir-index'), prefix, 'Nothing here — directories exist through the concepts in them.');
+  loadDirIndex($('#dir-index'), prefix, 'ここには何もありません — ディレクトリは、その中の concept があってはじめて存在します。');
 }
 
 export function viewHome() {
@@ -61,9 +61,9 @@ export function viewHome() {
       <a class="btn" id="home-go" href="#/search">検索</a>
     </div>
     <p style="color:var(--muted);font-size:.9rem">
-      <a href="#/review">レビューキュー</a> — verify or reject what agents drafted ·
-      <a href="#/search/reported-wrong">間違いと報告された</a> — verified knowledge that came back wrong ·
-      <a class="write-only" href="#/new">＋ New concept</a> ·
+      <a href="#/review">レビューキュー</a> — エージェントが書いた draft を検証する / 却下する ·
+      <a href="#/search/reported-wrong">間違いと報告された</a> — 検証済みなのに間違いだったナレッジ ·
+      <a class="write-only" href="#/new">＋ concept を作る</a> ·
       <a href="#" id="home-export" title="ナレッジベースを OKF バンドル(tar.gz)として書き出す">OKF を書き出す</a>
     </p>
     <div id="home-index" style="margin-top:1.4rem"><div class="empty">…</div></div>`;

--- a/internal/webui/static/js/views/editor.js
+++ b/internal/webui/static/js/views/editor.js
@@ -70,7 +70,7 @@ export async function viewEditor(id, prefix = '') {
           <label class="top" for="e-type">型</label>
           <select id="e-type">${KNOWN_TYPES.map(t =>
             `<option value="${t}"${t === 'Insight' ? ' selected' : ''}>${t}</option>`).join('')}</select>
-          <div class="hint">Sets <code>type:</code> in the document below, with any key that type is refused without.
+          <div class="hint">下のドキュメントの <code>type:</code> を設定します。その型が無いと受け付けられないキーも一緒に入ります。
           ドキュメントを編集するまでは全体が入れ直され、編集した後はその行だけが変わります。
           保存されるのはこのドキュメントです。</div>
         </div>`}
@@ -78,16 +78,16 @@ export async function viewEditor(id, prefix = '') {
       <div class="field">
         <label class="top" for="e-doc">ドキュメント</label>
         <textarea id="e-doc" rows="26" class="mono" spellcheck="false" required>${esc(doc)}</textarea>
-        <div class="hint">OKF frontmatter between <code>---</code> lines, then markdown.
+        <div class="hint"><code>---</code> の行にはさまれた OKF frontmatter、そのあとに markdown。
         他の concept へは、そのパスへの markdown リンクで結ぶ — <code>[revenue](/metrics/revenue.md)</code> —
-        and it becomes a link both ways. ochakai が定義していないキーは書いたまま保たれます。
+        と、両方向のリンクになります。ochakai が定義していないキーは書いたまま保たれます。
         サーバーが持つキー(<code>generated</code>・<code>verified</code>・<code>created_by</code>)は
-        are not yours to set and are ignored if present.</div>
+        あなたが決めるものではないので、書いてあっても無視されます。</div>
       </div>
       <div id="editor-error"></div>
       <div class="toolbar" style="justify-content:flex-end">
         <a class="btn" href="${editing ? '#/k/' + idPath(entryID) : '#/search'}">キャンセル</a>
-        <button class="btn primary write-only" type="submit">${editing ? 'Save' : 'Create'}</button>
+        <button class="btn primary write-only" type="submit">${editing ? '保存' : '作成'}</button>
       </div>
     </form>`;
 
@@ -140,9 +140,10 @@ export async function viewEditor(id, prefix = '') {
       });
       dirty = false;
       // The server says which of the three the write was (design doc
-      // 0097), so the toast can stop guessing: "Saved." after a write
-      // that stored nothing is the one message a curator cannot check.
-      toast(saved && saved.plan === 'unchanged' ? 'No change.' : editing ? 'Saved.' : 'Created.');
+      // 0097), so the toast can stop guessing: "保存しました。" after a
+      // write that stored nothing is the one message a curator cannot
+      // check.
+      toast(saved && saved.plan === 'unchanged' ? '変更はありません。' : editing ? '保存しました。' : '作成しました。');
       refreshTree();
       refreshQueues(); // an edit is what clears the past-expiry queue (design doc 0037 §2.2)
       location.hash = '#/k/' + idPath((saved && saved.id) || entryId);
@@ -155,7 +156,7 @@ export async function viewEditor(id, prefix = '') {
       // 412 rather than a 409 because the page writes with If-None-Match
       // and that is a precondition failing (design doc 0083).
       const dupLink = !editing && e.code === 'already_exists'
-        ? ` — <a href="#/k/${idPath(entryId)}">view the existing ${esc(entryId)}</a> (edit it, or pick another ID)`
+        ? ` — <a href="#/k/${idPath(entryId)}">既にある ${esc(entryId)} を開く</a>(それを編集するか、別の ID を選んでください)`
         : '';
       // The precondition failed: somebody else saved while this form was
       // open. Say that rather than showing the server's sentence about
@@ -169,7 +170,7 @@ export async function viewEditor(id, prefix = '') {
           残すべきところを移してから、もう一度この画面を開いてください。</div>`;
         return;
       }
-      errBox.innerHTML = `<div class="error-banner" role="alert">${editing ? 'Save' : 'Create'} failed: ${esc(e.message)}${dupLink}</div>`;
+      errBox.innerHTML = `<div class="error-banner" role="alert">${editing ? '保存' : '作成'}に失敗しました: ${esc(e.message)}${dupLink}</div>`;
     }
   });
 }

--- a/internal/webui/static/js/views/explore.js
+++ b/internal/webui/static/js/views/explore.js
@@ -78,11 +78,11 @@ export function viewExplore() {
                value="${esc(explore.prefix)}" style="width:8rem">
         <span class="fb-sep"></span>
         <label class="chip" title="検証が古い順 — 検証済みクエリを再確認するためのカナリア"><input
-          type="checkbox" id="f-age" aria-label="検証の古さのフィード" ${explore.ageFeed ? 'checked' : ''}>verification age</label>
+          type="checkbox" id="f-age" aria-label="検証の古さのフィード" ${explore.ageFeed ? 'checked' : ''}>検証の古さ</label>
         <label class="chip" title="間違いと報告され(report_outcome failed)、その後検証されていない concept — 再検証のフィード"><input
-          type="checkbox" id="f-failed" aria-label="再検証のフィード" ${explore.failedFeed ? 'checked' : ''}>reported wrong</label>
+          type="checkbox" id="f-failed" aria-label="再検証のフィード" ${explore.failedFeed ? 'checked' : ''}>間違いと報告された</label>
         <label class="chip" title="著者が宣言した stale_after を過ぎたもの — 検証ではなく、concept を編集すると消える"><input
-          type="checkbox" id="f-expired" aria-label="期限切れのフィード" ${explore.expiredFeed ? 'checked' : ''}>stale</label>
+          type="checkbox" id="f-expired" aria-label="期限切れのフィード" ${explore.expiredFeed ? 'checked' : ''}>期限切れ</label>
       </div>
     </details>
     <div id="results"><div class="empty">…</div></div>
@@ -141,8 +141,8 @@ export async function runSearch(append = false) {
   const p = new URLSearchParams();
   const isFeed = explore.ageFeed || explore.failedFeed || explore.expiredFeed || !!explore.source;
   // The query as the server and the messages below see it: a box holding
-  // only spaces is no query, and saying `ナレッジが見つかりません for “  ”`
-  // describes something the user did not ask.
+  // only spaces is no query, and saying `「  」に一致するナレッジが
+  // 見つかりません` describes something the user did not ask.
   const q = explore.q.trim();
   // source is a filter, not a mode: it rides along with whatever the
   // chain below picks (design doc 0037 §2.3).
@@ -181,8 +181,8 @@ export async function runSearch(append = false) {
   // screens, where an empty result would otherwise look like an empty
   // knowledge base.
   const scopeNote = explore.prefix
-    ? `<div class="truncation-note">Scoped to <code>/${esc(explore.prefix)}</code> and everything under it ·
-         <a href="#" id="scope-clear">search everywhere</a></div>`
+    ? `<div class="truncation-note"><code>/${esc(explore.prefix)}</code> とその下だけに絞っています ·
+         <a href="#" id="scope-clear">全体を検索する</a></div>`
     : '';
   const wireScope = () => $('#scope-clear')?.addEventListener('click', e => {
     e.preventDefault();
@@ -199,7 +199,7 @@ export async function runSearch(append = false) {
     const hits = explore.loaded = explore.loaded.concat(page.hits || []);
     explore.cursor = page.cursor || '';
     if (!hits.length) {
-      out.innerHTML = scopeNote + `<div class="empty">ナレッジが見つかりません${q ? ' for “' + esc(q) + '”' : ''}.</div>`;
+      out.innerHTML = scopeNote + `<div class="empty">${q ? '「' + esc(q) + '」に一致する' : ''}ナレッジが見つかりません。</div>`;
       wireScope();
       return;
     }
@@ -220,23 +220,23 @@ export async function runSearch(append = false) {
       html = `<div class="truncation-note">まだ検索がありません — よく検索される concept から並べています。</div>` + html;
     }
     if (weak.length) {
-      html += `<details class="weak-matches"><summary>${weak.length} weak match${weak.length > 1 ? 'es' : ''} —
-        barely related, probably noise</summary>${weak.map(hitCard).join('')}</details>`;
+      html += `<details class="weak-matches"><summary>弱い一致 ${weak.length} 件 —
+        ほとんど関係がなく、おそらくノイズです</summary>${weak.map(hitCard).join('')}</details>`;
     }
     if (explore.cursor) {
-      html += `<div class="truncation-note">Showing ${hits.length} concepts ·
-           <a href="#" id="feed-more">load more</a></div>`;
+      html += `<div class="truncation-note">${hits.length} 件の concept を表示 ·
+           <a href="#" id="feed-more">もっと読み込む</a></div>`;
     } else if (!isFeed && hits.length >= limit) {
       // A search does not page: 50 is the whole contract, and the way on
       // is a narrower question rather than a next page (0050 §2.2).
       html += `<div class="truncation-note">先頭 ${limit} ${q ? '件の一致' : '件の concept'} を表示
-           (server cap) — narrow with filters or a more specific query.</div>`;
+           (サーバー側の上限)— 絞り込みか、より具体的な問いで狭めてください。</div>`;
     }
     out.innerHTML = scopeNote + html;
     wireScope();
     $('#feed-more')?.addEventListener('click', e => { e.preventDefault(); runSearch(true); });
   } catch (e) {
     if (my !== runSearch._seq || out !== $('#results')) return;
-    out.innerHTML = `<div class="error-banner" role="alert">Search failed: ${esc(e.message)}</div>`;
+    out.innerHTML = `<div class="error-banner" role="alert">検索に失敗しました: ${esc(e.message)}</div>`;
   }
 }

--- a/internal/webui/static/js/views/review.js
+++ b/internal/webui/static/js/views/review.js
@@ -30,16 +30,16 @@ export function viewReview() {
     <p style="color:var(--muted);max-width:48rem">エージェントが書き戻した draft を、求められている順に — 検索ヒット数と、
     その draft が実際に検索で浮いた回数で順位が付きます。正しいものは検証し、そうでないものは却下します
     (理由は status_note として残るので、エージェントは同じ提案を繰り返さなくなります)。一度も使われていない
-    draft は下に沈みます。<em>stale</em> を切り替えると、その仕分けができます。</p>
+    draft は下に沈みます。<em>放置されたものだけ</em> を切り替えると、その仕分けができます。</p>
     <p style="color:var(--muted);font-size:.9rem;max-width:48rem">検証済みのナレッジには、それ自身の二つのキューがある:
     <a href="#/search/reported-wrong">間違いと報告された</a>(失敗の報告に応えていない concept)と、
     <a href="#/search/verification-age">検証の古さ</a>(検証が古い順)です。検証すると、その concept は両方から消えます。
-    A third, <a href="#/search/stale">stale</a>, lists concepts past the expiry their author declared — that one is cleared by
-    editing the concept, not by verifying.</p>
+    三つ目の <a href="#/search/stale">期限切れ</a> は、著者が宣言した期限を過ぎた concept を並べます。
+    こちらは検証ではなく、concept を編集すると片付きます。</p>
     <div id="loop-stats"></div>
     <div class="toolbar">
       <label class="check"><input type="checkbox" id="r-stale" ${review.staleOnly ? 'checked' : ''}>
-        stale only (0 hits, ≥ ${STALE_DAYS} days old)</label>
+        放置されたものだけ(ヒット 0 件、${STALE_DAYS} 日以上前)</label>
       <span class="grow"></span>
       <span id="queue-strip" style="display:flex;gap:.35rem">${queueStrip()}</span>
     </div>
@@ -108,28 +108,27 @@ export async function loadLoopStats() {
   const truncated = s.embedding?.enabled ? (s.embedding.truncated ?? 0) : 0;
   out.innerHTML = `
     <div class="stat-tiles" style="max-width:52rem;margin:.2rem 0 1rem">
-      <div class="tile"><div class="num">${s.concepts?.total ?? 0}</div><div class="lbl">concepts</div></div>
-      <div class="tile"><div class="num">${confirmed}</div><div class="lbl">confirmed by somebody</div></div>
-      <div class="tile"><div class="num">${s.review?.verifications ?? 0}</div><div class="lbl">verified in ${s.window_days} days</div></div>
+      <div class="tile"><div class="num">${s.concepts?.total ?? 0}</div><div class="lbl">concept</div></div>
+      <div class="tile"><div class="num">${confirmed}</div><div class="lbl">誰かが確認した</div></div>
+      <div class="tile"><div class="num">${s.review?.verifications ?? 0}</div><div class="lbl">直近 ${s.window_days} 日の検証</div></div>
       <div class="tile"><div class="num">${s.misses?.recording ? (s.misses.count ?? 0) : '–'}</div>
-        <div class="lbl">searches that found nothing</div></div>
+        <div class="lbl">何も見つからなかった検索</div></div>
       <div class="tile"><div class="num">${s.outcomes?.concepts_reported ?? 0}/${s.outcomes?.concepts_used ?? 0}</div>
-        <div class="lbl">used concepts reported back on</div></div>
+        <div class="lbl">使われた concept のうち結果が返ってきたもの</div></div>
     </div>` + sparkline(s.review?.weekly) + (dropped ? `
     <p style="max-width:48rem;margin:0 0 1.2rem;color:var(--muted);font-size:.9rem">
-      ${dropped} observation${dropped === 1 ? '' : 's'} were recorded and then lost in these
-      ${s.window_days} days, so the numbers above undercount by at least that much. Usage is
-      buffered in memory and written in batches; an instance that went away took what it was
-      holding with it.</p>` : '') + (truncated ? `
+      この ${s.window_days} 日で、記録されたあと失われた観測が ${dropped} 件あります。
+      上の数字は、少なくともその分だけ実際より少なく出ています。利用状況はメモリに溜めて
+      まとめて書き出しているので、居なくなったインスタンスは抱えていた分を持っていきます。</p>` : '') + (truncated ? `
     <p style="max-width:48rem;margin:0 0 1.2rem;color:var(--muted);font-size:.9rem">
       ${truncated} 件の concept が、埋め込みモデルの入力窓に収まらず<strong>前半だけ</strong>
       ベクトル検索に載っています(全 ${s.embedding.vectors} 件中)。後半に書かれていることでは
       見つかりません — 語句そのものが含まれていれば字句検索は当てます。長すぎる concept を
       分けるか、より広い窓のモデルに移すかのどちらかです。</p>` : '') + (gaps.length ? `
     <details style="max-width:48rem;margin:0 0 1.2rem">
-      <summary style="cursor:pointer;color:var(--muted)">Asked for, not found — what to write next</summary>
-      <p style="color:var(--muted);font-size:.9rem;margin:.5rem 0">直近 ${s.window_days} 日の検索
-      that returned nothing, most-asked first. Not a queue anything empties: it stops appearing when the answer exists.</p>
+      <summary style="cursor:pointer;color:var(--muted)">訊かれたのに無かったもの — 次に書くこと</summary>
+      <p style="color:var(--muted);font-size:.9rem;margin:.5rem 0">直近 ${s.window_days} 日で何も返さなかった検索を、
+      よく訊かれた順に。誰かが片付けるキューではありません: 答えが存在すれば、そのまま出なくなります。</p>
       ${gaps.map(g => `<div style="display:flex;gap:.6rem;align-items:baseline;padding:.25rem 0">
         <span class="badge">${g.count}×</span>
         <a href="#/search" class="mono" data-gap="${esc(g.query)}">${esc(g.query)}</a></div>`).join('')}
@@ -170,8 +169,8 @@ export async function runReview(append = false) {
     }
     out.innerHTML = list.map(reviewCard).join('')
       + (review.cursor
-        ? `<div class="truncation-note">Showing ${list.length} drafts ·
-             <a href="#" id="review-more">load more</a></div>`
+        ? `<div class="truncation-note">${list.length} 件の draft を表示 ·
+             <a href="#" id="review-more">もっと読み込む</a></div>`
         : '');
     $('#review-more')?.addEventListener('click', e => { e.preventDefault(); runReview(true); });
     wireReviewActions(out);
@@ -193,14 +192,14 @@ export function reviewCard(h) {
   // three times last week.
   const r = u.recent || {};
   const usageBits = (u.search_hits || u.fetches)
-    ? `🔍 ${u.search_hits || 0} hits · fetched ${u.fetches || 0} (${r.fetches || 0} in ${r.days || 0}d)`
-    : 'no usage yet';
+    ? `🔍 ヒット ${u.search_hits || 0} · 取得 ${u.fetches || 0}(直近 ${r.days || 0} 日で ${r.fetches || 0})`
+    : 'まだ使われていません';
   const outcomeBits = (u.worked || u.failed)
-    ? `${u.failed ? '⚠️ ' : ''}worked ${u.worked || 0} · failed ${u.failed || 0}`
+    ? `${u.failed ? '⚠️ ' : ''}うまくいった ${u.worked || 0} · 失敗 ${u.failed || 0}`
     : '';
   const meta = [
     who ? esc(who) : '',
-    age !== null ? 'created ' + esc(fmtAge(age)) : '',
+    age !== null ? '作成 ' + esc(fmtAge(age)) : '',
     usageBits,
     outcomeBits,
   ].filter(Boolean).join(' · ');
@@ -209,7 +208,7 @@ export function reviewCard(h) {
       <span class="type-ico" title="${esc(h.type)}">${icon(h.type)}</span>
       <a class="title" href="${entryHash(h)}" title="ochakai://${esc(h.id)}">${esc(displayTitle(h))}</a>
       <span class="badge draft">draft</span>
-      ${isStaleDraft(h) ? '<span class="badge" title="検索ヒット 0 で動きもない — 落とす候補">🕸️ stale</span>' : ''}
+      ${isStaleDraft(h) ? '<span class="badge" title="検索ヒット 0 で動きもない — 落とす候補">🕸️ 放置</span>' : ''}
       ${tags}
       <span class="actions write-only" style="margin-left:auto;display:flex;gap:.45rem">
         <button class="btn small primary" data-act="verify">✓ 検証</button>
@@ -232,15 +231,15 @@ export function wireReviewActions(container) {
     try {
       if (btn.dataset.act === 'verify') {
         await verifyEntry(id);
-        toast('Verified.');
+        toast('検証しました。');
       } else {
         const note = prompt('なぜ受け入れないのか?(裁定として残るので、エージェントは同じ提案を繰り返さなくなる)', '');
         if (note === null) return;
         await rejectEntry(id, note);
-        toast('Rejected.');
+        toast('却下しました。');
       }
       refreshTree(); // the tree shows status badges (and hides rejected)
       runReview();
-    } catch (e) { toast('Failed: ' + e.message); }
+    } catch (e) { toast('失敗しました: ' + e.message); }
   }));
 }


### PR DESCRIPTION
[#626](https://github.com/na0fu3y/ochakai/pull/626) narrowed the translation entry's claim from *every user-visible string* to the pages alone, and named what was left rather than implying it — the toast every action answers with, the stat-tile labels, `load more`, the editor's two buttons — because the words an action says back are worth a maintainer's eye rather than a bulk pass. **This is that change.**

The screen a reader met was Japanese and the screen that answered them was not. [`js/views/detail.js`](internal/webui/static/js/views/detail.js) had `'先にファイルを選んでください。'` three lines above `toast('Added.')`.

## Who got stuck

The reader C8 names. A Japanese page that answers `Failed:` when a save is refused is a page that is Japanese right up to the moment something goes wrong — which is the moment the words matter most. No surface widens here: this is copy, and the count in `docs/surface.md` is unchanged.

## What moved

Those four, and the rest of the same shape — the strings written where the work happens rather than where the page is laid out:

- **every action toast and confirmation** — saving, verifying, rejecting, withdrawing, moving, deleting, attaching, detaching, exporting
- **every failure banner** — `Failed:`, `... failed:`, `Could not load`, `Tree failed`, `Browse failed`
- **the stat tiles** on both the concept and the review page, and the loop paragraphs beside them
- **the provenance line** in `detail.js` that says who created, confirmed, rejected and updated a concept
- **the relative dates** in `format.js`

Plus two kinds that hide: a `title=` whose `aria-label` was already Japanese, and the pluralization ternaries — `n === 1 ? 'draft' : 'drafts'` cannot survive a translation into a language with no plural, so it is a reliable marker of copy nobody read.

And two the page was contradicting itself over. The search bar's three filter chips said `verification age`, `reported wrong` and `stale` while the feed banner *directly above them* told the reader to uncheck 検証の古さ, 間違いと報告された and 期限切れ. The review page's stale toggle was the same: named in Japanese prose, drawn in English.

## What stays in Latin script

The contract's vocabulary, since it is what the API answers and what the page filters on: the lifecycle values (`draft`, `stable`, `deprecated`), the trust tiers, the rulings, the OKF type names in `js/vocab.js`, the frontmatter keys — and `concept`, which the already-Japanese copy uses untranslated.

## Two notes for the reviewer

**`js/format.js` is the one module whose strings a test pins**, so [`jstest/format.test.js`](internal/webui/jstest/format.test.js) moves with it. `actorStr`'s ` via `/` using ` become 経由/使用 inside one parenthesis rather than two (`🤖 sa@p(a@b 経由・claude/1 使用)`), and `fmtAge` returns 今日 / 昨日 / N 日前. Nothing else in the build reads the language of UI copy, which is how the half-translated state stayed green.

**`detail.js` gains a `TAB_LABELS` map.** The tab-load failure banner names the tab it could not load, and would otherwise have spelled each label a second way.

## The changelog

The changelog quoted the editor toast, and so did a comment three lines above it in `editor.js`; both now quote what the page says.

The entry #626 rewrote is **folded rather than answered by a second one**. *"These are still English"* and *"now they are not"* in one `[Unreleased]` section is a section that contradicts itself, and nothing in the build checks either sentence — so the one entry now says the second pass happened and why it was a second pass.

## Checks

`scripts/check` on this base: 41/41 node tests, all Go packages ok, golangci-lint 0 issues. Store tests skip without `--db`, as usual; CI runs them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)