### PR TITLE
Prepare v0.21.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Version
       description: Output of `ochakai version`, or the image tag you deployed.
-      placeholder: "0.20.0"
+      placeholder: "0.21.0"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ last entry.
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-08-11
+
 ### Fixed
 
 - **Thirteen error responses were missing the `code` the entry below
@@ -4070,7 +4072,8 @@ worth naming: SQL injection in `compile_sql` through undeclared field
 pass-through, fixed in 0.8.0 — v0.7.0 and earlier are affected. Details
 are in git history.
 
-[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.20.0...HEAD
+[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.21.0...HEAD
+[0.21.0]: https://github.com/na0fu3y/ochakai/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/na0fu3y/ochakai/compare/v0.19.1...v0.20.0
 [0.19.1]: https://github.com/na0fu3y/ochakai/compare/v0.19.0...v0.19.1
 [0.19.0]: https://github.com/na0fu3y/ochakai/compare/v0.18.0...v0.19.0

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -74,7 +74,7 @@ info:
     is a security defect, shipped in the next release with no deprecation
     window (SECURITY.md). MCP, the CLI and the stored shape stay unstable
     while the major version is 0 and may still change in a minor release.
-  version: 0.20.0
+  version: 0.21.0
   license:
     name: MIT
 servers:

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -79,7 +79,7 @@ export IMAGE=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:$VERSION
 `:latest` ではなくバージョンを固定し、再デプロイを意識的な判断にする。
 `gh` CLI が無ければ
 [リリースページ](https://github.com/na0fu3y/ochakai/releases)から番号
-を読み、手で設定する — `export VERSION=0.20.0`。
+を読み、手で設定する — `export VERSION=0.21.0`。
 
 (このガイドは 0.9.0 以降を前提にしている。それより前のリリースは
 [retract](https://go.dev/ref/mod#go-mod-file-retract) 済みでサポート外


### PR DESCRIPTION
## What and why

v0.21.0 のリリース準備。`[Unreleased]` に **BREAKING** が4件(MCP のツール分割、`get_context` の予算、ファイルベクトルの鍵、`trust` → `trusts`)あるので、patch ではなく **minor** を上げる。

タグが更新しない4ファイルを揃えた:

1. `CHANGELOG.md` — `## [Unreleased]` を `## [0.21.0] - 2026-08-11` に閉じ、空の `[Unreleased]` を上に足し、compare リンクを2本
2. `api/openapi.yaml` — `info.version`
3. `.github/ISSUE_TEMPLATE/bug_report.yml` — placeholder
4. `deploy/cloudrun/README.md` — 手で設定する `export VERSION=`

`grep -rn '0\.20\.0'` の残りは `CHANGELOG.md`・`docs/design`・`cmd/ochakai/main_test.go` のコメント(「0.16.0 から 0.20.0 まで attrs.question と言い続けていた」という史実)だけで、いずれも正当。

**0088 のウィンドウは今回閉じるものが無い。** `RetiredToolNames` と `retiredCommands` はどちらも既に空で、このサイクルの改名は引数とフィルタ(`trust` → `trusts`)— 0088 §2 と 0096 が言うとおり、名前ではないのでウィンドウは付かない。

## リリース内容の確認結果

[#626](https://github.com/na0fu3y/ochakai/pull/626) と [#627](https://github.com/na0fu3y/ochakai/pull/627) で、v0.20.0 以降 160 コミット分のレビューで見つかった不整合を解消済み — 設計ドキュメント 0031 と実装の矛盾(→ 0099)、`[Unreleased]` の自己矛盾4点、`public-demo` アンカーの迷子、Web UI の翻訳未完了。**マージ後に再確認し、Web UI に残る英語は識別子・CSS クラス・イベント名・OKF 語彙(`draft` / `stable` / 型名)のみ**で、これらは契約の語彙なので正しく英語のまま。

**判断を一つしている**: Terraform の Cloud SQL 日次バックアップ既定 on に **BREAKING** を付けなかった。0.20.0 がリージョン挙動に付けた前例は、**製品がデータ所在地を黙って決めていた**是正であって、「追加的な保護が増え、月1ドル未満、`database_backups = false` で降りられる」はどのクライアントが依存していた挙動も壊さない。付けるとマーカーが薄まると判断した。異論があれば言ってほしい — マージ前なら直せる。

## Checks

`scripts/check` と `scripts/check --db` が両方通っている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)