### PR TITLE
Stop asserting that an orphaned blob outlives a global sweep

### DIFF
--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -1033,15 +1033,28 @@ func TestIntegrationAttachments(t *testing.T) {
 		t.Errorf("replace should keep one attachment with new content: %+v", list)
 	}
 
-	// The dedup blob store keeps both contents (revision history can
-	// reference the old hash).
+	// A replacement is a new blob row, not a mutated one — that is what
+	// content addressing buys. The row this path names now must exist:
+	// SweepBlobs only deletes what no object and no attachment
+	// references, so a hash a live attachment names is the one thing it
+	// may never take (sweep.go, design doc 0099).
+	//
+	// The replaced hash is deliberately not asserted on. It is orphaned
+	// the moment the new bytes land, and the sweep is global — it does
+	// not know about the namespace this test runs in, so any purge or
+	// file delete in another package's tests, running against the shared
+	// database, may legitimately reclaim it first. lockLiveAttachments
+	// does not help: those tests sweep without taking it.
 	var blobs int
 	if err := s.pool.QueryRow(ctx,
-		`SELECT count(*) FROM blob WHERE sha256 IN ($1, $2)`, att.SHA256, list[0].SHA256).Scan(&blobs); err != nil {
+		`SELECT count(*) FROM blob WHERE sha256 = $1`, list[0].SHA256).Scan(&blobs); err != nil {
 		t.Fatal(err)
 	}
-	if blobs != 2 {
-		t.Errorf("blob count = %d, want 2", blobs)
+	if blobs != 1 {
+		t.Errorf("blob rows for the hash the attachment names = %d, want 1", blobs)
+	}
+	if list[0].SHA256 == att.SHA256 {
+		t.Errorf("replacement reused the old hash: %s", att.SHA256)
 	}
 
 	if err := s.DeleteFile(ctx, path, actor); err != nil {


### PR DESCRIPTION
## What and why

`TestIntegrationAttachments` が main で断続的に落ちている — `blob count = 1, want 2`。直近20回の CI で2回、うち一度は [#627](https://github.com/na0fu3y/ochakai/pull/627)(Web UI の翻訳)のマージで、**触ってもいない PR が何かを壊したように見えていた**。v0.21.0 のリリース準備中に、赤い main の原因を追って見つけたもの。

### 何が起きていたか

この assertion は「blob を消すものが何も無かった頃」に書かれている: ファイルのバイト列を差し替えても両方のハッシュが残る、なぜなら「リビジョン履歴が旧ハッシュを参照しうる」から、と。**このコメントは二重に古い**。

1. ファイルのリビジョン行はハッシュを持たず `doc` も空である(`addFileRevision`)。差し替え前のバイト列を取り出す経路は存在しない。
2. [#557](https://github.com/na0fu3y/ochakai/pull/557) 以降、purge とファイル削除が `SweepBlobs` を走らせる。これは **object も attachment も参照していない blob を、大域で**消す。

`testdb` は各テストに名前空間を渡すが、**掃除は名前空間を読まない**。したがって `internal/service` や `internal/restapi` の purge するテストが、このテストの「上書きで孤児になった blob」を、上書きと assertion の間に正当に回収しうる。`lockLiveAttachments` も助けにならない — このテストはロックを取っているが、**掃除する側のテストが取っていない**。

### どう直したか

孤児はこのテストが主張してよいものではない。主張してよく、かつ**掃除が絶対に間違えてはいけない**のは反対側 — **生きた attachment が名指しているハッシュは消えてはならない**。これは `sweep.go` の advisory lock が閉じている競合そのもの(設計ドキュメント 0099)で、ここを assert すると**フレークが「ロックが壊れたら落ちるテスト」に変わる**。差し替え後のハッシュが元と異なることを見る行で、コンテンツアドレスの側も残した。

**製品の挙動は変わらないし、正しい。** 掃除のバグではない。

## Checks

`scripts/check --db` が通っている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)