### PR TITLE
Release 0.24.0, and file three entries under the release that carries them

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Version
       description: Output of `ochakai version`, or the image tag you deployed.
-      placeholder: "0.23.0"
+      placeholder: "0.24.0"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ last entry.
 
 ## [Unreleased]
 
-## [0.23.0] - 2026-08-17
+## [0.24.0] - 2026-08-17
 
 ### Added
 
@@ -39,6 +39,60 @@ last entry.
   as fetched for being named — and the addition is response-only,
   outside the freeze (design doc 0082). `ochakai get` prints the rows
   on stderr beside the file hints; the MCP schema does not move a byte.
+
+### Changed
+
+- **BREAKING: the REST freeze narrows to the OKF core** ([design doc
+  0107](docs/design/0107-the-freeze-holds-the-okf-core.md)). What stays
+  frozen is the bundle round trip — `GET`/`PUT`/`DELETE
+  /api/v1/bundle/{path}` — and `GET /api/v1/search`; the ruling, usage,
+  stats, move and reembed operations return to the 0.x-unstable regime
+  MCP and the CLI were already under, where a breaking change is marked
+  BREAKING here and carries a design record. **Not a byte of the wire
+  moves in this entry** — what changes is the promise: since 0.18.0 this
+  page and [docs/compatibility.md](docs/compatibility.md) said all of
+  `/api/v1` was frozen, and that scope is retracted, not reinterpreted.
+  The record says why the boundary was wrong (fourteen days of
+  corrections, all pointing at OKF) and why it cannot move again: the
+  core can only ever widen. If you built against a non-core endpoint,
+  nothing breaks today; from here on, watch the BREAKING entries the way
+  you already do for the CLI.
+  ([design doc 0102](docs/design/0102-one-history-in-one-spelling.md)).
+  The markdown rendering of one object's history is gone. OKF SPEC §9
+  defines one markdown history — the reserved `log.md` beside the
+  objects — and this address rendered a second one from the same ledger
+  rows, which is what left a single `?history&limit=500` on a concept
+  answering 400 as JSON and 200 as markdown (0064 §14.1 wrote that split
+  down rather than closing it). A concept's `?history` is now 50 rows by
+  default and 200 at most on every read.
+
+### Removed
+
+- **BREAKING: the context pack is retired from every surface** ([design
+  doc 0108](docs/design/0108-the-context-pack-retires.md)). `GET
+  /api/v1/context`, the MCP tool `get_context` and `ochakai context`
+  are gone, and with them the `budget` parameter and flag. The pack was
+  built for a world where round trips were expensive for agents: it
+  made the server decide what should be read — greedy packing, outline,
+  excerpt, a two-direction link hop — and an agent that iterates
+  search → get on its own was having that judgment taken away from it.
+  What the pack bundled survives in primitives: the reverse hop arrives
+  as `linked_from` on the concept itself (design doc 0106), and the
+  write-back hint now rides on `get_concept`'s answer. What a client
+  does about it: call `GET /api/v1/search` and read the concepts worth
+  reading at `GET /api/v1/bundle/{id}.md` (MCP: `search_concepts` then
+  `get_concept`; CLI: `ochakai search` then `ochakai get`). The bundled
+  recall hook now injects search pointers instead of a pack, and
+  `OCHAKAI_RECALL_BUDGET` became `OCHAKAI_RECALL_LIMIT` (rows, default
+  8). This is a removal, not a rename, so no one-release window
+  applies; the REST removal rides on design doc 0107 having moved
+  `/context` outside the frozen core, so `api/openapi.frozen.txt` does
+  not move. MCP resident bytes drop 13,460 → 11,629 and the MCP-BYTES
+  ceiling goes down to 12,000.
+
+## [0.23.0] - 2026-08-17
+
+### Added
 
 - **A concept is found by the other names its writer gave it** ([design
   doc 0105](docs/design/0105-a-concept-answers-to-its-other-names.md)).
@@ -88,47 +142,9 @@ last entry.
   be added safely afterwards, and 0082 had written down only the response
   half of that. `api/openapi.frozen.txt` grows by two lines.
 
