### PR TITLE
Make the MCP bundle spawn the server it carries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,20 @@ last entry.
 
 ### Fixed
 
+- **The MCP bundle could not start the server it carries.** The
+  `.mcpb` manifest named its command `server/ochakai` — a path relative
+  to whatever directory the desktop app happens to run from, not to the
+  unpacked bundle — so the bundle installed, appeared in the app's
+  settings, and died at the first message with
+  `Failed to spawn process: No such file or directory`. The command is
+  now `${__dirname}/server/ochakai`, the token the format defines for
+  the bundle's own directory. **What to do about it**: reinstall the
+  bundle from a release carrying this fix; nothing else about it
+  changes, and the configured server URL is kept. Every released
+  `.mcpb` up to and including `0.25.0` is affected — the manual's
+  hand-written Claude Desktop JSON
+  ([docs/guides/mcp-clients.md](docs/guides/mcp-clients.md)) was never
+  affected, since it already tells the reader to use an absolute path.
 - **The compatibility policy said a new error `code` could be added,
   and it cannot.** [docs/compatibility.md](docs/compatibility.md) now
   says what the checks have enforced since the freeze: the twelve-word

--- a/cmd/ochakai/mcpb_test.go
+++ b/cmd/ochakai/mcpb_test.go
@@ -101,8 +101,19 @@ func TestMCPBManifestRunsACommandTheBinaryHas(t *testing.T) {
 	if got, _ := server["entry_point"].(string); got != "server/ochakai" {
 		t.Errorf("entry_point = %q, want server/ochakai (scripts/mcpb writes it there)", got)
 	}
-	if got, _ := cfg["command"].(string); got != "server/ochakai" {
-		t.Errorf("command = %q, want server/ochakai", got)
+	// A command is spawned from whatever directory the desktop app happens
+	// to be in, not from the unpacked bundle, so a bare relative path
+	// installs fine and then dies with "No such file or directory" the
+	// first time the app starts the server. ${__dirname} is the bundle's
+	// own directory, and it is the only thing that makes the path absolute
+	// at spawn time.
+	commands := map[string]any{"command": cfg["command"], "platform_overrides.win32.command": win["command"]}
+	for where, v := range commands {
+		command, _ := v.(string)
+		if !strings.HasPrefix(command, "${__dirname}/server/ochakai") {
+			t.Errorf("%s = %q, want it under ${__dirname}/server/: a relative command is "+
+				"resolved against the desktop app's own directory and fails to spawn", where, command)
+		}
 	}
 
 	// scripts/mcpb stamps the release version over this exact string.

--- a/packaging/mcpb/manifest.json
+++ b/packaging/mcpb/manifest.json
@@ -22,12 +22,12 @@
     "type": "binary",
     "entry_point": "server/ochakai",
     "mcp_config": {
-      "command": "server/ochakai",
+      "command": "${__dirname}/server/ochakai",
       "args": ["mcp-stdio", "--url", "${user_config.url}"],
       "env": {},
       "platform_overrides": {
         "win32": {
-          "command": "server/ochakai.exe"
+          "command": "${__dirname}/server/ochakai.exe"
         }
       }
     }


### PR DESCRIPTION
## What and why

The `.mcpb` bundle could not start the server it carries. Its manifest
named the command `server/ochakai` — a path relative to whatever
directory the desktop app happens to run from, not to the unpacked
bundle — so the bundle installed, appeared in the app's settings list,
and died at the first message:

```
[ochakai] [info] Using MCP server command: server/ochakai with path: { … }
[ochakai] [info] Server started and connected successfully
Failed to spawn process: No such file or directory
[ochakai] [info] Server transport closed unexpectedly …
```

`Server started and connected successfully` is the app's own transport,
not the child; the process never ran. Every released `.mcpb` up to and
including `0.25.0` is affected. The hand-written Claude Desktop JSON in
`docs/guides/mcp-clients.md` never was — it already tells the reader to
use an absolute path — so the people who configured it by hand were the
only ones for whom this worked.

`${__dirname}` is the token the bundle format defines for the bundle's
own directory. Two details settle how it is written here, both read out
of the desktop app rather than assumed: the app binds `__dirname` to the
extension path in the same substitution table that carries
`user_config.*`, and it applies `platform_overrides` **before**
substituting — so the `win32` command needs the prefix too, not just the
default one. `entry_point` stays relative: it locates a file inside the
bundle and is not what gets spawned.

**Why no test caught it.** `cmd/ochakai/mcpb_test.go` already read the
manifest back against the build — it fails on a subcommand the CLI does
not have and on a `${user_config.…}` nothing defines. What it did not
read was whether the path resolves, which is the one field here that can
be a well-formed string and still fail at every single launch. That gap
matters more than usual because `scripts/mcpb` deliberately packs with
`zip` rather than `mcpb pack` (an unpinned npm dependency in the release
job is the supply chain this repo otherwise refuses), which leaves this
test file as the only thing validating the manifest at all. It now
requires both commands to sit under `${__dirname}/server/`.

Reviewers can confirm the fix without a release: the installed manifest
under `Claude Extensions/` is unsigned, and editing those two strings in
place plus restarting the app is enough. The configured server URL lives
in a separate file and survives.

## Checks

- [x] `scripts/check` is clean — add `--db` when the change touches the store
      (`scripts/check core`; the store is untouched)
- [x] Behavior changes come with tests

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing; a new endpoint has an
      integration test — n/a, no endpoint changes
- [x] The change lands on every surface it belongs on — REST / MCP / CLI /
      Web UI — and what it stays off is deliberate (design doc 0067). This is
      packaging for the MCP surface; it adds nothing to any surface and
      changes no tool, command or endpoint
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens a surface? No. Nothing is added: `docs/surface.md` counts the
      same tools, commands and variables as before, and the three questions
      do not apply to a fix that restores a shipped surface to working

## Design docs

- [x] Alters an accepted decision? No. `scripts/mcpb` already documents the
      bundle as `ochakai mcp-stdio` behind a manifest, and that is still what
      ships; a manifest that spells its own command wrong is a defect, not a
      decision somebody could have been depending on. Recorded under
      `### Fixed` in `[Unreleased]` instead
- [x] Commit messages and code comments are in English
