### PR TITLE
Make the MCP guide's counts and section links land where they say

### DIFF
--- a/cmd/ochakai/surface_test.go
+++ b/cmd/ochakai/surface_test.go
@@ -1593,3 +1593,72 @@ func TestEveryErrorResponseDeclaresACode(t *testing.T) {
 		t.Fatal("no error-shaped response found in openapi.yaml: this check now guards nothing")
 	}
 }
+
+// japaneseNumerals is enough of the counting words to read a small count
+// out of the manual's prose. The manual writes these as words rather than
+// digits, so a check that reads them back has to speak the same spelling.
+var japaneseNumerals = map[string]int{
+	"一": 1, "二": 2, "三": 3, "四": 4, "五": 5,
+	"六": 6, "七": 7, "八": 8, "九": 9, "十": 10,
+}
+
+// manualToolCountRe reads "六つのツール" out of docs/README.md's entry for
+// the MCP page — the one place in the manual that states a surface's size
+// in prose rather than by listing it.
+var manualToolCountRe = regexp.MustCompile(`([一二三四五六七八九十])つのツール`)
+
+// docs/surface.md is checked against the build by the tests above, but the
+// index that sends a reader to a page also describes it, and prose does
+// not fail to compile. Its entry for the MCP guide said seven tools when
+// the server offered six — a number that had been wrong across a
+// supersession in either direction, since 0076 took the count from eight
+// to six and the index landed between the two. A reader budgeting context
+// for their agent believes that number before they open the page.
+func TestManualIndexCountsToolsCorrectly(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	srv := httptest.NewServer(mcpserver.Handler(&service.Service{}, "test"))
+	defer srv.Close()
+
+	cs, err := mcp.NewClient(&mcp.Implementation{Name: "index-test", Version: "1"}, nil).
+		Connect(ctx, &mcp.StreamableClientTransport{Endpoint: srv.URL}, nil)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = cs.Close() }()
+
+	res, err := cs.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	if len(res.Tools) == 0 {
+		t.Fatal("the server offered no tools: this check now guards nothing")
+	}
+
+	const index = "../../docs/README.md"
+	body, err := os.ReadFile(index)
+	if err != nil {
+		t.Fatalf("read %s: %v", index, err)
+	}
+	m := manualToolCountRe.FindSubmatch(body)
+	if m == nil {
+		t.Fatalf("%s states no tool count matching %s — the entry's wording changed, "+
+			"and this check now guards nothing", index, manualToolCountRe)
+	}
+	if got := japaneseNumerals[string(m[1])]; got != len(res.Tools) {
+		t.Errorf("%s says %s (%d) tools; the server offers %d (%s).\n\n"+
+			"The index is what a reader budgets context from before they open the page.",
+			index, m[1], got, len(res.Tools), strings.Join(toolNames(res.Tools), ", "))
+	}
+}
+
+// toolNames is the names alone, for an error message that says which
+// tools the count disagreed with.
+func toolNames(tools []*mcp.Tool) []string {
+	out := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		out = append(out, tool.Name)
+	}
+	return out
+}

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -465,6 +465,8 @@ provenance が崩れる。
 gating は、すべて運用ガイドの
 [Hardening](../../docs/guides/operating.md#hardening) にある。
 
+<a id="7-troubleshooting-in-a-security-hardened-org"></a>
+
 ## 7. セキュリティを固めた組織でのトラブルシューティング
 
 - **`allUsers` の binding が "do not belong to a permitted customer" で

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,7 +52,7 @@ otherwise have to hunt for. Not a translation; a way in.
   `ochakai <command> -h` をそのまま出力したもので、両者が食い違えば
   テストが落ちる。バイナリを持つ前から読め、持った後も古びない。
 - [MCP クライアントを繋ぐ](guides/mcp-clients.md) — エージェントに見える
-  七つのツール、そしてクライアントごとの URL か `mcp-stdio` ブリッジ、
+  六つのツール、そしてクライアントごとの URL か `mcp-stdio` ブリッジ、
   各クライアントが読む設定ファイル。
 - [最初のカタログを作る](../examples/bigquery-catalog) — BigQuery の
   テーブルを concept として取り込む day-one の手順、それを走らせる job、

--- a/docs/guides/mcp-clients.md
+++ b/docs/guides/mcp-clients.md
@@ -69,7 +69,9 @@ JSON のキー名が違うだけなので、[その他のクライアント](#�
 `ochakai://metrics/revenue` や `ochakai://queries/sales/top-customers`。
 リソース参照(`@` メンション)に対応するクライアントは、ツール呼び出し
 無しで concept を OKF ドキュメント — frontmatter と本文 — として引き
-込める。発見のための手段は引き続き `search_concepts` である。読み取り系のツールには `readOnly` の、書き込み系には
+込める。発見のための手段は引き続き `search_concepts` である。
+
+読み取り系のツールには `readOnly` の、書き込み系には
 `destructive: false` のアノテーションが付いているので、クライアントの
 自動承認ポリシーは説明文を解析しなくても機能する。破壊的なツールは
 一本も無い。
@@ -249,7 +251,8 @@ ochakai ui        # http://127.0.0.1:8098/mcp
 
 `gcloud run services proxy` が三つ目の方法である — MCP 固有の振る舞い
 を持たない、ただの HTTP トンネル。deploy ガイドはこれを `curl` 越しの
-デプロイ検証に使っているが([§3](../../deploy/cloudrun/README.md))、
+デプロイ検証に使っているが
+([§3](../../deploy/cloudrun/README.md#3-deploy-cloud-run-dedicated-identity-passwordless-org-restricted))、
 クライアントを繋ぐためではない。そちらにはブリッジか上の
 `ochakai ui` を使う。
 
@@ -282,7 +285,8 @@ ochakai を公開で呼び出せる状態にすることは、デプロイの一
   問題である: Cloud Run に対してはブリッジが `gcloud auth login`
   (または ADC)を済ませている必要があり、呼び出し元は
   `roles/run.invoker` を持っている必要がある。deploy ガイドの
-  [§7](../../deploy/cloudrun/README.md) が Google 側の症状を扱う。
+  [§7](../../deploy/cloudrun/README.md#7-troubleshooting-in-a-security-hardened-org)
+  が Google 側の症状を扱う。
 - **サーバーは curl には応答するがクライアントには応答しない。** パス
   を確認する — `/mcp` であって、ルートではない。ochakai サーバーへの
   `GET /` は、それが提供するエンドポイントを表示する。

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -2,7 +2,7 @@
 
 ローカルとクライアント側の症状。Google Cloud 側の症状 — `/healthz` を
 GFE が横取りする、`NOT_AUTHORIZED`、IAM の伝播遅延 — は
-[デプロイガイドの §7](../../deploy/cloudrun/README.md)にある。MCP
+[デプロイガイドの §7](../../deploy/cloudrun/README.md#7-troubleshooting-in-a-security-hardened-org)にある。MCP
 クライアントがまったく繋がらない場合は
 [MCP クライアントを繋ぐ](mcp-clients.md)にある。
 


### PR DESCRIPTION
## What and why

Follow-up to #691, extending the same pass to
`docs/guides/mcp-clients.md`, which that PR did not clean — it was only
covered by the citation guard, which it passed.

**The manual index counted seven tools; the server offers six.**
`docs/README.md`'s entry for the MCP guide had been wrong across a
supersession in either direction — 0076 took the count from eight to six
and the index landed between the two. `docs/surface.md` says `MCP (6)`
and is checked against the build; the index that sends a reader to the
page is prose, and prose does not fail to compile. That number is what a
reader budgets their agent's context from before they open the page.

**Three links named a section and landed at the top of a 523-line
page.** `[§3]` and `[§7]` in this guide, and `[デプロイガイドの §7]` in
`troubleshooting.md`. §3 already had a stable anchor and simply was not
using it; §7 had none, so it gets one in the style the deployment guide's
other linked sections (§3, §4, §5d) already use.

**A paragraph had been welded into another mid-line.** The tool
annotations topic (`readOnly` / `destructive: false`) ran on from the end
of the MCP resources paragraph, leaving one line half again as wide as
any other in the file and two unrelated topics in one block. Split and
rewrapped; no wording changed.

Checked against the build rather than read, and all correct as written —
the six tool names, `mcp-stdio --url`, the `/mcp` path, `ochakai ui`'s
8098 and `deploy/compose.yaml`'s 8080 all match what the guide tells a
reader to type. The client-configuration table is left alone on purpose:
the page says outright that those six rows were copied from each client's
own documentation and that nobody runs them here, which is the honest
thing to say about configurations this repo does not test.

`TestManualIndexCountsToolsCorrectly` reads the index's stated count back
against a running server's tool list, the same source
`TestSurfaceDocCountsMCPTools` already uses. It guards one sentence
today, which is the sentence that just drifted. Mutation-checked:
restoring "七つ" fails it with the six names listed.

## Checks

- [x] `scripts/check` is clean — add `--db` when the change touches the store
- [x] Behavior changes come with tests

`scripts/check core` and `scripts/check lint` are green (0 issues). No
store code is touched, so `--db` adds nothing here; CI runs it. As in
#691, `govulncheck` cannot run in this environment — the egress proxy
returns 403 for `vuln.go.dev` — and CI covers it.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — untouched
- [x] The change lands on every surface it belongs on — documentation
      only; no surface changes
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens no surface — no REST operation, MCP tool, CLI command or
      environment variable is added. `docs/surface.md` was already right
      at `MCP (6)`; this corrects the index that disagreed with it, and
      adds no manual page

## Design docs

- [x] Alters no accepted decision — this makes the manual agree with
      0076, which already took the tool count to six
- [x] Commit messages and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHPDcffaRe5yky2sSqLngC

---
_Generated by [Claude Code](https://claude.ai/code/session_01YHPDcffaRe5yky2sSqLngC)_