### PR TITLE
Point the changer pages' links somewhere, and keep them pointed

### DIFF
--- a/.claude/hooks/ochakai-write-back.sh
+++ b/.claude/hooks/ochakai-write-back.sh
@@ -12,7 +12,7 @@
 # work, and the instructions point at the ochakai MCP tools rather than
 # the CLI — on the dev instance CLI writes are recorded as the anonymous
 # human, while the MCP connection carries the agent's process identity
-# (kb/policies/ai-human-identity.md).
+# (kb/bundle/policies/ai-human-identity.md).
 #
 # Requires: jq. Failures are silent: never block the agent from stopping.
 set -eu
@@ -50,5 +50,5 @@ fi
 
 jq -n --arg outcome "$outcome_reason" '{
   decision: "block",
-  reason: ($outcome + "Before finishing: if this session learned something durable about ochakai — how a failure was diagnosed, a constraint of an environment, a convention written nowhere — write it back to the knowledge base as a draft with the put_concept MCP tool. Search first with search_concepts (including rejected=true) to avoid re-proposing what was already turned down. Use the MCP tools, never the ochakai CLI, for writes and reports: the MCP connection carries your process identity, the CLI would record you as the anonymous human (kb/policies/ai-human-identity.md). If nothing durable was learned, finish now without creating anything — do not invent knowledge.")
+  reason: ($outcome + "Before finishing: if this session learned something durable about ochakai — how a failure was diagnosed, a constraint of an environment, a convention written nowhere — write it back to the knowledge base as a draft with the put_concept MCP tool. Search first with search_concepts (including rejected=true) to avoid re-proposing what was already turned down. Use the MCP tools, never the ochakai CLI, for writes and reports: the MCP connection carries your process identity, the CLI would record you as the anonymous human (kb/bundle/policies/ai-human-identity.md). If nothing durable was learned, finish now without creating anything — do not invent knowledge.")
 }'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Checked-in Claude Code settings for this repository. Hooks, plus the one permissions rule that is not a personal choice: the deny list keeps agent sessions from writing to the dogfood knowledge base through the CLI, which the dev instance would record as the anonymous human — agent writes go through the ochakai MCP tools, whose connection carries the process identity (kb/policies/ai-human-identity.md). Everything else about permissions belongs in the untracked settings.local.json.",
