### PR TITLE
Say what a client's row limit does to a seeded catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,23 @@ last entry.
 
 ### Fixed
 
+- **The day-one catalog could arrive with 100 rows of it and no
+  complaint.** Every documented `bq query` that feeds `ochakai seed` or
+  the query-history drafter now passes `--max_rows`: `bq` prints the
+  first 100 rows and says nothing about the rest, so a dataset whose
+  columns add up past that seeded only the tables those rows reached —
+  no error, no warning, and a bundle that looks exactly like a small
+  warehouse. `ochakai seed` now prints a `note:` on **stderr** when its
+  input is exactly 100 rows, naming the flag; it stays a note rather
+  than a refusal, because 100 rows is also just 100 rows. **What to do
+  about it**: if a catalog was seeded before this, rerun the query with
+  the limit raised and `ochakai import --dry-run` the result first — the
+  tables that were missing come back as *created*, and anything counted
+  as *updated* is an entry the projection would replace with a fresh
+  skeleton (the version somebody wrote is kept as a revision, but it is
+  no longer what the entry says). Where drafts have been filled in
+  already, `ochakai seed cols.json > catalog.tar.gz` and import the
+  missing tables out of it instead. Reported by a user.
 - **The MCP bundle could not start the server it carries.** The
   `.mcpb` manifest named its command `server/ochakai` — a path relative
   to whatever directory the desktop app happens to run from, not to the

--- a/README.md
+++ b/README.md
@@ -158,10 +158,13 @@ page's counters read zero, by design.
 
 That shop is invented. Your own tables go in the same way, and ochakai
 never touches the warehouse to get them — you run the schema query with
