### PR TITLE
Seed the smoke's base with a ruling, since an import no longer makes one

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,6 +149,14 @@ jobs:
             sleep 1
           done
           /tmp/ochakai import examples/demo --url http://127.0.0.1:8080
+          # The review page draws its trend only for a base somebody has
+          # ruled on: eight zeroes would read as "review stopped", so the
+          # sparkline is absent instead (design doc 0095), and the smoke
+          # asserts the shape. An import does not rule on what it writes
+          # (design doc 0009 §3.2) — so the ruling is made here, the way
+          # a curator makes it, rather than as a side effect of loading
+          # the corpus.
+          /tmp/ochakai verify metrics/revenue --url http://127.0.0.1:8080
           OCHAKAI_URL=http://127.0.0.1:8080 /tmp/ochakai ui --port 8098 &
           for i in $(seq 1 60); do
             curl -sf http://127.0.0.1:8098/ > /dev/null && exit 0


### PR DESCRIPTION
## What and why

**main の `webui` ジョブが [#633](https://github.com/na0fu3y/ochakai/pull/633) 以来ずっと落ちている。**

```
the review trend is drawn, and is readable without seeing it
gave up after 20000 ms — #view held 1339 characters, #tree held 304
```

**ページは壊れていない。** レビューのトレンドは「**誰かが裁定したベース**」にだけ描かれる — `sparkline()` はサーバが週次トレンドを送ってこないとき `''` を返す。ゼロのバーが8本並ぶと「レビューが**止まった**」に読めてしまい、「**まだ誰も始めていない**」とは読めないからである(設計ドキュメント 0095)。

CI のコーパスは `ochakai import examples/demo` で、デモの concept は `verified:` を持っている。**#633 までは import 自身がそれらを確定していた**ので、smoke の前提条件は「コーパスを読み込んだ副作用」として成立していた。

#633 が「import は書いたものを裁定しない」(設計ドキュメント 0009 §3.2)にしたのは正しく、そして**その前提条件も一緒に消えた**。

## 直し方

**裁定を明示的に一手打つ** — `ochakai verify metrics/revenue` を import の直後に。キュレーターが実際にやることであり、**実デプロイでトレンドが埋まる唯一の経路**でもある。

## 検証

push して様子を見るのではなく、**スクラッチのデータベースで実際に再現して確かめた**:

| | 結果 |
|---|---|
| import のみ(現状の CI) | `review: {verifications: 0}`、`weekly` **無し** → spark は描かれない |
| import + verify 一手 | `verifications: 1`、`weekly` **8バケット** → `rect` 8本 |
| Chrome で smoke 全体 | **通る** — 落ちていた `the review trend is drawn...` を含む |

quickstart ジョブは変更不要(検索ヒットしか見ておらず、トレンドは見ていない)。

## リリースとの関係

これがマージされて main が緑になってから、[#634](https://github.com/na0fu3y/ochakai/pull/634)(Prepare v0.22.0)をマージしてタグを打つ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)