### PR TITLE
Release 0.23.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Version
       description: Output of `ochakai version`, or the image tag you deployed.
-      placeholder: "0.22.1"
+      placeholder: "0.23.0"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ last entry.
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-08-17
+
 ### Added
 
 - **A concept is found by the other names its writer gave it** ([design
@@ -4402,7 +4404,8 @@ worth naming: SQL injection in `compile_sql` through undeclared field
 pass-through, fixed in 0.8.0 — v0.7.0 and earlier are affected. Details
 are in git history.
 
-[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.22.1...HEAD
+[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.23.0...HEAD
+[0.23.0]: https://github.com/na0fu3y/ochakai/compare/v0.22.1...v0.23.0
 [0.22.1]: https://github.com/na0fu3y/ochakai/compare/v0.22.0...v0.22.1
 [0.22.0]: https://github.com/na0fu3y/ochakai/compare/v0.21.1...v0.22.0
 [0.21.1]: https://github.com/na0fu3y/ochakai/compare/v0.21.0...v0.21.1

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -74,7 +74,7 @@ info:
     is a security defect, shipped in the next release with no deprecation
     window (SECURITY.md). MCP, the CLI and the stored shape stay unstable
     while the major version is 0 and may still change in a minor release.
-  version: 0.22.1
+  version: 0.23.0
   license:
     name: MIT
 servers:

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -80,7 +80,7 @@ export IMAGE=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:$VERSION
 `:latest` ではなくバージョンを固定し、再デプロイを意識的な判断にする。
 `gh` CLI が無ければ
 [リリースページ](https://github.com/na0fu3y/ochakai/releases)から番号
-を読み、手で設定する — `export VERSION=0.22.1`。
+を読み、手で設定する — `export VERSION=0.23.0`。
 
 (このガイドは 0.9.0 以降を前提にしている。それより前のリリースは
 [retract](https://go.dev/ref/mod#go-mod-file-retract) 済みでサポート外

--- a/internal/service/service_integration_test.go
+++ b/internal/service/service_integration_test.go
@@ -667,10 +667,7 @@ func TestReembedReportsWhatIsLeft(t *testing.T) {
 	var stable bool // an attempt whose corpus did hold still
 	var missing, left int
 	for range reembedPinAttempts {
-		base, err := svc.Store.CountUnembedded(ctx, model)
-		if err != nil {
-			t.Fatal(err)
-		}
+		base := unembeddedTotal(t, ctx, svc, model)
 		res, err := svc.Reembed(ctx, "", 2)
 		if err != nil {
 			t.Fatal(err)
@@ -683,10 +680,7 @@ func TestReembedReportsWhatIsLeft(t *testing.T) {
 		// arithmetic on the baseline. The bug this covers is a two-off
 		// (subtracting the pass's work from a total that already excluded
 		// it), which no tolerance wide enough for the drift could catch.
-		after, err := svc.Store.CountUnembedded(ctx, model)
-		if err != nil {
-			t.Fatal(err)
-		}
+		after := unembeddedTotal(t, ctx, svc, model)
 		// The pass takes the oldest unembedded entries in the whole
 		// database, so a parallel package deleting one of its own
 		// candidates mid-pass leaves the pass short, and one writing
@@ -709,6 +703,31 @@ func TestReembedReportsWhatIsLeft(t *testing.T) {
 	}
 	t.Errorf("Missing = %d, want %d — the pass must report what is left, not what is left minus its own work",
 		missing, left)
+}
+
+// unembeddedTotal counts what Reembed reports as Missing: the concepts
+// with no vector plus the files, which carry vectors of their own
+// (design doc 0020) and are counted into the same number. Measuring only
+// the concept half made the assertion fail on a row belonging to nobody
+// in this package — internal/store's attachment tests hold unembedded
+// file rows in the shared database, Missing saw them, and the count it
+// was compared against did not. The stability guard could not catch it
+// either, since it watched the same concept-only count.
+//
+// This is measurement, not tolerance: a file row is genuinely still
+// unembedded, so the equality is restored by counting it on both sides
+// rather than by allowing the two numbers to differ.
+func unembeddedTotal(t *testing.T, ctx context.Context, svc *Service, model string) int {
+	t.Helper()
+	concepts, err := svc.Store.CountUnembedded(ctx, model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	files, err := svc.Store.CountUnembeddedFiles(ctx, model, svc.embeddableFileTypes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return concepts + files
 }
 
 // reembedPinAttempts is how many times TestReembedReportsWhatIsLeft will


### PR DESCRIPTION
<!-- Keep PRs small and focused. Link the issue or design doc, if there
is one. -->

## What and why

The preparation PR for **0.23.0**. Two **BREAKING** entries take the minor
rather than the patch (CONTRIBUTING.md: while the major is 0, only a
BREAKING entry moves the minor).

Both breaks are in REST, and both use a reason
[0064](../blob/main/docs/design/0064-rest-stops-at-api-v1.md) §11 carries
but nothing had used before:

- **[0100](../blob/main/docs/design/0100-md-is-how-a-concept-is-spelled.md)** —
  a `.md` path holds a concept and nothing else, because an export
  carrying a typeless markdown file hands out a bundle that fails OKF
  SPEC §11.1 and §11.2. Migration `0039` renames stored markdown files
  off concept addresses, moving their history rows with them.
- **[0102](../blob/main/docs/design/0102-one-history-in-one-spelling.md)** —
  `?history` answers JSON whatever the `Accept` says, because SPEC §9
  defines one markdown history (`log.md`) and this address rendered a
  second one from the same rows.

Neither moves a line of `api/openapi.frozen.txt` — OpenAPI cannot spell a
`requestBody` that differs per address, and the media type 0102 drops is
shared with the concept export — so the CHANGELOG entries and the two
records are the only place they are written down.

Six records land in this release, 0100 to 0105. The rest of the section is
`cursor` paging on directory listings (0101, the first optional query
parameter added since the freeze), MCP handing back one copy of a tool's
answer and declaring no output schema (0103), a rejection's reason
travelling with the ruling (0104), `synonyms` reaching the lexical
haystack (0105, migration `0040`), a handful of CLI legibility fixes, a
bilingual `examples/demo`, and the Go 1.26.6 build.

What this PR itself changes is only bookkeeping: CHANGELOG's unreleased
section closes as 0.23.0 with the JST tag date — it is already the 17th in
Tokyo — a fresh empty one goes above it, and the compare links gain the
new tag with `[Unreleased]` repointed at it. Then the three files a tag
does not update: `api/openapi.yaml`'s `info.version`, the bug report
template's placeholder, and the hand-set `export VERSION=` in the Cloud
Run guide, which is there for the reader with no `gh` CLI.
`grep -rn '0.22.1'` finds no fourth outside CHANGELOG and `docs/design`,
where old versions are named legitimately.

`RetiredToolNames` and `retiredCommands` are both empty, so this release
ends no rename window ([0088](../blob/main/docs/design/0088-a-retired-name-answers-for-one-release.md)).

One thing to hold until after the tag: Dependabot #654 moves the build
image to Go **1.27rc2**, which contradicts this release's Security entry
("Built with Go 1.26.6") and is a release candidate besides.

## Checks

CI runs the same script; make it pass locally first (CONTRIBUTING.md has
the
context, including the store integration test and the fuzz targets).

- [x] `scripts/check` is clean — add `--db` when the change touches the store
- [x] Behavior changes come with tests

`scripts/check core --db`, `ui` and `lint` are all green here — the store
tests ran against PostgreSQL 16.13, not the `pgvector/pgvector:pg17` CI
uses. `scripts/check vuln` could not run: this environment's proxy answers
`Forbidden` for `vuln.go.dev`, which is the fetch being refused rather
than a finding, so CI's vuln job is the one that counts.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing; a new endpoint has an
      integration test, which is what puts it under the OpenAPI contract check
- [x] The change lands on every surface it belongs on — REST / MCP / CLI /
      Web UI — and what it stays off is deliberate (design doc 0067)
- [x] `api/openapi.frozen.txt` is untouched. REST is frozen at `/api/v1`
      (design doc 0064), and `cmd/ochakai/frozenwire_test.go` fails on any
      wire change; regenerating that file is a decision, and §11 leaves a
      security defect as the only reason — say which one, here
- [x] Widens a surface — a REST operation, an MCP tool, a CLI command, an
      environment variable? `docs/surface.md` is updated
      (`cmd/ochakai/surface_test.go` says so), the description names which of
      its eight conditions the addition serves, and the three questions are
      answered under *What and why*: who actually got stuck, why an existing
      surface does not already cover it, and what is folded away in exchange.
      The default answer is no

This PR is a version bump; it adds no surface and touches no wire. The
`info.version` line is the one contract file it edits, and
`api/openapi.frozen.txt` does not carry the version, so the fingerprint
does not move.

## Design docs

- [x] Alters an accepted decision? A new numbered doc under `docs/design` is in
      this PR — or: it does not, and this box is not applicable. The index
      entries, the `Status:` headers at both ends and the two indexes agreeing
      about them are checked by `cmd/ochakai/designdocs_test.go`; what is left
      for a human is whether the index's opening table still points at the doc
      to read now, and whether the English summary says what was decided
- [x] Commit messages and code comments are in English

No new record: every decision this release ships already landed with its
own, 0100 through 0105.

---
_Generated by [Claude Code](https://claude.ai/code/session_014HQ4WjStBRNXm2SDBU5uZB)_