### PR TITLE
Say where an answer came from

### DIFF
--- a/examples/claude-code/CLAUDE.md
+++ b/examples/claude-code/CLAUDE.md
@@ -24,9 +24,10 @@ ochakai はメトリクスの定義、attested computation(sanctioned な SQL。
 学んだことを書き戻すこと。
 
 - `ochakai search "<question or keyword>" [--type '<Type>'] [--trust human-reviewed]`
-  — データの問いはここから始める。1 行 1 ヒット: score、uri、status、
-  title。検証済みの concept は信用してよい。`draft` の concept は
-  provenance で判断する(`--json` が `created_by` を出す)。読む価値の
+  — データの問いはここから始める。1 行 1 ヒット: uri、status、title。
+  検証済みの concept は信用してよい(`--json` の各ヒットが `trust` と
+  `verified_at` を持つ)。`draft` の concept は provenance で判断する —
+  誰が書いたかはヒットには無いので、下の get の stderr で読む。読む価値の
   ある hit は下の get で全文を取る。
 - `ochakai get <id>` — concept の全文を markdown(YAML frontmatter +
   本文)で。stderr の `linked from:` 行は、この concept を本文から指す
@@ -59,6 +60,25 @@ ochakai はメトリクスの定義、attested computation(sanctioned な SQL。
 - `ochakai export <dir>` — ナレッジベース全体を markdown としてスナップ
   ショットする。`ochakai import <dir>` はバンドルを読み戻す(どの OKF
   バンドルでもよい)。
+
+**答えるときは、どの concept から来たかを言う。** ナレッジベースから
+持ってきた定義・数え方・SQL は、**concept の id と、それが人に確認された
+ものかどうか**を添えて答えに書くこと —「売上は税と送料を除く
+(`metrics/revenue`、2026-07-14 に human-reviewed)」のように。値は
+`ochakai get` が stderr に出す一行(`verified by … on …; created by …`)
+にあり、`ochakai search --json` の各ヒットは `trust` と `verified_at` を
+持つ。
+
+理由は二つある。**読んだ人が確かめられる** — 引用が無ければ、人が検証
+した定義と、あなたがその場で組み立てた推測が、答えの中で同じ顔をして
+並ぶ。そして **直せる場所が分かる**: 定義が古いと分かったとき人が開くのは
+その concept であり、`ochakai report <id> failed` を打てるのも id を
+知っているときだけである。引用は、上の report の習慣を**人間の側にも**
+使えるようにする一行である。
+
+**確認されていないものは、そう言う。** `draft` の concept を引くのは
+構わない — 黙って引くのが間違いである。「まだ draft」と書けば、読んだ人は
+その一行を自分で確かめるかどうかを決められる。
 
 ここに挙げた以外の型を使ってよいし(任意のスラグが通る — 例
 `runbook/…`)、関連するナレッジをまとめるために id は階層的でよい

--- a/examples/claude-code/hooks/ochakai-recall.sh
+++ b/examples/claude-code/hooks/ochakai-recall.sh
@@ -41,4 +41,4 @@ if [ -n "$session" ]; then
 		>>"${TMPDIR:-/tmp}/ochakai-recalled-$session"; } 2>/dev/null || true
 fi
 
-printf 'Team knowledge in ochakai that may bear on this request — pointers, not the knowledge itself. Fetch what you rely on before answering (`ochakai get <id>`); a fetched concept lists the concepts that link at it under linked_from, which is where the caveat that says how to read a number lives. Trust verified concepts; judge drafts by created_by:\n\n%s\n' "$rows"
+printf 'Team knowledge in ochakai that may bear on this request — pointers, not the knowledge itself. Fetch what you rely on before answering (`ochakai get <id>`); a fetched concept lists the concepts that link at it under linked_from, which is where the caveat that says how to read a number lives. Trust verified concepts; `ochakai get` prints who wrote and who confirmed one on stderr, which is how a draft is judged. Cite what you use: name the concept id and whether a human confirmed it, so the reader can check the answer and knows which concept to fix:\n\n%s\n' "$rows"


### PR DESCRIPTION
Ticks one box of #677 — **引用の規約**(監査 #16): consumer 側が concept id
+ trust + verified_at を答えに引くための一段落を
`examples/claude-code/CLAUDE.md` に。

## What and why

**誰が詰まったか。** 書き戻しの習慣は二層とも教えている(CLAUDE.md の
`report` / `put`、Stop フック)。**読む側には何も無かった。** エージェント
は検索し、定義を読み、人に答える — そのとき「どの concept から来たか」
「人が確認したものか」を言えとは、どこにも書いていない。

その一行が無いと二つ壊れる。**人が検証した定義と、モデルがその場で
組み立てた推測が、答えの中で同じ顔をして並ぶ。** そして数字がおかしいと
気づいた人の手元に **id が無い** — 開く先も、`ochakai verify` する先も、
`ochakai report <id> failed` を打つ先も分からない。0069 のループは
「人間が判断を供給する」に賭けているのに、**判断すべき対象を人に渡す経路が
consumer 側に無かった**。当たる条件は C7、次いで C5。

**既存の面で回避できるか。** できない — これは面ではなく規約であり、
足すコードは無い。

**何が畳めるか。** 面は増えないので畳むものも無い。代わりに、間違って
いた記述を二つ畳んだ(下)。

## 何を書いたか

`examples/claude-code/README.md` が二層について書いていることに従って、
**両方に**置いた:

- **CLAUDE.md**(層 1)に一段落。concept の id と、人に確認されたものか
  どうかを答えに書く。値の在り処 —— `ochakai get` が stderr に出す
  `verified by … on …; created by …` の行、検索ヒットの `trust` と
  `verified_at`。そして **`draft` を引くのは構わないが、黙って引くのは
  間違い**:「まだ draft」と書けば、読んだ人はその一行を自分で確かめるか
  決められる。
- **想起フック**(層 2)に一文。README 自身が層 1 について
  「指示はエージェントが覚えていることに頼るので、**遵守は完全ではない**」
  と書いており、規約が毎回届く場所はフックのほうである。
  **代金は約 40 トークン** — フックが既に払っているコンテキストの上に
  乗る分で、`OCHAKAI_RECALL_LIMIT` の節が「効くつまみはこれ一つ」と言って
  いるその予算である。フックが存在する理由そのものの挙動なので払った。

## ついでに直した二つの嘘

どちらも読み手が真似すると外れる記述である。

1. **検索の行に `score` は無い。**
   [0110](https://github.com/na0fu3y/ochakai/blob/main/docs/design/0110-the-first-column-is-the-key-you-asked-for.md)
   が第一列を落としたので、いまは `uri / status / title` である
   (`printHits`)。CLAUDE.md はまだ `score、uri、status、title` と教えて
   いた。
2. **`created_by` は検索ヒットに無い。** `domain.Summary` が持つのは
   `trust` と `verified_at` までで、`created_by` は全文読み(`observed`)
   の側にある。CLAUDE.md は「`--json` が `created_by` を出す」と書き、
   想起フックは「judge drafts by created_by」と、**その値を持たない行の
   すぐ隣で**指示していた。どちらも実際の在り処(`ochakai get` の stderr)
   を指すように直した。

## Checks

- [x] `scripts/check` is clean — `core` と `lint`(0 issues)。この変更は
      Go にも store にも触れないので `--db` は要らない。`govulncheck` は
      この環境の egress ポリシーが `vuln.go.dev` に 403 を返すため実行
      できず、落ちたのではなく確認できない状態(CI が走らせる)。
- [x] Behavior changes come with tests — 該当なし(散文と、フックの
      printf 一行)。フックは `bash -n` と、CLI が届かないときに黙って
      exit 0 する経路を実際に走らせて確かめた(README がそう約束している)。

## Surfaces and contract

- [x] 表面は一つも動かない。REST 操作・パラメータ・ヘッダ・MCP ツール・
      CLI コマンド・フラグ・環境変数・語彙、どれも増減なし。
      `api/openapi.frozen.txt` は無傷。
- [x] 0067 の四面: これは面ではなく **consumer に渡す規約**で、置き場所は
      Claude Code の例(C5 の面)である。**MCP には入れない** — `Instructions`
      は常駐で数えられており(`MCP-BYTES` 12,000 に対して実測 11,788)、
      残りは 212 バイトしかない。しかも 0096 §3 が書いたとおり
      **ホストは instructions を落とす自由がある**ので、そこに置いた規約は
      届く保証が最も薄い。ブラウザホストのエージェントに同じことを教える
      経路は別途要るが、この PR では断る。

## Design docs

- [x] 該当なし。ワイヤも保存形も identity も Google Cloud 依存も動かず、
      新しい拒否でもない — 利用者にコピーされる例の中の規約である
      ([0048](https://github.com/na0fu3y/ochakai/blob/main/docs/design/0048-decision-records-for-wire-contracts.md)
      §2.1 の下では PR の説明で足りる)。
- [x] Commit messages and code comments are in English(散文は日本語の
      ページなので日本語のまま)。

---
_Generated by [Claude Code](https://claude.ai/code/session_01VrmHiT529qkyGGa6UMXFS3)_