### PR TITLE
Hold the search eval floors in both directions; give the access tests a database

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,6 +188,36 @@ answers it (design doc 0089 §4). A script like this is not a surface —
 nobody has to learn it, no endpoint answers it — so it is cheap to write
 and cheap to delete once it has been read.
 
+### The search eval harness
+
+The standing measurement is `TestSearchEvalIntegration`
+(`internal/service/searcheval_integration_test.go`): a golden set of
+questions, each paired with the concept a good ranking puts in front of
+the reader, scored as recall@10 and MRR over the shipped `examples/demo`
+bundle. It runs the set twice — lexical only, which is the search a
+deployment without Vertex AI gets, and lexical fused with a vector
+ranking from the stand-in encoder beside it, which is the configuration
+every Google Cloud deployment runs (design doc 0080 §1.1). The stand-in
+is deterministic, so the fused half needs no API key and reaches no
+network.
+
+```sh
+scripts/check --db      # it runs with everything else
+OCHAKAI_TEST_DATABASE_URL=… go test ./internal/service/ \
+    -run TestSearchEvalIntegration -v      # -v prints the per-case ranks
+```
+
+A change to ranking lands with these numbers in its PR. **The floors
+beside them fail in both directions.** Under a floor is the regression
+the floor exists to catch. More headroom over it than
+`evalFloorSlackCases` allows is a floor nobody raised when the ranking
+improved, which is `DOC-LINES-SLACK`'s argument applied to a floor
+rather than a ceiling: banked headroom is budget the next regression
+spends without moving a number anybody reads. The tolerance is derived
+from the size of the set instead of declared here, because the noise it
+is sized against is one case moving and the set has been 14, 36, 41 and
+37 cases.
+
 ## Working with Claude Code
 
 The repository checks in a `.claude/settings.json` with four hooks and

--- a/internal/service/access_integration_test.go
+++ b/internal/service/access_integration_test.go
@@ -30,10 +30,14 @@ type accessFixture struct {
 	adminCtx, readCt context.Context
 }
 
