### PR TITLE
Say a sandbox is one to the agent writing into it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ last entry.
 
 ### Fixed
 
+- **A sandbox now says so to agents too, not only to people.** The CLI
+  and the web UI announce the disposable posture; MCP did not, so an
+  agent pointed at one — which the bundled `.mcpb` does by default, its
+  prefilled URL being the public demo — wrote drafts that the next
+  restore erased, with nothing having told it. A sandbox's `initialize`
+  instructions now carry one sentence saying it. It is not a tool:
+  MCP's default is no because a tool schema is resident in every agent's
+  context on every turn (design doc 0067 §4), and this is a sentence
+  only the deployment it is true of ever sends — an ordinary
+  deployment's resident bytes do not move, and `MCP-BYTES` is unchanged.
+  A `dev` deployment stays out on purpose: what it costs is the name on
+  a ruling, which is the operator's to know and the CLI already prints.
 - **The quick start's first three commands failed on a machine that has
   gcloud but cannot mint a token.** A session due for reauthentication,
   no account selected, or any non-interactive shell (an agent's, a CI

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -364,6 +364,18 @@ Web UI に、いずれもそのまま残る(CLI が完全性の面であると�
 である — `domain.TypesGuide()` の 1,319 バイトと、読みのツールが同じ
 フィルタの語をそれぞれのスキーマに持つぶん。
 
+**数えるのは通常の姿勢である。** サンドボックスだけは instructions に
+一文を足す — 匿名で書けて、次の復元で消えることを、エージェントにも
+言う([0087](design/0087-a-sandbox-says-it-is-one.md) §3。README を
+読んでいない呼び出し元の代表がエージェントであり、書くのはそれである)。
+ツールではなく instructions に載るのは、この面の既定が no である理由
+そのものによる([0067](design/0067-four-faces-and-what-they-decline.md)
+§4)— 守っているのは**すべてのエージェントが毎ターン払う文脈**であり、
+一つのデプロイだけが送る一文はそこに入らない。だから天井は動かず、
+その一文は `TestASandboxSaysSoInItsInstructions` が別に上限を持つ。
+`dev` は載せない: 失われるのは書いたものではなく裁定に載る名前で、
+それを知る必要があるのは運用者だから、CLI の `posture:` 行が言う。
+
 8 本のまま、もう一度。PR [#407](https://github.com/na0fu3y/ochakai/issues/407)
 (design doc [0064](design/0064-rest-stops-at-api-v1.md)) が
 `get_attachment` を `get_file` に改めた — ワイヤの `attachments` が

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -159,9 +159,38 @@ const instructions = "ochakai serves human-curated knowledge for data work: metr
 	"After acting on knowledge, call report_outcome. Write learnings back with " +
 	"put_concept as drafts for a human to confirm. Knowledge is co-owned by humans and agents."
 
+// sandboxNotice is what a sandbox owes the agent writing into it. Design
+// doc 0087 §3 requires the deployment to say what it is, because a
+// sandbox that does not takes the work of whoever wrote there — and an
+// agent writes there under instruction, which makes the loss a person's.
+//
+// It rides on the instructions rather than a tool of its own: MCP's
+// default is no (design doc 0067 §4) because a tool schema is resident in
+// every agent's context on every turn, and this is a sentence that only
+// the deployment it is true of ever sends. An ordinary deployment's
+// resident bytes do not move, which is what
+// TestMCPStaysUnderItsResidentByteCap measures.
+//
+// A `dev` deployment is deliberately not announced here. What it costs is
+// that no ruling names anybody, which is the operator's problem and the
+// CLI says it there; nothing an agent writes to it is lost.
+const sandboxNotice = "\nThis deployment is a sandbox: anyone may write, nobody is identified, " +
+	"and the whole base is restored on a schedule — a draft you write here will be erased. " +
+	"Write to it to try the loop, and say so when you report having written."
+
+// instructionsFor returns what this deployment tells a client to hold for
+// the whole conversation. Everything but the posture is the same
+// everywhere.
+func instructionsFor(cfg *config.Config) string {
+	if cfg != nil && cfg.Sandbox {
+		return instructions + sandboxNotice
+	}
+	return instructions
+}
+
 func newServer(svc *service.Service, version string, retired []RetiredToolName) *mcp.Server {
 	s := mcp.NewServer(&mcp.Implementation{Name: serverName, Version: version}, &mcp.ServerOptions{
-		Instructions: instructions,
+		Instructions: instructionsFor(svc.Config),
 	})
 
 	// A name this release renamed still answers, for this release only

--- a/internal/mcpserver/residentbytes_test.go
+++ b/internal/mcpserver/residentbytes_test.go
@@ -10,6 +10,11 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/na0fu3y/ochakai/internal/config"
+	"github.com/na0fu3y/ochakai/internal/service"
 )
 
 // The tool count is a budget, and it has been one since design doc 0015
@@ -78,6 +83,12 @@ func residentBytes(t *testing.T) (total int, perTool map[string]int) {
 		perTool[tool.Name+" (schema)"] = len(schema)
 		total += n
 	}
+	// The ordinary posture's instructions, which is what connect(t)
+	// serves and what all but one deployment sends. A sandbox appends a
+	// sentence (sandboxNotice) and is the only deployment that pays for
+	// it — counting it here would put every other deployment's budget
+	// under a warning that is not true of it. What keeps that honest is
+	// TestASandboxSaysSoInItsInstructions, which bounds the addition.
 	total += len(instructions)
 	return total, perTool
 }
@@ -174,5 +185,78 @@ func TestMCPBManifestListsTheToolsTheServerServes(t *testing.T) {
 		if !served[name] {
 			t.Errorf("the bundle's manifest lists %s, which the server does not serve", name)
 		}
+	}
+}
+
+// noticeCap bounds what a sandbox may add to the instructions. It is not
+// MCP-BYTES — no ordinary deployment pays it — but it is not free
+// either: the agent connected to a sandbox holds it for the whole
+// conversation, and the reason for the announcement does not license a
+// paragraph. One sentence's worth.
+const noticeCap = 300
+
+// A sandbox announces itself to agents as well as to people. Design doc
+// 0087 §3 puts the announcement on the product rather than on the README
+// somebody may not have read, and an agent is exactly the caller that
+// read no README: it writes drafts where it is pointed, and on a sandbox
+// they are erased on the next restore.
+//
+// The channel is the instructions rather than a tool, because MCP's
+// default is no (0067 §4) and what that protects is the context every
+// agent spends on every turn — which this leaves untouched everywhere
+// but on the one deployment the sentence is true of.
+func TestASandboxSaysSoInItsInstructions(t *testing.T) {
+	ordinary := instructionsFor(&config.Config{})
+	if ordinary != instructions {
+		t.Errorf("an ordinary deployment's instructions are not the plain ones:\n%s", ordinary)
+	}
+	// A client that predates the field, and the zero Service the other
+	// tests connect with, must not crash on a nil config.
+	if instructionsFor(nil) != instructions {
+		t.Error("a nil config did not read as the ordinary posture")
+	}
+
+	sandbox := instructionsFor(&config.Config{Sandbox: true})
+	if sandbox == ordinary {
+		t.Fatal("a sandbox said nothing about being one")
+	}
+	if !strings.HasPrefix(sandbox, instructions) {
+		t.Error("the sandbox notice replaced the instructions rather than adding to them")
+	}
+	// The words that carry the warning, not the sentence verbatim: what
+	// must survive an edit is that an agent is told it may write and that
+	// what it writes goes away.
+	for _, want := range []string{"sandbox", "erased"} {
+		if !strings.Contains(sandbox, want) {
+			t.Errorf("the sandbox notice does not say %q:\n%s", want, sandbox)
+		}
+	}
+	if added := len(sandbox) - len(ordinary); added > noticeCap {
+		t.Errorf("the sandbox notice is %d bytes, over the %d a sentence is worth", added, noticeCap)
+	}
+
+	// A dev deployment is left out on purpose: what it costs is that no
+	// ruling names anybody, which is the operator's to know and the CLI's
+	// to print, and nothing an agent writes to it is lost.
+	if instructionsFor(&config.Config{InsecureDev: true}) != instructions {
+		t.Error("dev announced itself here; that announcement belongs to the CLI")
+	}
+
+	// And it reaches a client, which is the only form of the claim worth
+	// checking: read back off a real initialize rather than off the
+	// function that composed it (design doc 0035).
+	ctx := context.Background()
+	ct, st := mcp.NewInMemoryTransports()
+	svc := &service.Service{Config: &config.Config{Sandbox: true}}
+	if _, err := newServer(svc, "test", RetiredToolNames).Connect(ctx, st, nil); err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	cs, err := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0"}, nil).Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer cs.Close()
+	if got := cs.InitializeResult().Instructions; got != sandbox {
+		t.Errorf("initialize carried different instructions than the server composed:\n%s", got)
 	}
 }


### PR DESCRIPTION
<!-- Follows #639, which left this open: the CLI announces the sandbox, MCP did not. -->

## What and why

#639 gave the sandbox posture a voice on the CLI and left one question
open in its own description: **an agent writing drafts into a sandbox
loses them exactly as a person does, and it hears nothing.** This closes
that.

An agent is the caller most likely never to have read the README — it
writes where it is pointed — and the bundled `.mcpb` points at the public
demo by default, which is a sandbox. Design doc 0087 §3 is written about
exactly this: a sandbox that does not say so takes the work of whoever
wrote there.

**Why the instructions and not a tool.** MCP's default is no (0067 §4),
and what that default protects is the context every agent spends on every
turn. A tool schema is resident in every conversation against every
deployment; this is one sentence sent only by the deployment it is true
of. The number that settled it:

```
resident bytes: 13474        (MCP-BYTES: 13500, MCP-BYTES-SLACK: 500)
  instructions   1021
```

**26 bytes of headroom.** An unconditional sentence would have gone over,
raising `MCP-BYTES` to 14,000 — every ordinary deployment paying, on
every turn, for a warning that is not true of it. Conditional, the
measured number does not move at all, and `MCP-BYTES` is unchanged.

`instructionsFor(cfg)` returns the plain instructions unless the
deployment is a sandbox. `TestMCPStaysUnderItsResidentByteCap` reads the
ordinary posture and now says why; the notice carries a cap of its own
(300 bytes) so that the reason for announcing does not license a
paragraph.

**`dev` deliberately stays out.** What a dev deployment costs is the name
on a ruling — the operator's to know, and `ochakai whoami` prints it
there. Nothing an agent writes to a dev base is lost, so the sentence
0087 §3 is about does not apply.

### Verified against a real server

`OCHAKAI_MODE=sandbox`, a throwaway Postgres, an `initialize` over
`/mcp`:

```
…Knowledge is co-owned by humans and agents.
This deployment is a sandbox: anyone may write, nobody is identified, and
the whole base is restored on a schedule — a draft you write here will be
erased. Write to it to try the loop, and say so when you report having
written.
```

The test asserts the same thing the same way — read back off a session's
`InitializeResult`, not off the function that composed it (design doc
0035).

## Checks

- [x] `scripts/check` is clean — add `--db` when the change touches the store
  — `scripts/check --db` green.
- [x] Behavior changes come with tests — `TestASandboxSaysSoInItsInstructions`
  covers the ordinary posture (unchanged), a nil config, the sandbox
  (contains the warning, added to rather than replacing the instructions,
  under its own cap), `dev` (silent here), and delivery over a real
  initialize.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — REST is untouched; the
      posture is already on `GET /api/v1/stats`, which is where the CLI
      and the web UI read it.
- [x] The change lands on every surface it belongs on — this *is* the
      remaining surface. CLI and web UI announce it already; REST answers
      it on stats; MCP was the gap.
- [x] `api/openapi.frozen.txt` is untouched.
- [x] Widens a surface? No tool, no parameter, no environment variable,
      no command. `docs/surface.md`'s MCP section gains the paragraph
      saying the count is of the ordinary posture and why the sandbox's
      sentence sits outside it. The three questions, since prose on this
      surface is a cost: **who got stuck** — an agent writing into
      demo.ochak.ai, told nothing, losing it at the next restore;
      **why an existing surface does not cover it** — the announcement
      lives on stats and the web UI banner, and MCP has no stats tool
      while the demo serves no pages; **what is folded in exchange** —
      nothing, and nothing is owed: the resident byte count does not
      move for any deployment that is not a sandbox.

## Design docs

- [x] Alters an accepted decision? No. 0087 §4 justified `stats` against
      a *header* — the wire was frozen against a new one — and did not
      weigh instructions. This carries out 0087 §3's requirement on the
      surface it had not reached, and reverses nothing.
- [x] Commit messages and code comments are in English.
