### PR TITLE
Sweep the rows a test writes, including the ones with no id

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,21 @@ own concept — a failure that reads as a search bug in whatever change
 happens to cross the threshold. `TestNoTestRollsItsOwnNamespace` fails
 on a hand-rolled one.
 
+**A cleanup written by hand is the same mistake wearing a tidier hat,
+and it now misses half the rows.** Several tests delete their own rows
+on the way in — `DELETE FROM knowledge_revision WHERE id LIKE 'it-x-%'`
+— which was equivalent while every row a test wrote had an id. A file
+stopped having one: it is an object at its own path (design docs 0075
+§5, 0100), so its rows carry `path` and no `id`, and
+`knowledge_revision`'s primary key is `(path, rev)`. An id-keyed delete
+leaves a file's revisions behind, and the next run against that database
+collides on the primary key. Worse, the file it leaves is *live*, and
+its bytes exist only in the test's fake blob store — so
+`internal/restapi`'s export tests answer 501 for that database from then
+on, in a package that never wrote it. `testdb.Sweep` deletes on `id`
+**or** `path`, which is the whole difference; ask `testdb.Unique` for a
+namespace and delete nothing by hand.
+
 `--db` prefers Docker, because `pgvector/pgvector:pg17` is the database
 CI runs. Where Docker cannot serve one — no daemon, or a network that
 will not let the image be pulled — it builds a throwaway cluster out of

