### PR TITLE
docs: say how the size of a change decides how it should arrive

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -882,6 +882,17 @@ Two pieces of bookkeeping, both easy to forget:
 
 ## Pull requests
 
+Review is the scarce resource here, and code being cheap to write has
+made it scarcer rather than less important: a large unsolicited PR
+donates the half of the work that is now easy and creates the half that
+is not. Issues and pull requests are still welcome — this is about how a
+change should arrive, not whether. A small, self-contained fix is a PR.
+Anything larger is worth proposing first, in an issue or a
+[discussion](https://github.com/na0fu3y/ochakai/discussions): the default
+answer to a feature is no ("Proposing a feature" above), and finding that
+out from a review costs you the time you spent writing it, not only the
+time it takes to read.
+
 - Keep PRs small and focused; include tests for behavior changes.
 - A PR that widens a surface — a REST operation, an MCP tool, a CLI
   command, an environment variable — names which of


### PR DESCRIPTION
## What and why

CONTRIBUTING.md opens with "issues and pull requests are welcome" and says nothing about size until the *Pull requests* bullets, by which point somebody has usually written the code. *Proposing a feature* covers the feature case — the default answer is no, `docs/surface.md` makes it concrete — but only for somebody who read that section first. Nothing says what to do with a large change that is not a feature: a refactor, a rewrite, a doc overhaul.

This adds a lead paragraph to *Pull requests* naming review as the scarce resource, and saying that code being cheap to write has made it scarcer rather than less important. The point is not to keep contributions out — the sentence says so — it is that a large unsolicited PR donates the half of the work that is now easy and creates the half that is not, and that learning "no" from a review costs the contributor the time they spent writing it, not only the time it takes to read.

The observation is [cloudflare/cloudflare-os](https://github.com/cloudflare/cloudflare-os)'s, from a review of what that repository has that this one could use. Its own CONTRIBUTING takes it much further — no outside contribution at all beyond a dozen lines, big ideas to Discussions — which is a policy for a repository with a company behind it. This takes the reasoning and leaves the policy: the existing "welcome" stands, and what changes is the advice about how a change should arrive.

The rest of that review found nothing else worth importing, which is the more useful half of the result. Two things worth recording here rather than in the tree: their asynchronous human-in-the-loop mechanism (an agent's writes are queued and approved later, so nobody reaches for `--dangerously-skip-permissions`) is what `draft` → `verify` already is for knowledge; and their gatekeeper observer model classifies a service by whether it has a per-observer ACL oracle, under which ochakai lands where Supabase's project binding does — the deployment is the atomic unit, since 0065 §1 has whoever reaches it read and write. So a bundle- or prefix-scoped permission model, which is what prompted the review, is not needed to be a good citizen of that system; it would be a second answer to a question 0065 §7 already answers with "separate deployments, separated by IAM".

No surface moves and no ceiling moves — `surface_test.go:1053` excludes CONTRIBUTING.md from `DOC`, as the surface somebody changing ochakai reads rather than somebody using it. No CHANGELOG entry: nothing here is what an operator upgrading needs to know.

## Checks

- [x] `scripts/check` is clean — add `--db` when the change touches the store

  `scripts/check core` and `scripts/check lint` are green. The store is untouched, so `--db` is not implicated; `scripts/check vuln` is not verifiable in this environment (the egress policy refuses `vuln.go.dev`) and is CI's to run.
- [x] Behavior changes come with tests

  No behavior changes. CONTRIBUTING.md *is* read by tests — `RECORD-LINES`, `TOMBSTONE-LINES`, `RECORD-CORPUS-LINES` are declared in it — and those parse cleanly, which `scripts/check core` confirms.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and `internal/apiclient` say the same thing; a new endpoint has an integration test, which is what puts it under the OpenAPI contract check

  Untouched.
- [x] The change lands on every surface it belongs on — REST / MCP / CLI / Web UI — and what it stays off is deliberate (design doc 0067)

  Not applicable: no surface is involved.
- [x] `api/openapi.frozen.txt` is untouched. REST is frozen at `/api/v1`
- [x] Widens a surface — a REST operation, an MCP tool, a CLI command, an environment variable? `docs/surface.md` is updated

  Not applicable. Nothing is widened, and CONTRIBUTING.md is outside what `docs/surface.md` counts.

## Design docs

- [x] Alters an accepted decision? A new numbered doc under `docs/design` is in this PR — or: it does not, and this box is not applicable

  Not applicable. A contribution norm is not a decision somebody using ochakai can observe (0048), and 0048 §3 rules out records about process besides.
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01GymmTaGuGWtT8Rjyass1Tv)_