### PR TITLE
Prepare 0.26.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Version
       description: Output of `ochakai version`, or the image tag you deployed.
-      placeholder: "0.26.0"
+      placeholder: "0.26.1"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ last entry.
 
 ## [Unreleased]
 
+## [0.26.1] - 2026-08-19
+
 ### Added
 
 - **The MCP bundle now carries an icon.** A desktop app draws a tile for
@@ -4774,7 +4776,8 @@ worth naming: SQL injection in `compile_sql` through undeclared field
 pass-through, fixed in 0.8.0 — v0.7.0 and earlier are affected. Details
 are in git history.
 
-[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.26.0...HEAD
+[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.26.1...HEAD
+[0.26.1]: https://github.com/na0fu3y/ochakai/compare/v0.26.0...v0.26.1
 [0.26.0]: https://github.com/na0fu3y/ochakai/compare/v0.25.0...v0.26.0
 [0.25.0]: https://github.com/na0fu3y/ochakai/compare/v0.24.1...v0.25.0
 [0.24.1]: https://github.com/na0fu3y/ochakai/compare/v0.24.0...v0.24.1

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -74,7 +74,7 @@ info:
     is a security defect, shipped in the next release with no deprecation
     window (SECURITY.md). MCP, the CLI and the stored shape stay unstable
     while the major version is 0 and may still change in a minor release.
-  version: 0.26.0
+  version: 0.26.1
   license:
     name: MIT
 servers:

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -77,7 +77,7 @@ export IMAGE=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:$VERSION
 `:latest` ではなくバージョンを固定し、再デプロイを意識的な判断にする。
 `gh` CLI が無ければ
 [リリースページ](https://github.com/na0fu3y/ochakai/releases)から番号
-を読み、手で設定する — `export VERSION=0.26.0`。
+を読み、手で設定する — `export VERSION=0.26.1`。
 
 (このガイドは 0.9.0 以降を前提にしている。それより前のリリースは
 [retract](https://go.dev/ref/mod#go-mod-file-retract) 済みでサポート外

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -5,7 +5,7 @@ region     = "us-central1"
 
 # Pin a released version, not "latest", so a redeploy is a decision:
 # https://github.com/na0fu3y/ochakai/releases
-image_tag = "0.26.0"
+image_tag = "0.26.1"
 
 # Who can reach ochakai. This is the whole access-control surface — whoever
 # reaches it can read and write everything. Never allUsers.


### PR DESCRIPTION
## What and why

Cut a patch release. `main` carries four merged PRs since v0.26.0:
- #689 The MCP bundle now carries an icon
- #691 Terraform sandbox posture fixes (precondition, output, stale image_tag)
- #692, #693 doc-only counting/link fixes to the MCP and demo-bundle guides (no CHANGELOG entry — no user-observable behavior change)

No BREAKING entry in the unreleased section, so this is a patch bump (0.26.0 → 0.26.1), not a minor.

## Changes

The four files a tag does not update, per the `release` skill / CONTRIBUTING.md:
- `CHANGELOG.md` — `[Unreleased]` → `[0.26.1] - 2026-08-19`, fresh empty `[Unreleased]`, new compare link
- `api/openapi.yaml` — `info.version`
- `.github/ISSUE_TEMPLATE/bug_report.yml` — version placeholder
- `deploy/cloudrun/README.md` — hand-set `export VERSION=` example
- `deploy/terraform/terraform.tfvars.example` — `image_tag`

Both retired-name tables (`mcpserver.RetiredToolNames`, `retiredCommands`) are already empty — no window to close for this release.

## Test plan

- [x] `scripts/check --db` — all green (gofmt, go vet, go test -race including DB-backed packages, build, node --test, golangci-lint, govulncheck)
- [ ] Merge, then tag `v0.26.1` and verify per the `release` skill