--- a/internal/service/stats_integration_test.go
+++ b/internal/service/stats_integration_test.go
@@ -39,10 +39,6 @@ func TestSearchMissesAreRecordedIntegration(t *testing.T) {
 	t.Cleanup(func() { deleteMisses(ctx, t, dbURL, nonsense) })
 
 	since := time.Now().Add(-time.Hour)
-	before, err := s.Stats(ctx, since, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	if hits, err := svc.Search(ctx, nonsense, store.Filter{}, 10); err != nil {
 		t.Fatal(err)
@@ -62,12 +58,18 @@ func TestSearchMissesAreRecordedIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Misses.Count <= before.Misses.Count {
-		t.Errorf("misses.count did not move: %d, was %d", got.Misses.Count, before.Misses.Count)
+	// Not a delta against a snapshot taken before the writes: the
+	// instance-wide number moves under a test that shares the database
+	// with three other packages, and it moves *down* as well as up —
+	// a neighbour sweeping its own misses between the two reads made
+	// this assertion fail with "did not move: 6, was 7". What is true
+	// whatever the neighbours do is that this run's own two questions
+	// are in the window the number counts.
+	if got.Misses.Count < 2 {
+		t.Errorf("misses.count = %d, want at least the two this test just recorded", got.Misses.Count)
 	}
-	// This query's own rows, counted directly: the instance-wide number
-	// moves under a test that shares the database with three other
-	// packages, and what is being asserted is that each way of asking
+	// And this query's own rows, counted directly, which is the
+	// assertion that actually pins the behaviour: each way of asking
 	// recorded exactly one miss.
 	if n := countMisses(ctx, t, dbURL, nonsense); n != 2 {
 		t.Errorf("the question was recorded %d times, want 2 (the search and the context call)", n)

--- a/internal/store/store_integration_test.go
+++ b/internal/store/store_integration_test.go
@@ -699,42 +699,49 @@ func TestIntegrationMove(t *testing.T) {
 		t.Fatal(err)
 	}
 	s.UseBlobStore(newFakeBlobStore())
-	for _, table := range []string{"object", "knowledge_revision", "knowledge_embedding"} {
-		if _, err := s.pool.Exec(ctx, `DELETE FROM `+table+` WHERE id LIKE 'it-move-%'`); err != nil {
-			t.Fatal(err)
-		}
-	}
-	for _, table := range []string{"knowledge_event", "knowledge_usage", "attachment"} {
-		if _, err := s.pool.Exec(ctx, `DELETE FROM `+table+` WHERE knowledge_id LIKE 'it-move-%'`); err != nil {
-			t.Fatal(err)
-		}
-	}
+	// A namespace of its own, swept when the test ends (CONTRIBUTING,
+	// *Tests and checks*). This test used to delete its own rows by
+	// `id LIKE 'it-move-%'` on the way in, which reads as the same thing
+	// and is not: a file is an object at its own path and carries no id
+	// (design docs 0075 §5, 0100), so the revisions of chart.png below
+	// survived every run and the next one collided on
+	// knowledge_revision's (path, rev). testdb.Sweep deletes on id *or*
+	// path, which is the difference.
+	run := testdb.Unique(t, "it-move-")
+	var (
+		src     = run + "/src/metric"
+		sibling = run + "/src/sibling" // same directory as src, so ./metric.md resolves
+		dst     = run + "/dst/metric"
+		bare    = run + "/bare"
+		attrs   = run + "/attrs"
+		taken   = run + "/taken"
+	)
 
 	actor := domain.Actor{Kind: "human", Name: "test"}
 	entries := []*domain.Knowledge{
-		{Type: domain.TypeMetrics, ID: "it-move-src/metric", Title: "target", Status: domain.StatusStable, CreatedBy: actor},
-		{Type: domain.TypeInsights, ID: "it-move-bare", Title: "bare link", Status: domain.StatusDraft, CreatedBy: actor,
-			Body:  "Explains [the metric](/it-move-src/metric.md).",
-			Links: []domain.Link{{Target: "it-move-src/metric", Text: "the metric"}}},
-		{Type: domain.TypeInsights, ID: "it-move-src/sibling", Title: "relative link", Status: domain.StatusDraft, CreatedBy: actor,
+		{Type: domain.TypeMetrics, ID: src, Title: "target", Status: domain.StatusStable, CreatedBy: actor},
+		{Type: domain.TypeInsights, ID: bare, Title: "bare link", Status: domain.StatusDraft, CreatedBy: actor,
+			Body:  "Explains [the metric](/" + src + ".md).",
+			Links: []domain.Link{{Target: src, Text: "the metric"}}},
+		{Type: domain.TypeInsights, ID: sibling, Title: "relative link", Status: domain.StatusDraft, CreatedBy: actor,
 			Body:  "Explains [the metric](./metric.md) further.",
-			Links: []domain.Link{{Target: "it-move-src/metric", Text: "the metric"}}},
-		{Type: domain.TypeMetrics, ID: "it-move-attrs", Title: "attrs.model ref", Status: domain.StatusDraft, CreatedBy: actor,
-			Attrs: map[string]any{"model": "it-move-src/metric"}},
-		{Type: domain.TypeInsights, ID: "it-move-taken", Title: "occupies destination", Status: domain.StatusDraft, CreatedBy: actor},
+			Links: []domain.Link{{Target: src, Text: "the metric"}}},
+		{Type: domain.TypeMetrics, ID: attrs, Title: "attrs.model ref", Status: domain.StatusDraft, CreatedBy: actor,
+			Attrs: map[string]any{"model": src}},
+		{Type: domain.TypeInsights, ID: taken, Title: "occupies destination", Status: domain.StatusDraft, CreatedBy: actor},
 	}
 	for _, k := range entries {
 		if err := s.Create(ctx, k, false); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if _, _, err := s.PutFile(ctx, "it-move-src/metric/chart.png", "image/png", []byte("png"), actor); err != nil {
+	if _, _, err := s.PutFile(ctx, src+"/chart.png", "image/png", []byte("png"), actor); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.UpsertEmbedding(ctx, "it-move-src/metric", "test-model", []float32{1, 0, 0, 0}, false); err != nil {
+	if err := s.UpsertEmbedding(ctx, src, "test-model", []float32{1, 0, 0, 0}, false); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.RecordEvents(ctx, domain.EventFetched, actor, []string{"it-move-src/metric"}); err != nil {
+	if err := s.RecordEvents(ctx, domain.EventFetched, actor, []string{src}); err != nil {
 		t.Fatal(err)
 	}
 	// Flush before Move so the event is persisted under the old id and the
@@ -744,22 +751,22 @@ func TestIntegrationMove(t *testing.T) {
 	}
 
 	// Occupied destinations refuse, live or soft-deleted.
-	if _, err := s.Move(ctx, "it-move-src/metric", "it-move-taken", actor); !errors.Is(err, ErrAlreadyExists) {
+	if _, err := s.Move(ctx, src, taken, actor); !errors.Is(err, ErrAlreadyExists) {
 		t.Fatalf("move onto a live entry: got %v, want ErrAlreadyExists", err)
 	}
-	if err := s.SoftDelete(ctx, "it-move-taken", actor, nil); err != nil {
+	if err := s.SoftDelete(ctx, taken, actor, nil); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := s.Move(ctx, "it-move-src/metric", "it-move-taken", actor); !errors.Is(err, ErrAlreadyExists) {
+	if _, err := s.Move(ctx, src, taken, actor); !errors.Is(err, ErrAlreadyExists) {
 		t.Fatalf("move onto a soft-deleted entry: got %v, want ErrAlreadyExists", err)
 	}
 
 	mover := domain.Actor{Kind: "human", Name: "mover"}
-	moved, err := s.Move(ctx, "it-move-src/metric", "it-move-dst/metric", mover)
+	moved, err := s.Move(ctx, src, dst, mover)
 	if err != nil {
 		t.Fatalf("Move: %v", err)
 	}
-	if moved.ID != "it-move-dst/metric" {
+	if moved.ID != dst {
 		t.Errorf("moved.ID = %q", moved.ID)
 	}
 	// A move rewrites the moved entry's links and every referrer's body,
@@ -768,7 +775,7 @@ func TestIntegrationMove(t *testing.T) {
 	if moved.UpdatedBy != mover {
 		t.Errorf("moved.UpdatedBy = %v, want %v", moved.UpdatedBy, mover)
 	}
-	for _, id := range []string{"it-move-dst/metric", "it-move-bare", "it-move-attrs"} {
+	for _, id := range []string{dst, bare, attrs} {
 		k, err := s.Get(ctx, id)
 		if err != nil {
 			t.Fatalf("%s: %v", id, err)
@@ -777,15 +784,15 @@ func TestIntegrationMove(t *testing.T) {
 			t.Errorf("%s updated_by = %v after the move, want %v", id, k.UpdatedBy, mover)
 		}
 	}
-	if _, err := s.Get(ctx, "it-move-src/metric"); !errors.Is(err, ErrNotFound) {
+	if _, err := s.Get(ctx, src); !errors.Is(err, ErrNotFound) {
 		t.Errorf("old id still resolves: %v", err)
 	}
-	if _, err := s.Get(ctx, "it-move-dst/metric"); err != nil {
+	if _, err := s.Get(ctx, dst); err != nil {
 		t.Errorf("new id does not resolve: %v", err)
 	}
 
 	// History follows: create + move under the new id.
-	revs, err := s.ListRevisions(ctx, "it-move-dst/metric", 10)
+	revs, err := s.ListRevisions(ctx, dst, 10)
 	if err != nil {
 		t.Fatalf("ListRevisions: %v", err)
 	}
@@ -794,17 +801,17 @@ func TestIntegrationMove(t *testing.T) {
 	}
 
 	// Attachments and usage follow.
-	atts, err := s.ListAttachments(ctx, "it-move-dst/metric")
+	atts, err := s.ListAttachments(ctx, dst)
 	if err != nil || len(atts) != 1 || atts[0].Name != "chart.png" {
 		t.Errorf("attachments after move: %v, %v", atts, err)
 	}
-	usage, err := s.Usage(ctx, "it-move-dst/metric")
+	usage, err := s.Usage(ctx, dst)
 	if err != nil || usage.Fetches < 1 {
 		t.Errorf("usage after move: %+v, %v", usage, err)
 	}
 	var embedded bool
 	if err := s.pool.QueryRow(ctx,
-		`SELECT EXISTS (SELECT 1 FROM knowledge_embedding WHERE id='it-move-dst/metric')`).Scan(&embedded); err != nil || !embedded {
+		`SELECT EXISTS (SELECT 1 FROM knowledge_embedding WHERE id=$1)`, dst).Scan(&embedded); err != nil || !embedded {
 		t.Errorf("embedding did not follow: %v, %v", embedded, err)
 	}
 
@@ -814,8 +821,8 @@ func TestIntegrationMove(t *testing.T) {
 	// bundle-absolute whichever form it went in as, since that is the one
 	// form a later move cannot reinterpret (0024 §3.5).
 	for id, wantBody := range map[string]string{
-		"it-move-bare":        "Explains [the metric](/it-move-dst/metric.md).",
-		"it-move-src/sibling": "Explains [the metric](/it-move-dst/metric.md) further.",
+		bare:    "Explains [the metric](/" + dst + ".md).",
+		sibling: "Explains [the metric](/" + dst + ".md) further.",
 	} {
 		k, err := s.Get(ctx, id)
 		if err != nil {
@@ -824,29 +831,29 @@ func TestIntegrationMove(t *testing.T) {
 		if k.Body != wantBody {
 			t.Errorf("%s body after move: %q, want %q", id, k.Body, wantBody)
 		}
-		if len(k.Links) != 1 || k.Links[0].Target != "it-move-dst/metric" {
-			t.Errorf("%s links after move: %+v, want target it-move-dst/metric", id, k.Links)
+		if len(k.Links) != 1 || k.Links[0].Target != dst {
+			t.Errorf("%s links after move: %+v, want target %s", id, k.Links, dst)
 		}
 		revs, err := s.ListRevisions(ctx, id, 10)
 		if err != nil || len(revs) < 2 || revs[0].Change != "update" {
 			t.Errorf("%s should carry an update revision for the rewrite: %+v, %v", id, revs, err)
 		}
 	}
-	ka, err := s.Get(ctx, "it-move-attrs")
+	ka, err := s.Get(ctx, attrs)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ka.Attrs["model"] != "it-move-dst/metric" {
+	if ka.Attrs["model"] != dst {
 		t.Errorf("attrs.model after move: %v", ka.Attrs["model"])
 	}
-	backlinks, err := s.ListByAddress(ctx, Filter{LinksTo: "it-move-dst/metric"}, nil, 10)
+	backlinks, err := s.ListByAddress(ctx, Filter{LinksTo: dst}, nil, 10)
 	if err != nil || len(backlinks) != 2 {
 		t.Errorf("backlinks after move: %d, %v", len(backlinks), err)
 	}
 
 	// Leave no live attachment behind: its bytes exist only in this
 	// test's fake blob store, and export scans every live attachment.
-	if err := s.DeleteFile(ctx, "it-move-dst/metric/chart.png", actor); err != nil {
+	if err := s.DeleteFile(ctx, dst+"/chart.png", actor); err != nil {
 		t.Fatalf("cleanup DeleteFile: %v", err)
 	}
 }
@@ -1219,11 +1226,13 @@ func TestIntegrationSearchTextFollowsAttachmentsAndMoves(t *testing.T) {
 		return got
 	}
 
-	const id, moved = "it-haystack", "it-haystack-moved"
-	for _, dead := range []string{id, moved} {
-		_, _ = s.pool.Exec(ctx, `DELETE FROM object WHERE id = $1`, dead)
-		_, _ = s.pool.Exec(ctx, `DELETE FROM knowledge_revision WHERE id = $1`, dead)
-	}
+	// Swept by token rather than by hand: the id-keyed delete this
+	// replaces could not reach seeds.txt's revisions, because a file is
+	// an object at its own path with no id of its own (design docs 0075
+	// §5, 0100) — so they survived, and the next run against the same
+	// database collided on knowledge_revision's (path, rev).
+	run := testdb.Unique(t, "it-haystack-")
+	id, moved := run, run+"-moved"
 	k := &domain.Knowledge{
 		Type: domain.TypeTerms, ID: id, Title: "haystack", Tags: []string{"ledger"},
 		Status: domain.StatusDraft, CreatedBy: actor, Body: "prose",


### PR DESCRIPTION
## What and why

`go test ./internal/store/` passes once against a database and fails every time after that:

```
--- FAIL: TestIntegrationMove
    Move: ERROR: duplicate key value violates unique constraint "knowledge_revision_pkey" (SQLSTATE 23505)
--- FAIL: TestIntegrationSearchTextFollowsAttachmentsAndMoves
```

CONTRIBUTING says the database is shared on purpose — CI runs one container per run, and by hand you keep one up across sessions — so this is a documented workflow that does not work. It was noted as an aside in [#650](https://github.com/na0fu3y/ochakai/pull/650); this is the cause and the fix.

**Two tests delete their own rows on the way in instead of taking a namespace, and they delete them by `id`.**

```go
DELETE FROM knowledge_revision WHERE id LIKE 'it-move-%'
```

That was equivalent while every row a test wrote had an id. A file stopped having one: it is an object at its own path ([0075](docs/design/0075-the-bundle-is-the-address-space.md) §5, [0100](docs/design/0100-md-is-how-a-concept-is-spelled.md)), so its rows carry `path` and no `id` — and `knowledge_revision`'s primary key is `(path, rev)`. What was left behind after one run, read straight out of the database (`id_is_null` is the giveaway):

```
 it-haystack/seeds.txt        | 1 | create | t
 it-move-src/metric/chart.png | 1 | create | t
 it-move-dst/metric/chart.png | 2 | delete | t
```

The next run rewrites the same file at the same path and collides.

**The leftover is worse than a collision.** The file it leaves is *live*, and its bytes exist only in the test's fake blob store — so `internal/restapi`'s export tests answer `501 files are not supported without GCS` for that database from then on:

```
--- FAIL: TestRESTIntegration
    export: status = 501
--- FAIL: TestRESTIntegrationTheArchiveCarriesAFileNothingOwns
--- FAIL: TestRESTIntegrationIndexListsTheFilesInADirectory
```

Three failures in a package that never wrote the row. One run of the store tests poisoned the database for everything else, which is why a `createdb` was the only thing that made a local run look sane.

**The fix is the one CONTRIBUTING already prescribes**: both tests take a swept namespace from `testdb.Unique` and delete nothing by hand. `testdb.Sweep` already deletes on `id` **or** `path` — that is the whole difference, and the hand-rolled cleanups go away with the bug.

### And one assertion that cannot survive a shared database

`TestSearchMissesAreRecordedIntegration` compared the instance-wide miss count against a snapshot taken before its own writes, and that number moves *down* as well as up when a neighbouring package sweeps its misses between the two reads:

```
--- FAIL: TestSearchMissesAreRecordedIntegration
    stats_integration_test.go:66: misses.count did not move: 6, was 7
```

The test's own comment already knew — it had added the assertion that pins the behaviour (this query's own rows, counted directly) *because* the global number is unreliable — and left the unreliable one standing above it. The delta becomes a floor instead: the two questions this run recorded are in the window whatever the neighbours do, and `Stats` is still exercised.

## Checks

- [x] `scripts/check core` **twice against one database**, both green. Before this, the second run failed.
- [x] The three database packages (`store`, `service`, `restapi`) four rounds against one database, all green — and 0 rows left under either test's paths afterwards, on `object` and on `knowledge_revision`.
- [x] `scripts/check lint` clean. `scripts/check vuln` is unverifiable in this environment (the egress policy answers `Forbidden` for `vuln.go.dev`); CI runs it.

## Surfaces and contract

- [x] No surface, no product code: two integration tests, one assertion, and the paragraph in CONTRIBUTING that explains the trap.

## Design docs

- [x] Not applicable — nothing a user can observe changes.
- [x] Commit message and code comments in English.

### What this deliberately does not do

`TestNoTestRollsItsOwnNamespace` guards the *previous* shape of this mistake (`time.Now().UnixNano()` built by hand) and cannot see a constant id or a hand-written `DELETE`. Roughly seven other cleanups in `internal/store` still delete by `id` alone; none of them writes a file, so none of them leaks today. Making that a check means converting all of them, which is a bigger change than the failure in front of us — so what this PR leaves behind is the paragraph in CONTRIBUTING naming the trap, not a green light. Worth its own change if the next one bites.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fec93psz7QFVNX8Q8hPbAF)_