### PR TITLE
Widen the search eval set to 56 cases and report per dimension

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,6 +201,17 @@ every Google Cloud deployment runs (design doc 0080 §1.1). The stand-in
 is deterministic, so the fused half needs no API key and reaches no
 network.
 
+Each case is labelled with the dimension of query behaviour it
+exercises — natural questions, keyword lookups, warehouse English
+inside a Japanese sentence, English questions, spelling variants,
+synonyms, two-character terms — and both runs log a recall/MRR line per
+dimension beside the aggregate. The floors hold only the aggregate; the
+dimension lines are where to look when deciding what to improve next,
+and where a change to search should show its effect landing. A question
+the bundle deliberately answers in several linked places lists the
+other correct concepts in `accept`, and the first acceptable concept's
+rank is what scores.
+
 ```sh
 scripts/check --db      # it runs with everything else
 OCHAKAI_TEST_DATABASE_URL=… go test ./internal/service/ \
@@ -215,8 +226,8 @@ improved, which is `DOC-LINES-SLACK`'s argument applied to a floor
 rather than a ceiling: banked headroom is budget the next regression
 spends without moving a number anybody reads. The tolerance is derived
 from the size of the set instead of declared here, because the noise it
-is sized against is one case moving and the set has been 14, 36, 41 and
-37 cases.
+is sized against is one case moving and the set has been 14, 36, 41, 37
+and 56 cases.
 
 ## Working with Claude Code
 

--- a/internal/service/searcheval_integration_test.go
+++ b/internal/service/searcheval_integration_test.go
@@ -56,13 +56,49 @@ import (
 // quality, and the fused number is the arithmetic of the merge — the
 // stand-in shares the lexical side's vocabulary, so it cannot stand in
 // for what a trained encoder is for.
+//
+// Every case carries the dimension of query behaviour it exercises, and
+// both runs report a recall/MRR line per dimension beside the
+// aggregate. The floors hold only the aggregate — a dimension is a
+// handful of cases, all noise — but the per-dimension lines are what
+// turn "MRR moved" into "the orthography cases moved", which is the
+// difference between knowing a change landed and knowing where to aim
+// the next one.
 
 // evalCase is one golden question: a query somebody would actually ask,
-// and the concept a good ranking puts in front of them.
+// the concept a good ranking puts in front of them, and the dimension of
+// query behaviour the case exercises.
 type evalCase struct {
 	query string
 	want  string // id relative to the import prefix
+	// accept names the other concepts that answer the same question, for
+	// the questions whose answer the bundle deliberately keeps in more
+	// than one place — the 経理 mismatch is a policy, a definition and a
+	// month-end note at once, and the bundle says so by linking them.
+	// The rank scored is the first acceptable concept (want or accept):
+	// a case that punishes one correct answer for not being the chosen
+	// one measures tie order, not ranking.
+	accept []string
+	// dim assigns the case to one line of the per-dimension report the
+	// scorer logs. The aggregate says whether a ranking change moved
+	// anything; the dimension says where, which is what makes the next
+	// change targetable. Dimensions are diagnostic only — a handful of
+	// cases is inside its own noise, so no floor reads them.
+	dim string
 }
+
+// The dimensions, in the order a reader meets them below. A new case
+// takes the dimension that names what makes it hard, not a new label: a
+// report of one-case dimensions says nothing.
+const (
+	dimQuestion    = "question"    // natural questions, corpus language
+	dimKeyword     = "keyword"     // bare terms and jargon lookups
+	dimMixed       = "mixed"       // warehouse English inside a Japanese sentence
+	dimEnglish     = "english"     // English asked of a Japanese base
+	dimOrthography = "orthography" // spelling variants of the same word
+	dimSynonyms    = "synonyms"    // names only the synonyms key holds
+	dimShort       = "short"       // two-character terms below trigram
+)
 
 // evalCases is the golden set. Keep queries phrased as questions and
 // keywords a data agent would send — the point is aboutness, not exact
@@ -71,63 +107,124 @@ type evalCase struct {
 var evalCases = []evalCase{
 	// Questions against the demo bundle, in the language it is written
 	// in.
-	{query: "なぜ売上が落ちているのか", want: "insights/reading-revenue"},
-	{query: "月次売上", want: "queries/sales/monthly-revenue"},
-	{query: "チャネル別の売上", want: "queries/sales/revenue-by-channel"},
-	{query: "売上とは何か", want: "metrics/revenue"},
-	{query: "完了した注文とは", want: "glossary/completed-order"},
-	{query: "リピート購入率", want: "metrics/repeat-purchase-rate"},
-	{query: "チャネルコードの一覧", want: "references/order-channel-codes"},
-	{query: "売上計上のルール", want: "policies/revenue-recognition"},
-	{query: "注文テーブルのスキーマ", want: "tables/shop-orders"},
-	{query: "BigQuery のクエリはどう実行するか", want: "skills/run-bigquery-query"},
-	{query: "月末の着地見込み", want: "insights/着地見込み"},
+	{query: "なぜ売上が落ちているのか", want: "insights/reading-revenue", dim: dimQuestion},
+	{query: "月次売上", want: "queries/sales/monthly-revenue", dim: dimKeyword},
+	{query: "チャネル別の売上", want: "queries/sales/revenue-by-channel", dim: dimKeyword},
+	{query: "売上とは何か", want: "metrics/revenue", dim: dimQuestion},
+	{query: "完了した注文とは", want: "glossary/completed-order", dim: dimQuestion},
+	{query: "リピート購入率", want: "metrics/repeat-purchase-rate", dim: dimKeyword},
+	{query: "チャネルコードの一覧", want: "references/order-channel-codes", dim: dimQuestion},
+	{query: "売上計上のルール", want: "policies/revenue-recognition", dim: dimQuestion},
+	{query: "注文テーブルのスキーマ", want: "tables/shop-orders", dim: dimQuestion},
+	{query: "BigQuery のクエリはどう実行するか", want: "skills/run-bigquery-query", dim: dimQuestion},
+	{query: "月末の着地見込み", want: "insights/着地見込み", dim: dimKeyword},
 	// A second pass over the same corpus, phrased the way somebody asks
 	// rather than the way a title reads. Fourteen cases put MRR inside
 	// its own noise — one case moving from rank 1 to 2 moved it by 0.036
 	// — so the set is widened as far as twelve concepts honestly
 	// support. Beyond that a case stops being a question anybody has and
 	// becomes a restatement of a title, which measures the fixture.
-	{query: "売上が下がった理由", want: "insights/reading-revenue"},
-	{query: "お盆", want: "insights/reading-revenue"},
-	{query: "普通の月はいくらか", want: "insights/reading-revenue"},
-	{query: "大口の注文で山ができた", want: "insights/reading-revenue"},
-	{query: "パーティションの遅れ", want: "insights/reading-revenue"},
-	{query: "季節性", want: "insights/reading-revenue"},
-	{query: "売上に税は含まれるか", want: "metrics/revenue"},
-	{query: "純売上との違い", want: "metrics/revenue"},
-	{query: "どの注文を売上として数えるか", want: "policies/revenue-recognition"},
-	{query: "返金は引くのか", want: "policies/revenue-recognition"},
-	{query: "キャンセルした注文", want: "glossary/completed-order"},
-	{query: "受注と完了の違い", want: "glossary/completed-order"},
-	{query: "売上が伸びているチャネル", want: "queries/sales/revenue-by-channel"},
-	{query: "今年度の売上を月ごとに", want: "queries/sales/monthly-revenue"},
-	{query: "買い直した客の割合", want: "metrics/repeat-purchase-rate"},
-	{query: "ゲスト購入", want: "metrics/repeat-purchase-rate"},
-	{query: "注文はどこに入っているか", want: "tables/shop-orders"},
-	{query: "receipt には何を返すのか", want: "skills/run-bigquery-query"},
-	{query: "今月はどうなりそうか", want: "insights/着地見込み"},
+	{query: "売上が下がった理由", want: "insights/reading-revenue", dim: dimQuestion},
+	{query: "お盆", want: "insights/reading-revenue", dim: dimKeyword},
+	{query: "普通の月はいくらか", want: "insights/reading-revenue", dim: dimQuestion},
+	{query: "大口の注文で山ができた", want: "insights/reading-revenue", dim: dimQuestion},
+	{query: "パーティションの遅れ", want: "insights/reading-revenue",
+		accept: []string{"tables/shop-orders"}, dim: dimQuestion},
+	{query: "季節性", want: "insights/reading-revenue", dim: dimKeyword},
+	{query: "売上に税は含まれるか", want: "metrics/revenue", dim: dimQuestion},
+	{query: "純売上との違い", want: "metrics/revenue", dim: dimQuestion},
+	{query: "どの注文を売上として数えるか", want: "policies/revenue-recognition",
+		accept: []string{"glossary/completed-order"}, dim: dimQuestion},
+	{query: "返金は引くのか", want: "policies/revenue-recognition",
+		accept: []string{"metrics/revenue"}, dim: dimQuestion},
+	{query: "キャンセルした注文", want: "glossary/completed-order", dim: dimKeyword},
+	{query: "受注と完了の違い", want: "glossary/completed-order", dim: dimQuestion},
+	{query: "売上が伸びているチャネル", want: "queries/sales/revenue-by-channel", dim: dimQuestion},
+	{query: "今年度の売上を月ごとに", want: "queries/sales/monthly-revenue", dim: dimQuestion},
+	{query: "買い直した客の割合", want: "metrics/repeat-purchase-rate", dim: dimQuestion},
+	{query: "ゲスト購入", want: "metrics/repeat-purchase-rate", dim: dimKeyword},
+	{query: "注文はどこに入っているか", want: "tables/shop-orders", dim: dimQuestion},
+	{query: "receipt には何を返すのか", want: "skills/run-bigquery-query", dim: dimMixed},
+	{query: "今月はどうなりそうか", want: "insights/着地見込み", dim: dimQuestion},
+	// A third pass, added with the dimension report: questions whose
+	// answer the bundle holds as a fact rather than as a title — the
+	// payday spike, the 与信 hold, the split shipment — and the questions
+	// the bundle answers in several linked places at once, which is what
+	// accept is for. Each anchors to prose one concept actually carries;
+	// none restates a name.
+	{query: "今日の売上が少なく見える", want: "tables/shop-orders",
+		accept: []string{"insights/reading-revenue"}, dim: dimQuestion},
+	{query: "経理の締めと合わないのはなぜか", want: "policies/revenue-recognition",
+		accept: []string{"metrics/revenue", "glossary/completed-order", "insights/着地見込み"},
+		dim:    dimQuestion},
+	{query: "月がずれる", want: "tables/shop-orders",
+		accept: []string{"queries/sales/monthly-revenue", "insights/着地見込み"}, dim: dimQuestion},
+	{query: "一部返品された注文はどう数えるか", want: "glossary/completed-order",
+		accept: []string{"policies/revenue-recognition", "metrics/revenue"}, dim: dimQuestion},
+	{query: "アプリからの注文はどのコードか", want: "references/order-channel-codes", dim: dimQuestion},
+	{query: "どのサービスアカウントで実行するか", want: "skills/run-bigquery-query", dim: dimQuestion},
+	{query: "25日の山", want: "insights/着地見込み", dim: dimKeyword},
+	{query: "分割出荷", want: "glossary/completed-order", dim: dimKeyword},
+	{query: "遡る期間", want: "metrics/repeat-purchase-rate", dim: dimKeyword},
+	// Warehouse English inside a Japanese sentence, which is how a data
+	// agent actually talks to this base: the column name stays English,
+	// the question around it does not. scriptRuns is what keeps the two
+	// halves findable (store/search.go), and nothing measured it.
+	{query: "channel_code が null の行", want: "tables/shop-orders",
+		accept: []string{"queries/sales/revenue-by-channel", "references/order-channel-codes"},
+		dim:    dimMixed},
+	{query: "created_at はどのタイムゾーンか", want: "tables/shop-orders", dim: dimMixed},
+	{query: "from_date は必須か", want: "queries/sales/revenue-by-channel", dim: dimMixed},
 	// English, and still against the shipped bundle: the names the
 	// warehouse supplies stayed English when the prose became Japanese,
 	// which is what a Japanese team's own base looks like. A base that
 	// could not be asked `total_price` would have translated the wrong
 	// half.
-	{query: "total_price column", want: "tables/shop-orders"},
-	{query: "web_direct", want: "references/order-channel-codes"},
-	{query: "channel_code enum", want: "references/order-channel-codes"},
-	{query: "status completed", want: "glossary/completed-order"},
+	{query: "total_price column", want: "tables/shop-orders", dim: dimEnglish},
+	{query: "web_direct", want: "references/order-channel-codes", dim: dimEnglish},
+	{query: "channel_code enum", want: "references/order-channel-codes", dim: dimEnglish},
+	{query: "status completed", want: "glossary/completed-order", dim: dimEnglish},
+	// The whole English question, not only the keyword — the exact input
+	// queryFragments was written around (store/search.go names it), sent
+	// by the teammate who does not read the base's language. The stemmer
+	// drops its stopwords and "revenue" reaches the synonyms key, so
+	// what this measures is which of the concepts sharing that one word
+	// comes first for a question none of them contains.
+	{query: "why is revenue down", want: "insights/reading-revenue",
+		accept: []string{"metrics/revenue"}, dim: dimEnglish},
+	{query: "customer_id is null", want: "tables/shop-orders", dim: dimEnglish},
+	// Spelling variants of words the bundle writes another way. These
+	// are the improvement backlog, kept as measured cases rather than as
+	// a to-do: 売り上げ is the okurigana spelling every IME offers
+	// first, and its windows (売り, 上げ) share nothing with the 売上
+	// the corpus writes — the case rides entirely on the rest of the
+	// sentence, which is what a reader typing it gets. チャンネル shares
+	// two of its four windows with チャネル, so the n-gram treatment
+	// absorbs that variant on its own. Full-width ＢｉｇＱｕｅｒｙ is
+	// what a Japanese IME yields mid-sentence; no width folding exists,
+	// so the Latin term is lost and the Japanese half of the sentence
+	// has to carry the case. A normalization that closes any of these
+	// moves this dimension's line without touching the others — that is
+	// the report doing its job.
+	{query: "売り上げの定義", want: "metrics/revenue", dim: dimOrthography},
+	{query: "チャンネルごとの売上", want: "queries/sales/revenue-by-channel", dim: dimOrthography},
+	{query: "ＢｉｇＱｕｅｒｙの実行", want: "skills/run-bigquery-query", dim: dimOrthography},
 	// The other names the writer gave the metric (design doc 0105).
 	// "top line" appears nowhere in the bundle but the synonyms key, so
 	// this case answers only when the haystack reads it — and unlike the
 	// "net sales" it replaced, it is a name for this metric rather than
 	// for the 純売上 the concept spends a paragraph saying it is not.
-	{query: "top line", want: "metrics/revenue"},
-	// Japanese, against the inline supplement below. 解約 is a
-	// two-character term — exactly the shape the trigram index cannot
-	// serve and the windowed scan answers — in a corpus that has no other
-	// home for it.
-	{query: "解約率", want: "ja/metrics/kaiyakuritsu"},
-	{query: "解約の分母", want: "ja/metrics/kaiyakuritsu"},
+	// トップライン is the same key's Japanese entry, windowed instead of
+	// stemmed — the two spellings take different paths to the same row.
+	{query: "top line", want: "metrics/revenue", dim: dimSynonyms},
+	{query: "トップライン", want: "metrics/revenue", dim: dimSynonyms},
+	// Two-character terms — exactly the shape the trigram index cannot
+	// serve and the windowed scan answers. 解約 lives in the inline
+	// supplement below, in a corpus with no other home for it; 与信 is
+	// the demo's own, one concept's single sentence about credit holds.
+	{query: "解約率", want: "ja/metrics/kaiyakuritsu", dim: dimShort},
+	{query: "解約の分母", want: "ja/metrics/kaiyakuritsu", dim: dimShort},
+	{query: "与信", want: "glossary/completed-order", dim: dimShort},
 }
 
 // japaneseSupplement holds the inline Japanese concepts, keyed by id
@@ -181,21 +278,32 @@ const evalVerified = "policies/revenue-recognition"
 // then by id (store/search.go).
 //
 // The set grew from 14 cases to 36, then to 41 when the demo gained a
-// Japanese half, and stands at 37 now that the demo is Japanese and the
-// two supplement concepts the bundle had come to duplicate are gone.
-// Fourteen put MRR inside its own noise: one case moving from rank 1 to
-// rank 2 moved it by 0.036, which is the size of the differences anybody
-// was reading. The second pass asks the same corpus the way somebody
-// asks rather than the way a title reads — 「お盆」「ゲスト購入」
-// 「返金は引くのか」 — and twelve concepts do not honestly support many
-// more than that.
+// Japanese half, to 37 when the demo became Japanese and the two
+// supplement concepts the bundle had come to duplicate were gone, and
+// stands at 56 with the dimension labels. Fourteen put MRR inside its
+// own noise: one case moving from rank 1 to rank 2 moved it by 0.036,
+// which is the size of the differences anybody was reading. The second
+// pass asks the same corpus the way somebody asks rather than the way a
+// title reads — 「お盆」「ゲスト購入」「返金は引くのか」 — and twelve
+// concepts do not honestly support many more *of that kind*. The third
+// pass got past that limit two ways: by anchoring to facts rather than
+// concepts (与信, 分割出荷, the 25日 spike — one concept holds several
+// facts somebody asks for separately), and by asking the same fact in
+// the spellings the corpus does not use (売り上げ, チャンネル,
+// ＢｉｇＱｕｅｒｙ), which is where queries actually differ from
+// documents. accept opened the questions the bundle deliberately
+// answers in several linked places, which single-answer scoring had
+// been excluding as ambiguous.
 //
 // **The numbers moved when the demo became Japanese, and the two runs
 // are not comparable.** Both the corpus and the questions changed:
 // lexical went 0.90 → 0.78 and fused 0.85 → 0.77, while recall went to
-// 1.00 on both halves — nothing fell out of the top ten. What the MRR
-// is made of is 24 of 37 cases at rank 1 and two at rank 7. The drop is
-// the corpus, not the ranking, and it is two effects worth naming:
+// 1.00 on both halves — nothing fell out of the top ten. They moved
+// again at 56 cases (lexical 0.78 → 0.80, fused 0.77 → 0.78), and
+// again the runs are not comparable: the set changed under the number,
+// partly because accept stopped charging the multi-homed questions to
+// the ranking. The 37-case story below still names the two effects that
+// govern this corpus:
 //
 //   - A monolingual Japanese corpus about one shop shares 売上 across
 //     every concept, and the concept whose name *is* 売上 takes the name
@@ -220,24 +328,25 @@ const evalVerified = "policies/revenue-recognition"
 // vocabulary at all, and no number on this page says how much that is.
 const (
 	evalK = 10
-	// Lexical, measured at 1.00 / 0.78. The MRR floor is two cases'
-	// worth under it: one case slipping from rank 1 to rank 2 is 0.014
+	// Lexical, measured at 1.00 / 0.80. The MRR floor is two cases'
+	// worth under it: one case slipping from rank 1 to rank 2 is 0.009
 	// here, so a floor closer than that fails on noise.
-	evalRecallFloor = 0.95
-	evalMRRFloor    = 0.75
+	evalRecallFloor = 0.97
+	evalMRRFloor    = 0.77
 	// Fused: the same questions with the stand-in encoder on, measured
-	// at 1.00 / 0.77. This floor is the one that catches the verified
+	// at 1.00 / 0.78. This floor is the one that catches the verified
 	// addend going back to 0.002 — that constant is the kind that gets
 	// nudged by whoever is looking at one query — so it was re-measured
-	// against this corpus rather than carried over: at 0.002 the fused
-	// run scores 0.73, and the floor sits between.
+	// when it was set: at 0.002 the 37-case fused run scored 0.73, and
+	// the floor sat between.
 	//
-	// It read 0.83 against 0.85 measured over the bilingual corpus, and
-	// before that 0.86 against 0.89. Each move came from the corpus
-	// changing under it, not from the merge; what the number certifies is
-	// still only that the merge does no harm.
-	evalFusedRecallFloor = 0.95
-	evalFusedMRRFloor    = 0.74
+	// It read 0.74 against 0.77 measured when the demo became Japanese,
+	// 0.83 against 0.85 over the bilingual corpus, and before that 0.86
+	// against 0.89. Each move came from the corpus or the set changing
+	// under it, not from the merge; what the number certifies is still
+	// only that the merge does no harm.
+	evalFusedRecallFloor = 0.97
+	evalFusedMRRFloor    = 0.75
 )
 
 // evalFloorSlackCases is how far a floor may sit under what was measured
@@ -258,11 +367,11 @@ const (
 //
 // Two cases, and derived from the size of the set rather than declared
 // as a score, because everything on this page that reasons about noise
-// reasons in cases: one case slipping from rank 1 to rank 2 is 0.014
-// here, one case leaving the top k is 0.027, and the floors above were
+// reasons in cases: one case slipping from rank 1 to rank 2 is 0.009
+// here, one case leaving the top k is 0.018, and the floors above were
 // chosen as about two cases under what was measured. A tolerance written
 // as 0.05 would have to be rewritten every time the set grows, and the
-// set has been 14, then 36, then 41, then 37.
+// set has been 14, then 36, then 41, then 37, then 56.
 const evalFloorSlackCases = 2
 
 // checkEvalFloors holds one configuration's numbers to their floors in
@@ -360,7 +469,14 @@ func TestSearchEvalIntegration(t *testing.T) {
 	}
 
 	const lexical = "lexical only"
-	recall, mrr := scoreGoldenSet(t, ctx, svc, prefix, lexical)
+	filter := store.Filter{Prefixes: []string{prefix}}
+	recall, mrr := scoreGoldenSet(t, lexical, prefix, func(query string) []domain.SearchHit {
+		hits, _, err := svc.Search(ctx, query, filter, evalK)
+		if err != nil {
+			t.Fatalf("search %q: %v", query, err)
+		}
+		return hits
+	})
 	checkEvalFloors(t, lexical, recall, mrr, evalRecallFloor, evalMRRFloor)
 
 	// The same questions with the vector half on, which is the
@@ -369,39 +485,82 @@ func TestSearchEvalIntegration(t *testing.T) {
 	checkEvalFloors(t, "fused", fusedRecall, fusedMRR, evalFusedRecallFloor, evalFusedMRRFloor)
 }
 
-// scoreGoldenSet runs every case and reports recall@k and MRR, naming
-// the configuration in the line it logs — a number without its
-// configuration beside it is the thing this harness exists to stop.
-func scoreGoldenSet(t *testing.T, ctx context.Context, svc *Service, prefix, config string) (recall, mrr float64) {
+// rank is the position of the first acceptable concept — want, or one of
+// accept — in the hits, or zero when none is in them. The first
+// acceptable, not want's own: for the questions the bundle answers in
+// several linked places, want records the best entry point and accept
+// keeps the case from punishing the others for existing.
+func (c evalCase) rank(prefix string, hits []domain.SearchHit) int {
+	acceptable := map[string]bool{prefix + "/" + c.want: true}
+	for _, id := range c.accept {
+		acceptable[prefix+"/"+id] = true
+	}
+	for i, h := range hits {
+		if acceptable[h.ID] {
+			return i + 1
+		}
+	}
+	return 0
+}
+
+// scoreGoldenSet runs every case through search and reports recall@k and
+// MRR, naming the configuration in the line it logs — a number without
+// its configuration beside it is the thing this harness exists to stop.
+// Both configurations run through this one loop, so what a hit is and
+// what gets logged cannot drift between them.
+//
+// Beside the aggregate it logs one line per dimension. The aggregate
+// says whether a ranking change moved anything; the dimension lines say
+// where — an orthography change that costs the mixed-script cases shows
+// up as two lines moving in opposite directions, which the aggregate
+// would have averaged into silence. They carry no floors: the smallest
+// dimension is two cases, and everything on this page that reasons about
+// noise reasons in cases.
+func scoreGoldenSet(t *testing.T, config, prefix string, search func(query string) []domain.SearchHit) (recall, mrr float64) {
 	t.Helper()
-	filter := store.Filter{Prefixes: []string{prefix}}
+	type tally struct {
+		cases, found int
+		rr           float64
+	}
+	byDim := map[string]*tally{}
 	found := 0
 	for _, c := range evalCases {
-		hits, _, err := svc.Search(ctx, c.query, filter, evalK)
-		if err != nil {
-			t.Fatalf("search %q: %v", c.query, err)
+		d := byDim[c.dim]
+		if d == nil {
+			d = &tally{}
+			byDim[c.dim] = d
 		}
-		rank := 0
-		for i, h := range hits {
-			if h.ID == prefix+"/"+c.want {
-				rank = i + 1
-				break
-			}
-		}
+		d.cases++
+		hits := search(c.query)
+		rank := c.rank(prefix, hits)
 		if rank == 0 {
 			got := make([]string, 0, len(hits))
 			for _, h := range hits {
 				got = append(got, strings.TrimPrefix(h.ID, prefix+"/"))
 			}
-			t.Logf("miss (%s): %q did not surface %s in the top %d; got %v", config, c.query, c.want, evalK, got)
+			t.Logf("miss (%s, %s): %q did not surface %s in the top %d; got %v",
+				config, c.dim, c.query, c.want, evalK, got)
 			continue
 		}
 		found++
 		mrr += 1.0 / float64(rank)
-		t.Logf("hit (%s): %q -> %s at rank %d", config, c.query, c.want, rank)
+		d.found++
+		d.rr += 1.0 / float64(rank)
+		// The id that answered, not want: when an accept answers first,
+		// the line says which concept the reader actually met.
+		t.Logf("hit (%s, %s): %q -> %s at rank %d",
+			config, c.dim, c.query, strings.TrimPrefix(hits[rank-1].ID, prefix+"/"), rank)
 	}
 	recall = float64(found) / float64(len(evalCases))
 	mrr /= float64(len(evalCases))
+	for _, dim := range []string{dimQuestion, dimKeyword, dimMixed, dimEnglish, dimOrthography, dimSynonyms, dimShort} {
+		d := byDim[dim]
+		if d == nil {
+			t.Fatalf("dimension %s has no cases; drop it from this list or give it one", dim)
+		}
+		t.Logf("  %-11s recall@%d = %d/%d, MRR = %.2f (%s)",
+			dim, evalK, d.found, d.cases, d.rr/float64(d.cases), config)
+	}
 	t.Logf("recall@%d = %.2f (%d/%d), MRR = %.2f, %s", evalK, recall, found, len(evalCases), mrr, config)
 	return recall, mrr
 }
@@ -437,41 +596,17 @@ func scoreFusedGoldenSet(t *testing.T, ctx context.Context, svc *Service, prefix
 	}
 
 	filter := store.Filter{Prefixes: []string{prefix}}
-	found := 0
-	for _, c := range evalCases {
-		lexical, err := svc.Store.SearchLexical(ctx, c.query, filter, evalK*2)
+	return scoreGoldenSet(t, "fused", prefix, func(query string) []domain.SearchHit {
+		lexical, err := svc.Store.SearchLexical(ctx, query, filter, evalK*2)
 		if err != nil {
-			t.Fatalf("search %q: %v", c.query, err)
+			t.Fatalf("search %q: %v", query, err)
 		}
-		vectors, err := enc.Embed(ctx, embed.TaskQuery, []string{c.query})
+		vectors, err := enc.Embed(ctx, embed.TaskQuery, []string{query})
 		if err != nil {
 			t.Fatal(err)
 		}
-		hits := rrfFuse(c.query, evalK, lexical, nearest(corpus, vectors[0], evalK*2))
-		rank := 0
-		for i, h := range hits {
-			if h.ID == prefix+"/"+c.want {
-				rank = i + 1
-				break
-			}
-		}
-		if rank == 0 {
-			t.Logf("miss (fused): %q did not surface %s in the top %d", c.query, c.want, evalK)
-			continue
-		}
-		found++
-		mrr += 1.0 / float64(rank)
-		// Logged like the lexical half's hits: without the per-case rank
-		// on this side, a fused number that moves says only that
-		// something did, and the only way to find out which case was to
-		// add this line and run it again.
-		t.Logf("hit (fused): %q -> %s at rank %d", c.query, c.want, rank)
-	}
-	recall = float64(found) / float64(len(evalCases))
-	mrr /= float64(len(evalCases))
-	t.Logf("recall@%d = %.2f (%d/%d), MRR = %.2f, lexical + vector (stand-in encoder)",
-		evalK, recall, found, len(evalCases), mrr)
-	return recall, mrr
+		return rrfFuse(query, evalK, lexical, nearest(corpus, vectors[0], evalK*2))
+	})
 }
 
 // embedded is one concept with the vector the stand-in encoder gave it.


### PR DESCRIPTION
<!-- Keep PRs small and focused. Link the issue or design doc, if there is one. -->

## What and why

The search eval harness (`TestSearchEvalIntegration`, issue #528) reported one recall@10/MRR pair per configuration. That says *whether* a ranking change moved anything, not *where* — and its 37 cases had stopped at "what twelve concepts honestly support" because every case had to name exactly one concept and avoid restating a title. This PR is the search-engineer pass over that set: enumerate the dimensions of query behaviour a reader actually exercises, give each a measured line, and remove the two constraints that were keeping honest cases out.

**The set grows 37 → 56 without restating titles**, three ways:

- **Cases anchor to facts, not only to concepts.** One concept holds several facts somebody asks for separately — 与信 (the credit hold), 分割出荷, the 25日 payday spike, `customer_id is null` — so the corpus supports more questions than it has titles.
- **Cases ask in the spellings the corpus does not use.** 売り上げ (the okurigana every IME offers first, whose 2-character windows share nothing with 売上), チャンネル vs チャネル, full-width ＢｉｇＱｕｅｒｙ from a Japanese IME, and the whole English question "why is revenue down" — queries differ from documents mostly in spelling, and nothing measured that.
- **`accept` opens the multi-homed questions.** The 経理 mismatch is a policy, a definition and a month-end note at once, and the bundle links them on purpose; single-answer scoring had excluded such questions as "ambiguous". The rank scored is now the first acceptable concept — a case that punishes one correct answer for not being the chosen one measures tie order, not ranking.

**Every case carries a dimension label** — question / keyword / mixed (warehouse English inside a Japanese sentence) / english / orthography / synonyms / short — and both runs log a recall/MRR line per dimension beside the aggregate. Measured now (lexical):

```
question    27/27  MRR 0.76      english     6/6  MRR 0.69
keyword     11/11  MRR 0.94      orthography 3/3  MRR 0.67
mixed        4/4   MRR 0.71      synonyms    2/2  MRR 1.00
                                 short       3/3  MRR 1.00
