### PR TITLE
Release 0.25.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Version
       description: Output of `ochakai version`, or the image tag you deployed.
-      placeholder: "0.24.1"
+      placeholder: "0.25.0"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ last entry.
 
 ## [Unreleased]
 
+## [0.25.0] - 2026-08-17
+
 ### Added
 
 - **The CLI's human-facing lines carry bold and dim at a terminal**
@@ -4589,7 +4591,8 @@ worth naming: SQL injection in `compile_sql` through undeclared field
 pass-through, fixed in 0.8.0 — v0.7.0 and earlier are affected. Details
 are in git history.
 
-[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.24.1...HEAD
+[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.25.0...HEAD
+[0.25.0]: https://github.com/na0fu3y/ochakai/compare/v0.24.1...v0.25.0
 [0.24.1]: https://github.com/na0fu3y/ochakai/compare/v0.24.0...v0.24.1
 [0.24.0]: https://github.com/na0fu3y/ochakai/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/na0fu3y/ochakai/compare/v0.22.1...v0.23.0

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -74,7 +74,7 @@ info:
     is a security defect, shipped in the next release with no deprecation
     window (SECURITY.md). MCP, the CLI and the stored shape stay unstable
     while the major version is 0 and may still change in a minor release.
-  version: 0.24.1
+  version: 0.25.0
   license:
     name: MIT
 servers:

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -80,7 +80,7 @@ export IMAGE=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:$VERSION
 `:latest` ではなくバージョンを固定し、再デプロイを意識的な判断にする。
 `gh` CLI が無ければ
 [リリースページ](https://github.com/na0fu3y/ochakai/releases)から番号
-を読み、手で設定する — `export VERSION=0.24.1`。
+を読み、手で設定する — `export VERSION=0.25.0`。
 
 (このガイドは 0.9.0 以降を前提にしている。それより前のリリースは
 [retract](https://go.dev/ref/mod#go-mod-file-retract) 済みでサポート外


### PR DESCRIPTION
## Summary
- Close `[Unreleased]` as `0.25.0` (BREAKING minor bump: design doc 0110 drops the CLI search score column; design doc 0111 adds terminal bold/dim styling)
- Bump the version placeholders that drift silently: `api/openapi.yaml`, `.github/ISSUE_TEMPLATE/bug_report.yml`, `deploy/cloudrun/README.md`
- `RetiredToolNames` and `retiredCommands` are both already empty — nothing to prune this release

## Test plan
- [x] `scripts/check` passes (PostgreSQL-dependent tests skipped, as usual outside CI)
- [x] Confirmed `git log v0.24.1..origin/main` matches the two Unreleased entries exactly