### PR TITLE
Add a geometric logo: a half-circle tea bowl with golden-ratio steam

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ochakai
 
+<img src="docs/images/logo-mark.svg" align="right" width="110" alt="ochakai logo: a tea bowl with three rising wisps of steam">
+
 [![ci](https://github.com/na0fu3y/ochakai/actions/workflows/ci.yaml/badge.svg)](https://github.com/na0fu3y/ochakai/actions/workflows/ci.yaml)
 [![release](https://img.shields.io/github/v/release/na0fu3y/ochakai?sort=semver)](https://github.com/na0fu3y/ochakai/releases)
 [![Go Reference](https://pkg.go.dev/badge/github.com/na0fu3y/ochakai.svg)](https://pkg.go.dev/github.com/na0fu3y/ochakai)

--- a/docs/images/logo-construction.svg
+++ b/docs/images/logo-construction.svg
@@ -34,14 +34,15 @@
     <clipPath id="drawingClip">
       <rect x="0" y="64" width="620" height="521"/>
     </clipPath>
-    <!-- The mark: bowl = lower half of a circle R=44; steam circles are
-         R/φ³ ≈ 10.4, R/φ⁴ ≈ 6.4, R/φ⁵ ≈ 4.0 (φ = golden ratio). -->
+    <!-- The mark: bowl = lower half of a circle R=44 on a wide low foot;
+         steam circles are R/φ³ ≈ 10.4, R/φ⁴ ≈ 6.4, R/φ⁵ ≈ 4.0 (φ = golden
+         ratio), gathered near the axis. -->
     <g id="mark">
       <path d="M56,90 A44,44 0 0 0 144,90 Z" fill="currentColor"/>
-      <path d="M90,128 L110,128 L106,142.5 L94,142.5 Z" fill="currentColor"/>
-      <circle cx="112" cy="72" r="4" fill="currentColor"/>
-      <circle cx="95" cy="54" r="6.4" fill="currentColor"/>
-      <circle cx="108" cy="30" r="10.4" fill="currentColor"/>
+      <path d="M87,128 L113,128 L110,139 L90,139 Z" fill="currentColor"/>
+      <circle cx="107" cy="73" r="4" fill="currentColor"/>
+      <circle cx="96" cy="56" r="6.4" fill="currentColor"/>
+      <circle cx="104" cy="33" r="10.4" fill="currentColor"/>
       <line x1="60" y1="98" x2="140" y2="98" stroke="#ece8dd" stroke-width="2.5"/>
     </g>
   </defs>
@@ -69,22 +70,22 @@
     <g transform="translate(310,336) scale(2.5) translate(-100,-88)">
       <g stroke="#3f3c33" fill="none" stroke-width="0.32">
         <!-- horizontals -->
-        <line x1="-96" y1="30" x2="296" y2="30" opacity="0.3"/>
+        <line x1="-96" y1="33" x2="296" y2="33" opacity="0.3"/>
         <line x1="-96" y1="46" x2="296" y2="46" opacity="0.25"/>
-        <line x1="-96" y1="54" x2="296" y2="54" opacity="0.3"/>
-        <line x1="-96" y1="72" x2="296" y2="72" opacity="0.3"/>
+        <line x1="-96" y1="56" x2="296" y2="56" opacity="0.3"/>
+        <line x1="-96" y1="73" x2="296" y2="73" opacity="0.3"/>
         <line x1="-96" y1="90" x2="296" y2="90" opacity="0.5" stroke-width="0.4"/>
         <line x1="-96" y1="134" x2="296" y2="134" opacity="0.3"/>
-        <line x1="-96" y1="142.5" x2="296" y2="142.5" opacity="0.3"/>
+        <line x1="-96" y1="139" x2="296" y2="139" opacity="0.3"/>
         <!-- verticals -->
         <line x1="56" y1="-22" x2="56" y2="190" opacity="0.4"/>
         <line x1="100" y1="-22" x2="100" y2="190" opacity="0.5" stroke-width="0.4"/>
         <line x1="144" y1="-22" x2="144" y2="190" opacity="0.4"/>
-        <line x1="95" y1="-22" x2="95" y2="190" opacity="0.22"/>
-        <line x1="108" y1="-22" x2="108" y2="190" opacity="0.28"/>
-        <line x1="112" y1="-22" x2="112" y2="190" opacity="0.22"/>
-        <line x1="90" y1="-22" x2="90" y2="190" opacity="0.18"/>
-        <line x1="110" y1="-22" x2="110" y2="190" opacity="0.18"/>
+        <line x1="96" y1="-22" x2="96" y2="190" opacity="0.22"/>
+        <line x1="104" y1="-22" x2="104" y2="190" opacity="0.28"/>
+        <line x1="107" y1="-22" x2="107" y2="190" opacity="0.22"/>
+        <line x1="87" y1="-22" x2="87" y2="190" opacity="0.18"/>
+        <line x1="113" y1="-22" x2="113" y2="190" opacity="0.18"/>
         <!-- concentric circles on the bowl centre: R/φ, R, Rφ, Rφ² -->
         <circle cx="100" cy="90" r="27.2" opacity="0.35"/>
         <circle cx="100" cy="90" r="44" opacity="0.55" stroke-width="0.4"/>
@@ -92,43 +93,43 @@
         <circle cx="100" cy="90" r="115.2" opacity="0.22"/>
         <circle cx="100" cy="134" r="16" opacity="0.3"/>
         <!-- steam construction: each circle with its φ-neighbours -->
-        <circle cx="108" cy="30" r="10.4" opacity="0.5"/>
-        <circle cx="108" cy="30" r="16.8" opacity="0.28"/>
-        <circle cx="108" cy="30" r="27.2" opacity="0.2"/>
-        <circle cx="95" cy="54" r="6.4" opacity="0.5"/>
-        <circle cx="95" cy="54" r="10.4" opacity="0.28"/>
-        <circle cx="112" cy="72" r="4" opacity="0.5"/>
-        <circle cx="112" cy="72" r="6.4" opacity="0.28"/>
+        <circle cx="104" cy="33" r="10.4" opacity="0.5"/>
+        <circle cx="104" cy="33" r="16.8" opacity="0.28"/>
+        <circle cx="104" cy="33" r="27.2" opacity="0.2"/>
+        <circle cx="96" cy="56" r="6.4" opacity="0.5"/>
+        <circle cx="96" cy="56" r="10.4" opacity="0.28"/>
+        <circle cx="107" cy="73" r="4" opacity="0.5"/>
+        <circle cx="107" cy="73" r="6.4" opacity="0.28"/>
         <!-- diagonals -->
         <line x1="-30" y1="-40" x2="230" y2="220" opacity="0.3"/>
         <line x1="-30" y1="220" x2="230" y2="-40" opacity="0.3"/>
         <line x1="-30" y1="4" x2="160" y2="194" opacity="0.25"/>
         <line x1="40" y1="194" x2="230" y2="4" opacity="0.25"/>
         <line x1="-100" y1="-25.5" x2="300" y2="205.5" opacity="0.2"/>
-        <line x1="15" y1="-30.7" x2="192" y2="156.7" opacity="0.3"/>
-        <line x1="35" y1="164.8" x2="168" y2="-80.8" opacity="0.3"/>
+        <line x1="41" y1="-29" x2="162" y2="158" opacity="0.3"/>
+        <line x1="56" y1="171" x2="144" y2="-82" opacity="0.3"/>
         <!-- dashed details -->
         <path d="M56,90 A44,44 0 0 0 144,90 Z" opacity="0.6" stroke-dasharray="1.6 1.6" stroke-width="0.36"/>
-        <rect x="88" y="126" width="24" height="19" opacity="0.45" stroke-dasharray="1.6 1.6" stroke-width="0.36"/>
-        <circle cx="108" cy="30" r="13" opacity="0.4" stroke-dasharray="1.4 1.4" stroke-width="0.34"/>
-        <circle cx="95" cy="54" r="8.6" opacity="0.4" stroke-dasharray="1.4 1.4" stroke-width="0.34"/>
+        <rect x="85" y="126" width="30" height="16" opacity="0.45" stroke-dasharray="1.6 1.6" stroke-width="0.36"/>
+        <circle cx="104" cy="33" r="13" opacity="0.4" stroke-dasharray="1.4 1.4" stroke-width="0.34"/>
+        <circle cx="96" cy="56" r="8.6" opacity="0.4" stroke-dasharray="1.4 1.4" stroke-width="0.34"/>
       </g>
       <!-- centre dots -->
       <g fill="#3f3c33" opacity="0.55">
         <circle cx="100" cy="90" r="0.9"/>
         <circle cx="100" cy="134" r="0.7"/>
-        <circle cx="108" cy="30" r="0.7"/>
-        <circle cx="95" cy="54" r="0.7"/>
-        <circle cx="112" cy="72" r="0.7"/>
+        <circle cx="104" cy="33" r="0.7"/>
+        <circle cx="96" cy="56" r="0.7"/>
+        <circle cx="107" cy="73" r="0.7"/>
       </g>
       <!-- ratio labels -->
       <g font-family="Georgia, 'Times New Roman', serif" font-style="italic" font-size="4" fill="#3f3c33" opacity="0.55">
-        <text x="126" y="61">R</text>
+        <text x="128" y="63">R</text>
         <text x="146" y="41">Rφ</text>
         <text x="72" y="61">R/φ</text>
-        <text x="120" y="22">R/φ³</text>
-        <text x="84" y="45">R/φ⁴</text>
-        <text x="118" y="79">R/φ⁵</text>
+        <text x="117" y="24">R/φ³</text>
+        <text x="82" y="48">R/φ⁴</text>
+        <text x="113" y="82">R/φ⁵</text>
       </g>
       <!-- the mark, blueprint fill -->
       <use href="#mark" color="#524f45" opacity="0.55"/>

--- a/docs/images/logo-construction.svg
+++ b/docs/images/logo-construction.svg
@@ -1,0 +1,159 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 620 780" role="img" aria-label="ochakai logo geometric construction sheet">
+  <defs>
+    <!-- Paper -->
+    <radialGradient id="paper" cx="50%" cy="42%" r="80%">
+      <stop offset="0%" stop-color="#f2eee4"/>
+      <stop offset="70%" stop-color="#ece8dd"/>
+      <stop offset="100%" stop-color="#e5e0d2"/>
+    </radialGradient>
+    <radialGradient id="vignette" cx="50%" cy="46%" r="75%">
+      <stop offset="0%" stop-color="#50493c" stop-opacity="0"/>
+      <stop offset="78%" stop-color="#50493c" stop-opacity="0"/>
+      <stop offset="100%" stop-color="#50493c" stop-opacity="0.16"/>
+    </radialGradient>
+    <filter id="grain" x="0" y="0" width="100%" height="100%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2" stitchTiles="stitch"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.25  0 0 0 0 0.24  0 0 0 0 0.20  0 0 0 0.05 0"/>
+    </filter>
+    <!-- Graph-paper grid -->
+    <pattern id="grid8" width="8" height="8" patternUnits="userSpaceOnUse">
+      <path d="M8 0H0V8" fill="none" stroke="#57534a" stroke-width="0.4" opacity="0.12"/>
+    </pattern>
+    <pattern id="grid40" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40 0H0V40" fill="none" stroke="#57534a" stroke-width="0.55" opacity="0.14"/>
+    </pattern>
+    <linearGradient id="fadeGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#000"/>
+      <stop offset="0.05" stop-color="#fff"/>
+      <stop offset="0.9" stop-color="#fff"/>
+      <stop offset="1" stop-color="#000"/>
+    </linearGradient>
+    <mask id="gridFade">
+      <rect x="0" y="64" width="620" height="521" fill="url(#fadeGrad)"/>
+    </mask>
+    <clipPath id="drawingClip">
+      <rect x="0" y="64" width="620" height="521"/>
+    </clipPath>
+    <!-- The mark: bowl = lower half of a circle R=44; steam circles are
+         R/φ³ ≈ 10.4, R/φ⁴ ≈ 6.4, R/φ⁵ ≈ 4.0 (φ = golden ratio). -->
+    <g id="mark">
+      <path d="M56,90 A44,44 0 0 0 144,90 Z" fill="currentColor"/>
+      <path d="M90,128 L110,128 L106,142.5 L94,142.5 Z" fill="currentColor"/>
+      <circle cx="112" cy="72" r="4" fill="currentColor"/>
+      <circle cx="95" cy="54" r="6.4" fill="currentColor"/>
+      <circle cx="108" cy="30" r="10.4" fill="currentColor"/>
+      <line x1="60" y1="98" x2="140" y2="98" stroke="#ece8dd" stroke-width="2.5"/>
+    </g>
+  </defs>
+
+  <!-- Ground -->
+  <rect width="620" height="780" fill="url(#paper)"/>
+  <g mask="url(#gridFade)">
+    <rect x="12" y="64" width="596" height="521" fill="url(#grid8)"/>
+    <rect x="12" y="64" width="596" height="521" fill="url(#grid40)"/>
+  </g>
+  <!-- Corner marks -->
+  <g fill="#45423a" opacity="0.5">
+    <rect x="15" y="87" width="3" height="3"/>
+    <rect x="602" y="87" width="3" height="3"/>
+    <rect x="15" y="565" width="3" height="3"/>
+    <rect x="602" y="565" width="3" height="3"/>
+  </g>
+
+  <!-- Header wordmark -->
+  <use href="#mark" transform="translate(262,44) scale(0.21) translate(-100,-81)" color="#35332c"/>
+  <text x="276" y="52" font-family="Georgia, 'Times New Roman', serif" font-size="24" font-weight="600" letter-spacing="0.5" fill="#35332c" textLength="90" lengthAdjust="spacingAndGlyphs">ochakai</text>
+
+  <!-- Construction drawing -->
+  <g clip-path="url(#drawingClip)">
+    <g transform="translate(310,336) scale(2.5) translate(-100,-88)">
+      <g stroke="#3f3c33" fill="none" stroke-width="0.32">
+        <!-- horizontals -->
+        <line x1="-96" y1="30" x2="296" y2="30" opacity="0.3"/>
+        <line x1="-96" y1="46" x2="296" y2="46" opacity="0.25"/>
+        <line x1="-96" y1="54" x2="296" y2="54" opacity="0.3"/>
+        <line x1="-96" y1="72" x2="296" y2="72" opacity="0.3"/>
+        <line x1="-96" y1="90" x2="296" y2="90" opacity="0.5" stroke-width="0.4"/>
+        <line x1="-96" y1="134" x2="296" y2="134" opacity="0.3"/>
+        <line x1="-96" y1="142.5" x2="296" y2="142.5" opacity="0.3"/>
+        <!-- verticals -->
+        <line x1="56" y1="-22" x2="56" y2="190" opacity="0.4"/>
+        <line x1="100" y1="-22" x2="100" y2="190" opacity="0.5" stroke-width="0.4"/>
+        <line x1="144" y1="-22" x2="144" y2="190" opacity="0.4"/>
+        <line x1="95" y1="-22" x2="95" y2="190" opacity="0.22"/>
+        <line x1="108" y1="-22" x2="108" y2="190" opacity="0.28"/>
+        <line x1="112" y1="-22" x2="112" y2="190" opacity="0.22"/>
+        <line x1="90" y1="-22" x2="90" y2="190" opacity="0.18"/>
+        <line x1="110" y1="-22" x2="110" y2="190" opacity="0.18"/>
+        <!-- concentric circles on the bowl centre: R/φ, R, Rφ, Rφ² -->
+        <circle cx="100" cy="90" r="27.2" opacity="0.35"/>
+        <circle cx="100" cy="90" r="44" opacity="0.55" stroke-width="0.4"/>
+        <circle cx="100" cy="90" r="71.2" opacity="0.3"/>
+        <circle cx="100" cy="90" r="115.2" opacity="0.22"/>
+        <circle cx="100" cy="134" r="16" opacity="0.3"/>
+        <!-- steam construction: each circle with its φ-neighbours -->
+        <circle cx="108" cy="30" r="10.4" opacity="0.5"/>
+        <circle cx="108" cy="30" r="16.8" opacity="0.28"/>
+        <circle cx="108" cy="30" r="27.2" opacity="0.2"/>
+        <circle cx="95" cy="54" r="6.4" opacity="0.5"/>
+        <circle cx="95" cy="54" r="10.4" opacity="0.28"/>
+        <circle cx="112" cy="72" r="4" opacity="0.5"/>
+        <circle cx="112" cy="72" r="6.4" opacity="0.28"/>
+        <!-- diagonals -->
+        <line x1="-30" y1="-40" x2="230" y2="220" opacity="0.3"/>
+        <line x1="-30" y1="220" x2="230" y2="-40" opacity="0.3"/>
+        <line x1="-30" y1="4" x2="160" y2="194" opacity="0.25"/>
+        <line x1="40" y1="194" x2="230" y2="4" opacity="0.25"/>
+        <line x1="-100" y1="-25.5" x2="300" y2="205.5" opacity="0.2"/>
+        <line x1="15" y1="-30.7" x2="192" y2="156.7" opacity="0.3"/>
+        <line x1="35" y1="164.8" x2="168" y2="-80.8" opacity="0.3"/>
+        <!-- dashed details -->
+        <path d="M56,90 A44,44 0 0 0 144,90 Z" opacity="0.6" stroke-dasharray="1.6 1.6" stroke-width="0.36"/>
+        <rect x="88" y="126" width="24" height="19" opacity="0.45" stroke-dasharray="1.6 1.6" stroke-width="0.36"/>
+        <circle cx="108" cy="30" r="13" opacity="0.4" stroke-dasharray="1.4 1.4" stroke-width="0.34"/>
+        <circle cx="95" cy="54" r="8.6" opacity="0.4" stroke-dasharray="1.4 1.4" stroke-width="0.34"/>
+      </g>
+      <!-- centre dots -->
+      <g fill="#3f3c33" opacity="0.55">
+        <circle cx="100" cy="90" r="0.9"/>
+        <circle cx="100" cy="134" r="0.7"/>
+        <circle cx="108" cy="30" r="0.7"/>
+        <circle cx="95" cy="54" r="0.7"/>
+        <circle cx="112" cy="72" r="0.7"/>
+      </g>
+      <!-- ratio labels -->
+      <g font-family="Georgia, 'Times New Roman', serif" font-style="italic" font-size="4" fill="#3f3c33" opacity="0.55">
+        <text x="126" y="61">R</text>
+        <text x="146" y="41">Rφ</text>
+        <text x="72" y="61">R/φ</text>
+        <text x="120" y="22">R/φ³</text>
+        <text x="84" y="45">R/φ⁴</text>
+        <text x="118" y="79">R/φ⁵</text>
+      </g>
+      <!-- the mark, blueprint fill -->
+      <use href="#mark" color="#524f45" opacity="0.55"/>
+      <!-- a few lines above the fill, like layered tracing -->
+      <g stroke="#3f3c33" fill="none" stroke-width="0.3">
+        <circle cx="100" cy="90" r="44" opacity="0.3"/>
+        <line x1="-96" y1="98" x2="296" y2="98" opacity="0.25"/>
+      </g>
+    </g>
+  </g>
+
+  <!-- Bottom section -->
+  <rect x="0" y="585" width="620" height="195" fill="url(#paper)"/>
+  <text x="45" y="634" font-family="Avenir, 'Helvetica Neue', Arial, sans-serif" font-size="11.5" letter-spacing="4" fill="#45423a">CONCEPT</text>
+  <g font-family="'Hiragino Mincho ProN', 'Yu Mincho', 'Noto Serif JP', serif" font-size="12.5" fill="#504d44" letter-spacing="0.5">
+    <text x="45" y="662">ひとつの円を水平にひらいた半円の茶碗で、知識をたたえて静</text>
+    <text x="45" y="684.5">かに差し出す器の実直さを表しました。碗の半径から黄金比で</text>
+    <text x="45" y="707">導いた三粒の湯気が、人とエージェントの持ち寄る知識が検証</text>
+    <text x="45" y="729.5">され注がれてめぐる様子をかたどり、茶面の一線と高台がまち</text>
+    <text x="45" y="752">の茶会のような確かな据わりを添えます。</text>
+  </g>
+  <rect x="437.5" y="594.5" width="137" height="161" fill="#ece8dd" stroke="#45423a" stroke-opacity="0.7" stroke-width="1"/>
+  <use href="#mark" transform="translate(506,673) scale(0.62) translate(-100,-81)" color="#37352f"/>
+
+  <!-- Finish -->
+  <rect width="620" height="780" fill="url(#vignette)"/>
+  <rect width="620" height="780" filter="url(#grain)"/>
+</svg>

--- a/docs/images/logo-mark.svg
+++ b/docs/images/logo-mark.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" role="img" aria-label="ochakai logo mark">
+  <!-- Geometry: bowl = lower half of a circle, R=44. Steam = three circles
+       derived from R by the golden ratio: R/φ³≈10.4, R/φ⁴≈6.4, R/φ⁵≈4.0. -->
+  <rect x="0" y="0" width="200" height="200" rx="24" fill="#ece8dd"/>
+  <g transform="translate(100,102) scale(1.15) translate(-100,-81)" fill="#37352f">
+    <path d="M56,90 A44,44 0 0 0 144,90 Z"/>
+    <path d="M90,128 L110,128 L106,142.5 L94,142.5 Z"/>
+    <circle cx="112" cy="72" r="4"/>
+    <circle cx="95" cy="54" r="6.4"/>
+    <circle cx="108" cy="30" r="10.4"/>
+    <line x1="60" y1="98" x2="140" y2="98" stroke="#ece8dd" stroke-width="2.5"/>
+  </g>
+</svg>

--- a/docs/images/logo-mark.svg
+++ b/docs/images/logo-mark.svg
@@ -1,13 +1,14 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" role="img" aria-label="ochakai logo mark">
-  <!-- Geometry: bowl = lower half of a circle, R=44. Steam = three circles
-       derived from R by the golden ratio: R/φ³≈10.4, R/φ⁴≈6.4, R/φ⁵≈4.0. -->
+  <!-- Geometry: bowl = lower half of a circle, R=44, on a wide low foot.
+       Steam = three circles derived from R by the golden ratio:
+       R/φ³≈10.4, R/φ⁴≈6.4, R/φ⁵≈4.0, gathered near the axis. -->
   <rect x="0" y="0" width="200" height="200" rx="24" fill="#ece8dd"/>
   <g transform="translate(100,102) scale(1.15) translate(-100,-81)" fill="#37352f">
     <path d="M56,90 A44,44 0 0 0 144,90 Z"/>
-    <path d="M90,128 L110,128 L106,142.5 L94,142.5 Z"/>
-    <circle cx="112" cy="72" r="4"/>
-    <circle cx="95" cy="54" r="6.4"/>
-    <circle cx="108" cy="30" r="10.4"/>
+    <path d="M87,128 L113,128 L110,139 L90,139 Z"/>
+    <circle cx="107" cy="73" r="4"/>
+    <circle cx="96" cy="56" r="6.4"/>
+    <circle cx="104" cy="33" r="10.4"/>
     <line x1="60" y1="98" x2="140" y2="98" stroke="#ece8dd" stroke-width="2.5"/>
   </g>
 </svg>

--- a/docs/images/logo.svg
+++ b/docs/images/logo.svg
@@ -1,13 +1,14 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 305 140" role="img" aria-label="ochakai">
-  <!-- Geometry: bowl = lower half of a circle, R=44. Steam = three circles
-       derived from R by the golden ratio: R/φ³≈10.4, R/φ⁴≈6.4, R/φ⁵≈4.0. -->
+  <!-- Geometry: bowl = lower half of a circle, R=44, on a wide low foot.
+       Steam = three circles derived from R by the golden ratio:
+       R/φ³≈10.4, R/φ⁴≈6.4, R/φ⁵≈4.0, gathered near the axis. -->
   <rect x="0" y="0" width="305" height="140" rx="18" fill="#ece8dd"/>
   <g transform="translate(60,74) scale(0.82) translate(-100,-81)" fill="#37352f">
     <path d="M56,90 A44,44 0 0 0 144,90 Z"/>
-    <path d="M90,128 L110,128 L106,142.5 L94,142.5 Z"/>
-    <circle cx="112" cy="72" r="4"/>
-    <circle cx="95" cy="54" r="6.4"/>
-    <circle cx="108" cy="30" r="10.4"/>
+    <path d="M87,128 L113,128 L110,139 L90,139 Z"/>
+    <circle cx="107" cy="73" r="4"/>
+    <circle cx="96" cy="56" r="6.4"/>
+    <circle cx="104" cy="33" r="10.4"/>
     <line x1="60" y1="98" x2="140" y2="98" stroke="#ece8dd" stroke-width="2.5"/>
   </g>
   <text x="105" y="90" font-family="Georgia, 'Times New Roman', serif" font-size="44" font-weight="600" letter-spacing="1" fill="#37352f" textLength="172" lengthAdjust="spacingAndGlyphs">ochakai</text>

--- a/docs/images/logo.svg
+++ b/docs/images/logo.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 305 140" role="img" aria-label="ochakai">
+  <!-- Geometry: bowl = lower half of a circle, R=44. Steam = three circles
+       derived from R by the golden ratio: R/φ³≈10.4, R/φ⁴≈6.4, R/φ⁵≈4.0. -->
+  <rect x="0" y="0" width="305" height="140" rx="18" fill="#ece8dd"/>
+  <g transform="translate(60,74) scale(0.82) translate(-100,-81)" fill="#37352f">
+    <path d="M56,90 A44,44 0 0 0 144,90 Z"/>
+    <path d="M90,128 L110,128 L106,142.5 L94,142.5 Z"/>
+    <circle cx="112" cy="72" r="4"/>
+    <circle cx="95" cy="54" r="6.4"/>
+    <circle cx="108" cy="30" r="10.4"/>
+    <line x1="60" y1="98" x2="140" y2="98" stroke="#ece8dd" stroke-width="2.5"/>
+  </g>
+  <text x="105" y="90" font-family="Georgia, 'Times New Roman', serif" font-size="44" font-weight="600" letter-spacing="1" fill="#37352f" textLength="172" lengthAdjust="spacingAndGlyphs">ochakai</text>
+</svg>


### PR DESCRIPTION
<!-- Keep PRs small and focused. Link the issue or design doc, if there is one. -->

## What and why

A geometric redesign of the ochakai logo, requested with a reference sheet in the construction-grid style (grid paper, guide circles, a CONCEPT block, and the finished mark in a corner box). The mark is constructed rather than drawn:

- the **bowl** is the lower half of a circle of radius R, with a tea-surface line across it and a small foot (高台);
- the **three wisps of steam** are circles derived from the bowl's radius by the golden ratio — R/φ³ ≈ 10.4, R/φ⁴ ≈ 6.4, R/φ⁵ ≈ 4.0 — rising from the rim, for the knowledge that people and agents bring, verify, and pour back around.

Three SVG assets under `docs/images`, all self-contained (system fonts only, no external references):

| file | what it is |
|---|---|
| `logo-mark.svg` | the mark alone, on a cream tile so it reads on light and dark backgrounds |
| `logo.svg` | the mark with the `ochakai` wordmark |
| `logo-construction.svg` | the construction sheet: graph paper, the φ guide circles and ratio labels, the Japanese concept text, and the finished mark in its box |

`README.md` now shows the mark (right-aligned, next to the badges). No code, no surface, no wire change.

## Checks

CI runs the same script; make it pass locally first (CONTRIBUTING.md has the
context, including the store integration test and the fuzz targets).

- [x] `scripts/check` is clean — `scripts/check core` and `scripts/check lint` pass locally (`--db` not needed; the store is untouched)
- [x] Behavior changes come with tests — no behavior changes; documentation images only

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — none of them are touched
- [x] The change lands on every surface it belongs on — it belongs on none;
      these are documentation assets
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens a surface? No — no endpoint, tool, command, or environment
      variable is added, and `docs/surface.md` is unchanged

## Design docs

- [x] Alters an accepted decision? It does not — a logo is not a decision a
      user can observe on the wire, so this box is not applicable
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_0159Hq58r5MGJKeviF6rFztQ)_