### PR TITLE
An import writes documents; it does not rule on them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,39 @@ last entry.
 
 ## [Unreleased]
 
+### Fixed
+
+- **BREAKING (CLI): `ochakai import` no longer verifies what it writes.**
+  A document whose frontmatter carried `verified:` was confirmed on
+  arrival, with whoever ran the import recorded as the verifier — so a
+  bundle of ten concepts came out `human-reviewed` by the importer,
+  timestamped the moment the import ran, and the reviewer nobody
+  performed was indistinguishable from the one somebody did.
+  **Three places already said it should not**: design doc
+  [0009](docs/design/0009-provenance-portability.md) §3.2 — *merge は
+  verify ではない*, and a verification comes down from
+  `POST /api/v1/review/{id}`; [the Git-review
+  guide](docs/guides/git-review.md), under that same heading; and the
+  note the import itself prints on every such document, which says the
+  keys stay a claim that no trust tier answers from. Only the code
+  disagreed.
+  It disagreed for a reason that leaves no trace in a diff: the call
+  landed in 2026-07-28 citing 0009 §3.2, and **that section then read
+  「Git はレビュー経路、verifier は取り込んだ者」** — it endorsed exactly
+  this. A week later the record was settled and its body replaced, and
+  the citation was left pointing at the sentence that now forbids it.
+  Nothing failed, because no test watched the ruling surface during an
+  import; `TestImportDoesNotRuleOnWhatItCarries` does now.
+  **Nothing is lost.** What the document asserted is still on the
+  concept, under `received`, exactly as before — a claim, held apart
+  from this instance's ledger. What changes is that the ledger stays
+  empty until a human rules: `ochakai verify <id>`, or the web UI.
+  Anyone who was relying on an import to confirm a reviewed bundle has
+  to make that a verify. The demo is the case that found it: a public
+  sandbox is anonymous and writable, so **any visitor could import a
+  bundle and have every concept come out `human-reviewed`** — by
+  `human:anonymous`, which is the tier's whole meaning inverted.
+
 ## [0.21.1] - 2026-08-11
 
 ### Fixed

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -1530,21 +1530,20 @@ func cmdImport(ctx context.Context, args []string) error {
 			" — the document is still in the bundle you imported from")
 		fmt.Fprintln(os.Stderr, "skip:", skipped[len(skipped)-1])
 	}