+// The policy this fixture writes is the whole deployment's, so the
+// fixture takes a database of its own rather than a prefix in the shared
+// one (testdb.Private): a rule here would otherwise scope the callers in
+// every package running beside this one.
 func newAccessFixture(t *testing.T) *accessFixture {
 	t.Helper()
 	ctx := context.Background()
-	s, err := store.New(ctx, testdb.URL(t), false)
+	s, err := store.New(ctx, testdb.Private(t, "acl"), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -224,9 +228,12 @@ func TestPolicyBelongsToAdministratorsIntegration(t *testing.T) {
 // TestNoPolicyIsTheDeploymentThatCameBeforeIntegration is the promise
 // every existing deployment rests on: with no rules, nothing here
 // applies — not to a caller the configuration never heard of either.
+// It reads a database of its own for the same reason the fixture does,
+// in the other direction: what it asserts is the absence of a policy,
+// and in the shared database a neighbour's rule would be present.
 func TestNoPolicyIsTheDeploymentThatCameBeforeIntegration(t *testing.T) {
 	ctx := context.Background()
-	s, err := store.New(ctx, testdb.URL(t), false)
+	s, err := store.New(ctx, testdb.Private(t, "aclopen"), false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/service/searcheval_integration_test.go
+++ b/internal/service/searcheval_integration_test.go
@@ -2,7 +2,9 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"io/fs"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -238,6 +240,64 @@ const (
 	evalFusedMRRFloor    = 0.74
 )
 
+// evalFloorSlackCases is how far a floor may sit under what was measured
+// before that gap is itself a failure, counted in cases.
+//
+// The floors above check one direction: under them fails, over them is
+// free. That lets an improvement bank quietly — a ranking change that
+// lifts MRR and leaves the floor where it was hands the next regression
+// a gap to fall into, and a number nobody moved is a number nobody
+// reads. The line ceilings found the same hole from the other side and
+// closed it the same way: d28c3c8 shortened the deploy guide, raised
+// DOC-LINES for the room the fold needed, and left 28 lines nobody
+// returned, which is why DOC-LINES-SLACK and RECORD-CORPUS-LINES-SLACK
+// exist (surface_test.go, CONTRIBUTING.md). **The comment above already
+// states the rule this closes** — "a change that moves those numbers —
+// either way — says so in its PR" — and nothing could check the
+// either-way half of it.
+//
+// Two cases, and derived from the size of the set rather than declared
+// as a score, because everything on this page that reasons about noise
+// reasons in cases: one case slipping from rank 1 to rank 2 is 0.014
+// here, one case leaving the top k is 0.027, and the floors above were
+// chosen as about two cases under what was measured. A tolerance written
+// as 0.05 would have to be rewritten every time the set grows, and the
+// set has been 14, then 36, then 41, then 37.
+const evalFloorSlackCases = 2
+
+// checkEvalFloors holds one configuration's numbers to their floors in
+// both directions: under a floor is the regression the floor exists to
+// catch, and further over it than evalFloorSlackCases allows is a floor
+// that was not raised when the ranking improved.
+func checkEvalFloors(t *testing.T, config string, recall, mrr, recallFloor, mrrFloor float64) {
+	t.Helper()
+	cases := float64(len(evalCases))
+	slack := evalFloorSlackCases / cases
+	for _, m := range []struct {
+		name       string
+		got, floor float64
+	}{
+		{fmt.Sprintf("recall@%d", evalK), recall, recallFloor},
+		{"MRR", mrr, mrrFloor},
+	} {
+		switch {
+		case m.got < m.floor:
+			t.Errorf("%s (%s) fell to %.2f, under the %.2f baseline: a ranking change made the golden set worse",
+				m.name, config, m.got, m.floor)
+		case m.got-m.floor > slack:
+			// Rounded up, because the floor is written to two decimals
+			// and rounding the other way would advise a number that
+			// fails this same check on the next run.
+			want := math.Ceil((m.got-slack)*100) / 100
+			t.Errorf(`%s (%s) measures %.2f against a floor of %.2f — %.1f cases' worth of headroom, wider than the %d
+evalFloorSlackCases this file allows. Raise the floor to at least %.2f in the PR that
+earned the improvement: a floor left under a number that moved up is budget the next
+regression spends without moving anything anybody reads.`,
+				m.name, config, m.got, m.floor, (m.got-m.floor)*cases, evalFloorSlackCases, want)
+		}
+	}
+}
+
 // loadDemoBundle imports every document under examples/demo with the
 // run-unique prefix prepended to its path-derived id, and returns the
 // number imported. Root-relative links inside the bodies keep pointing
@@ -299,17 +359,14 @@ func TestSearchEvalIntegration(t *testing.T) {
 		t.Fatalf("verify %s: %v", evalVerified, err)
 	}
 
-	recall, mrr := scoreGoldenSet(t, ctx, svc, prefix, "lexical only")
-	if recall < evalRecallFloor {
-		t.Errorf("recall@%d fell to %.2f, under the %.2f baseline: a ranking change made the golden set worse", evalK, recall, evalRecallFloor)
-	}
-	if mrr < evalMRRFloor {
-		t.Errorf("MRR fell to %.2f, under the %.2f baseline: the golden set still surfaces but lower than it did", mrr, evalMRRFloor)
-	}
+	const lexical = "lexical only"
+	recall, mrr := scoreGoldenSet(t, ctx, svc, prefix, lexical)
+	checkEvalFloors(t, lexical, recall, mrr, evalRecallFloor, evalMRRFloor)
 
 	// The same questions with the vector half on, which is the
 	// configuration a Google Cloud deployment runs.
-	scoreFusedGoldenSet(t, ctx, svc, prefix)
+	fusedRecall, fusedMRR := scoreFusedGoldenSet(t, ctx, svc, prefix)
+	checkEvalFloors(t, "fused", fusedRecall, fusedMRR, evalFusedRecallFloor, evalFusedMRRFloor)
 }
 
 // scoreGoldenSet runs every case and reports recall@k and MRR, naming
@@ -367,7 +424,7 @@ func scoreGoldenSet(t *testing.T, ctx context.Context, svc *Service, prefix, con
 // named-concept sort key surviving it, the verification tie-break under
 // it. What it does not measure is the SQL that produces the vector list
 // in production, which the store's own vector tests cover.
-func scoreFusedGoldenSet(t *testing.T, ctx context.Context, svc *Service, prefix string) {
+func scoreFusedGoldenSet(t *testing.T, ctx context.Context, svc *Service, prefix string) (recall, mrr float64) {
 	t.Helper()
 	dim, ok := embed.Dimension("gemini-embedding-001")
 	if !ok {
@@ -380,7 +437,7 @@ func scoreFusedGoldenSet(t *testing.T, ctx context.Context, svc *Service, prefix
 	}
 
 	filter := store.Filter{Prefixes: []string{prefix}}
-	found, mrr := 0, 0.0
+	found := 0
 	for _, c := range evalCases {
 		lexical, err := svc.Store.SearchLexical(ctx, c.query, filter, evalK*2)
 		if err != nil {
@@ -410,16 +467,11 @@ func scoreFusedGoldenSet(t *testing.T, ctx context.Context, svc *Service, prefix
 		// add this line and run it again.
 		t.Logf("hit (fused): %q -> %s at rank %d", c.query, c.want, rank)
 	}
-	recall := float64(found) / float64(len(evalCases))
+	recall = float64(found) / float64(len(evalCases))
 	mrr /= float64(len(evalCases))
 	t.Logf("recall@%d = %.2f (%d/%d), MRR = %.2f, lexical + vector (stand-in encoder)",
 		evalK, recall, found, len(evalCases), mrr)
-	if recall < evalFusedRecallFloor {
-		t.Errorf("fused recall@%d fell to %.2f, under the %.2f baseline", evalK, recall, evalFusedRecallFloor)
-	}
-	if mrr < evalFusedMRRFloor {
-		t.Errorf("fused MRR fell to %.2f, under the %.2f baseline", mrr, evalFusedMRRFloor)
-	}
+	return recall, mrr
 }
 
 // embedded is one concept with the vector the stand-in encoder gave it.

--- a/internal/testdb/testdb.go
+++ b/internal/testdb/testdb.go
@@ -18,7 +18,9 @@ package testdb
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -87,6 +89,78 @@ func Unique(t *testing.T, name string) string {
 	token := fmt.Sprintf("%s%d", name, time.Now().UnixNano())
 	t.Cleanup(func() { Sweep(t, token) })
 	return token
+}
+
+// Private hands the test a database of its own on the same server and
+// drops it when the test ends, for state that Unique cannot isolate.
+//
+// Unique is what almost everything here wants: rows carry a token, the
+// sweep takes them back, and one shared database is what keeps the suite
+// quick. It works because every row has an address to put the token in.
+//
+// The access policy has none. It is one document for the whole
+// deployment (design doc 0109 §5), and a single rule anywhere in a
+// database puts *every* caller of that database inside a boundary —
+// reads outside the granted prefixes become ErrNotFound and the
+// whole-bundle operations become ErrForbidden. `go test ./...` runs the
+// packages in parallel against one database, so while a test holds a
+// policy, the integration tests in restapi, mcpserver and store are
+// callers of a scoped deployment without knowing it. That is a race
+// nobody can see in the failing test: it surfaces as a 403 on an export
+// three packages away.
+//
+// So a test that writes a policy takes a database with it. Call this
+// before the store the test writes through — cleanups run
+// last-registered-first, so the drop registered here runs after that
+// pool has closed.
+func Private(t *testing.T, name string) string {
+	t.Helper()
+	shared := URL(t) // skips the test when there is no database
+	// net/url rather than pgx.ParseConfig, because the config's
+	// ConnString reports the string it was parsed from: changing the
+	// database on the struct would hand back a URL still naming the
+	// shared one, and the test would pass while isolating nothing.
+	u, err := url.Parse(shared)
+	if err != nil || u.Scheme == "" {
+		t.Fatalf("testdb: OCHAKAI_TEST_DATABASE_URL is not a URL, so a private database cannot be named from it: %q", shared)
+	}
+	// Lowercase and digits only: an unquoted identifier is folded, and a
+	// name that needed quoting everywhere it appears is a trap for the
+	// next person to write one of these by hand.
+	db := fmt.Sprintf("%s_%d", strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			return r
+		}
+		return '_'
+	}, strings.ToLower(name)), time.Now().UnixNano())
+
+	// Outlives t.Context(), which is cancelled before cleanups run.
+	ctx := context.Background()
+	exec := func(sql string) error {
+		conn, err := pgx.Connect(ctx, shared)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = conn.Close(ctx) }()
+		_, err = conn.Exec(ctx, sql)
+		return err
+	}
+	quoted := pgx.Identifier{db}.Sanitize()
+	if err := exec("CREATE DATABASE " + quoted); err != nil {
+		t.Fatalf("testdb: creating %s: %v", db, err)
+	}
+	t.Cleanup(func() {
+		// FORCE because a pool that failed to close would otherwise keep
+		// the database alive and the next run would find it: a leaked
+		// database is worse than a leaked row, since nothing sweeps it.
+		if err := exec("DROP DATABASE IF EXISTS " + quoted + " WITH (FORCE)"); err != nil {
+			t.Errorf("testdb: dropping %s: %v", db, err)
+		}
+	})
+
+	private := *u
+	private.Path = "/" + db
+	return private.String()
 }
 
 // Sweep removes every row whose object, ledger or measurement key


### PR DESCRIPTION
Prompted by a read of [garrytan/gbrain](https://github.com/garrytan/gbrain), whose CI gates retrieval on a replayed baseline. The thing worth taking was not the harness — ochakai already has one, and with gold labels rather than a relative baseline — but the discipline of not letting the gate drift looser than what it measures.

**Two commits, and the second one is not about the first.** The first CI run on this branch failed in `internal/restapi`, and the cause turned out to be a race on main. It is fixed here because this branch cannot go green without it; it is a separate commit and reviewable on its own.

---

## 1. Hold the eval floors in both directions

`TestSearchEvalIntegration` scores a golden set of 37 questions as recall@10 and MRR, twice: lexical only, and lexical fused with the stand-in encoder. Four floors fail the build when a number drops.

**They check one direction.** Under a floor fails; over it is free. That lets an improvement bank quietly — a ranking change that lifts MRR and leaves the floor where it was hands the next regression a gap to fall into, and a number nobody moved is a number nobody reads. The file's own comment already states the rule this closes:

> a change that moves those numbers — either way — says so in its PR, because that is the point of having them

Nothing could check the either-way half of it.

This is the hole `DOC-LINES-SLACK` and `RECORD-CORPUS-LINES-SLACK` already closed for the line ceilings, arriving at a floor instead of a ceiling. The precedent is on file: d28c3c8 shortened the deploy guide, raised `DOC-LINES` for the room the fold needed, landed under it, and left 28 lines nobody returned (#376).

**The tolerance is derived, not declared.** `evalFloorSlackCases` is 2, and the score it allows is computed from the size of the set, because everything in that file that reasons about noise reasons in cases — one case slipping rank 1 to rank 2 is 0.014, one case leaving the top k is 0.027. A tolerance written as `0.05` would need rewriting every time the set grows, and the set has been 14, 36, 41 and 37. It also means there is no second number to keep true.

**No floor moved.** All four sit inside two cases' worth of what is measured today (1.00 / 0.78 lexical, 1.00 / 0.77 fused), so this installs the check without relitigating constants that were measured carefully. Verified in both directions by hand — dropping the MRR floor to 0.60 fails with *"6.8 cases' worth of headroom, wider than the 2 evalFloorSlackCases this file allows"*, and raising it to 0.95 fails as a regression.

`CONTRIBUTING.md` gains a subsection under *Measuring before proposing*: the harness was reachable only by knowing it existed, and this PR gives it a rule worth reading before touching ranking.

## 2. Give the access tests a database, not a prefix

The first CI run failed with `export without files: status = 403` in `internal/restapi` — a package this branch does not touch.

**Every integration test isolates itself with a prefix** (`testdb.Unique`): rows carry a run-unique token and the sweep takes them back. That works because every row has an address to put a token in.

**The access policy has none.** It is one document for the whole deployment (0109 §5), so a single rule anywhere in a database puts every caller of that database inside a boundary: reads outside the granted prefixes become `ErrNotFound`, and the whole-bundle operations — `Stats`, `Move`, `Reembed`, the tar of a subtree — become `ErrForbidden`. `go test ./...` runs the packages in parallel against one database, so while `access_integration_test.go` holds its policy, the integration tests in restapi, mcpserver and store are callers of a scoped deployment without knowing it. The failure surfaces three packages away, in a test that never mentions access.

Measured rather than argued, in both directions:

- Planting one unrelated row — `INSERT INTO access_rule VALUES ('someoneelse/growth','human:other')` — makes `TestRESTIntegration` fail deterministically against an otherwise clean database.
- Polling the shared database while the old fixture runs observes its 2 rows sitting there. With this change it stays empty for the whole run.

The window is narrow — the policy is held for roughly 50ms per test — so this reproduces by timing rather than on demand, which is why main is green and why it would have bitten again.

**The fix.** `testdb.Private` hands a test a database of its own and drops it when the test ends, and the six tests in `access_integration_test.go` take one. The unit of isolation has to be a database because the thing being isolated is global to a database: a prefix cannot narrow a document defined as applying to everything. It costs about 135ms of migration per test. `TestNoPolicyIsTheDeploymentThatCameBeforeIntegration` needed it for the mirror reason — what it asserts is the *absence* of a policy, which in the shared database a neighbour can falsify.

`net/url` builds the private URL rather than `pgx.ConnConfig`, because `ConnString` reports the string it was parsed from: setting `.Database` on the struct would hand back a URL still naming the shared database, and the test would pass while isolating nothing.

---

## Checks

- [x] `scripts/check` is clean — `scripts/check --db core` and `scripts/check lint` both green, and the shared database holds no `access_rule` rows and no leftover databases afterwards. The store tests ran against PostgreSQL 16.13, not the `pgvector/pgvector:pg17` CI runs. `scripts/check vuln` is not verifiable in this environment (the proxy refuses `vuln.go.dev`); CI covers it.
- [x] Behavior changes come with tests — both changes *are* tests. The eval check had each of its two failure paths exercised by temporarily moving a floor; the isolation fix was confirmed by observing the shared database during a run, before and after.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, `internal/apiclient` — untouched, no wire change.
- [x] Lands on every surface it belongs on — none. Both changes are test-side.
- [x] `api/openapi.frozen.txt` is untouched.
- [x] Widens a surface? **No.** Nothing a user can call, set, or has to learn changes, so no count in `docs/surface.md` moves. `CONTRIBUTING.md` is in `userDocs`' `forChangers` set and is excluded from `DOC`, so no ceiling moves either.

## Design docs

- [x] Alters an accepted decision? **No** — not applicable. The floors and their tolerance are internal to the harness, and the isolation fix changes how 0109's tests are set up, not what 0109 decided. A reader of ochakai observes nothing different, which is what puts both in a PR description rather than a numbered record (0048).
- [x] Commit messages and code comments are in English.