### PR TITLE
Close the tree on navigation, and let the search row wrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,16 @@ last entry.
   0101 place outside the freeze. Nothing in the product changes; a
   client that already treats an unrecognized code as its status alone
   keeps doing exactly the right thing.
+- **On a phone, opening an entry from the tree looked like it did
+  nothing.** Where the layout is one column, the knowledge tree is a
+  disclosure that sits above the view in the document, so an entry
+  opened with the tree left open put the page it asked for a screenful
+  below the tap that asked for it. It now closes on navigation, the way
+  a drawer does, and the entry starts under the top bar. In the same
+  pass the search row wraps instead of sharing one line: the query
+  field and a feed's banner were down to half a phone's width beside
+  the create button, which left the banner reading a word to the line.
+  Wide screens are unchanged.
 
 ## [0.25.0] - 2026-08-17
 

--- a/internal/webui/static/app.css
+++ b/internal/webui/static/app.css
@@ -205,8 +205,13 @@ input[type=date]:not(:focus):invalid, input[type=date]:not(:focus):placeholder-s
 .btn.danger:hover { border-color: var(--rejected-bd); color: var(--rejected-fg); }
 .btn.small { padding: .22rem .6rem; font-size: .84rem; }
 
-.searchbox { display: flex; gap: .6rem; margin-bottom: 1rem; }
-.searchbox input { font-size: 1rem; padding: .55rem .8rem; }
+/* The row wraps: the input (or a feed banner) keeps a readable line and
+   the create button drops below it on a narrow screen, where sharing the
+   row squeezed each to half a phone's width. On wide screens the basis
+   leaves room to spare, so the row renders as the single line it was. */
+.searchbox { display: flex; flex-wrap: wrap; gap: .6rem; margin-bottom: 1rem; }
+.searchbox input { font-size: 1rem; padding: .55rem .8rem; flex: 1 1 14rem; width: auto; }
+.searchbox .feed-banner { flex: 1 1 30rem; margin-bottom: 0; }
 
 /* ---- cards ---- */
 .card {

--- a/internal/webui/static/js/router.js
+++ b/internal/webui/static/js/router.js
@@ -3,7 +3,7 @@
 // after a save, and does it from inside a handler long after both
 // modules have finished evaluating.
 
-import { view } from './dom.js';
+import { $, view } from './dom.js';
 import { markTreeSelection } from './tree.js';
 import { viewAccess } from './views/access.js';
 import { viewDetail } from './views/detail.js';
@@ -104,6 +104,12 @@ export function route() {
     viewHome();
   }
   markTreeSelection();
+  // On a narrow screen the sidebar is a disclosure that sits above the
+  // view in the document. Left open across a navigation, it kept the new
+  // content a screenful below the tap that asked for it — so a tap on a
+  // tree entry looked like it did nothing. Navigating is the moment the
+  // tree has served its purpose; close it, like a drawer.
+  if (matchMedia('(max-width: 800px)').matches) $('#side-details').open = false;
   // A navigation replaced the main region in place. Focus follows it, so
   // the next Tab continues inside the new view and a screen reader reads
   // it out — but not on the first render, where the browser has just

--- a/internal/webui/static/js/views/explore.js
+++ b/internal/webui/static/js/views/explore.js
@@ -46,18 +46,18 @@ export function viewExplore() {
   <section>
     <div class="searchbox">
       ${explore.ageFeed
-        ? `<div class="feed-banner" style="flex:1;margin-bottom:0">検証の古さのフィード — 最後に検証してから時間が経ったものから順に並べています。
+        ? `<div class="feed-banner">検証の古さのフィード — 最後に検証してから時間が経ったものから順に並べています。
            古びた検証済みクエリを浮かせるためのカナリアです。
            検索に戻るには <strong>検証の古さ</strong> のチェックを外してください。</div>`
         : explore.failedFeed
-        ? `<div class="feed-banner" style="flex:1;margin-bottom:0">再検証のフィード — 失敗の報告(report_outcome failed)にまだ応えていない concept を、
+        ? `<div class="feed-banner">再検証のフィード — 失敗の報告(report_outcome failed)にまだ応えていない concept を、
            報告が多いものから順に並べています。開いて中身を確かめ、検証し直すとこのフィードから外れます。
            検索に戻るには <strong>間違いと報告された</strong> のチェックを外してください。</div>`
         : explore.source
-        ? `<div class="feed-banner" style="flex:1;margin-bottom:0"><code>${esc(explore.source)}</code> を引いている concept — この資料から派生したものすべてです。
+        ? `<div class="feed-banner"><code>${esc(explore.source)}</code> を引いている concept — この資料から派生したものすべてです。
            <a href="#/search">検索に戻る</a>。</div>`
         : explore.expiredFeed
-        ? `<div class="feed-banner" style="flex:1;margin-bottom:0">期限切れのフィード — 書き手が宣言した <code>stale_after</code> を過ぎた concept を、
+        ? `<div class="feed-banner">期限切れのフィード — 書き手が宣言した <code>stale_after</code> を過ぎた concept を、
            超過が大きいものから順に並べています。<strong>検証してもこのキューは片付きません</strong>:
            その日付はサーバーが測ったものではなく書き手の宣言なので、concept を確かめ直したうえで編集し、
            新しい期限を宣言する(あるいは外す)必要があります。


### PR DESCRIPTION
<!-- Keep PRs small and focused. Link the issue or design doc, if there is one. -->

## What and why

Reported from the field: the web UI is unusable at a narrow window and on
a phone. It measured clean — every route at 375px has
`scrollWidth === innerWidth`, and the media queries have been in place
since `0.21.0` — so the two causes are both about what the reader can
reach, not about what fits.

**A tap on a tree entry looked like it did nothing.** Where the layout is
one column the knowledge tree is a disclosure, and it sits above the view
in the document. Opening an entry with the tree left open re-rendered the
view *below* the open tree — `#view` started around y=1160 on a
375×812 screen, with the scroll position still at 0 — so the page the
reader asked for was a screenful under the tap that asked for it. It
closes on navigation now, the way a drawer does; the entry lands under
the top bar (y≈130).

**The search row could not wrap.** `.searchbox` was a nowrap flex line,
so the query field shared a phone's width with `＋ concept を作る` and
came out at ~170px; on the three feeds the banner took that same half
width and rendered a word to the line, which is what made the feeds
unreadable rather than merely cramped. It wraps now, with `flex-basis`
wide enough (14rem for the field, 30rem for a banner) that the row still
renders as one line above the breakpoint — verified at 1280px, where the
banner and the button stay on the same row as before. The four banners'
inline `style="flex:1;margin-bottom:0"` moved into the rule with it.

This is a bug fix inside an existing surface: nothing is added, and no
count in `docs/surface.md` moves. Both defects are present in every
release from `0.21.0` through `0.25.0`, so demo, example and dev-sk all
have them today.

Verified by driving the running UI against a local dogfood instance at
375px: no horizontal scroll on any route (home, search, all four feeds,
review, detail, editor, directory index, access), a tree tap now landing
at the top of the view, and the search row wrapping — then the same
checks at 1280px to confirm nothing above the breakpoint moved.

One trap worth writing down for the next person: assigning the same value
to `location.hash` fires no `hashchange`, so "tap the same entry again"
silently tests nothing. The re-test has to leave the route and come back.

## Checks

- [x] `scripts/check` is clean — the store is untouched, so `--db` adds
      nothing here
- [x] Behavior changes come with tests — no new test: both defects are
      geometry in a browser (an element's position after a route change, a
      flex line's wrapping), which the jstest suite has no viewport to
      observe; the verification above was done against the running page

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver` and
      `internal/apiclient` are untouched — this is the web UI's own layout
- [x] The change lands on every surface it belongs on (design doc 0067) —
      web UI only; the other three have no viewport
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens a surface? No. Nothing is added; `docs/surface.md` is unchanged

## Design docs

- [x] Alters an accepted decision? No — 0067 already makes the web UI a
      curation surface, and this only makes the existing one reachable on a
      phone
- [x] Commit messages and code comments are in English