-	// A document that carried a verified key is confirmed by whoever ran
-	// the import — the actor who put it through the review gate (design
-	// docs 0009 §3.2, 0043 §3.2). The values inside the key never become
-	// this instance's ledger: what the document said stays a claim beside
-	// it (design doc 0046 §2.2), and the verification recorded here is
-	// the importer's own.
-	confirm := func(ctx context.Context, d *okf.Doc) string {
-		if !d.Verified {
-			return ""
-		}
-		if _, err := c.Verify(ctx, d.ID); err != nil {
-			return fmt.Sprintf("%s imported, but recording its verification failed: %v", d.ID, err)
-		}
-		return ""
-	}
+	// An import rules on nothing. A document that carries a verified key
+	// says so as a claim, kept beside the concept under `received`
+	// (design doc 0046 §2.2); it does not move the trust tier, because
+	// **a merge is not a verify** — Git's review is not ochakai's ruling
+	// surface, and a verification comes down from
+	// `POST /api/v1/review/{id}` (design doc 0009 §3.2).
+	//
+	// This used to call c.Verify on every such document, recording the
+	// importer as its verifier. That was 0009 §3.2 as it read when the
+	// code was written — the section was titled "verifier は取り込んだ者"
+	// — and the record's body was replaced when it was settled, leaving
+	// the citation pointing at the sentence that forbids it. Nothing is
+	// lost by stopping: what the document asserted is still on the
+	// concept, as the claim it always was.
 	err = eachConcurrently(ctx, len(entries), func(ctx context.Context, i int) error {
 		d := &entries[i]
 		k := &d.Knowledge
@@ -1576,18 +1575,10 @@ func cmdImport(ctx context.Context, args []string) error {
 		// (design doc 0046 §2.2), which is what keeps the Git review loop
 		// note-free.
 		notes = okf.NoteStoredClaim(notes, d.Claimed, stored.Document)
-		verifyNote := ""
-		if wasCreated || changed {
-			verifyNote = confirm(ctx, d)
-		}
 		mu.Lock()
 		defer mu.Unlock()
 		noted += len(notes)
 		reportNotes(notes)
-		if verifyNote != "" {
-			noted++
-			fmt.Fprintln(os.Stderr, "note:", verifyNote)
-		}
 		switch {
 		case wasCreated:
 			created++

--- a/cmd/ochakai/client_test.go
+++ b/cmd/ochakai/client_test.go
@@ -676,6 +676,68 @@ func TestImportReportsAKeptClaim(t *testing.T) {
 	}
 }
 
+// **A merge is not a verify** (design doc 0009 §3.2): an import writes
+// documents and rules on nothing, so a `verified` key in the bundle is a
+// claim the concept carries and never a verification this instance made.
+//
+// This is a regression test with a story. The import used to call
+// `POST /api/v1/review/{id}` for every document that carried the key,
+// recording whoever ran it as the verifier — correct under 0009 §3.2 as
+// it read when that code was written ("verifier は取り込んだ者"), and
+// forbidden by the same section after the record was settled and its
+// body replaced. Nothing failed in between, because no test watched the
+// ruling surface during an import. This one does.
+func TestImportDoesNotRuleOnWhatItCarries(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "metrics"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const claimed = "---\ntype: metric\ntitle: Claimed\n" +
+		"verified:\n  - by: human:ceo@example.co.jp\n    at: 2026-07-02T00:00:00Z\n" +
+		"---\n\nbody\n"
+	if err := os.WriteFile(filepath.Join(dir, "metrics", "claimed.md"), []byte(claimed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var rulings int
+	var mu sync.Mutex
+	mux := http.NewServeMux()
+	mux.HandleFunc("PUT /api/v1/bundle/{path...}", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.NewEncoder(w).Encode(domain.View{Document: string(body)})
+	})
+	mux.HandleFunc("POST /api/v1/review/{id...}", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		rulings++
+		mu.Unlock()
+		_ = json.NewEncoder(w).Encode(domain.View{})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	orig, origErr := os.Stdout, os.Stderr
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout, os.Stderr = pw, pw
+	importErr := cmdImport(context.Background(), []string{dir, "--url", srv.URL})
+	pw.Close()
+	os.Stdout, os.Stderr = orig, origErr
+	out, err := io.ReadAll(pr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if importErr != nil {
+		t.Fatalf("cmdImport: %v\noutput:\n%s", importErr, out)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if rulings != 0 {
+		t.Errorf("import made %d ruling(s) on the concepts it wrote; a merge is not a verify (design doc 0009 §3.2)\noutput:\n%s", rulings, out)
+	}
+}
+
 // The false green --dry-run was: a bundle with nothing wrong in it as far
 // as the parse could see, and a note the server raises at write time (a
 // trust family kept as the document's own claim). The dry run reported it


### PR DESCRIPTION
## What and why

`ochakai import` は、frontmatter に `verified:` を持つ文書ごとに `POST /api/v1/review/{id}` を呼び、**import を実行した者を検証者として記録**していた。10 概念のバンドルを取り込むと、全部が `human-reviewed` になる — 誰もレビューしていないのに、import が走った瞬間のタイムスタンプで。**信頼段の意味が反転している**(その段は「人間が見た」と言うために存在する)。

**三箇所が既に「そうすべきでない」と言っていた**:

- 設計ドキュメント [0009](docs/design/0009-provenance-portability.md) §3.2 — 「**merge は verify ではない**…取り込みは trust tier を動かさない。検証は `POST /api/v1/review/{id}` から下る」
- [Git レビューのガイド](docs/guides/git-review.md) — **同じ見出しの節**がある
- **import 自身が印字するノート** — 「`received` の下に主張として保存され、どの信頼段も答えない」

コードだけが違うことをしていた。

### なぜ気付かれなかったか

**コードは一行も変わらないまま、孤立した。** この呼び出しは 2026-07-28(`dd77e40`、PR #249)に 0009 §3.2 を引用して入った。当時の §3.2 の見出しは **「Git はレビュー経路、verifier は取り込んだ者」** で、まさにこれを規範化していた — **引用は正しかった**。

1週間後の 2026-08-05、`8642fd5`(Settle 0009)が **0009 の本文を差し替えた**。新しい §3.2 は旧 §3.2 が規範化したことを禁じており、コメントの引用だけthat が取り残された。

[#626](https://github.com/na0fu3y/ochakai/pull/626) の 0031/purge と**同型で矢印が逆**である(あちらはコードが記録を追い越し、こちらは記録がコードを追い越した)。`designdocs_test` はどちらも見ない — `Status:` ヘッダはどちらの場合も自己整合しているから。

## 失われるものは無い

文書が主張した内容は **`received` の下にそのまま残る** — 元からそこにあった。二つの挙動は排他ではなく**加算**だった。変わるのは、**人間が裁定するまで台帳が空のまま**になること。`ochakai verify <id>` か Web UI の「検証」で下ろす。

import で「レビュー済みバンドルを確定させる」運用をしていた場合は、そこを verify に置き換える必要がある。

## これを見つけた経緯

demo.ochak.ai を sandbox 姿勢(0087)に切り替えたとき。**サンドボックスは匿名で書けるので、訪問者が誰でもバンドルを import して全概念を `human-reviewed` にできた** — `human:anonymous` の名前で。

## テスト

**import 中の裁定面を見ているテストが一つも無かった。** それが、記録がコードを追い越しても誰も気付かなかった理由である。`TestImportDoesNotRuleOnWhatItCarries` を追加した — 旧挙動に対して**実際に落ちることを確認済み**。

## 設計記録

**新しい番号は取らない。** これは 0009 §3.2 という Accepted で現行の決定に**コードを合わせる修正**であり、新しい決定ではない。

## Checks

`scripts/check --db` が通っている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)