+  "$comment": "Checked-in Claude Code settings for this repository. Hooks, plus the one permissions rule that is not a personal choice: the deny list keeps agent sessions from writing to the dogfood knowledge base through the CLI, which the dev instance would record as the anonymous human — agent writes go through the ochakai MCP tools, whose connection carries the process identity (kb/bundle/policies/ai-human-identity.md). Everything else about permissions belongs in the untracked settings.local.json.",
   "permissions": {
     "deny": [
       "Bash(ochakai put:*)",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,5 +130,5 @@ checked-in deny list enforces it — because the dev instance records CLI
 callers as the anonymous human, while the MCP connection carries your
 process identity, and that distinction is what keeps the trust tier
 honest about who reviewed what
-([kb/policies/ai-human-identity.md](kb/policies/ai-human-identity.md)).
+([kb/bundle/policies/ai-human-identity.md](kb/bundle/policies/ai-human-identity.md)).
 Rulings — verify and reject — belong to the human.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,21 +175,32 @@ and cheap to delete once it has been read.
 
 ## Working with Claude Code
 
-The repository checks in a `.claude/settings.json` with **hooks only**.
-One runs `gofmt` on Go files as they are written, since that is the
-cheapest CI failure to avoid. The other runs at session start and does
-nothing at all unless `CLAUDE_CODE_REMOTE` says the session is a
-disposable cloud container, where it installs pgvector beside the
-container's PostgreSQL so `scripts/check --db` has something to fall back
-to, and tells the agent what that environment cannot check. Docker has a
-CLI there but no daemon, and starting `dockerd` does not help because the
-egress policy refuses Docker Hub's blob CDN; the same policy refuses
-`vuln.go.dev`. So the store tests run, `core` and `lint` are honest there,
-and the `Dockerfile`, `deploy/compose.yaml` and `govulncheck` are CI's to
-verify — which is worth saying plainly, because an agent that reports a
-blocked host as a failing check is the expensive outcome. Permissions
-are a personal choice and belong in `.claude/settings.local.json`, which
-is not tracked.
+The repository checks in a `.claude/settings.json` with four hooks and
+one permissions rule. Two hooks serve the checks: one runs `gofmt` on Go
+files as they are written, since that is the cheapest CI failure to
+avoid; the other runs at session start and does nothing at all unless
+`CLAUDE_CODE_REMOTE` says the session is a disposable cloud container,
+where it installs pgvector beside the container's PostgreSQL so
+`scripts/check --db` has something to fall back to, and tells the agent
+what that environment cannot check. Docker has a CLI there but no
+daemon, and starting `dockerd` does not help because the egress policy
+refuses Docker Hub's blob CDN; the same policy refuses `vuln.go.dev`. So
+the store tests run, `core` and `lint` are honest there, and the
+`Dockerfile`, `deploy/compose.yaml` and `govulncheck` are CI's to verify
+— which is worth saying plainly, because an agent that reports a blocked
+host as a failing check is the expensive outcome.
+
+The other two hooks and the permissions rule are the dogfood loop
+([kb/README.md](kb/README.md)): recall injects concepts from the local
+instance as a prompt comes in, write-back asks its two questions once
+per session before the agent stops, and the deny list keeps agent
+sessions off the CLI write commands, which the dev instance would record
+as the anonymous human — agent writes go through the MCP tools, whose
+connection carries the process identity
+([kb/bundle/policies/ai-human-identity.md](kb/bundle/policies/ai-human-identity.md)).
+That deny list is the one permissions entry that is not a personal
+choice; everything else about permissions belongs in
+`.claude/settings.local.json`, which is not tracked.
 
 `.claude/skills/` holds the procedures that are long enough to get wrong
 from memory: `release` and `design-doc`. They are the same procedures
@@ -692,7 +703,7 @@ ceiling used to sit at the exact total with 15 lines of tolerance, beside
 a second one — `RECORD-COUNT` — that had to match the number of records
 exactly. Both are gone in favour of one number on a 500-line grid, after
 six records were written in parallel and every one of them had to rewrite
-the same two lines. [docs/surface.md](../docs/surface.md) had already
+the same two lines. [docs/surface.md](docs/surface.md) had already
 diagnosed this and prescribed the cure for the manual: **an alarm that
 sounds every time tells nobody anything**, and a line every concurrent PR
 edits is a line every concurrent PR conflicts on. A ceiling meant to make

--- a/cmd/ochakai/links_test.go
+++ b/cmd/ochakai/links_test.go
@@ -69,6 +69,12 @@ func TestManualLinksResolve(t *testing.T) {
 		pages = append(pages, root+name)
 	}
 	pages = append(pages, designIndex, designEnglishIndex)
+	// CLAUDE.md and CONTRIBUTING.md are changer-facing and so excluded
+	// from userDocs, but they are living pages whose links are meant to
+	// keep resolving — and a broken one survives review the same way a
+	// dead fragment does. CHANGELOG.md and IMPROVEMENT_PLAN.md stay out:
+	// each of their entries records the tree as it stood when written.
+	pages = append(pages, root+"CLAUDE.md", root+"CONTRIBUTING.md")
 	if len(pages) == 0 {
 		t.Fatal("no pages to read: this check now guards nothing")
 	}


### PR DESCRIPTION
<!-- Keep PRs small and focused. Link the issue or design doc, if there is one. -->

## What and why

A development-environment review, in three parts:

- **Fix a path that never existed.** The dogfood commit (8cc87ae) wrote
  `kb/policies/ai-human-identity.md` into CLAUDE.md,
  `.claude/settings.json` and `.claude/hooks/ochakai-write-back.sh`; the
  file has always lived at `kb/bundle/policies/ai-human-identity.md`.
  CONTRIBUTING.md also linked `../docs/surface.md`, one directory above
  the repository. All four references now resolve.
- **Bring CONTRIBUTING's *Working with Claude Code* back to the truth.**
  It still described the pre-dogfood `.claude/settings.json` — "hooks
  only", two of them, "permissions are a personal choice". The section
  now describes what is checked in: four hooks, and the one deny-list
  rule that is not a personal choice, with the two dogfood hooks pointed
  at kb/README.md and the identity policy.
- **Keep it that way.** None of this was caught because
  `TestManualLinksResolve` reads `userDocs`, which excludes the
  changer-facing pages. CLAUDE.md and CONTRIBUTING.md are living pages,
  not snapshots, so they join the link check; CHANGELOG.md and
  IMPROVEMENT_PLAN.md stay out because their entries record the tree as
  it stood when written.

Also reviewed and found sound, so left alone: the deny list still covers
every CLI write command (`seed` only prints a bundle; the write is
`import`, which is denied), the `.claude` hooks match their
`examples/claude-code` ancestors where they claim to and diverge where
their headers say they do, and `.github`'s workflows, dependabot config
and templates are current.

## Checks

CI runs the same script; make it pass locally first (CONTRIBUTING.md has the
context, including the store integration test and the fuzz targets).

- [x] `scripts/check` is clean — `--db core`, `ui` and `lint` ran green here
      (store tests against the local PostgreSQL 16 + pgvector fallback;
      `vuln` and the Docker-based jobs are CI's to verify in this
      environment)
- [x] Behavior changes come with tests — the link check now covers the two
      pages this PR fixes

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — untouched
- [x] The change lands on every surface it belongs on — no surface is
      touched; this is contributor docs, hooks and a test
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens a surface? No — nothing user-facing changes, and
      CONTRIBUTING.md is outside the counted manual

## Design docs

- [x] Alters an accepted decision? It does not — this box is not applicable
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_014zqpqZth6KzFVwHpmHMKdP)_