### PR TITLE
Say why the browser smoke could not start a browser

### DIFF
--- a/internal/webui/jstest/smoke.mjs
+++ b/internal/webui/jstest/smoke.mjs
@@ -76,18 +76,58 @@ if (!await reachable(BASE + '/')) {
 }
 
 const profile = mkdtempSync(join(tmpdir(), 'ochakai-smoke-'));
+// stderr is kept, not discarded. It is where chromium says why it will
+// not start — a missing shared library, a sandbox it cannot use, a
+// profile directory it cannot write — and it is also where it announces
+// "DevTools listening on ws://…". Throwing it away is what made a
+// failed launch unactionable: the harness could say only that a port
+// never opened, and every such failure cost a re-run to learn nothing.
+// Bounded, because a browser that is unhappy repeats itself.
 const chrome = spawn(browser, [
   '--headless=new', '--remote-debugging-port=' + PORT, '--no-sandbox',
   '--disable-gpu', '--user-data-dir=' + profile, 'about:blank',
-], { stdio: ['ignore', 'ignore', 'ignore'] });
+], { stdio: ['ignore', 'ignore', 'pipe'] });
+
+let said = '';
+chrome.stderr.setEncoding('utf8');
+chrome.stderr.on('data', d => { said = (said + d).slice(-4000); });
+
+// Whether the process is still trying. A launch that fails and a launch
+// that is slow look identical from the port alone, and they are not the
+// same failure: one is this machine, the other is this minute.
+let exit = null;
+chrome.on('exit', (code, signal) => { exit = { code, signal }; });
+
+// 60 seconds, from 20. The evidence for the raise is what CI leaves
+// behind when this fails: the chrome process is still alive at job
+// cleanup, so it had not crashed — it had not finished starting. A cold
+// first launch on a loaded runner is slower than the old budget, and the
+// job that pays for it is the one that just built the Go binaries.
+// Nothing waits the full minute on a healthy run: the loop ends the
+// moment the port answers.
+const launchBudgetMs = 60_000;
 
 async function debuggerURL() {
-  for (let i = 0; i < 80; i++) {
+  const step = 250;
+  for (let waited = 0; waited < launchBudgetMs; waited += step) {
     try {
       return (await (await fetch(`http://127.0.0.1:${PORT}/json/version`)).json()).webSocketDebuggerUrl;
-    } catch { await sleep(250); }
+    } catch { /* not up yet */ }
+    if (exit) {
+      throw new Error(`chromium exited before opening its debugging port ` +
+        `(${exit.signal ? 'signal ' + exit.signal : 'exit code ' + exit.code})` + saidBy(said));
+    }
+    await sleep(step);
   }
-  throw new Error('chromium never opened its debugging port');
+  throw new Error(`chromium never opened its debugging port within ${launchBudgetMs / 1000}s ` +
+    `(it is still running, so it was starting rather than broken)` + saidBy(said));
+}
+
+// What chromium said, indented under the error, or nothing when it said
+// nothing — an empty "chromium said:" reads like the output was lost.
+function saidBy(text) {
+  text = text.trim();
+  return text ? '\nchromium said:\n  ' + text.replace(/\n/g, '\n  ') : '';
 }
 
 const ws = new WebSocket(await debuggerURL());


### PR DESCRIPTION
## What and why

The `webui` job fails intermittently with exactly one line of explanation:

```
Error: chromium never opened its debugging port
    at debuggerURL (internal/webui/jstest/smoke.mjs:90:9)
```

It hit [#650](https://github.com/na0fu3y/ochakai/pull/650) twice, and `main` at [e700a98](https://github.com/na0fu3y/ochakai/commit/e700a98) the same afternoon with the identical error — so it is not a change's fault, and there is nothing in a diff to look at. **The only way to learn anything was to re-run the job**, which is what happened both times.

That is the part this fixes. The launch discarded chromium's stderr (`stdio: ['ignore', 'ignore', 'ignore']`), which is where a browser says why it will not start — a missing shared library, a sandbox it cannot use, a profile directory it cannot write — and also where it announces `DevTools listening on ws://…`.

Three changes:

- **stderr is kept** (bounded to the last 4KB) and printed under the error.
- **A launch that died and a launch that is slow are told apart.** The process is watched for exit: if it is gone, the error names the exit code or signal and stops waiting immediately, instead of polling a port that nothing will ever open.
- **The budget goes 20s → 60s**, which is the guess at the failure itself. The evidence is what CI leaves behind: the job's cleanup step terminates an orphan `chrome` process every time this fails, so chromium had **not** crashed — it had not finished starting. A cold first launch on a loaded runner is slower than 20s, and the job that pays for it is the one that just built the Go binaries. A healthy run waits no longer than before: the loop ends the moment the port answers.

If the raise turns out not to be the fix, the next failure now says which of the two cases it was and what chromium said about it, which is the thing that was missing.

## Checks

- [x] `scripts/check ui` clean.
- [x] Verified against a real chromium, all three paths:

| case | before | after |
|---|---|---|
| a working browser | 20 checks pass | 20 checks pass, unchanged |
| a browser that exits (`exit 127`, complaining about `libnss3.so`) | 20s wait, then "never opened its debugging port" | immediate: `chromium exited before opening its debugging port (exit code 127)` and the message it printed |
| a browser that stays up and never listens | same sentence, indistinguishable from the above | `never opened its debugging port within 60s (it is still running, so it was starting rather than broken)`, with its stderr |

No Go code changes, so `scripts/check core` and `lint` are unaffected; CI runs them anyway.

## Surfaces and contract

- [x] No surface: this is the test harness. No REST operation, MCP tool, CLI command, flag or environment variable is added, and `docs/surface.md`'s counts do not move.

## Design docs

- [x] Not applicable — nothing a user can observe changes. This is a check explaining itself better, which is what [0035](docs/design/0035-verifiability.md) asks of a check.
- [x] Commit message and code comments in English.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fec93psz7QFVNX8Q8hPbAF)_