### PR TITLE
Make the web UI's Japanese read as Japanese

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ last entry.
 
 ### Fixed
 
+- **The web UI's Japanese reads as Japanese.** The home page's opening
+  paragraph, the three feed banners and the review page's prose had
+  sentences whose halves did not agree — a clause ending in `に` where a
+  verb belonged, an id called "そのパス" with nothing for その to point
+  at — and the home page's shortcut row broke wherever the window
+  happened to end, leaving the separator at the head of a line and a
+  "link — what it is" pair split across two. That row is now a list
+  whose entries are flex items, so a break falls between entries rather
+  than inside one. Two of the sentences were also untrue: the draft
+  queue ranks on fetches and not on search hits (design doc 0090), and
+  verifying a concept drops it from 間違いと報告された but only re-sorts
+  it in 検証の古さ, which lists the whole base and never empties.
 - **A sandbox now says so to agents too, not only to people.** The CLI
   and the web UI announce the disposable posture; MCP did not, so an
   agent pointed at one — which the bundled `.mcpb` does by default, its

--- a/internal/webui/static/app.css
+++ b/internal/webui/static/app.css
@@ -459,6 +459,15 @@ table.kv td.k { color: var(--muted); width: 11rem; white-space: nowrap; }
 @media (max-width: 620px) { .row-trio { grid-template-columns: 1fr; } }
 
 .section-title { font-size: 1.25rem; font-weight: 700; margin: .2rem 0 1rem; }
+/* The home page's shortcuts. Each entry is a flex item so a line breaks
+   between entries rather than inside one — as a run of text separated by
+   middots, a narrow window put the separator at the head of a line and
+   split "link — what it is" across two. */
+.home-links {
+  display: flex; flex-wrap: wrap; gap: .35rem 1.4rem;
+  list-style: none; margin: .9rem 0 0; padding: 0;
+  color: var(--muted); font-size: .9rem;
+}
 .toolbar { display: flex; align-items: center; gap: .6rem; margin-bottom: 1rem; flex-wrap: wrap; }
 .toolbar .grow { flex: 1; }
 

