### PR TITLE
Drop the duplicated 0102 entry the release prep left in 0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,14 +57,6 @@ last entry.
   core can only ever widen. If you built against a non-core endpoint,
   nothing breaks today; from here on, watch the BREAKING entries the way
   you already do for the CLI.
-  ([design doc 0102](docs/design/0102-one-history-in-one-spelling.md)).
-  The markdown rendering of one object's history is gone. OKF SPEC §9
-  defines one markdown history — the reserved `log.md` beside the
-  objects — and this address rendered a second one from the same ledger
-  rows, which is what left a single `?history&limit=500` on a concept
-  answering 400 as JSON and 200 as markdown (0064 §14.1 wrote that split
-  down rather than closing it). A concept's `?history` is now 50 rows by
-  default and 200 at most on every read.
 
 ### Removed
 


### PR DESCRIPTION
While cutting v0.24.0 from the merged prep PR (#663), the tag was held back on this.

Moving the three misfiled entries into `[0.24.0]` copied the body of the `?history` entry along with them. Seven lines describing design doc 0102 sit at the end of the freeze-narrowing bullet with no bullet marker and no title, so they read as a continuation of a different BREAKING entry — one bullet that starts on the REST freeze and ends on `?history` limits.

The entry itself is not misplaced. 0102 shipped in v0.23.0, and its properly titled bullet is still under `[0.23.0]`, whose section this checks byte for byte against `git show v0.23.0:CHANGELOG.md`. Only the stray untitled copy under `[0.24.0]` goes.

No surface moves and no decision changes, so no design doc: this is the changelog describing what already shipped. Caught before the tag is pushed, so the v0.24.0 release page — which is copied from the tag message, not this file — is unaffected either way, but the file a reader upgrading actually reads is now correct at the tagged commit.

`scripts/check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)