-### Removed
-
-- **BREAKING: the context pack is retired from every surface** ([design
-  doc 0108](docs/design/0108-the-context-pack-retires.md)). `GET
-  /api/v1/context`, the MCP tool `get_context` and `ochakai context`
-  are gone, and with them the `budget` parameter and flag. The pack was
-  built for a world where round trips were expensive for agents: it
-  made the server decide what should be read — greedy packing, outline,
-  excerpt, a two-direction link hop — and an agent that iterates
-  search → get on its own was having that judgment taken away from it.
-  What the pack bundled survives in primitives: the reverse hop arrives
-  as `linked_from` on the concept itself (design doc 0106), and the
-  write-back hint now rides on `get_concept`'s answer. What a client
-  does about it: call `GET /api/v1/search` and read the concepts worth
-  reading at `GET /api/v1/bundle/{id}.md` (MCP: `search_concepts` then
-  `get_concept`; CLI: `ochakai search` then `ochakai get`). The bundled
-  recall hook now injects search pointers instead of a pack, and
-  `OCHAKAI_RECALL_BUDGET` became `OCHAKAI_RECALL_LIMIT` (rows, default
-  8). This is a removal, not a rename, so no one-release window
-  applies; the REST removal rides on design doc 0107 having moved
-  `/context` outside the frozen core, so `api/openapi.frozen.txt` does
-  not move. MCP resident bytes drop 13,460 → 11,629 and the MCP-BYTES
-  ceiling goes down to 12,000.
-
 ### Changed
 
-- **BREAKING: the REST freeze narrows to the OKF core** ([design doc
-  0107](docs/design/0107-the-freeze-holds-the-okf-core.md)). What stays
-  frozen is the bundle round trip — `GET`/`PUT`/`DELETE
-  /api/v1/bundle/{path}` — and `GET /api/v1/search`; the ruling, usage,
-  stats, move and reembed operations return to the 0.x-unstable regime
-  MCP and the CLI were already under, where a breaking change is marked
-  BREAKING here and carries a design record. **Not a byte of the wire
-  moves in this entry** — what changes is the promise: since 0.18.0 this
-  page and [docs/compatibility.md](docs/compatibility.md) said all of
-  `/api/v1` was frozen, and that scope is retracted, not reinterpreted.
-  The record says why the boundary was wrong (fourteen days of
-  corrections, all pointing at OKF) and why it cannot move again: the
-  core can only ever widen. If you built against a non-core endpoint,
-  nothing breaks today; from here on, watch the BREAKING entries the way
-  you already do for the CLI.
+- **BREAKING: `?history` answers JSON, whatever the `Accept` says**
   ([design doc 0102](docs/design/0102-one-history-in-one-spelling.md)).
   The markdown rendering of one object's history is gone. OKF SPEC §9
   defines one markdown history — the reserved `log.md` beside the
@@ -182,9 +198,10 @@ last entry.
   catalog. Notes are now grouped by text, with the concepts each one was
   true of listed under it (up to five, then a count). The `N notes`
   summary and what `--strict` fails on are unchanged.
-- **`ochakai search` says when nothing matched.** It printed nothing at
-  all and exited 0, which reads the same as a server that did not
-  answer. The line goes to stderr, so a pipeline is unaffected.
+- **`ochakai context` and `ochakai search` say when nothing matched.**
+  They printed nothing at all and exited 0, which reads the same as a
+  server that did not answer. The line goes to stderr, so a pipeline is
+  unaffected, and `context` names the write-back that would fix it.
 - **An unknown command answers with a suggestion instead of the whole
   command list.** `ochakai serach` now offers `search`; `ochakai --url X
   whoami` says that a flag goes after the command rather than printing
@@ -192,7 +209,7 @@ last entry.
 - **The demo knowledge base is bilingual, and gained an eleventh
   concept.** `examples/demo` was entirely English, so a Japanese reader
   following the quick start — including `examples/README.md`'s own
-  `ochakai search "なぜ売上が落ちているのか"` — got silence, and the
+  `ochakai context "なぜ売上が落ちているのか"` — got silence, and the
   Japanese-search claim could not be tried without writing your own
   concepts first. The metric now records what the number is called
   (`売上`, and the two things it is not), the glossary carries the