```

The orthography line is the improvement backlog, kept as measured cases rather than a to-do: 売り上げ rides entirely on the rest of its sentence, and no width folding exists for full-width Latin. A normalization that closes either moves that one line without touching the others — which is what starts the improvement cycle the harness exists for.

Floors stay aggregate-only (the smallest dimension is two cases, all noise) and are re-measured at 56 cases: lexical 1.00/0.80 (floors 0.97/0.77), fused 1.00/0.78 (floors 0.97/0.75). The two-sided floor check keeps forcing them to track future improvements. The two scorer loops were one loop asked twice, so they are one function now, with hit acquisition passed in as a closure.

No surface changes: the diff is one integration-test file and the CONTRIBUTING section describing it. This serves the harness's own condition — a measurable improvement loop (C7) — by making the measurement targetable.

## Checks

CI runs the same script; make it pass locally first (CONTRIBUTING.md has the
context, including the store integration test and the fuzz targets).

- [x] `scripts/check` is clean — add `--db` when the change touches the store (`core`, `lint` and the store tests against a throwaway PostgreSQL 16 ran here; Docker/vuln are CI's to verify in this environment)
- [x] Behavior changes come with tests (the change is the test)

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — untouched
- [x] The change lands on every surface it belongs on — it touches none
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens a surface? No — a test file and contributor docs only

## Design docs

- [x] Alters an accepted decision? No — measurement of existing behaviour; not applicable
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmF42nZ26ztXudQnqrwzZ4)_