-your own client and your own identity, and pipe the rows in:
+your own client and your own identity, and pipe the rows in. Raise your
+client's row limit while you do: `bq query` prints the first 100 rows and
+says nothing about the rest, so a dataset with more columns than that
+seeds only the tables the first 100 rows reached.
 
 ```sh
-bq query --format=json --nouse_legacy_sql \
+bq query --max_rows=100000 --format=json --nouse_legacy_sql \
   'SELECT table_schema, table_name, column_name, data_type, is_nullable, description
      FROM `your-project.your_dataset.INFORMATION_SCHEMA.COLUMNS`
     ORDER BY ordinal_position' \

--- a/cmd/ochakai/seed.go
+++ b/cmd/ochakai/seed.go
@@ -30,10 +30,17 @@ import (
 // draft concepts and prints them as an OKF bundle, which `ochakai import`
 // writes like any other bundle:
 //
-//	bq query --format=json --nouse_legacy_sql \
+//	bq query --max_rows=100000 --format=json --nouse_legacy_sql \
 //	  'SELECT table_schema, table_name, column_name, data_type, is_nullable
 //	     FROM `proj.dataset.INFORMATION_SCHEMA.COLUMNS` ORDER BY ordinal_position' |
 //	  ochakai seed - | ochakai import -
+//
+// The row limit in that first line is not decoration. `bq query` prints
+// the first 100 rows and says nothing about the rest, so a dataset with
+// more columns than that seeds only the tables those rows reached — with
+// no error anywhere, because nothing downstream can tell a truncated
+// listing from a small one. seedTruncationNote below is what ochakai can
+// say about it from where it stands.
 //
 // Nothing here connects to anything. No warehouse client is linked into
 // the binary, no credential is read, and the same command serves any
@@ -82,8 +89,11 @@ func cmdSeed(_ context.Context, args []string) error {
 			"the query, with your own client and your own identity, and pipe the answer\n"+
 			"here. Every concept comes out as a draft, because a projected schema is a\n"+
 			"skeleton somebody still has to say something about — which is what the\n"+
-			"review queue is for.",
-		"  bq query --format=json --nouse_legacy_sql \\\n"+
+			"review queue is for.\n\n"+
+			"Raise your client's row limit when you run that query: `bq query` prints\n"+
+			"the first 100 rows unless --max_rows says otherwise, and a listing cut\n"+
+			"there looks exactly like a small dataset from here.",
+		"  bq query --max_rows=100000 --format=json --nouse_legacy_sql \\\n"+
 			"    'SELECT table_schema, table_name, column_name, data_type, is_nullable\n"+
 			"       FROM `proj.dataset.INFORMATION_SCHEMA.COLUMNS` ORDER BY ordinal_position' |\n"+
 			"    ochakai seed - | ochakai import -\n"+
@@ -108,6 +118,9 @@ func cmdSeed(_ context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
+	if note := seedTruncationNote(len(cols)); note != "" {
+		fmt.Fprintln(os.Stderr, "note:", note)
+	}
 	tables := gatherSeedTables(cols)
 	if len(tables) == 0 {
 		return fmt.Errorf("no rows with a table_name: is this the output of a SELECT over INFORMATION_SCHEMA.COLUMNS?")
@@ -117,6 +130,27 @@ func cmdSeed(_ context.Context, args []string) error {
 	}
 	fmt.Fprintf(os.Stderr, "seeded %d tables as drafts; pipe into `ochakai import -` to write them\n", len(tables))
 	return nil
+}
+
+// clientDefaultRows is what `bq query` prints when nobody passes
+// --max_rows, and the shape of the one failure this path has that nothing
+// else can catch: the pipe succeeds, the bundle is well-formed, and the
+// tables past the cut are simply not in it. A listing truncated there is
+// indistinguishable from a small warehouse — except for its size, which is
+// this exact number and rarely anything else by accident.
+const clientDefaultRows = 100
+
+// seedTruncationNote is that suspicion, said out loud once and never as an
+// error: exactly 100 rows is a legitimate listing often enough that
+// refusing it would be wrong, and a silent partial catalog is the thing
+// somebody actually lost a day to.
+func seedTruncationNote(rows int) string {
+	if rows != clientDefaultRows {
+		return ""
+	}
+	return fmt.Sprintf("the input is exactly %d rows, which is what a client's default row limit looks like:\n"+
+		"      `bq query` prints %d unless you pass --max_rows, and drops the rest without saying so.\n"+
+		"      If the schema is larger than that, rerun the query with the limit raised.", clientDefaultRows, clientDefaultRows)
 }
 
 // readSeedColumns accepts both shapes a warehouse client prints: one JSON

--- a/cmd/ochakai/seed_test.go
+++ b/cmd/ochakai/seed_test.go
@@ -208,3 +208,24 @@ func TestSeedPipesIntoImport(t *testing.T) {
 		t.Errorf("wrote %v, want the one table at its own address", written)
 	}
 }
+
+// The failure this path cannot see from the inside: `bq query` stops at
+// 100 rows unless told otherwise, and a catalog cut there is a valid
+// bundle of the tables that fit. Nothing downstream can tell it from a
+// small warehouse, so the count itself is the only thing left to say
+// something about — and it says it as a note, because 100 rows is also
+// just 100 rows.
+func TestSeedNotesAnInputCutAtAClientsDefault(t *testing.T) {
+	note := seedTruncationNote(clientDefaultRows)
+	if note == "" {
+		t.Fatalf("%d rows drew no note: the truncation a reporter lost a day to passes in silence", clientDefaultRows)
+	}
+	if !strings.Contains(note, "--max_rows") {
+		t.Errorf("the note does not name the flag that fixes it:\n%s", note)
+	}
+	for _, rows := range []int{0, 1, clientDefaultRows - 1, clientDefaultRows + 1, 1000} {
+		if got := seedTruncationNote(rows); got != "" {
+			t.Errorf("%d rows drew a note: %s", rows, got)
+		}
+	}
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -693,6 +693,10 @@ here. Every concept comes out as a draft, because a projected schema is a
 skeleton somebody still has to say something about — which is what the
 review queue is for.
 
+Raise your client's row limit when you run that query: `bq query` prints
+the first 100 rows unless --max_rows says otherwise, and a listing cut
+there looks exactly like a small dataset from here.
+
 Flags:
   -prefix string
     	the id prefix each concept is written under, e.g. tables/shop/orders (default "tables")
@@ -700,7 +704,7 @@ Flags:
     	the warehouse project or account the tables live in, written into each concept's resource address
 
 Examples:
-  bq query --format=json --nouse_legacy_sql \
+  bq query --max_rows=100000 --format=json --nouse_legacy_sql \
     'SELECT table_schema, table_name, column_name, data_type, is_nullable
        FROM `proj.dataset.INFORMATION_SCHEMA.COLUMNS` ORDER BY ordinal_position' |
     ochakai seed - | ochakai import -

--- a/docs/guides/onboarding.md
+++ b/docs/guides/onboarding.md
@@ -55,12 +55,18 @@ BigQuery カタログの初日の全手順は
 スキーマは自分で撃って、答えを渡す。ochakai は倉庫に接続しない:
 
 ```sh
