### PR TITLE
Make the sandbox posture deployable and the deploy docs reproducible

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -33,8 +33,9 @@ top of a red main.
 
 ## 1. The preparation PR
 
-Branch off `origin/main`. Four files that drift silently — nothing
-fails when they are stale — and one window that has to close:
+Branch off `origin/main`. Five files that carry a version number, and
+one window that has to close. `TestReleaseVersionsAgree` fails on four of
+them, so a forgotten bump is a red test rather than a stale page:
 
 1. **`CHANGELOG.md`**
    - `## [Unreleased]` → `## [x.y.z] - YYYY-MM-DD` (tag date, JST)
@@ -45,14 +46,17 @@ fails when they are stale — and one window that has to close:
 3. **`.github/ISSUE_TEMPLATE/bug_report.yml`** — the version placeholder
 4. **`deploy/cloudrun/README.md`** — the hand-set `export VERSION=`
    example, for the reader with no `gh` CLI
-5. **`mcpserver.RetiredToolNames` and `retiredCommands`** — delete every
+5. **`deploy/terraform/terraform.tfvars.example`** — `image_tag`. Unlike
+   the four above it is not a sentence about a version but a value that
+   gets applied, so a stale pin deploys the stale image
+6. **`mcpserver.RetiredToolNames` and `retiredCommands`** — delete every
    entry whose `Release` is older than the version you are cutting. A renamed
    MCP tool or CLI command answers under its old name for one release
    (design doc 0088), and this release ends the previous one's window.
    `TestARetiredNameLastsOneRelease` fails until they are gone, so the
    prep PR is where you find out.
 
-`grep -rn '<prev>' --exclude-dir=.git .` catches a fifth if one appears;
+`grep -rn '<prev>' --exclude-dir=.git .` catches a sixth if one appears;
 `CHANGELOG.md` and `docs/design` name old versions legitimately, so read
 the hits rather than replacing them.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,28 @@ last entry.
   `mcp-stdio` bridge changed; a bundle from an earlier release keeps
   working and simply stays blank.
 
+### Fixed
+
+- **`sandbox = true` could not be applied at all.** The Terraform module
+  widened the `allUsers` grant to cover the disposable sandbox but left
+  its plan-time precondition demanding `OCHAKAI_MODE=public`, so a
+  sandbox produced a plan that asked for the binding and then refused
+  itself. The precondition now names both postures that justify a public
+  binding — `public` and `sandbox` — and still refuses every other one.
+  Nothing changes for a deployment that was already applying.
+- **`terraform output` called a sandbox private.** `posture` fell through
+  to "private read-write" and `demo_url` returned null for a service that
+  `allUsers` can reach, so the output that exists to answer "is this one
+  public?" answered it wrongly for the one posture that is public *and*
+  writable. Both now follow the `allUsers` grant rather than
+  `var.public_read_only` alone.
+- **The recommended deployment pinned a nine-release-old image.**
+  `deploy/terraform/terraform.tfvars.example` is copied to
+  `terraform.tfvars` and applied as written, and its `image_tag` had
+  stayed at 0.17.0. It tracks the current release again, and
+  `TestReleaseVersionsAgree` now reads it — and the deployment guide's
+  hand-set `export VERSION=` — back against the changelog.
+
 ## [0.26.0] - 2026-08-18
 
 ### Changed

