### PR TITLE
Prepare 0.26.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Version
       description: Output of `ochakai version`, or the image tag you deployed.
-      placeholder: "0.25.0"
+      placeholder: "0.26.0"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ last entry.
 
 ## [Unreleased]
 
+## [0.26.0] - 2026-08-18
+
 ### Changed
 
 - **The write-back habit now says to link a draft to what it came from.**
@@ -4738,7 +4740,8 @@ worth naming: SQL injection in `compile_sql` through undeclared field
 pass-through, fixed in 0.8.0 — v0.7.0 and earlier are affected. Details
 are in git history.
 
-[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.25.0...HEAD
+[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.26.0...HEAD
+[0.26.0]: https://github.com/na0fu3y/ochakai/compare/v0.25.0...v0.26.0
 [0.25.0]: https://github.com/na0fu3y/ochakai/compare/v0.24.1...v0.25.0
 [0.24.1]: https://github.com/na0fu3y/ochakai/compare/v0.24.0...v0.24.1
 [0.24.0]: https://github.com/na0fu3y/ochakai/compare/v0.23.0...v0.24.0

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -74,7 +74,7 @@ info:
     is a security defect, shipped in the next release with no deprecation
     window (SECURITY.md). MCP, the CLI and the stored shape stay unstable
     while the major version is 0 and may still change in a minor release.
-  version: 0.25.0
+  version: 0.26.0
   license:
     name: MIT
 servers:

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -80,7 +80,7 @@ export IMAGE=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:$VERSION
 `:latest` ではなくバージョンを固定し、再デプロイを意識的な判断にする。
 `gh` CLI が無ければ
 [リリースページ](https://github.com/na0fu3y/ochakai/releases)から番号
-を読み、手で設定する — `export VERSION=0.25.0`。
+を読み、手で設定する — `export VERSION=0.26.0`。
 
 (このガイドは 0.9.0 以降を前提にしている。それより前のリリースは
 [retract](https://go.dev/ref/mod#go-mod-file-retract) 済みでサポート外


### PR DESCRIPTION
## What and why

The release preparation for **0.26.0** — the four files a tag does not update,
and nothing else:

1. `CHANGELOG.md` — `## [Unreleased]` becomes `## [0.26.0] - 2026-08-18` (tag
   date, JST), a fresh empty `Unreleased` above it, the compare link added and
   `[Unreleased]` repointed at the new tag
2. `api/openapi.yaml` — `info.version`
3. `.github/ISSUE_TEMPLATE/bug_report.yml` — the version placeholder
4. `deploy/cloudrun/README.md` — the hand-set `export VERSION=` example, for the
   reader with no `gh` CLI

**Minor rather than patch**, because the section carries a BREAKING entry: design
doc 0112 stops a start that carries an `OCHAKAI_` variable ochakai does not read.
An operator upgrading reads that entry first; what to remove is named in the
failed revision's own startup log, and on Cloud Run a revision that does not
start takes no traffic, so the previous one goes on answering.

**Both retired-name tables are empty** (`mcpserver.RetiredToolNames`,
`retiredCommands`), so this release closes no rename window — nothing to delete
here, and `TestARetiredNameLastsOneRelease` agrees.

The entries were read against `git log v0.25.0..main` before the heading moved:
13 pull requests, of which the documentation-only ones (positioning, the
reshot screenshots, the deleted improvement plan) are deliberately not in the
changelog. `grep -rn '0\.25\.0'` outside `CHANGELOG.md` and `docs/design` now
returns nothing — the remaining mentions are the ones that name the old version
legitimately, including the `.mcpb` fix that says every bundle up to and
including 0.25.0 is affected.

Nothing about the product changes in this PR.

## Checks

- [x] `scripts/check` is clean — add `--db` when the change touches the store
- [x] Behavior changes come with tests

`core` and `lint` (0 issues) are clean on this tree; nothing here touches the
store or any behavior. `vuln` cannot run in this environment — the egress proxy
answers `Forbidden` for vuln.go.dev — so CI's govulncheck job is the one that
counts.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver` and
      `internal/apiclient` say the same thing — only `info.version` moves
- [x] The change lands on every surface it belongs on (design doc 0067) — n/a,
      no surface changes
- [x] `api/openapi.frozen.txt` is untouched. The frozen golden carries no
      version, which is why a release does not move it
- [x] Widens a surface? No. Every count in `docs/surface.md` stays where it was.

## Design docs

- [x] Alters an accepted decision? No — a release records no decision of its own.
- [x] Commit messages and code comments are in English

After this merges, the tag is next: annotated, with the release notes as its
message, since the workflow fills the release body from it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmErTHxM9uFEuQKJreXGzR)_