### PR TITLE
Count the demo bundle rather than remembering it

### DIFF
--- a/cmd/ochakai/surface_test.go
+++ b/cmd/ochakai/surface_test.go
@@ -1662,3 +1662,74 @@ func toolNames(tools []*mcp.Tool) []string {
 	}
 	return out
 }
+
+// demoBundleCountRe reads a claim about how many concepts the demo bundle
+// holds. The manual states it three ways — "11 concept", "11 件", "11 個"
+// — so the check reads the number and the counter word together rather
+// than pinning one phrasing.
+var demoBundleCountRe = regexp.MustCompile(`([0-9]+)\s*(?:concept|件|個)`)
+
+// demoBundleWindow is how far after a mention of examples/demo a count
+// still belongs to it. Long enough to cross the manual's line wrapping,
+// which puts the counter word on the line after the number, and short
+// enough not to reach the next paragraph.
+const demoBundleWindow = 160
+
+// The demo bundle is what a reader imports in their first ten minutes,
+// and four places tell them how big it is. It grew to eleven concepts and
+// only the index was updated, so three went on promising ten — the
+// same shape as the tool count: a number about a thing in this repository,
+// stated in prose, that nothing read back. Counting the bundle is cheap,
+// and it is the only honest source (design doc 0035).
+func TestManualCountsTheDemoBundle(t *testing.T) {
+	const bundle = "../../examples/demo"
+	want := 0
+	err := filepath.WalkDir(bundle, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || filepath.Ext(path) != ".md" {
+			return err
+		}
+		body, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		// A markdown file is a concept when it opens with OKF
+		// frontmatter; anything else in a bundle is a plain file.
+		if strings.HasPrefix(string(body), "---\n") {
+			want++
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", bundle, err)
+	}
+	if want == 0 {
+		t.Fatalf("%s holds no concept: this check now guards nothing", bundle)
+	}
+
+	docs, _ := userDocs(t)
+	checked := 0
+	for _, page := range docs {
+		body, err := os.ReadFile(filepath.Join("../..", page))
+		if err != nil {
+			t.Fatalf("read %s: %v", page, err)
+		}
+		text := string(body)
+		for _, at := range regexp.MustCompile(`examples/demo`).FindAllStringIndex(text, -1) {
+			end := min(at[1]+demoBundleWindow, len(text))
+			m := demoBundleCountRe.FindStringSubmatch(text[at[1]:end])
+			if m == nil {
+				continue
+			}
+			checked++
+			if m[1] != strconv.Itoa(want) {
+				t.Errorf("%s says the demo bundle holds %s concepts; it holds %d.\n\n"+
+					"It is the first thing a reader imports, and more than one page states\n"+
+					"its size — growing the bundle means saying so in every one of them.",
+					page, m[1], want)
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no page states the demo bundle's size: this check now guards nothing")
+	}
+}

--- a/docs/guides/operating.md
+++ b/docs/guides/operating.md
@@ -905,7 +905,7 @@ gcloud run services add-iam-policy-binding ochakai --region=$REGION \
 
 ### シードする
 
-[examples/demo](../../examples/demo) は読ませるために作られた 10 個の
+[examples/demo](../../examples/demo) は読ませるために作られた 11 個の
 concept を持つナレッジベースである: リンクされた concept、混在した
 type、そして `sort=usage` が何かを意味するだけの利用実績。サービスが
 まだ非公開のうちに import せよ。認証の方法はデプロイガイド §5 とまったく
@@ -917,10 +917,10 @@ git clone --depth 1 https://github.com/na0fu3y/ochakai && cd ochakai
 go run ./cmd/ochakai import examples/demo    # $OCHAKAI_URL は上で
 ```
 
-その 10 個の concept は `human:you@your-org.example` として記録される —
+その 11 個の concept は `human:you@your-org.example` として記録される —
 このベースが受け取る最後の provenance であり、切り替えの後に訪問者が
 見る唯一の `created_by` である。(この手順はローカルサーバーに対して
-リハーサル済みである: 書き込み可能な状態で import — 10 created、0
+リハーサル済みである: 書き込み可能な状態で import — 11 created、0
 skipped — それから `OCHAKAI_MODE=public` で再起動すると、読み取りは
 匿名で応答し、すべての書き込みが拒否される。Cloud Run が足すのは IAM の
 binding だけである。)

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -1072,7 +1072,7 @@ Computation` が canary としてそれを継続実行する — が、**三つ�
   毎回鳴る警報と、並行 PR の唯一の衝突点 — で退役した)。読むのは利用者ではなく変える人で、
   `RECORD-LINES`(一冊の天井)と同じ読者の同じ種類の天井だから、ここに
   十一本目の上限を足すより、その天井の隣に置くほうが筋が通る。
-- **OKF ドキュメント。** `examples/demo` の 10 件も
+- **OKF ドキュメント。** `examples/demo` の 11 件も
   `examples/bigquery-catalog/bundle` も、プロジェクト自身のナレッジで
   ある `kb/bundle` も、ochakai が**保存するもの**であって ochakai に
   ついての説明ではない。frontmatter を持つ md は知識であり、ここでは

--- a/examples/claude-code/CLAUDE.md
+++ b/examples/claude-code/CLAUDE.md
@@ -13,7 +13,7 @@
 
 ナレッジベースがまだ空で、concept の形を先に見たいなら、ochakai の
 リポジトリで `ochakai import examples/demo` を**捨ててよいサーバー**に
-対して走らせる — 9 型のうち 8 型の見本が 10 concept 入っている。数字も
+対して走らせる — 9 型のうち 8 型の見本が 11 concept 入っている。数字も
 店も全部作り物なので、実際に使うナレッジベースには入れない
 ([examples/README.md](../README.md))。
 -->


### PR DESCRIPTION
## What and why

A sweep of the rest of the manual, applying the defect classes #691 and
#692 turned up. Most of it came back clean; one thing did not.

**`examples/demo` grew to eleven concepts and three places still say
ten.** `6931110` added `insights/着地見込み.md` and updated only
`docs/README.md`. Still promising ten: `docs/surface.md`'s list of what
counts as knowledge rather than documentation, the seeding step in
`docs/guides/operating.md` — twice, once as the count and once inside a
rehearsed import summary a reader compares their own output against —
and the agent instructions in `examples/claude-code/CLAUDE.md`.

It is the first thing anybody imports, so this is a number in the first
ten minutes of using ochakai. `TestManualCountsTheDemoBundle` counts the
concepts on disk (a markdown file with OKF frontmatter) and checks every
claim near a mention of `examples/demo` across the user-facing docs. It
found the fourth site, which a grep for the phrasings in the other three
had missed — which is the argument for the test rather than the grep.

The rehearsed summary's counter words are unchanged: `client.go` prints
`"%d created, … %d skipped"`, so only the number was wrong. I could not
run the import to re-rehearse it — this repository's checked-in deny list
blocks writes through the `ochakai` CLI, and I left that alone — so the
number is derived from the bundle contents and the summary's format
string, and the new test recounts the bundle on every CI run.

### What came back clean

Worth recording, since "checked and fine" is most of a sweep:

| checked | result |
|---|---|
| REST paths named in the manual vs `api/openapi.yaml` | clean — the unmatched ones are `compatibility.md` and `surface.md` discussing removed spellings on purpose |
| MCP tool names in prose vs a running server | clean — `get_context`, `get_attachment` are named as retired/renamed; `search_tsv`/`search_text` are database columns, not tools |
| CLI flags on `ochakai` invocations vs `docs/cli.md` | clean — the only misses are in `docs/design`, describing flags that were retired |
| `README.md`'s quickstart | reproducible — `insights/reading-revenue` exists, `--type Metric` and `--trust human-reviewed` are both real values |
| every manual page reachable from `docs/README.md` | clean |
| `docs/en.md`'s environment-variable list vs `surface.md`'s ENV (15) | identical |
| `docs/en.md`'s "five postures" and "seven English pages" | both correct |
| "三つのフィード" across four pages | correct — three review feeds; `usage` is the fourth `ListSorts` value but not a feed |
| `examples/claude-code`'s "9 型のうち 8 型" | correct — 9 recommended types, the demo uses 8 |
| cost claims ($10/month) and ports (8080 / 8098 / 8787 / 55432) across all pages | consistent |
| section links landing at a page top | none left after #692 |
| merged-paragraph formatting damage | none left after #692; remaining wide lines are long URLs and design records |

## Checks

- [x] `scripts/check` is clean — add `--db` when the change touches the store
- [x] Behavior changes come with tests

`scripts/check core` and `scripts/check lint` are green (0 issues). No
store code is touched. As in the previous two PRs, `govulncheck` cannot
run here — the egress proxy returns 403 for `vuln.go.dev` — and CI covers
it.

Mutation-checked: putting any of the four sites back to ten fails the new
test with the file named.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — untouched
- [x] The change lands on every surface it belongs on — documentation
      only
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens no surface — no REST operation, MCP tool, CLI command or
      environment variable is added, and no manual page. `docs/surface.md`
      changes by one character

## Design docs

- [x] Alters no accepted decision — a stale number in four places
- [x] Commit messages and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHPDcffaRe5yky2sSqLngC

---
_Generated by [Claude Code](https://claude.ai/code/session_01YHPDcffaRe5yky2sSqLngC)_