### PR TITLE
Prepare v0.22.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Version
       description: Output of `ochakai version`, or the image tag you deployed.
-      placeholder: "0.21.1"
+      placeholder: "0.22.0"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ last entry.
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-08-11
+
 ### Fixed
 
 - **BREAKING (CLI): `ochakai import` no longer verifies what it writes.**
@@ -4123,7 +4125,8 @@ worth naming: SQL injection in `compile_sql` through undeclared field
 pass-through, fixed in 0.8.0 — v0.7.0 and earlier are affected. Details
 are in git history.
 
-[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.21.1...HEAD
+[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.22.0...HEAD
+[0.22.0]: https://github.com/na0fu3y/ochakai/compare/v0.21.1...v0.22.0
 [0.21.1]: https://github.com/na0fu3y/ochakai/compare/v0.21.0...v0.21.1
 [0.21.0]: https://github.com/na0fu3y/ochakai/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/na0fu3y/ochakai/compare/v0.19.1...v0.20.0

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -74,7 +74,7 @@ info:
     is a security defect, shipped in the next release with no deprecation
     window (SECURITY.md). MCP, the CLI and the stored shape stay unstable
     while the major version is 0 and may still change in a minor release.
-  version: 0.21.1
+  version: 0.22.0
   license:
     name: MIT
 servers:

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -19,7 +19,8 @@ Cloud SQL インスタンス一つでナレッジベース全体を賄う — �
 よい。取り壊しのコマンドは末尾にある。
 
 **推奨: [deploy/terraform](../terraform) で立ち上げる** — §1–§4b(web UI
-とデモの姿勢を含む)を 13 手順の `terraform apply` にまとめてあり、diff
+とデモの姿勢を含む)を一回の `terraform apply` と手作業ひとつ(スキーマの
+bootstrap)にまとめてあり、diff
 としてレビューでき、環境ごとに再現でき、きれいに壊せる。このガイドは引
 き続きリファレンスであり続ける — 各リソースがなぜそう作られているかを
 説明し、コマンドを手で打ちたい場合の経路でもある。§1–§5、§5d、§9 をカ
@@ -79,7 +80,7 @@ export IMAGE=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:$VERSION
 `:latest` ではなくバージョンを固定し、再デプロイを意識的な判断にする。
 `gh` CLI が無ければ
 [リリースページ](https://github.com/na0fu3y/ochakai/releases)から番号
-を読み、手で設定する — `export VERSION=0.21.1`。
+を読み、手で設定する — `export VERSION=0.22.0`。
 
 (このガイドは 0.9.0 以降を前提にしている。それより前のリリースは
 [retract](https://go.dev/ref/mod#go-mod-file-retract) 済みでサポート外


### PR DESCRIPTION
## What and why

v0.22.0 のリリース準備。`[Unreleased]` のエントリは1件で **BREAKING (CLI)**(`ochakai import` が書いたものを裁定しなくなる、[#633](https://github.com/na0fu3y/ochakai/pull/633))なので、patch ではなく **minor** を上げる。

タグが更新しない4ファイルを揃えた: `CHANGELOG.md`(`[Unreleased]` を `## [0.22.0] - 2026-08-11` に閉じ、空の `[Unreleased]` と compare リンク2本)、`api/openapi.yaml` の `info.version`、bug report の placeholder、デプロイガイドの `export VERSION=`。

**0088 のウィンドウは今回も閉じるものが無い** — `RetiredToolNames` と `retiredCommands` はどちらも空で、v0.21.1 以降に改名は無い。

## ついでに直したもの

**[#626](https://github.com/na0fu3y/ochakai/pull/626) が取りこぼした4箇所目の「13 手順」。** あの PR は、どの数え方でも再現せずどのテストも読んでいない数字として `docs/README.md`・`deploy/terraform/README.md`・`docs/en.md` の記述を置き換えたが、`deploy/cloudrun/README.md` にも同じ主張が残っていた — しかも今回どのみち触る `export VERSION=` の3段落上に。

見落とした理由もはっきりしている: あのときの grep は **「13 手順」と「36 手順」の対**を探していて、ここは**前者しか持っていない**。[[引用番号の修正はリポジトリ全体で grep する]] と同じ形の失敗で、**古い数字そのものをリポジトリ全体で grep する**のが正しいやり方だった。

## リリース前の確認

- main の CI は、既知の chromium 起動フレーク(`webui` ジョブ)で一度赤くなったので**再実行して緑を取り直してからタグを打つ**。`test` ジョブは [#630](https://github.com/na0fu3y/ochakai/pull/630) の修正で通っている。
- **v0.21.1 でドラフト方式([#631](https://github.com/na0fu3y/ochakai/pull/631))が実際に効いたことを確認済み** — `ochakai_0.21.1.mcpb` が付き、本文も入っている。v0.22.0 も完全な形で出るはず。

## Checks

`scripts/check` が通っている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)