### PR TITLE
Release 0.22.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Version
       description: Output of `ochakai version`, or the image tag you deployed.
-      placeholder: "0.22.0"
+      placeholder: "0.22.1"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ last entry.
 
 ## [Unreleased]
 
+## [0.22.1] - 2026-08-14
+
 ### Added
 
 - **A guide for the first month with an empty base**
@@ -4230,7 +4232,8 @@ worth naming: SQL injection in `compile_sql` through undeclared field
 pass-through, fixed in 0.8.0 — v0.7.0 and earlier are affected. Details
 are in git history.
 
-[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.22.0...HEAD
+[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.22.1...HEAD
+[0.22.1]: https://github.com/na0fu3y/ochakai/compare/v0.22.0...v0.22.1
 [0.22.0]: https://github.com/na0fu3y/ochakai/compare/v0.21.1...v0.22.0
 [0.21.1]: https://github.com/na0fu3y/ochakai/compare/v0.21.0...v0.21.1
 [0.21.0]: https://github.com/na0fu3y/ochakai/compare/v0.20.0...v0.21.0

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -74,7 +74,7 @@ info:
     is a security defect, shipped in the next release with no deprecation
     window (SECURITY.md). MCP, the CLI and the stored shape stay unstable
     while the major version is 0 and may still change in a minor release.
-  version: 0.22.0
+  version: 0.22.1
   license:
     name: MIT
 servers:

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -80,7 +80,7 @@ export IMAGE=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:$VERSION
 `:latest` ではなくバージョンを固定し、再デプロイを意識的な判断にする。
 `gh` CLI が無ければ
 [リリースページ](https://github.com/na0fu3y/ochakai/releases)から番号
-を読み、手で設定する — `export VERSION=0.22.0`。
+を読み、手で設定する — `export VERSION=0.22.1`。
 
 (このガイドは 0.9.0 以降を前提にしている。それより前のリリースは
 [retract](https://go.dev/ref/mod#go-mod-file-retract) 済みでサポート外


### PR DESCRIPTION
## What and why

Cuts **0.22.1** from `4bf3de9`. Seven fixes and one guide since v0.22.0
(2026-08-11), no **BREAKING** entry among them, so this takes the patch
rather than the minor — CONTRIBUTING.md: while the major version is 0,
only a release with a BREAKING entry takes the minor.

Three of the fixes are on the path a new reader actually walks, which is
what makes this worth cutting three days after the last one:

- **The quick start's first three commands failed** on a machine with
  gcloud but no mintable token — a session due for reauth, no account
  selected, or any non-interactive shell (an agent's, a CI job's). The
  client committed to the gcloud path on the mere presence of the binary,
  so even requests to the public demo, which reads no identity, were
  aborted before being sent.
- **The web UI's review queue was unreachable** wherever a banner shows —
  `dev` and `sandbox` — on any screen wider than 800px: the banner took
  the content cell and the view was auto-placed under the sticky sidebar.
  That is the human half of the loop, missing on exactly the two postures
  meant for trying ochakai out.
- **A sandbox did not say so** to CLI users or to MCP agents. Design doc
  0087 §3 requires the announcement because a sandbox that stays quiet
  takes the work of whoever wrote there, and the bundled `.mcpb` points
  at the demo — a sandbox — by default.

## What is in this PR

- `CHANGELOG.md`: `## [Unreleased]` closes as `## [0.22.1] - 2026-08-14`
  (JST), a fresh empty `## [Unreleased]` above it, the `[0.22.1]` compare
  link added and `[Unreleased]` repointed at the new tag.
- The three files a tag does not update: `api/openapi.yaml`'s
  `info.version`, `.github/ISSUE_TEMPLATE/bug_report.yml`'s placeholder,
  and `deploy/cloudrun/README.md`'s hand-set `export VERSION=` for the
  reader with no `gh` CLI.

`grep -rn 0.22.0` finds nothing else outside `CHANGELOG.md`, `docs/design`
and unrelated dependency versions in `go.mod`/`go.sum`.

**`RetiredToolNames` and `retiredCommands` are both empty**, so this
release ends no rename window (design doc 0088) and
`TestARetiredNameLastsOneRelease` has nothing to drop.

**The logo commits (`ccd99f9`, `a1a7c57`) get no changelog entry on
purpose.** They touch `README.md` and `docs/images/*.svg` only — no
shipped asset, no surface — and this file keeps what an operator
upgrading needs to know. Eight commits, eight entries, verified against
`git log v0.22.0..origin/main`.

## Checks

- [x] `scripts/check` is clean — add `--db` when the change touches the store
- [x] Behavior changes come with tests — no behavior change; version
      strings and the changelog only

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — only `info.version` moves
- [x] The change lands on every surface it belongs on — release
      bookkeeping, no surface change
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens a surface? No. `docs/surface.md` counts are unchanged

## Design docs

- [x] Alters an accepted decision? No
- [x] Commit messages and code comments are in English
