### PR TITLE
Build on Go 1.26.6 for the stdlib security fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,19 @@ last entry.
 
 ## [Unreleased]
 
+### Security
+
+- **Built with Go 1.26.6.** The 1.26.5 standard library carries seven
+  vulnerabilities this code reaches — quadratic `resolvePath` in
+  `net/url`, JavaScript regexp context tracking in `html/template`,
+  unbounded post-handshake messages in `crypto/tls`, a missing
+  `ReadHeaderTimeout` on the unencrypted HTTP/2 check in `net/http`,
+  recursion depth in `encoding/xml` and `encoding/asn1`, and
+  ASCII-only Punycode labels via `golang.org/x/net/idna` — all fixed
+  upstream in 1.26.6. The `toolchain` line and the build image move
+  together; the `go` directive stays `1.26`, so no minimum rises for
+  anyone installing with `GOTOOLCHAIN=local`.
+
 ## [0.22.1] - 2026-08-14
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Requires BuildKit: on the legacy builder (plain gcr.io/cloud-builders/docker
 # on Cloud Build, or docker without DOCKER_BUILDKIT=1) the next line fails
 # with `failed to parse platform : "" is an invalid component`.
-FROM --platform=$BUILDPLATFORM golang:1.26.5 AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.6 AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ go 1.26
 // toolchain, so a corporate CI running GOTOOLCHAIN=local on 1.26.2
 // fails at `go install` rather than building. As `toolchain` it is a
 // preference the local setting may decline.
-toolchain go1.26.5
+toolchain go1.26.6
 
 // Pre-0.9.0 releases are unsupported: superseded by 0.9.0 (the first
 // release the deploy guide and docs are written against; earlier images


### PR DESCRIPTION
## What and why

The `govulncheck` job is failing on `main`
([run 31857774386](https://github.com/na0fu3y/ochakai/actions/runs/31857774386/job/94945620807)).
Nothing in this repository's code is at fault: the Go 1.26.5 standard
library carries seven vulnerabilities that this code *reaches*, and
every one of them is fixed upstream in 1.26.6.

| ID | What | Where we reach it |
|---|---|---|
| GO-2026-6218 | quadratic `resolvePath` in `net/url` | `apiclient.Client.doRaw`, `blob.GCS.Put` |
| GO-2026-6091 | JavaScript regexp context tracking in `html/template` | `ochakai.serveAndDrain` |
| GO-2026-6090 | unbounded post-handshake messages in `crypto/tls` | `store.Store.Close`, `serveAndDrain`, `httpauth`, `apiclient` |
| GO-2026-6089 | missing `ReadHeaderTimeout` on the unencrypted HTTP/2 check in `net/http` | `ochakai.serveAndDrain` |
| GO-2026-6088 | recursion depth in `encoding/xml` | `store.Store.Usage` |
| GO-2026-5972 | recursion depth in `encoding/asn1` | `apiclient.Client.credentials` |
| GO-2026-5026 | ASCII-only Punycode labels via `golang.org/x/net/idna` | `apiclient`, `ochakai.withIAPIdentity` |

So the fix is the patch bump, in the two places that pin one:
`go.mod`'s `toolchain` line (which is what `actions/setup-go` reads
through `go-version-file: go.mod`, and what `scripts/check`'s
`tool_toolchain` builds the linters with) and the `golang:` build image
in the `Dockerfile`. They move together so CI, a local `scripts/check`
and the published image are on the same patch.

**The `go` directive stays `1.26`.** [#535](https://github.com/na0fu3y/ochakai/issues/535)
moved the patch off that line precisely so it stays a preference a
local `GOTOOLCHAIN` may decline, rather than a minimum that breaks
`go install` for anyone pinned to an older patch; this change keeps
that shape. The `retract` comment's mention of 1.26.5 is a historical
claim about pre-0.9.0 images and stays as written.

No surface is added or widened, so the three questions do not apply —
no REST operation, MCP tool, CLI command, flag, parameter, header,
variable or vocabulary word changed, and `docs/surface.md` is
untouched. The `CHANGELOG.md` entry lands under `[Unreleased]` →
`Security`, matching how the last such bump was recorded.

## Checks

- [x] `scripts/check` is clean — add `--db` when the change touches the store
- [x] Behavior changes come with tests

`scripts/check core` and `scripts/check lint` are green on Go 1.26.6.
No store code changed, so `--db` adds nothing here. No behavior
changed, so no test is due — the check this change exists to fix *is* a
CI job, and the `govulncheck` job on this PR is what confirms it.

`govulncheck` could not be re-run in this environment: its egress
policy answers 403 for `vuln.go.dev`
(`connect_rejected` … `gateway answered 403 to CONNECT`), which is the
proxy refusing the host, not a finding. Reporting it as unverified here
rather than as a pass.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and `internal/apiclient` say the same thing — none of them changed
- [x] The change lands on every surface it belongs on — it lands on none; a toolchain patch is invisible from all four
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens a surface? No. `docs/surface.md` is unchanged and every dimension's count holds

## Design docs

- [x] Alters an accepted decision? It does not — not applicable. A patch-level toolchain bump changes nothing a user can observe: no wire shape, no stored form, no identity or provenance meaning, no new Google Cloud dependency, and nothing newly refused
- [x] Commit messages and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDXnjSfkvakczzuLoPsmE8

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDXnjSfkvakczzuLoPsmE8)_