### PR TITLE
Prepare v0.21.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Version
       description: Output of `ochakai version`, or the image tag you deployed.
-      placeholder: "0.21.0"
+      placeholder: "0.21.1"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ last entry.
 
 ## [Unreleased]
 
+## [0.21.1] - 2026-08-11
+
 ### Fixed
 
 - **A release assembles as a draft and is published last, so the MCP
@@ -4088,7 +4090,8 @@ worth naming: SQL injection in `compile_sql` through undeclared field
 pass-through, fixed in 0.8.0 — v0.7.0 and earlier are affected. Details
 are in git history.
 
-[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.21.0...HEAD
+[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.21.1...HEAD
+[0.21.1]: https://github.com/na0fu3y/ochakai/compare/v0.21.0...v0.21.1
 [0.21.0]: https://github.com/na0fu3y/ochakai/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/na0fu3y/ochakai/compare/v0.19.1...v0.20.0
 [0.19.1]: https://github.com/na0fu3y/ochakai/compare/v0.19.0...v0.19.1

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -74,7 +74,7 @@ info:
     is a security defect, shipped in the next release with no deprecation
     window (SECURITY.md). MCP, the CLI and the stored shape stay unstable
     while the major version is 0 and may still change in a minor release.
-  version: 0.21.0
+  version: 0.21.1
   license:
     name: MIT
 servers:

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -79,7 +79,7 @@ export IMAGE=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:$VERSION
 `:latest` ではなくバージョンを固定し、再デプロイを意識的な判断にする。
 `gh` CLI が無ければ
 [リリースページ](https://github.com/na0fu3y/ochakai/releases)から番号
-を読み、手で設定する — `export VERSION=0.21.0`。
+を読み、手で設定する — `export VERSION=0.21.1`。
 
 (このガイドは 0.9.0 以降を前提にしている。それより前のリリースは
 [retract](https://go.dev/ref/mod#go-mod-file-retract) 済みでサポート外


### PR DESCRIPTION
## What and why

**製品は v0.21.0 から一行も変わっていない。それがこのリリースの趣旨である。**

v0.21.0 は MCP バンドル(`ochakai_0.21.0.mcpb`)と、アーカイブの build provenance を欠いたまま公開された。公開済みリリースが immutable なのに、ワークフローが**公開後に**それらを足そうとしていたためである([#631](https://github.com/na0fu3y/ochakai/pull/631) で順序を反転済み — goreleaser はドラフトを残し、全部載ってから最後に公開する)。

v0.21.1 は、**v0.21.0 が本来そうあるべきだった形**を出す: 同じコード、同じワイヤ、揃ったアセット。

`[Unreleased]` に入っているのはその修正と blob sweep のテストフレーク([#630](https://github.com/na0fu3y/ochakai/pull/630))だけで、**BREAKING は無い**ので patch を上げる。

タグが更新しない4ファイル(CHANGELOG、`api/openapi.yaml`、bug report の placeholder、デプロイガイドの `export VERSION=`)を揃えた。`RetiredToolNames` と `retiredCommands` は空のままで、閉じるウィンドウは無い。

## Checks

`scripts/check` が通っている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)