-bq query --format=json --nouse_legacy_sql \
+bq query --max_rows=100000 --format=json --nouse_legacy_sql \
   'SELECT table_schema, table_name, column_name, data_type, is_nullable, description
      FROM `your-project.your_dataset.INFORMATION_SCHEMA.COLUMNS`
     ORDER BY ordinal_position' \
   | ochakai seed --project your-project - | ochakai import -
 ```
+
+**`--max_rows` は省けない。** `bq query` が既定で表示するのは先頭 100 行
+だけで、打ち切ったことは何も言わない — カラムが合計 100 本を超える
+データセットは、エラーも警告も無しに一部のテーブルだけが入る。行数を
+数えるのは投影の前であり、`seed` が最後に出す「seeded N tables」の N を
+自分のテーブル数と突き合わせるのが、その場でできる確認である。
 
 **全件 draft で着地する。** 投影されたスキーマは骨格であって、まだ
 ナレッジではない([0085](../design/0085-the-empty-base-and-what-fills-it.md) §3)。

--- a/examples/bigquery-catalog/README.md
+++ b/examples/bigquery-catalog/README.md
@@ -23,11 +23,16 @@ receipt も要らない — 自分で撃ったクエリの答えを `ochakai see
 draft の OKF バンドルになって出てくる([0085](../../docs/design/0085-the-empty-base-and-what-fills-it.md)):
 
 ```sh
-bq query --format=json --nouse_legacy_sql \
+bq query --max_rows=100000 --format=json --nouse_legacy_sql \
   'SELECT table_schema, table_name, column_name, data_type, is_nullable
      FROM `proj.dataset.INFORMATION_SCHEMA.COLUMNS` ORDER BY ordinal_position' |
   ochakai seed --project proj - | ochakai import -
 ```
+
+`--max_rows` はここでは飾りではない。`bq query` は既定で先頭 100 行しか
+出さず、打ち切りを何も言わない — カラムが 100 本を超えるデータセットは、
+黙って一部のテーブルだけが入る。`seed` の「seeded N tables」を自分の
+テーブル数と突き合わせること。
 
 `seed` もウェアハウスには接続しない — 撃つのはあなたの `bq` であり、
 ochakai が受け取るのはその出力だけである。出てくる draft の中身を
@@ -105,7 +110,7 @@ verify すること — それはちょうど、IAM ロールを実際に付与�
 答えをパイプで渡す:
 
 ```sh
-bq query --format=json --nouse_legacy_sql \
+bq query --max_rows=100000 --format=json --nouse_legacy_sql \
   'SELECT query, user_email, creation_time, referenced_tables
      FROM `region-us`.INFORMATION_SCHEMA.JOBS
     WHERE creation_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 90 DAY)
@@ -113,6 +118,10 @@ bq query --format=json --nouse_legacy_sql \
   python3 bundle/jobs/draft-from-query-history/draft-from-query-history.py |
   ochakai import -
 ```
+
+ここでも `--max_rows` が要る。既定の 100 行では 90 日分のつもりが直近の
+100 ジョブになり、「5 回以上」の敷居に届くものがほとんど無くなる —
+`jobs_read` の数を見ること。
 
 リテラルとコメントと空白だけが違う実行は**一つにまとまり**、5 回以上
 撃たれたものが draft として着地する。**LLM は入っていない** — 「この

--- a/examples/bigquery-catalog/bundle/jobs/draft-from-query-history.md
+++ b/examples/bigquery-catalog/bundle/jobs/draft-from-query-history.md
@@ -26,7 +26,7 @@ It reads `INFORMATION_SCHEMA.JOBS` rows as JSON on stdin and writes an OKF
 bundle of drafts on stdout, one per query somebody keeps running:
 
 ```sh
-bq query --format=json --nouse_legacy_sql \
+bq query --max_rows=100000 --format=json --nouse_legacy_sql \
   'SELECT query, user_email, creation_time, referenced_tables
      FROM `region-us`.INFORMATION_SCHEMA.JOBS
     WHERE creation_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 90 DAY)
@@ -46,6 +46,12 @@ It also makes the permission yours to have or not. Seeing anybody else's
 jobs needs `bigquery.jobs.listAll`; without it the history is your own
 queries, and the counts still look plausible — which is worse than no
 counts. Read the first line of the summary before the drafts.
+
+Your client's row limit does the same thing more quietly. `bq query`
+prints the first 100 rows unless `--max_rows` says otherwise and never
+mentions the ones it dropped, so 90 days of history arrives as the last
+100 jobs and almost nothing reaches `min_runs`. `jobs_read` in the
+receipt is the number to disbelieve when it is exactly 100.
 
 # There is no LLM in it
 

--- a/examples/bigquery-catalog/bundle/skills/run-a-python-job.md
+++ b/examples/bigquery-catalog/bundle/skills/run-a-python-job.md
@@ -110,7 +110,7 @@ before the stamp existed are still recognized by account.
 ## `draft-from-query-history`
 
 ```sh
