### PR TITLE
Say the error code vocabulary is closed, because the freeze holds it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@ last entry.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The compatibility policy said a new error `code` could be added,
+  and it cannot.** [docs/compatibility.md](docs/compatibility.md) now
+  says what the checks have enforced since the freeze: the twelve-word
+  `code` vocabulary (design doc 0083) is written into the `Error`
+  response the frozen core operations reach, so a thirteenth word moves
+  a line of [api/openapi.frozen.txt](api/openapi.frozen.txt) — a change
+  to the core rather than one of the two additions design docs 0082 and
+  0101 place outside the freeze. Nothing in the product changes; a
+  client that already treats an unrecognized code as its status alone
+  keeps doing exactly the right thing.
+
 ## [0.25.0] - 2026-08-17
 
 ### Added

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -119,8 +119,20 @@ moves:
   `no_rejection`) and two that share 412 (a stale `If-Match`, and an
   occupied path under `If-None-Match: *`), which is what made a
   string match the only way to tell them apart and this policy's
-  permission to reword them a trap. New codes may be added, so treat an
-  unrecognized one as the status alone would be treated.
+  permission to reword them a trap. **The vocabulary is closed at
+  twelve words, and the freeze holds it there** — the enum is written
+  into `components/responses/Error`, which the core operations reach, so
+  it is a line of the fingerprint, and a thirteenth code *moves* that
+  line rather than adding one, which is not what
+  [0082](design/0082-what-the-freeze-holds-still.md) and
+  [0101](design/0101-a-level-can-be-walked.md) left outside the freeze.
+  Nor is there a way in through a side door: `surface_test.go` requires
+  that enum and the server's own list to be the same list, and every
+  error response anywhere in the contract to draw from it. A thirteenth
+  code needs one of the three reasons above, the way any other change to
+  the core does. Treat an unrecognized code as the status alone would be
+  treated anyway — that costs nothing until the day one of those three
+  lands.
 - **MCP** — tool names, arguments, and which tools exist at all.
   `compile_sql` existed until `0.13.0` and does not now, and the five
   tools that said `knowledge` say `concept`. **A tool a release renames


### PR DESCRIPTION
`docs/compatibility.md` said:

> New codes may be added, so treat an unrecognized one as the status alone would be treated.

The first half has not been true since the sentence was written. It landed in
the **same commit** as design doc 0083 (`013a17b`), which in one go declared the
vocabulary "a closed set of twelve words", wrote that enum into
`components/responses/Error`, and wrote this sentence saying it could grow.
`Error` is a component the core operations reach, so its enum is a line of
`api/openapi.frozen.txt` — and a thirteenth code *moves* that line rather than
adding one, which design doc 0082 §2 names as exactly what the freeze does hold
(`enum や制約が動くこと`). It is neither of the two additions 0082 and 0101
place outside the freeze.

There is no side door either. `TestErrorCodesMatchTheContract` requires the
shared enum and `domain.ErrorCodes` to be the same list, and
`TestEveryErrorResponseDeclaresACode` requires every error response in the
contract to draw from it, so a code cannot slip in through one operation's own
inline response.

## This does not widen the freeze

**No line of `api/openapi.frozen.txt` moves** — the file is not in this diff.
The enum has been pinned there since 0083 landed, and survived 0107's narrowing
because `Error` is core-reachable. This is prose catching up to two accepted
records and a check that already agreed with each other, so **no design record
is taken**.

There was a fork, and this PR picks a side:

1. **The sentence was wrong** (taken) — the vocabulary is closed at twelve.
2. **The sentence was the promise** — then `frozenwire_test.go` should gain a
   third exemption for a *widening* response enum, which is a loosening, and
   would need its own number the way 0082 and 0101 each did.

(2) is rejected because 0064 §18's reason a response `pattern` cannot widen
after the freeze — *a validating client holds it* — applies to an enum
unchanged. A thirteenth value breaks a client validating against the twelve, so
(2) would be accepting a new risk rather than correcting a mistake.

If `compatibility.md` is read as the load-bearing promise rather than 0083 §2,
this flips into a numbered decision and should be rewritten as one — say so and
I will.

## What a client does

Unchanged, and the advice is kept: treat an unrecognized code as its status
alone would be treated. It costs nothing until one of the three reasons that may
still break the core lands.

## Surfaces

Documentation only. REST, MCP, CLI and the web UI are untouched, no surface
count moves, and `scripts/check` passes.

Note: [#TBD](../../pulls) (design doc 0112) also adds to `[Unreleased]`, under a
different heading (`### Changed`). Whichever merges second needs a trivial
CHANGELOG rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)