--- a/cmd/ochakai/designdocs_test.go
+++ b/cmd/ochakai/designdocs_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -672,4 +673,100 @@ func TestDesignRecordsCiteNumbersThatResolve(t *testing.T) {
 	if cited == 0 {
 		t.Fatal("no record cited another by filename: this check now guards nothing")
 	}
+}
+
+// operatorFacing is the text a person reads while deciding what ochakai
+// does and while deploying it: the manual pages, the deployment module and
+// its guide, and the bundles shipped as examples. Source files are not in
+// it — a comment beside code cites the record that was current when the
+// code was written, and rewriting those on every supersession would make
+// the citation a maintenance chore instead of a pointer to a decision.
+// Design records are not in it either, for the same reason and for their
+// own: they are immutable.
+var operatorFacing = []string{
+	"../../README.md",
+	"../../deploy",
+	"../../docs",
+	"../../examples",
+}
+
+// designCitationRe reads a citation of a numbered record out of prose, in
+// either language and with or without the section that follows it.
+var designCitationRe = regexp.MustCompile(`(?:design docs?|設計ドキュメント)\s*\[?(\d{4})`)
+
+// A citation is a pointer, and the reader follows it. Pointed at a record
+// whose Status: says Superseded, they land on a tombstone — one sentence
+// and a link to the commit that held the text — which answers a question
+// about the history of the project rather than the one they asked, which
+// was how the thing in front of them works.
+//
+// The deployment module was where this had gone furthest: fifteen of its
+// citations named records 0066 and 0065 had folded away, so `terraform
+// output posture` printed a record number whose own header disowned it,
+// while the two READMEs beside it cited the current one. Records are
+// immutable and their numbers are not reused, so nothing about a
+// supersession reaches the prose that cites it — something has to read it
+// back (design doc 0035).
+func TestOperatorFacingTextCitesCurrentRecords(t *testing.T) {
+	replacedBy := map[string]string{}
+	for _, r := range designRecords(t) {
+		if m := supersededByRe.FindStringSubmatch(r.status); m != nil {
+			replacedBy[r.number] = m[1]
+		}
+	}
+	if len(replacedBy) == 0 {
+		t.Fatal("no Superseded record found: this check now guards nothing")
+	}
+
+	cited := 0
+	for _, root := range operatorFacing {
+		err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			// docs/design holds the records themselves and their two
+			// indexes; the indexes are checked by their own tests above.
+			if d.IsDir() && path == filepath.Join("../..", "docs", "design") {
+				return fs.SkipDir
+			}
+			if d.IsDir() || !citableFile(path) {
+				return nil
+			}
+			body, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			for _, m := range designCitationRe.FindAllStringSubmatch(string(body), -1) {
+				cited++
+				current, superseded := replacedBy[m[1]]
+				if !superseded {
+					continue
+				}
+				t.Errorf(`%s cites design doc %s, which %s superseded.
+
+A reader following that number lands on a tombstone. Point it at %s, and at
+the section of it that decides what the sentence is about — the decision
+survived the renumbering, only the record that states it moved.`,
+					filepath.Clean(path), m[1], current, current)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", root, err)
+		}
+	}
+	if cited == 0 {
+		t.Fatal("no design record cited outside docs/design: this check now guards nothing")
+	}
+}
+
+// citableFile is the prose and the configuration an operator reads —
+// markdown pages, and the Terraform module whose descriptions, outputs and
+// error messages are read straight off a `terraform` run.
+func citableFile(path string) bool {
+	switch filepath.Ext(path) {
+	case ".md", ".tf", ".example":
+		return true
+	}
+	return false
 }

--- a/cmd/ochakai/release_version_test.go
+++ b/cmd/ochakai/release_version_test.go
@@ -6,13 +6,19 @@ import (
 	"testing"
 )
 
-// Three files carry a version number that tagging does not update, and
+// Five files carry a version number that tagging does not update, and
 // CONTRIBUTING.md's release checklist is the only thing that has kept them
 // together — "it describes the wire surface, so it drifts silently:
 // nothing fails when it is stale" was true of api/openapi.yaml until this
 // test. They are all set in the same release-prep PR, so they either agree
 // or one of them was forgotten (design doc 0035: check the invariant from
 // outside rather than trust the convention).