-bq query --format=json --nouse_legacy_sql '...' \
+bq query --max_rows=100000 --format=json --nouse_legacy_sql '...' \
   | python3 draft-from-query-history.py \
   | ochakai import -
 ```


### PR DESCRIPTION
## What and why

Reported by a user: the day-one pipeline (`bq query` → `ochakai seed` →
`ochakai import`) put in only part of a BigQuery dataset, with nothing
saying so. `bq query` prints the first **100 rows** unless `--max_rows`
raises the limit, and it says nothing about the rows it dropped — so a
dataset whose columns add up past 100 seeds only the tables those rows
reached. The documented examples carried no `--max_rows`, and no error
or warning appears anywhere: a truncated `INFORMATION_SCHEMA.COLUMNS`
listing is a perfectly well-formed listing of a smaller warehouse.

Two halves, because the documentation half alone leaves the silence:

- **Every documented `bq query` that feeds this path now passes
  `--max_rows`** — README, `docs/guides/onboarding.md` §1, the
  `examples/bigquery-catalog` README and its two bundle documents, and
  `ochakai seed -h` (hence the regenerated `docs/cli.md`). The pages
  that walk somebody through the first day say *why* the flag is there
  rather than carrying it silently, and both say to check the
  `seeded N tables` line against the number of tables you expected. The
  query-history drafter has the same failure in a nastier shape: 90 days
  of history arrives as the last 100 jobs, and almost nothing reaches
  the `min_runs` threshold, so its `jobs_read` receipt gets the same
  note.
- **`ochakai seed` prints a `note:` on stderr when its input is exactly
  100 rows**, naming the flag. That count is the only observation
  available from where ochakai stands — it never sees the warehouse, and
  nothing downstream can tell a cut listing from a small one. It stays a
  note rather than a refusal, because 100 rows is also just 100 rows;
  `note:` on stderr is the existing convention (`client.go`), so stdout
  and the exit code are unchanged and pipes are untouched.

No surface is widened: no flag, endpoint, tool schema, command or
environment variable is added, so `docs/surface.md`'s counters and
ceilings are unmoved (the manual lands at 7,458 of DOC-LINES' 7,500,
inside DOC-LINES-SLACK). The three questions therefore do not apply,
but for the record the condition served is C4 — no forward-deployed
engineer: the first thirty minutes cannot depend on knowing a client's
default page size.

## Checks

- [x] `scripts/check` is clean — add `--db` when the change touches the store
- [x] Behavior changes come with tests

`scripts/check core` and `scripts/check lint` are green here (0 issues).
This session's environment cannot reach Docker Hub or `vuln.go.dev`, so
the container build and `scripts/check vuln` are unverified here and
left to CI; the change touches neither the store nor the Dockerfile.
`TestSeedNotesAnInputCutAtAClientsDefault` covers the note, including
that 99, 101 and 1000 rows draw none.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — untouched; nothing on the wire
      changed
- [x] The change lands on every surface it belongs on — REST / MCP / CLI /
      Web UI. `seed` is a CLI-only, client-side command (design doc 0085 §2:
      it writes through the existing `import`), so the note belongs to the CLI
      and to no other face
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens a surface? No. Nothing was added to any of the nine dimensions;
      `docs/surface.md` needed no edit and its tests agree

## Design docs

- [x] Alters an accepted decision? No — not applicable. 0085's decision is
      unchanged: `seed` still connects to nothing, still writes through
      `import`, and still produces drafts. What changed is one stderr line and
      the prose around a documented example
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01XbheH7M5cUWvEJuWxK6wNz)_