--- a/internal/webui/static/js/views/dir.js
+++ b/internal/webui/static/js/views/dir.js
@@ -52,20 +52,22 @@ export function viewDir(rawPrefix) {
 export function viewHome() {
   view.innerHTML = `
     <div class="section-title" style="font-size:1.5rem">🍵 ochakai</div>
-    <p style="color:var(--muted);max-width:42rem">ナレッジはフォルダのツリーです — concept の id が
-    そのパスなので(<code>queries/sales/monthly-revenue</code>)、サイドバーのツリーが入口になります。
-    一緒に読まれるべきものは一緒に置き、ドキュメントのように辿ってください。どこを見ればよいか
-    分からないときが、検索の出番です。</p>
+    <p style="color:var(--muted);max-width:42rem">ナレッジはフォルダのツリーです。concept の id が
+    そのままパスになる(例: <code>queries/sales/monthly-revenue</code>)ので、サイドバーのツリーが
+    入口になります。まとめて読むものは同じ場所に置き、ドキュメントを読むように辿ってください。
+    どこを見ればよいか分からないときに、検索を使います。</p>
     <div class="searchbox" style="max-width:36rem">
       <input type="text" id="home-q" placeholder="メトリクス・検証済みクエリ・insight・用語・テーブルを検索…" autocomplete="off">
       <a class="btn" id="home-go" href="#/search">検索</a>
     </div>
-    <p style="color:var(--muted);font-size:.9rem">
-      <a href="#/review">レビューキュー</a> — エージェントが書いた draft を検証する / 却下する ·
-      <a href="#/search/reported-wrong">間違いと報告された</a> — 検証済みなのに間違いだったナレッジ ·
-      <a class="write-only" href="#/new">＋ concept を作る</a> ·
-      <a href="#" id="home-export" title="ナレッジベースを OKF バンドル(tar.gz)として書き出す">OKF を書き出す</a>
-    </p>
+    <ul class="home-links">
+      <li><a href="#/review">レビューキュー</a> — エージェントが書いた draft を検証・却下する</li>
+      <li><a href="#/search/reported-wrong">間違いと報告された</a> — 検証済みなのに間違いだったナレッジ</li>
+      <!-- Gated twice on purpose: the link is the write affordance, and the
+           item around it would otherwise leave a gap in the row. -->
+      <li class="write-only"><a class="write-only" href="#/new">＋ concept を作る</a></li>
+      <li><a href="#" id="home-export" title="ナレッジベースを OKF バンドル(tar.gz)として書き出す">OKF を書き出す</a></li>
+    </ul>
     <div id="home-index" style="margin-top:1.4rem"><div class="empty">…</div></div>`;
   $('#home-q').addEventListener('keydown', e => {
     if (e.key === 'Enter') { explore.q = e.target.value; location.hash = '#/search'; }

--- a/internal/webui/static/js/views/explore.js
+++ b/internal/webui/static/js/views/explore.js
@@ -46,19 +46,21 @@ export function viewExplore() {
   <section>
     <div class="searchbox">
       ${explore.ageFeed
-        ? `<div class="feed-banner" style="flex:1;margin-bottom:0">検証の古さのフィード — 検証が古い順で、検証済みクエリを再確認するためのカナリアです。
+        ? `<div class="feed-banner" style="flex:1;margin-bottom:0">検証の古さのフィード — 最後に検証してから時間が経ったものから順に並べています。
+           古びた検証済みクエリを浮かせるためのカナリアです。
            検索に戻るには <strong>検証の古さ</strong> のチェックを外してください。</div>`
         : explore.failedFeed
         ? `<div class="feed-banner" style="flex:1;margin-bottom:0">再検証のフィード — 失敗の報告(report_outcome failed)にまだ応えていない concept を、
-           ひどい順に。開いて読み直し、検証するとこのフィードから外れます。検索に戻るには
-           <strong>間違いと報告された</strong> のチェックを外してください。</div>`
+           報告が多いものから順に並べています。開いて中身を確かめ、検証し直すとこのフィードから外れます。
+           検索に戻るには <strong>間違いと報告された</strong> のチェックを外してください。</div>`
         : explore.source
         ? `<div class="feed-banner" style="flex:1;margin-bottom:0"><code>${esc(explore.source)}</code> を引いている concept — この資料から派生したものすべてです。
-           <a href="#/search">検索に戻る</a>.</div>`
+           <a href="#/search">検索に戻る</a>。</div>`
         : explore.expiredFeed
-        ? `<div class="feed-banner" style="flex:1;margin-bottom:0">期限切れのフィード — 著者が宣言した <code>stale_after</code> を過ぎた concept を、
-           超過が大きい順に。<strong>検証してもこのキューは片付きません</strong>: その日付は書き手の宣言なので、
-           concept を確かめ直したうえで編集し、新しい期限を宣言する(あるいは外す)必要があります。
+        ? `<div class="feed-banner" style="flex:1;margin-bottom:0">期限切れのフィード — 書き手が宣言した <code>stale_after</code> を過ぎた concept を、
+           超過が大きいものから順に並べています。<strong>検証してもこのキューは片付きません</strong>:
+           その日付はサーバーが測ったものではなく書き手の宣言なので、concept を確かめ直したうえで編集し、
+           新しい期限を宣言する(あるいは外す)必要があります。
            検索に戻るには <strong>期限切れ</strong> のチェックを外してください。</div>`
         : `<input type="text" id="q" placeholder="メトリクス・検証済みクエリ・insight・用語・テーブルを検索…"
                   value="${esc(explore.q)}" autocomplete="off">`}

--- a/internal/webui/static/js/views/review.js
+++ b/internal/webui/static/js/views/review.js
@@ -27,19 +27,20 @@ export function viewReview() {
     <div class="read-only-note">この ochakai は read-only なので、レビューの操作は
     表示されません。キューそのものは本物です — 書き込めるデプロイのレビュアーが
     片付けていくのが、これと同じ列です。</div>
-    <p style="color:var(--muted);max-width:48rem">エージェントが書き戻した draft を、求められている順に — 検索ヒット数と、
-    その draft が実際に検索で浮いた回数で順位が付きます。正しいものは検証し、そうでないものは却下します
-    (理由は status_note として残るので、エージェントは同じ提案を繰り返さなくなります)。一度も使われていない
-    draft は下に沈みます。<em>放置されたものだけ</em> を切り替えると、その仕分けができます。</p>
-    <p style="color:var(--muted);font-size:.9rem;max-width:48rem">検証済みのナレッジには、それ自身の二つのキューがある:
-    <a href="#/search/reported-wrong">間違いと報告された</a>(失敗の報告に応えていない concept)と、
-    <a href="#/search/verification-age">検証の古さ</a>(検証が古い順)です。検証すると、その concept は両方から消えます。
-    三つ目の <a href="#/search/stale">期限切れ</a> は、著者が宣言した期限を過ぎた concept を並べます。
-    こちらは検証ではなく、concept を編集すると片付きます。</p>
+    <p style="color:var(--muted);max-width:48rem">エージェントが書き戻した draft を、求められている順に並べています。
+    順位を決めるのは検索に出た回数ではなく、実際に読み込まれた回数です — 直近の期間を先に見て、同じなら通算で比べます。
+    正しいものは検証し、そうでないものは却下してください(理由が status_note として残るので、エージェントは
+    同じ提案を繰り返さなくなります)。一度も読まれていない draft は下に沈むので、
+    <em>放置されたものだけ</em> に切り替えると、その仕分けができます。</p>
+    <p style="color:var(--muted);font-size:.9rem;max-width:48rem">検証済みのナレッジには、それ自身のキューが二つあります:
+    <a href="#/search/reported-wrong">間違いと報告された</a>(失敗の報告にまだ応えていない concept)と、
+    <a href="#/search/verification-age">検証の古さ</a>(検証が古いものから順)です。検証し直すと、前者からは消え、
+    後者では最後尾に回ります。三つ目の <a href="#/search/stale">期限切れ</a> は、書き手が宣言した期限を過ぎた
+    concept を並べます。こちらは検証では片付かず、concept を編集して期限を宣言し直すと消えます。</p>
     <div id="loop-stats"></div>
     <div class="toolbar">
       <label class="check"><input type="checkbox" id="r-stale" ${review.staleOnly ? 'checked' : ''}>
-        放置されたものだけ(ヒット 0 件、${STALE_DAYS} 日以上前)</label>
+        放置されたものだけ(検索ヒット 0 件・作成から ${STALE_DAYS} 日以上)</label>
       <span class="grow"></span>
       <span id="queue-strip" style="display:flex;gap:.35rem">${queueStrip()}</span>
     </div>
@@ -126,9 +127,10 @@ export async function loadLoopStats() {
       見つかりません — 語句そのものが含まれていれば字句検索は当てます。長すぎる concept を
       分けるか、より広い窓のモデルに移すかのどちらかです。</p>` : '') + (gaps.length ? `
     <details style="max-width:48rem;margin:0 0 1.2rem">
-      <summary style="cursor:pointer;color:var(--muted)">訊かれたのに無かったもの — 次に書くこと</summary>
+      <summary style="cursor:pointer;color:var(--muted)">答えの無かった検索 — 次に書くもの</summary>
       <p style="color:var(--muted);font-size:.9rem;margin:.5rem 0">直近 ${s.window_days} 日で何も返さなかった検索を、
-      よく訊かれた順に。誰かが片付けるキューではありません: 答えが存在すれば、そのまま出なくなります。</p>
+      多く訊かれたものから順に並べています。誰かが片付けるキューではありません: 答えになる concept が書かれれば、
+      この一覧からは自然に消えます。</p>
       ${gaps.map(g => `<div style="display:flex;gap:.6rem;align-items:baseline;padding:.25rem 0">
         <span class="badge">${g.count}×</span>
         <a href="#/search" class="mono" data-gap="${esc(g.query)}">${esc(g.query)}</a></div>`).join('')}


### PR DESCRIPTION
## What and why

The prose a curator reads on the home page, the three feed banners and the
review page had sentences whose halves did not agree — a clause ending in `に`
where a verb belonged, an id called 「そのパス」 with nothing for その to point
at, 一緒に twice in one line, 著者 and 書き手 for the same person two
paragraphs apart. Nothing about the UI changed; the sentences did.

One of the items was a layout defect rather than a wording one. The home
page's shortcut row was a run of links separated by middots, so a line broke
wherever the window happened to end: the separator landed at the head of a
line and a 「リンク — それが何か」 pair got split across two. It is a list now
(`.home-links`), whose entries are flex items, so a break falls between
entries rather than inside one. The `＋ concept を作る` entry carries
`write-only` on both the link and its `<li>` — the link because that is the
write affordance the read-only guard checks, the item because otherwise a
hidden link leaves a gap in the row.

Rewriting two of the sentences was the occasion to notice they were untrue:

- The draft queue ranks on **fetches**, not on search hits (design doc 0090).
  The old text named both and made them sound like one number, which is
  exactly the confusion 0090 set out to end.
- Verifying a concept drops it from 間違いと報告された but only re-sorts it in
  検証の古さ, which lists the whole base and never empties
  ([docs/loop.md](docs/loop.md#feeds)). 「検証すると、その concept は両方から
  消えます」 promised an emptying that cannot happen.

The queue names, the three feed names and every id stay as they are — they are
the words `docs/loop.md` and the design records use. This changes how the
sentences around them read, not what anything is called.

Verified against a local instance (`ochakai serve` in dev mode with
`examples/demo` imported, behind `ochakai ui`): the home page at 1200px and
420px, the review page including the 答えの無かった検索 disclosure with real
misses recorded, and all three feed banners.

## Checks

- [x] `scripts/check` is clean — add `--db` when the change touches the store

  `scripts/check core ui lint` is green, as is the browser smoke
  (`internal/webui/jstest/smoke.mjs`, 18/18) against the local instance above.
  `scripts/check vuln` is unverifiable in this environment — the egress policy
  refuses `vuln.go.dev`, not a finding. The store is untouched, so `--db` adds
  nothing here; CI runs it.
- [x] Behavior changes come with tests

  No behavior change. The one structural edit is covered by the existing
  guard: `TestWriteAffordancesAreHiddenOnAReadOnlyDeployment` failed on the
  first attempt at the home-page list, which is how the `write-only` gating
  above got settled.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — untouched, no endpoint moved
- [x] The change lands on every surface it belongs on — Web UI only, because
      the text being fixed exists only there. The CLI and MCP print none of it
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens no surface: no operation, tool, command or variable is added, and
      `docs/surface.md` is unchanged (`cmd/ochakai/surface_test.go` passes)

## Design docs

- [x] Alters no accepted decision — not applicable. Nothing observable changes
      shape; the two factual corrections bring the page into line with design
      doc 0090 and `docs/loop.md` rather than departing from them
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_015why7cFH1SPhVoY3PX7teW)_