### PR TITLE
Assemble a release as a draft, and publish it last

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -87,6 +87,17 @@ message, so the tag you wrote in step 2 is already on the Releases page —
 which is the real reason to write that message properly rather than
 leaving it for later.
 
+**A published release here is immutable, so the workflow assembles a
+draft and publishes it last.** goreleaser creates the release as a draft
+(`release.draft`), the bundle, the notes and the attestations go on, and
+a final step flips `--draft=false`. Anything that tries to add an asset
+to an already-published release gets HTTP 422 — which is how v0.21.0
+shipped with no bundle, no notes and no archive attestations: the upload
+failed first and `set -e` took the steps behind it down. If you ever see
+that 422 again, the fix is the *order*, not a retry. A release body can
+still be edited after publication (`gh release edit --notes-file`);
+assets cannot.
+
 This is why the trap is upstream: a thin tag message is now a thin
 release page, immediately and publicly. Write for an operator upgrading —
 which migrations run, whether `updated_at` moves (held ETags,

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -134,3 +134,18 @@ jobs:
             dist/*.zip
             dist/*.mcpb
             dist/checksums.txt
+      # Publishing is last, because a published release is immutable
+      # here: GitHub answers 422 to an asset upload against one, and
+      # everything above this line is an addition to what goreleaser
+      # created. v0.21.0 is what that costs when the order is wrong —
+      # the bundle upload failed, and `set -e` took the notes and the
+      # attestations down with it, leaving a bare tag on the Releases
+      # page. goreleaser leaves a draft (`release.draft` in
+      # .goreleaser.yaml); this is the step that makes it a release.
+      - name: Publish the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          gh release edit "$TAG" --draft=false

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -101,6 +101,17 @@ release:
   # the tag already exists — drafted by hand, or by GitHub's generated
   # notes — attach to it and leave its body alone.
   mode: keep-existing
+  # Leave it a draft; the workflow publishes it as its last step, once
+  # the MCP bundle, the notes and the provenance are all on it.
+  #
+  # A published release in this repository is immutable: GitHub answers
+  # HTTP 422 to an asset upload against one. The workflow used to
+  # publish here and add the rest afterwards, which worked until
+  # immutability was on — then v0.21.0 shipped without its bundle,
+  # without its notes and without archive attestations, because the
+  # upload failed and `set -e` took the three steps behind it down too.
+  # A draft accepts assets, so the order is: assemble, then publish.
+  draft: true
 
 # Homebrew is off until the maintainer opts in: publishing a formula
 # needs a second repository (na0fu3y/homebrew-tap) and a PAT, because

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,22 @@ last entry.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A release assembles as a draft and is published last, so the MCP
+  bundle actually ships with it.** A published release in this
+  repository is immutable — GitHub answers `422 Cannot upload assets to
+  an immutable release` — and the workflow was adding the bundle, the
+  notes and the archive attestations *after* goreleaser had published.
+  **v0.21.0 is what that cost**: no `ochakai_0.21.0.mcpb`, no build
+  provenance on its archives, and a bare tag where the notes should have
+  been, because the upload failed and `set -e` took the two steps behind
+  it down. The notes were restored by hand (a body can still be edited
+  after publication; assets cannot), and v0.21.0's checksums, image and
+  binaries are unaffected — `checksums.txt` verifies and the binary
+  prints its own version. goreleaser now leaves a draft, and a final
+  step flips it to published once everything is attached.
+
 ## [0.21.0] - 2026-08-11
 
 ### Fixed


### PR DESCRIPTION
## What and why

**v0.21.0 は MCP バンドル無し・アーカイブの provenance 無し・本文が空、という状態で公開された。** goreleaser のせいではない — アーカイブも checksums も image も正常で、バイナリは自分のバージョンを正しく出す。

このリポジトリでは**公開済みリリースが immutable** で、GitHub は `HTTP 422 Cannot upload assets to an immutable release` を返す。ところがワークフローは逆順に組まれていた:

1. goreleaser が**公開**する
2. MCP バンドルを添付する ← **422 で失敗**
3. タグのメッセージから本文を流し込む ← 実行されず
4. アーカイブに provenance を付ける ← 実行されず

2 が `set -euo pipefail` の下にあるので、**一つの 422 が三つを道連れにした**。

## どう直したか

順序を反転させた。goreleaser は**ドラフト**を残し(`.goreleaser.yaml` の `release.draft`)、ドラフトはアセットを受け付けるので、バンドル・本文・provenance が全部載ってから、最後の一手 `gh release edit --draft=false` で公開する。**公開が最初ではなく最後になる。**

`release` skill にもこの罠を書いた — 422 を見たら再試行ではなく**順序**を疑うこと、そして**本文だけは公開後も編集できる**という非対称性(v0.21.0 の本文はこれで手動復旧した)。

## v0.21.0 の現状

| | 状態 |
|---|---|
| アーカイブ6種 + SBOM + `checksums.txt` | ✅ 公開済み・チェックサム照合 OK |
| `./ochakai version` | ✅ `v0.21.0` を出力(ldflags 正常) |
| GHCR イメージ + その provenance | ✅ publish ジョブは緑 |
| リリース本文 | ✅ **手動で復旧済み** |
| `ochakai_0.21.0.mcpb` | ❌ 添付不可(immutable) |
| アーカイブの provenance | ❌ 未添付(`gh attestation verify` が 404) |

**v0.21.1 を切るかどうかはメンテナの判断。** README と ROADMAP は「リリースは `.mcpb` を運ぶ」と書いており、v0.21.0 についてはそれが偽になっている。このワークフロー修正をマージした後なら、v0.21.1 は完全な形で出る。

## Checks

`scripts/check` が通っている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)