### PR TITLE
Release 0.24.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Version
       description: Output of `ochakai version`, or the image tag you deployed.
-      placeholder: "0.24.0"
+      placeholder: "0.24.1"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ last entry.
 
 ## [Unreleased]
 
+## [0.24.1] - 2026-08-17
+
 ### Added
 
 - **A directory can have readers and writers** (design doc 0109).
@@ -4546,7 +4548,8 @@ worth naming: SQL injection in `compile_sql` through undeclared field
 pass-through, fixed in 0.8.0 — v0.7.0 and earlier are affected. Details
 are in git history.
 
-[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.24.0...HEAD
+[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.24.1...HEAD
+[0.24.1]: https://github.com/na0fu3y/ochakai/compare/v0.24.0...v0.24.1
 [0.24.0]: https://github.com/na0fu3y/ochakai/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/na0fu3y/ochakai/compare/v0.22.1...v0.23.0
 [0.22.1]: https://github.com/na0fu3y/ochakai/compare/v0.22.0...v0.22.1

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -74,7 +74,7 @@ info:
     is a security defect, shipped in the next release with no deprecation
     window (SECURITY.md). MCP, the CLI and the stored shape stay unstable
     while the major version is 0 and may still change in a minor release.
-  version: 0.24.0
+  version: 0.24.1
   license:
     name: MIT
 servers:

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -80,7 +80,7 @@ export IMAGE=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:$VERSION
 `:latest` ではなくバージョンを固定し、再デプロイを意識的な判断にする。
 `gh` CLI が無ければ
 [リリースページ](https://github.com/na0fu3y/ochakai/releases)から番号
-を読み、手で設定する — `export VERSION=0.24.0`。
+を読み、手で設定する — `export VERSION=0.24.1`。
 
 (このガイドは 0.9.0 以降を前提にしている。それより前のリリースは
 [retract](https://go.dev/ref/mod#go-mod-file-retract) 済みでサポート外


### PR DESCRIPTION
## Summary
- Closes `[Unreleased]` as `## [0.24.1] - 2026-08-17` and opens a fresh empty `[Unreleased]`, with the compare-link footer updated.
- Bumps the three drifting version placeholders: `api/openapi.yaml` `info.version`, the bug report template's version placeholder, and the hand-set `export VERSION=` example in `deploy/cloudrun/README.md`.
- No entries added/removed to `RetiredToolNames` or `retiredCommands` — both are already empty, nothing to expire this release.
- No `BREAKING` entry in the unreleased section, so this is a patch bump (0.24.0 → 0.24.1) per the project's convention.

## What's shipping
- **A directory can have readers and writers** (design doc 0109) — access-policy grants on REST (`GET|PUT /api/v1/access`), CLI (`ochakai access`), and the web UI's アクセス tab. MCP deliberately does not carry it.
- The demo knowledge base is now written in Japanese, with the search-evaluation golden set and its floors following the same corpus.

## Test plan
- [x] `scripts/check` passes clean (lint, vet, tests, govulncheck; PostgreSQL-backed tests skip locally, run in CI)
- [x] Repo-wide grep for stray `0.24.0` references confirmed only the four intended files plus an unrelated third-party action pin
- [x] `RetiredToolNames` / `retiredCommands` confirmed empty — nothing to expire
- [ ] CI green on this PR (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)