@@ -4458,7 +4475,8 @@ worth naming: SQL injection in `compile_sql` through undeclared field
 pass-through, fixed in 0.8.0 — v0.7.0 and earlier are affected. Details
 are in git history.
 
-[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.23.0...HEAD
+[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.24.0...HEAD
+[0.24.0]: https://github.com/na0fu3y/ochakai/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/na0fu3y/ochakai/compare/v0.22.1...v0.23.0
 [0.22.1]: https://github.com/na0fu3y/ochakai/compare/v0.22.0...v0.22.1
 [0.22.0]: https://github.com/na0fu3y/ochakai/compare/v0.21.1...v0.22.0

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -74,7 +74,7 @@ info:
     is a security defect, shipped in the next release with no deprecation
     window (SECURITY.md). MCP, the CLI and the stored shape stay unstable
     while the major version is 0 and may still change in a minor release.
-  version: 0.23.0
+  version: 0.24.0
   license:
     name: MIT
 servers:

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -80,7 +80,7 @@ export IMAGE=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:$VERSION
 `:latest` ではなくバージョンを固定し、再デプロイを意識的な判断にする。
 `gh` CLI が無ければ
 [リリースページ](https://github.com/na0fu3y/ochakai/releases)から番号
-を読み、手で設定する — `export VERSION=0.23.0`。
+を読み、手で設定する — `export VERSION=0.24.0`。
 
 (このガイドは 0.9.0 以降を前提にしている。それより前のリリースは
 [retract](https://go.dev/ref/mod#go-mod-file-retract) 済みでサポート外


### PR DESCRIPTION
## What and why

**0.23.0 shipped while #661 was in flight, and the merge filed three of its entries under a heading that had already been tagged.** `v0.23.0` points at `99c3e15`, which contains none of `e394924`, `168db82` or `ded06d8` — but `CHANGELOG.md` on `main` listed all three under `## [0.23.0]`: `linked_from` (0106), the freeze narrowing (0107) and the pack retirement (0108). The merge also rewrote two of 0.23.0's *own* entries to describe a CLI command that still existed in that release ("`ochakai context` and `ochakai search` say when nothing matched", and the bilingual demo's quoted command).

Nobody would have noticed from a green check: nothing in the tree compares the changelog against a tag, and the published release page is fine — its body comes from the annotated tag's message, which was written before any of this and describes 0.23.0 correctly.

So this PR does two things:

- **`## [0.23.0]` is restored to exactly what the tag holds** — verified byte-for-byte against `git show v0.23.0:CHANGELOG.md`, including the two entries whose wording was edited out from under a shipped release.
- **`## [0.24.0] - 2026-08-17` opens with the three entries that actually carry those changes.** Two of them are BREAKING, which is a minor bump while the major version is 0.

The version number follows in the three places the tag does not update: `api/openapi.yaml`, the issue template's placeholder, and the deploy guide's hand-set `export VERSION=`.

Cross-checked against `git log v0.23.0..origin/main --oneline --no-merges`: apart from dependency bumps, what landed since the tag is the three design-doc commits, their manual follow-up (#662, prose corrections — no operator-facing change to record), and a CONTRIBUTING edit (#660, the contributor surface, not the changelog's).

## Checks

- [x] `scripts/check core` is clean, including the check that ties `api/openapi.yaml`'s version to the newest `CHANGELOG.md` entry and the issue template
- [x] Behavior changes come with tests — not applicable, no code changes

## Surfaces and contract

- [x] No surface moves; `api/openapi.frozen.txt` is untouched
- [x] The only `api/openapi.yaml` change is `info.version`

## Design docs

- [x] Alters no accepted decision — this makes the changelog agree with what each tag actually shipped
- [x] Commit messages and code comments are in English

Next step after merge is the tag itself, which is where the release notes are written — holding for your go-ahead on that, since a pushed tag is permanent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQgCxHxBicQzimF4Q2RDBA

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQgCxHxBicQzimF4Q2RDBA)_