### PR TITLE
State where ochakai stands relative to Apache Ossie

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -99,6 +99,16 @@ it.
   ([0106](docs/design/0106-a-read-carries-what-points-at-it.md)).
 - **Connector ingestion.** Knowledge is curated by humans and agents, not
   harvested by pipelines. Trust density over volume.
+- **A second format beside OKF — including Apache Ossie (formerly Open
+  Semantic Interchange).** Ossie standardizes the definition layer, and
+  ochakai stands on the other side of that boundary: nothing in its core spec
+  carries who wrote a definition, who confirmed it, or when it goes stale,
+  which is what OKF holds. Reading or writing it would be a second format
+  beside OKF, which C8's sibling condition C3 declines. The condition under
+  which this is revisited is written down
+  ([docs/positioning.md](docs/positioning.md#ウェアハウス-native-の-semantic-layer)):
+  Ossie leaving incubation with a place in its core for a human having
+  confirmed a definition.
 - **A chat UI or dashboards.** The bundled web UI is a curation surface, not a
   BI tool: no charts, no query execution, no chat. It feeds your agents rather
   than competing with them.

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -26,7 +26,7 @@ semantic layer は revenue = `SUM(price)` だと教えてくれる。100 とい�
 
 | 比較対象 | あちらが持つもの | あちらが持たないもの | 判定 |
 |---|---|---|---|
-| ウェアハウス native の semantic layer(dbt MCP、Cube、Lightdash、Snowflake Semantic Views、Databricks Metric Views) | メトリクス定義、ディメンション、コンパイルされた SQL | 解釈、用語集、書き戻し、ウェアハウスをまたぐもの | 両立 |
+| ウェアハウス native の semantic layer(dbt MCP、Cube、Lightdash、Snowflake Semantic Views、Databricks Metric Views)と、その標準([Apache Ossie](https://github.com/apache/ossie) — 旧 OSI) | メトリクス定義、ディメンション、コンパイルされた SQL | 解釈、用語集、書き戻し、ウェアハウスをまたぐもの、そして誰が確認したか | 両立 — 下記参照 |
 | 「コンテキスト層」になったカタログ(OpenMetadata、DataHub、Atlan) | 技術メタデータ、リネージ、オーナーシップ、大規模な収集 | キュレーションされた側が OSS であること — 解釈とレビューループは商用ティアに置かれがち | 両立、あるいは既に運用しているなら ochakai の代わりになる |
 | エージェントのメモリ層(mem0、Zep、Letta) | ユーザーごと・エージェントごとの記憶、自動抽出・自動注入 | チームの所有、人のレビュー、*no* の記録 | 両立 |
 | 自分の文書に対する RAG | 他の理由で書かれた文書からの断片 | 単位としてのレビュー済みの主張、provenance、著者の向き | 両立 |
@@ -47,6 +47,35 @@ concept は冗長である。残るのは semantic model の YAML に収まら�
 生成をやめたのは意図した決定であり
 ([0070](design/0070-what-was-retired-and-why.md) §3)、エージェントが
 必要とするのは検証済みのクエリとその周りの注意書きだからである。
+
+**その層は 2026 年に標準を持った — [Apache Ossie](https://github.com/apache/ossie)
+(incubating、旧 Open Semantic Interchange / OSI)である。** Snowflake・
+dbt Labs・Salesforce ほかが始め、Apache Software Foundation に寄贈されて
+Incubator に入った(Apache-2.0)。標準化するのは**定義の層**で、
+2026-08 に読んだ `core-spec/spec.yaml`(`0.2.0.dev0`、draft)の
+トップレベルは `semantic_model` / `datasets` / `fields` / `metrics` /
+`relationships` / `dialects` / `datatypes` である。
+
+**ochakai はこれと競合しない。同じ境界の反対側に立っている。** 上の
+「一行で」がその境界そのものである — Ossie が一つの綴りに揃えるのは
+revenue = `SUM(price)` の側で、ochakai が持つのは 100 が良いのか悪いのか
+の側である。決定的なのは、その `spec.yaml` に **provenance・検証・trust・
+鮮度・誰が書いたか を運ぶ構造が無い**ことで、あるのはベンダーごとの
+`custom_extensions` だけである。つまり OKF が中核に置いているもの —
+誰が書き、誰が確認し、いつ古びるか([0065](design/0065-identity-and-provenance.md)・
+[0069](design/0069-the-loop-and-what-measures-it.md))— は Ossie の枠の
+外にあり、**二つは同じものを二通りに言っているのではない**。重なって
+いないから、両方置ける。
+
+**いま実装はしない。** これは立場の表明であって計画ではない。Ossie を
+読み書きすることは OKF の横に第二の形式を持つことであり、C3 がそれを
+断っている。ウェアハウス側の semantic model を ochakai の `Metric`
+concept に投影したいなら、その形は既にある — 自分のサービスアカウントで
+動く普通のクライアント([例](../examples/bigquery-catalog))であって、
+ochakai が持つコネクタではない([0081](design/0081-what-ochakai-is-and-what-it-refuses-to-hold.md) §1)。
+**見直す条件は書いておく**: Ossie が incubating を出て、かつ「この定義を
+人が確認した」を core が運ぶようになったとき。そのときは重なりが本物に
+なるので、OKF との対応を書く価値がある。
 
 ### コンテキスト層としてのカタログ
 


### PR DESCRIPTION
Ticks one box of #677 — **OSI との関係表明**(監査 #22): Open Semantic
Interchange と OKF の関係を一段落。issue のとおり **実装より先に立場の
表明**である。

## 調べた結果、名前が変わっていた

**OSI は Apache Software Foundation に寄贈され、Incubator に入って
[Apache Ossie (incubating)](https://github.com/apache/ossie) になっている。**
リポジトリの README が
「Apache Ossie was formerly known as Open Semantic Interchange (OSI).」と
明言している。Snowflake・dbt Labs・Salesforce ほかが始めた取り組みで、
ライセンスは Apache-2.0。

事実は**報道ではなくプロジェクト自身のリポジトリ**から取った。
2026-08 に読んだ `core-spec/spec.yaml` は `0.2.0.dev0`(draft)で、
トップレベルは `semantic_model` / `datasets` / `fields` / `metrics` /
`relationships` / `dialects` / `datatypes`。**draft は動くので、本文には
観測日を書いてある。**

## 立場

`docs/positioning.md` が最初の段落で引いている境界がそのまま答えになる。

- **Ossie が一つの綴りに揃えるのは定義の層** — revenue = `SUM(price)` の
  側である。
- **決定的なのは、そこに無いもの。** `spec.yaml` には **誰が定義を書いた
  か・誰が確認したか・いつ古びるか を運ぶ構造が一つも無い**。拡張点は
  ベンダーごとの `custom_extensions` だけである。それは OKF が中核に
  置いているもの(0065・0069)なので、**二つは同じことを二通りに言って
  いるのではない**。重なっていないから、両方置ける。

これは「一行で」の節が最初から書いていたこと —「semantic layer は
revenue = `SUM(price)` だと教えてくれる。100 という数字が良いのか悪いの
かは教えてくれない」— を、標準の名前で言い直したものである。新しい主張は
していない。

## いま実装しない、その条件付きで

Ossie を読み書きすることは **OKF の横に第二の形式を持つこと**であり、
C3 がそれを断っている。ウェアハウス側の semantic model を `Metric`
concept に投影したいなら形は既にある — 自分のサービスアカウントで動く
普通のクライアント([examples/bigquery-catalog](examples/bigquery-catalog))
であって、ochakai が持つコネクタではない(0081 §1)。

拒否は**拒否が住む場所**(`ROADMAP.md` の *Considered and deliberately not
doing*)にも一行置いた。その節が「決定を見直す条件があるならドキュメント
が書く」と要求しているので、書いた: **Ossie が incubating を出て、かつ
「この定義を人が確認した」を core が運ぶようになったとき。** そのときは
重なりが本物になるので、OKF との対応を書く価値がある。

## Checks

- [x] `scripts/check` is clean — `core` と `lint`(0 issues)。散文だけの
      変更なので `--db` は要らない。`govulncheck` はこの環境の egress
      ポリシーが `vuln.go.dev` に 403 を返すため実行できず、落ちたのでは
      なく確認できない状態(CI が走らせる)。
- [x] Behavior changes come with tests — 該当なし(散文)。ただし
      ROADMAP から positioning の見出しへ張ったアンカーは
      `TestManualLinksResolve` が実際に検証していることを、**わざと壊して
      落ちることを確かめてから**戻して確認した。

## Surfaces and contract

- [x] 表面は一つも動かない。コードに触れていないので REST・MCP・CLI・
      Web UI・環境変数・語彙すべて増減なし。`api/openapi.frozen.txt` は
      無傷。`DOC` のページ数も増えない(既存ページへの加筆)。
- [x] 0067 の四面: 該当なし — これは面ではなく、評価している人が読む
      ページである。

## Design docs

- [x] 該当なし。ワイヤも保存形も identity も動かない。**新しい拒否では
      あるが、既にある拒否(C3・0081 §1)の当てはめ**であって、新しい
      決定ではない — だから番号ではなく ROADMAP の一行と positioning の
      散文になる。
- [x] Commit messages and code comments are in English(ページは日本語の
      マニュアルなので日本語、ROADMAP は英語の front door なので英語)。

---
_Generated by [Claude Code](https://claude.ai/code/session_01VrmHiT529qkyGGa6UMXFS3)_