+//
+// The two deployment pins were the ones the checklist did not hold:
+// terraform.tfvars.example is copied to terraform.tfvars and applied
+// verbatim, so a stale pin there is not a stale sentence but a deployment
+// of a version nobody is running — it sat nine releases behind before this
+// check existed.
 func TestReleaseVersionsAgree(t *testing.T) {
 	changelog := versionIn(t, "../../CHANGELOG.md",
 		`(?m)^## \[(\d+\.\d+\.\d+)\] - \d{4}-\d{2}-\d{2}$`)
@@ -20,6 +26,10 @@ func TestReleaseVersionsAgree(t *testing.T) {
 		`(?m)^  version: (\d+\.\d+\.\d+)$`)
 	template := versionIn(t, "../../.github/ISSUE_TEMPLATE/bug_report.yml",
 		`(?m)^      placeholder: "(\d+\.\d+\.\d+)"$`)
+	guide := versionIn(t, "../../deploy/cloudrun/README.md",
+		`export VERSION=(\d+\.\d+\.\d+)`)
+	tfvars := versionIn(t, "../../deploy/terraform/terraform.tfvars.example",
+		`(?m)^image_tag = "(\d+\.\d+\.\d+)"$`)
 
 	if spec != changelog {
 		t.Errorf("api/openapi.yaml says %s; the newest release in CHANGELOG.md is %s. "+
@@ -31,11 +41,22 @@ func TestReleaseVersionsAgree(t *testing.T) {
 			"A stale placeholder invites bug reports against a version nobody runs",
 			template, changelog)
 	}
+	if guide != changelog {
+		t.Errorf("deploy/cloudrun/README.md §1 hand-sets %s; the newest release is %s. "+
+			"That line is what a reader without the gh CLI types, so it is the version they deploy",
+			guide, changelog)
+	}
+	if tfvars != changelog {
+		t.Errorf("deploy/terraform/terraform.tfvars.example pins %s; the newest release is %s. "+
+			"That file is copied to terraform.tfvars and applied as written, so a stale pin "+
+			"deploys the stale version rather than merely describing it",
+			tfvars, changelog)
+	}
 }
 
 // versionIn returns the first capture of re in the named file. The first
 // match is the newest entry in every file this is used on: CHANGELOG.md is
-// newest-first, and the other two carry one version each.
+// newest-first, and the other four carry one version each.
 func versionIn(t *testing.T, path, re string) string {
 	t.Helper()
 	content, err := os.ReadFile(path)

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -20,25 +20,22 @@ Cloud SQL インスタンス一つでナレッジベース全体を賄う — �
 
 **推奨: [deploy/terraform](../terraform) で立ち上げる** — §1–§4b(web UI
 とデモの姿勢を含む)を一回の `terraform apply` と手作業ひとつ(スキーマの
-bootstrap)にまとめてあり、diff
-としてレビューでき、環境ごとに再現でき、きれいに壊せる。このガイドは引
-き続きリファレンスであり続ける — 各リソースがなぜそう作られているかを
-説明し、コマンドを手で打ちたい場合の経路でもある。§1–§5、§5d、§9 をカ
-バーし、web UI・公開デモ・org-policy によるガードレール・アップグレー
-ドの注意点は運用ガイドが、
-[docs/guides/rest-integration.md](../../docs/guides/rest-integration.md)
-は §5c と REST API を組み込むアプリケーションに要るその他すべてをカバー
-する。
+bootstrap)にまとめてあり、diff としてレビューでき、環境ごとに再現でき、
+きれいに壊せる。
 
-**すでにデプロイ済みなら?**
-[docs/guides/operating.md](../../docs/guides/operating.md) がその後を扱
-う — バックアップと復元、hardening、team web UI、監視、capacity、アッ
-プグレード。
+このガイドは引き続きリファレンスであり続ける — 各リソースがなぜそう作ら
+れているかを説明し、コマンドを手で打ちたい場合の経路でもある。どこを読む
+かは、いま何をしているかで決まる:
 
-**自分の製品に ochakai を組み込むなら?**
-[docs/guides/rest-integration.md](../../docs/guides/rest-integration.md)
-が、REST API を直接叩くアプリケーションのための認証、delegated
-provenance、安全な同時書き込みをカバーする。
+- **これから立てる** → このページの §1–§5、§5d、§9。
+- **すでに動いている** →
+  [運用ガイド](../../docs/guides/operating.md)。バックアップと復元、
+  hardening、team web UI、公開デモ、監視、capacity、org-policy による
+  ガードレール、アップグレード。
+- **自分の製品に組み込む** →
+  [REST 統合ガイド](../../docs/guides/rest-integration.md)。§5c にあたる
+  認証、delegated provenance、安全な同時書き込み、そして REST API を叩く
+  アプリケーションに要るその他すべて。
 
 ## 1. 前提条件
 
@@ -125,8 +122,8 @@ gcloud sql users create ochakai --instance=ochakai --password=$DB_PASSWORD
   と mTLS を経て、そのあとデータベース認証 — だけになる。ローカルの
   admin アクセス(§3 の SQL、§6 の保守)は
   [`cloud-sql-proxy`](https://cloud.google.com/sql/docs/postgres/sql-proxy)
-  を通す。これも同じコネクタ経路を使うので、リストに concept を持たせ
-  る必要は無い。空のままにしておけば、この姿勢は保たれる。到達可能な
+  を通す。これも同じコネクタ経路を使うので、リストにエントリを足す必要
+  は無い。空のままにしておけば、この姿勢は保たれる。到達可能な
   エンドポイントそのものを無くすには §2b を見よ。
 
 ### 2b. 任意の hardening: private IP のみにする

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -35,7 +35,7 @@ private IP(§2b)、GCS files(§4b)、IAP 越しの web UI(§5b)。
 
 ### パスワードはどこにも無い
 
-このモジュールに `random_password` は無く、Secret Manager の concept も、
+このモジュールに `random_password` は無く、Secret Manager のエントリも、
 サービスアカウントキーも、どのリソースにも `password` 引数は無い — 代わり
 にランタイムは Cloud SQL IAM データベース認証で Postgres に認証する。
 **Secret-zero** はこのプロジェクトの中心的な設計判断であって細部ではない。
@@ -53,7 +53,7 @@ private IP(§2b)、GCS files(§4b)、IAP 越しの web UI(§5b)。
   — 実行するにはパスワードを持つ必要があるからである。そのステップは手作
   業のまま残る。下を見よ。
 
-### 公開呼び出しは不可、名指しの例外が一つだけ
+### 公開呼び出しは不可、名指しの例外が二つだけ
 
 `invoker_members` は `allUsers` と `allAuthenticatedUsers` を拒む — ochakai
 が provenance として信じるヘッダーは、Cloud Run の IAM チェックの背後にあ
@@ -62,13 +62,18 @@ private IP(§2b)、GCS files(§4b)、IAP 越しの web UI(§5b)。
 同じ規則が、Domain Restricted Sharing の org policy とデプロイの互換性を保
 っている。
 
-例外は `public_read_only`(ガイド §5d、設計ドキュメント 0066 §3)で、これ自体
-が `allUsers` を付与する。変数を二つに分けず一つにしているのは、public が
-安全なのはそれに伴うものと組み合わさったときだけだからである: デプロイはす
-べての書き込みを拒み、identity を一切読まない — 偽装する provenance も、取
-り違える著者も存在しない。だから public で*書き込み可能*な ochakai には、
-このモジュールの中に綴りが無い — 覚えておくべきチェックではなく、表現し得
-ない状態である。
+例外は `public_read_only`(ガイド §5d、設計ドキュメント 0066 §3)と
+`sandbox`(同 §5d、設計ドキュメント 0087)の二つで、どちらもそれ自体が
+`allUsers` を付与する。どちらも変数を二つに分けず一つにしているのは、公開
+が安全なのはそれに伴うものと組み合わさったときだけだからである: 公開する
+のと同じ変数が、identity を読むのをやめさせる。`public_read_only` はさら
+にすべての書き込みを拒み、`sandbox` は書き込みを受ける代わりに、中身が消
+えることを自分で宣言する。
+
+だから、このモジュールの中に綴りが無いのは「公開かつ書き込み可能」ではな
+く、**公開でありながら著者を記録し続ける** ochakai である — 誰とも確かめ
+ようのない名前を記録に残す状態で、覚えておくべきチェックではなく、表現し
+得ない状態である。
 
 ## 使い方
 

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -10,18 +10,21 @@
 #     Postgres with Cloud SQL IAM database authentication, where the
 #     "password" is a short-lived IAM token fetched at connect time. If a
 #     change to this module ever needs a generated credential, the change is
-#     wrong for this project (design docs 0002, 0003).
+#     wrong for this project (design docs 0065, 0003).
 #
-#   * The service is not publicly invokable, with exactly one exception.
+#   * The service is not publicly invokable, with exactly two exceptions.
 #     ochakai performs no authorization of its own: it reads the caller
 #     identity Cloud Run has already verified and records it as provenance.
 #     Those headers only mean something behind Cloud Run's IAM check, so
 #     allUsers would not merely widen access, it would make provenance
-#     forgeable. The exception is var.public_read_only (design doc 0042),
-#     which grants allUsers only together with the flag that makes the
-#     deployment refuse every write and stop reading identity altogether —
-#     there is then no provenance to forge and no author to get wrong. A
-#     public binding from anywhere else in this module is a bug.
+#     forgeable. The exceptions are var.public_read_only (design doc 0066
+#     §3) and var.sandbox (design doc 0087), and each is a single variable
+#     rather than a combination: whichever one opens the service is also
+#     the one that stops it reading identity, so a deployment cannot end up
+#     public while still claiming to know who wrote what. Public read-only
+#     additionally refuses every write; a sandbox takes writes and declares
+#     that it will lose them. A public binding from anywhere else in this
+#     module is a bug.
 
 data "google_project" "this" {
   project_id = var.project_id
@@ -58,16 +61,16 @@ locals {
 
   iap_audience = "/projects/${data.google_project.this.number}/locations/${var.region}/services/${local.webui_name}"
 
-  # Public read-only implies read-only (design doc 0042): the server applies
-  # the implication itself and cannot be separated from it, so a publicly
-  # readable and writable ochakai is not a configuration it accepts. The
-  # module states the implication in the environment rather than leaving it
-  # to be read back off the running service, so the deployed configuration
+  # Public read-only implies read-only (design doc 0066 §3): the server
+  # applies the implication itself and cannot be separated from it, so a
+  # publicly readable and writable ochakai is not a configuration it accepts.
+  # The module states the implication in the environment rather than leaving
+  # it to be read back off the running service, so the deployed configuration
   # reads the same way the posture does.
-  # One word for the posture (design doc 0060): the module maps its two
+  # One word for the posture (design doc 0066 §1): the module maps its three
   # booleans onto the single OCHAKAI_MODE the server reads, and public
-  # wins because it is the stronger of the two — it is read-only plus
-  # believing nobody.
+  # wins over read-only because it is the stronger of the two — it is
+  # read-only plus believing nobody.
   # sandbox is checked first because it is the one posture that is
   # public *and* writable: read-only would silently win over it, and a
   # sandbox that cannot be written is the demo it exists to replace.
@@ -452,12 +455,14 @@ resource "google_cloud_run_v2_service_iam_member" "invokers" {
   member   = each.value
 }
 
-# The public read-only demo, and the only allUsers grant in this module
-# (design doc 0042). It is deliberately not something an operator can compose
-# out of parts: the same variable that opens the service is the one that makes
-# it refuse every write and stop reading identity, so "public" and "believes
-# nobody" cannot drift apart. A public writable ochakai would record authors
-# it has no way to know, which is worse than recording none.
+# The only allUsers grant in this module, shared by the two postures that
+# justify one: the public read-only demo (design doc 0066 §3) and the
+# disposable sandbox (design doc 0087). Neither is something an operator can
+# compose out of parts — the same variable that opens the service is the one
+# that stops it reading identity, so "public" and "believes nobody" cannot
+# drift apart. A public writable ochakai that still recorded authors would
+# name people it has no way to know, which is worse than naming none; the
+# sandbox takes writes precisely because it names nobody and keeps nothing.
 #
 # Domain Restricted Sharing (guide §6) rejects this binding, as it should —
 # a demo project is the place to lift it, not the org.
@@ -472,13 +477,16 @@ resource "google_cloud_run_v2_service_iam_member" "public_demo" {
 
   lifecycle {
     # Reads the environment the service actually carries rather than the
-    # variable that set it. Today the two cannot disagree; this exists for
+    # variables that set it. Today the two cannot disagree; this exists for
     # the edit that separates them, and it fails at plan time — an allUsers
     # binding must never outlive the posture that justifies it, not even for
-    # the length of an apply.
+    # the length of an apply. It lists both postures because the count above
+    # does: while it named only "public", var.sandbox produced a plan that
+    # asked for the binding and then refused itself, so the sandbox could
+    # not be deployed at all.
     precondition {
-      condition     = lookup(local.server_env, "OCHAKAI_MODE", "") == "public"
-      error_message = "Refusing to grant allUsers: the service is not running with OCHAKAI_MODE=public. Public is only safe while ochakai writes nothing and reads no identity (design doc 0042)."
+      condition     = contains(["public", "sandbox"], lookup(local.server_env, "OCHAKAI_MODE", ""))
+      error_message = "Refusing to grant allUsers: the service is running with neither OCHAKAI_MODE=public nor OCHAKAI_MODE=sandbox. Reaching everyone is only safe while ochakai reads no identity — writing nothing at all (design doc 0066 §3), or saying outright that what is written will be lost (design doc 0087)."
     }
   }
 }

--- a/deploy/terraform/outputs.tf
+++ b/deploy/terraform/outputs.tf
@@ -1,26 +1,30 @@
 output "service_url" {
-  description = "URL of the ochakai service. Not reachable without an identity: a plain curl gets Google's 401, which is the point — unless var.public_read_only is on, in which case see demo_url."
+  description = "URL of the ochakai service. Not reachable without an identity: a plain curl gets Google's 401, which is the point — unless var.public_read_only or var.sandbox is on, in which case see demo_url."
   value       = google_cloud_run_v2_service.ochakai.uri
 }
 
 output "demo_url" {
   description = <<-EOT
-    The public read-only demo URL — anyone with this link can read the whole
-    knowledge base, with no Google account and no token — or null when
-    var.public_read_only is false. It is the same service as service_url; the
-    output exists so that "is this one public?" is answerable from
-    `terraform output` alone, without reading the IAM policy.
+    The URL anyone can reach without a Google account and without a token —
+    the public read-only demo (var.public_read_only) or the disposable
+    sandbox (var.sandbox) — and null when this deployment is neither. It is
+    the same service as service_url; the output exists so that "is this one
+    public?" is answerable from `terraform output` alone, without reading the
+    IAM policy, which is why it follows the allUsers grant rather than one of
+    the two variables that can produce it.
   EOT
-  value       = var.public_read_only ? google_cloud_run_v2_service.ochakai.uri : null
+  value       = var.public_read_only || var.sandbox ? google_cloud_run_v2_service.ochakai.uri : null
 }
 
 output "posture" {
   description = "One line naming what this deployment will and will not do, so that a flip between demo and normal shows up in the output diff as well as the plan."
-  value = (var.public_read_only
-    ? "public read-only: anyone with the URL can read; no identity is read, every caller is human:anonymous, and nothing can be written (design doc 0042)"
+  value = (var.sandbox
+    ? "public sandbox: anyone with the URL can read and write; no identity is read, every caller is human:anonymous, and the contents are restored on a schedule rather than kept (design doc 0087)"
+    : var.public_read_only
+    ? "public read-only: anyone with the URL can read; no identity is read, every caller is human:anonymous, and nothing can be written (design doc 0066 §3)"
     : local.mode == "read-only"
-    ? "private read-only: only invoker_members can reach it, and nothing can be written (design doc 0040)"
-  : "private read-write: only invoker_members can reach it, and whoever reaches it can read and write everything (design doc 0002)")
+    ? "private read-only: only invoker_members can reach it, and nothing can be written (design doc 0066 §2)"
+  : "private read-write: only invoker_members can reach it, and whoever reaches it can read and write everything (design doc 0065 §1)")
 }
 
 output "use_command" {

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -5,7 +5,7 @@ region     = "us-central1"
 
 # Pin a released version, not "latest", so a redeploy is a decision:
 # https://github.com/na0fu3y/ochakai/releases
-image_tag = "0.17.0"
+image_tag = "0.26.0"
 
 # Who can reach ochakai. This is the whole access-control surface — whoever
 # reaches it can read and write everything. Never allUsers.
@@ -41,7 +41,7 @@ invoker_members = [
 # read_only = true
 
 # The public read-only demo, and the only posture in which this module grants
-# allUsers (guide §5d, design doc 0042). Anyone with the URL reads the base
+# allUsers (guide §5d, design doc 0066 §3). Anyone with the URL reads the base
 # with no Google account. Safe only because of what comes with it: writes are
 # refused (this implies read_only) and no identity is read at all — the
 # Authorization header is ignored, every caller is human:anonymous. Do not use

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -18,9 +18,9 @@ variable "region" {
 
 variable "image_tag" {
   description = <<-EOT
-    Release tag of ghcr.io/na0fu3y/ochakai to run, without the leading "v"
-    (for example "0.13.0"). Pinned rather than "latest" so that a redeploy is
-    a decision and shows up as a diff. See the releases page:
+    Release tag of ghcr.io/na0fu3y/ochakai to run, without the leading "v".
+    Pinned rather than "latest" so that a redeploy is a decision and shows up
+    as a diff. See the releases page for what to pin:
     https://github.com/na0fu3y/ochakai/releases
   EOT
   type        = string
@@ -59,7 +59,8 @@ variable "invoker_members" {
     "domain:your-org.example" / "user:..." / "serviceAccount:..." form. This
     is the entire access-control surface: whoever can reach ochakai can read
     and write everything, and ochakai itself authorizes nothing (design doc
-    0002). Empty by default, so a fresh apply reaches nobody but the deployer.
+    0065 §1). Empty by default, so a fresh apply reaches nobody but the
+    deployer.
   EOT
   type        = list(string)
   default     = []
@@ -129,8 +130,9 @@ variable "sandbox" {
 
 variable "public_read_only" {
   description = <<-EOT
-    The public read-only demo (OCHAKAI_MODE=public, design doc 0042).
-    This is the one posture where a publicly invokable ochakai is intended:
+    The public read-only demo (OCHAKAI_MODE=public, design doc 0066 §3).
+    The first of the two postures where a publicly invokable ochakai is
+    intended, and the read-only one:
     the module grants allUsers roles/run.invoker, so anyone with the URL can
     read the base with no Google account and no token.
 
@@ -155,7 +157,7 @@ variable "delegating_callers" {
   description = <<-EOT
     Callers allowed to forward an end user's identity with the
     Ochakai-On-Behalf-Of header (OCHAKAI_DELEGATING_CALLERS, design doc
-    0027). For applications that embed ochakai and serve many people;
+    0065 §3). For applications that embed ochakai and serve many people;
     without it every one of their users collapses into the application's one
     service account. Both identities are always recorded. The webui's own
     service account is added automatically when var.enable_webui and
@@ -251,7 +253,7 @@ variable "enable_vertex_embeddings" {
     Search is hybrid (trigram + vector, reciprocal rank fusion) using Vertex AI
     embeddings through the service identity — no API keys. On by default: this
     grants roles/aiplatform.user and enables the API, and ochakai finds the
-    project it runs in by itself (design doc 0053). It is what makes search work
+    project it runs in by itself (design doc 0080 §1.1). It is what makes search work
     on a Japanese knowledge base, where the trigram index degrades to a scan.
 
     Set it to false to run lexical-only: the role is not granted and
@@ -374,8 +376,8 @@ variable "webui_records_browser_user" {
     Record the person signed in to the browser as the author of their edits
     (`human:tanaka@… via process:<webui-sa>`) instead of the webui's own service
     account. Sets OCHAKAI_IAP_AUDIENCE on the webui and adds the webui's
-    service account to the server's delegating callers (design docs 0027,
-    0032). Once set, serve-ui refuses any request IAP did not sign, so a
+    service account to the server's delegating callers (design doc 0065
+    §§3, 5). Once set, serve-ui refuses any request IAP did not sign, so a
     misconfiguration surfaces immediately rather than as months of writes
     attributed to the wrong author.
   EOT

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -411,7 +411,7 @@ producer キーは索引しない: concept の別名ではなく concept につ�
 である。そこで ochakai はクエリの**用語** — ひらがなの間に挟まれた、
 漢字かカタカナを含む連なり — を取り出し、その名前を持つ concept を
 上に出す。名前は二つとも効く: `title` と、id の最後のセグメント
-(設計ドキュメント [0022](design/0022-filename-as-name.md))。
+(設計ドキュメント [0074 §1](design/0074-the-document-and-the-vocabulary-that-asks-it.md))。
 空白で語を区切る言語ではこれをしない — 英語の質問に出てくる
 "revenue" は、revenue という名前の concept を引きに来たわけではない
 からである。

--- a/examples/bigquery-catalog/bundle/jobs/sync-bigquery-catalog.md
+++ b/examples/bigquery-catalog/bundle/jobs/sync-bigquery-catalog.md
@@ -80,7 +80,7 @@ Three of those choices are load-bearing:
   `ochakai list --source bigquery://my-project.shop.orders` returns the
   catalog entry *and* every insight or computation written against the same
   table. `list`, not `search`: a reverse lookup is a listing and has no
-  query to rank by, which is the whole of design doc 0062. That lookup only
+  query to rank by, which is the whole of design doc 0068 §2. That lookup only
   works if everyone spells the URI the same way — pick the spelling once
   and keep it.
 - **Query counts go in `sources[].usage_count`, never into ochakai's usage
@@ -99,7 +99,7 @@ between the read and the write loses the race instead of being erased by
 it.
 
 "The projection's own" is recognized by the `Ochakai-Producer` stamp
-every write here carries (`sync-bigquery-catalog/2`, design doc 0052) —
+every write here carries (`sync-bigquery-catalog/2`, design doc 0065 §4) —
 deliberately the stamp, not the account. A catalog grown on demand is
 refreshed by whoever needed it: A's morning run under A's account, B's
 under B's, the nightly one under the scheduler's. A rule keyed to one


### PR DESCRIPTION
## What and why

A reproducibility pass over the two deployment guides ahead of wider
promotion of the project. Four things were wrong, and two of them stop a
documented deployment from happening at all.

**`sandbox = true` could not be applied.** The module widened the
`allUsers` grant's `count` to `var.public_read_only || var.sandbox` but
left the plan-time precondition demanding `OCHAKAI_MODE=public`. A
sandbox therefore produces a plan that asks for the binding and then
refuses itself, with an error message about a posture the operator did
not select. Verified by evaluating the module's own locals:

| variables | `local.mode` | `allUsers` count | precondition (before) |
|---|---|---|---|
| `sandbox` | `"sandbox"` | 1 | **false — plan fails** |
| `public_read_only` | `"public"` | 1 | true |
| `read_only` | `"read-only"` | 0 | n/a |
| none | `""` | 0 | n/a |

The precondition now names both postures that justify a public binding
and still refuses every other one — re-checked across the same four
combinations, it holds exactly where the count is 1.

**`terraform output` called a sandbox private.** `posture` fell through
to `"private read-write: only invoker_members can reach it"` and
`demo_url` returned null, for a service `allUsers` can reach. That output
exists so "is this one public?" is answerable without reading the IAM
policy, and it answered wrongly for the one posture that is public *and*
writable. Both now follow the grant rather than `var.public_read_only`
alone.

**The recommended path pinned a nine-release-old image.**
`terraform.tfvars.example` is copied to `terraform.tfvars` and applied as
written; its `image_tag` had stayed at `0.17.0` while releases moved to
`0.26.0`. The release checklist held the gcloud guide's hand-set
`export VERSION=` but never this one.

**Fifteen citations in the module named retired records.** `terraform
output posture` printed "design doc 0042", whose own `Status:` header
says it was superseded by 0066 — while the two READMEs beside it cited
0066. Retargeted to 0065 / 0066 / 0080 with sections, plus three other
operator-facing files.

Readability, in the guides the site points at:

- The terraform README's safety section was headed "名指しの例外が一つ
  だけ" and concluded that a public *writable* ochakai has no spelling in
  the module — while its own option table listed `sandbox`, which is
  exactly that. The invariant that actually holds is that no public
  deployment records an author it cannot know; the section says that now.
- `Secret Manager の concept` and `リストに concept を持たせる` were
  entry→concept replacement artifacts, reading as nonsense in Japanese.
- The gcloud guide opened with three overlapping navigation blocks, one
  of them a run-on splitting a single predicate across two subjects and a
  link. Now one list keyed by what the reader is doing.

Two tests so none of this drifts back:

- `TestReleaseVersionsAgree` reads the two deployment pins back against
  the changelog. Both were outside the checklist's reach; the skill's
  file list is updated to match.
- `TestOperatorFacingTextCitesCurrentRecords` reads the manual, the
  deployment module and the example bundles back against the records'
  `Status:` headers. Source comments are deliberately out of scope — a
  comment beside code cites what was current when it was written, and the
  843 such citations in the repo are that convention, not this defect.
  Mutation-checked: reverting one citation fails it.

No new decision is taken here — 0087 already decided the sandbox exists
and is publicly invokable, and the module simply did not implement it —
so there is no numbered doc, per the third checkbox below.

## Checks

- [x] `scripts/check` is clean — add `--db` when the change touches the store
- [x] Behavior changes come with tests

`scripts/check --db` is green: gofmt, vet, `go test -race` including the
store, service, restapi and mcpserver integration tests against a local
PostgreSQL, the web UI node tests, the build, and golangci-lint (0
issues). `terraform fmt -check -recursive` is clean.

`govulncheck` could not run — this environment's egress proxy returns 403
for `vuln.go.dev` (`CONNECT tunnel failed, response 403`). That is the
proxy refusing the host, not a finding; CI runs it. `terraform validate`
likewise could not run, since `registry.terraform.io` is refused, so the
module's semantics were checked by evaluating its locals directly in
`terraform console` rather than by a provider-backed plan.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — untouched by this PR
- [x] The change lands on every surface it belongs on — no surface changes;
      this is a deployment module and its two guides
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens no surface — no REST operation, MCP tool, CLI command or
      environment variable is added, so `docs/surface.md` is unchanged and
      the three questions do not apply

## Design docs

- [x] Alters no accepted decision — this brings the module into line with
      0087, which already decided the sandbox posture. Citations were
      retargeted to the records that describe these areas today (0065,
      0066, 0080, 0074, 0068), and the new test keeps them there
- [x] Commit messages and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHPDcffaRe5yky2sSqLngC

---
_Generated by [Claude Code](https://claude.ai/code/session_01YHPDcffaRe5yky2sSqLngC)_