### PR TITLE
Make the mark inside a loanword part of the word

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,23 @@ last entry.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A katakana word with a long vowel in it is one search term.**
+  ー belongs to no script — Unicode calls it Common, because it is
+  written after hiragana as readily as after katakana — so both halves
+  of the lexical search treated it as a word boundary. データ was two
+  runs of one character, asked for as the prefixes `デ:*` and `タ:*`,
+  and that is most of the vocabulary a data team writes in: テーブル,
+  ロード, パーティション, カレンダー, レポート, ユーザー. Measured over
+  `examples/demo`, each of eight katakana probes returned all twelve
+  concepts — the right one first and eleven trailing it on a shared
+  first character; they now return 2.6 on average. The halfwidth voiced
+  marks (ﾞ ﾟ) and halfwidth ｰ join for the same reason. **Migration 0042
+  recomputes the search index for every stored object**, so the first
+  start after upgrading writes once per row before it serves; a base of
+  a few thousand concepts takes seconds, and nothing else is affected.
+
 ## [0.26.1] - 2026-08-19
 
 ### Added

--- a/internal/service/searcheval_integration_test.go
+++ b/internal/service/searcheval_integration_test.go
@@ -95,6 +95,7 @@ const (
 	dimKeyword     = "keyword"     // bare terms and jargon lookups
 	dimMixed       = "mixed"       // warehouse English inside a Japanese sentence
 	dimEnglish     = "english"     // English asked of a Japanese base
+	dimKatakana    = "katakana"    // loanwords joined by the ー mark
 	dimOrthography = "orthography" // spelling variants of the same word
 	dimSynonyms    = "synonyms"    // names only the synonyms key holds
 	dimShort       = "short"       // two-character terms below trigram
@@ -166,6 +167,18 @@ var evalCases = []evalCase{
 	{query: "25日の山", want: "insights/着地見込み", dim: dimKeyword},
 	{query: "分割出荷", want: "glossary/completed-order", dim: dimKeyword},
 	{query: "遡る期間", want: "metrics/repeat-purchase-rate", dim: dimKeyword},
+	// Katakana loanwords, which is most of the vocabulary a data team
+	// writes in: the terms below are the only place each word appears in
+	// the corpus, so a case answers only if the term was looked up as a
+	// term. Every one of them is joined by ー — テーブル, ロード,
+	// カレンダー — and that mark is where a katakana word is cut, so
+	// these measure whether a loanword can be searched for at all.
+	{query: "ロケーション", want: "skills/run-bigquery-query", dim: dimKatakana},
+	{query: "データセット", want: "skills/run-bigquery-query", dim: dimKatakana},
+	{query: "毎時ロード", want: "tables/shop-orders", dim: dimKatakana},
+	{query: "カレンダー", want: "insights/reading-revenue",
+		accept: []string{"insights/着地見込み", "queries/sales/monthly-revenue"}, dim: dimKatakana},
+	{query: "フィード", want: "queries/sales/revenue-by-channel", dim: dimKatakana},
 	// Warehouse English inside a Japanese sentence, which is how a data
 	// agent actually talks to this base: the column name stays English,
 	// the question around it does not. scriptRuns is what keeps the two
@@ -280,7 +293,8 @@ const evalVerified = "policies/revenue-recognition"
 // The set grew from 14 cases to 36, then to 41 when the demo gained a
 // Japanese half, to 37 when the demo became Japanese and the two
 // supplement concepts the bundle had come to duplicate were gone, and
-// stands at 56 with the dimension labels. Fourteen put MRR inside its
+// stands at 61: 56 with the dimension labels, and five more when the
+// katakana dimension was added to measure migration 0042. Fourteen put MRR inside its
 // own noise: one case moving from rank 1 to rank 2 moved it by 0.036,
 // which is the size of the differences anybody was reading. The second
 // pass asks the same corpus the way somebody asks rather than the way a
@@ -302,8 +316,21 @@ const evalVerified = "policies/revenue-recognition"
 // again at 56 cases (lexical 0.78 → 0.80, fused 0.77 → 0.78), and
 // again the runs are not comparable: the set changed under the number,
 // partly because accept stopped charging the multi-homed questions to
-// the ranking. The 37-case story below still names the two effects that
-// govern this corpus:
+// the ranking.
+//
+// **Migration 0042 is the first entry here that moved the number
+// without the set changing under it**: at 61 cases, lexical went 0.82 →
+// 0.83 and fused stayed 0.80, all of it in the question dimension (0.76
+// → 0.79). That is the honest size of it, and it is much smaller than
+// what the migration actually bought — the golden set scores rank, and
+// what a loanword lookup fixes is the candidate set: over this corpus
+// the eight katakana probes went from returning all twelve concepts
+// each to returning 2.6 on average. A twelve-concept corpus cannot
+// charge for the nine wrong answers underneath a right one, which is
+// this harness's own limit written down.
+//
+// The 37-case story below still names the two effects that govern this
+// corpus:
 //
 //   - A monolingual Japanese corpus about one shop shares 売上 across
 //     every concept, and the concept whose name *is* 売上 takes the name
@@ -328,25 +355,26 @@ const evalVerified = "policies/revenue-recognition"
 // vocabulary at all, and no number on this page says how much that is.
 const (
 	evalK = 10
-	// Lexical, measured at 1.00 / 0.80. The MRR floor is two cases'
-	// worth under it: one case slipping from rank 1 to rank 2 is 0.009
+	// Lexical, measured at 1.00 / 0.83. The MRR floor is two cases'
+	// worth under it: one case slipping from rank 1 to rank 2 is 0.008
 	// here, so a floor closer than that fails on noise.
 	evalRecallFloor = 0.97
-	evalMRRFloor    = 0.77
+	evalMRRFloor    = 0.80
 	// Fused: the same questions with the stand-in encoder on, measured
-	// at 1.00 / 0.78. This floor is the one that catches the verified
+	// at 1.00 / 0.80. This floor is the one that catches the verified
 	// addend going back to 0.002 — that constant is the kind that gets
 	// nudged by whoever is looking at one query — so it was re-measured
 	// when it was set: at 0.002 the 37-case fused run scored 0.73, and
 	// the floor sat between.
 	//
-	// It read 0.74 against 0.77 measured when the demo became Japanese,
+	// It read 0.75 against 0.78 measured at 56 cases, 0.74 against 0.77
+	// when the demo became Japanese,
 	// 0.83 against 0.85 over the bilingual corpus, and before that 0.86
 	// against 0.89. Each move came from the corpus or the set changing
 	// under it, not from the merge; what the number certifies is still
 	// only that the merge does no harm.
 	evalFusedRecallFloor = 0.97
-	evalFusedMRRFloor    = 0.75
+	evalFusedMRRFloor    = 0.77
 )
 
 // evalFloorSlackCases is how far a floor may sit under what was measured
@@ -371,7 +399,7 @@ const (
 // here, one case leaving the top k is 0.018, and the floors above were
 // chosen as about two cases under what was measured. A tolerance written
 // as 0.05 would have to be rewritten every time the set grows, and the
-// set has been 14, then 36, then 41, then 37, then 56.
+// set has been 14, then 36, then 41, then 37, then 56, then 61.
 const evalFloorSlackCases = 2
 
 // checkEvalFloors holds one configuration's numbers to their floors in
@@ -553,7 +581,8 @@ func scoreGoldenSet(t *testing.T, config, prefix string, search func(query strin
 	}
 	recall = float64(found) / float64(len(evalCases))
 	mrr /= float64(len(evalCases))
-	for _, dim := range []string{dimQuestion, dimKeyword, dimMixed, dimEnglish, dimOrthography, dimSynonyms, dimShort} {
+	for _, dim := range []string{dimQuestion, dimKeyword, dimMixed, dimEnglish,
+		dimKatakana, dimOrthography, dimSynonyms, dimShort} {
 		d := byDim[dim]
 		if d == nil {
 			t.Fatalf("dimension %s has no cases; drop it from this list or give it one", dim)

--- a/internal/store/migrations/0042_a_long_vowel_is_inside_the_word.sql
+++ b/internal/store/migrations/0042_a_long_vowel_is_inside_the_word.sql
@@ -1,0 +1,57 @@
+-- The mark inside a loanword stops being a word boundary.
+--
+-- 0036 cut every run of Han/kana into two-character windows so that a
+-- two-character Japanese term could be looked up instead of scanned
+-- for, and pinned the class of characters it cuts to Go's unicode.Han,
+-- unicode.Hiragana and unicode.Katakana. ー is in none of them: Unicode
+-- gives the prolonged sound mark Script=Common, because it is written
+-- after hiragana as readily as after katakana. So both sides of the
+-- search treated it as a boundary, and データ was two runs of one
+-- character each — asked for as the prefixes デ:* and タ:*, and stored
+-- as the lone lexeme デ.
+--
+-- Measured over examples/demo before this migration: each of the eight
+-- katakana probes (データ, テーブル, ロード, フィード, パーティション,
+-- レポート, ページ, コード) returned all twelve concepts. The right one
+-- ranked first — the scorer is not what was broken — and eleven
+-- unrelated concepts followed it with a non-zero score, on the strength
+-- of a shared first character. That is the corpus reading itself, which
+-- is the cost 0036 exists to have removed, and it applies to most of
+-- the vocabulary a data team writes in.
+--
+-- The halfwidth voiced marks are the same defect in the other spelling:
+-- ﾃﾞｰﾀ is ﾃ + ﾞ + ｰ + ﾀ, and only ﾃ and ﾀ were in the class, so the run
+-- split at both marks. ｰ, ﾞ and ﾟ join here for the reason ー does.
+--
+-- ・ stays out. It separates words rather than joining them, which is
+-- what a boundary is for.
+CREATE OR REPLACE FUNCTION ochakai_cjk_class() RETURNS text
+LANGUAGE sql IMMUTABLE PARALLEL SAFE AS $$
+    SELECT '⺀-⺙⺛-⻳⼀-⿕々〇〡-〩'
+        || '〸-〻ぁ-ゖゝ-ゟァ-ヺーヽ-ヿ'
+        || 'ㇰ-ㇿ㋐-㋾㌀-㍗㐀-䶿一-鿿'
+        || '豈-舘並-龎ｦ-ﾟ'
+        || '\U00016FE2-\U00016FE3\U00016FF0-\U00016FF1'
+        || '\U0001AFF0-\U0001AFF3\U0001AFF5-\U0001AFFB\U0001AFFD-\U0001AFFE'
+        || '\U0001B000-\U0001B122\U0001B132\U0001B150-\U0001B152\U0001B155'
+        || '\U0001B164-\U0001B167\U0001F200'
+        || '\U00020000-\U0002A6DF\U0002A700-\U0002B739\U0002B740-\U0002B81D'
+        || '\U0002B820-\U0002CEA1\U0002CEB0-\U0002EBE0\U0002F800-\U0002FA1D'
+        || '\U00030000-\U0003134A\U00031350-\U000323AF'
+$$;
+
+-- Two edits to the string above, and both are ranges the old one wrote
+-- around: ー (U+30FC) sits between ヺ and ヽ, and ｰ ﾞ ﾟ (U+FF70,
+-- U+FF9E, U+FF9F) are what closing ｦ-ｯ ｱ-ﾝ up into ｦ-ﾟ takes in. ・
+-- (U+30FB) is still excluded, because ー is written in and the range
+-- stops before it. TestCJKClassAgreesWithGo walks every code point of
+-- the affected planes and holds this string to the Go predicate that
+-- cuts the query side (store.scriptWithoutSpaces), so the two halves
+-- cannot drift apart again.
+
+-- The windows already stored were cut by the old class. Assigning
+-- search_text to itself is how every migration since 0016 has asked the
+-- trigger to run, and the generated tsvector column follows it (0036) —
+-- which is what makes the derivation change reach what is already in
+-- the base rather than only what is written next.
+UPDATE object SET search_text = search_text WHERE id IS NOT NULL;

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -211,8 +211,48 @@ func scriptRuns(token string) []string {
 // scriptWithoutSpaces reports whether r belongs to a script that does not
 // separate words with spaces, so a token of it needs windowing rather than
 // taking whole.
+//
+// The three scripts, and the marks that are written inside a word
+// without belonging to a script (joiningMark).
 func scriptWithoutSpaces(r rune) bool {
-	return unicode.Is(unicode.Han, r) || unicode.Is(unicode.Hiragana, r) || unicode.Is(unicode.Katakana, r)
+	return unicode.Is(unicode.Han, r) || unicode.Is(unicode.Hiragana, r) ||
+		unicode.Is(unicode.Katakana, r) || joiningMark(r)
+}
+
+// joiningMark reports whether r is one of the marks a Japanese word is
+// written *through* — the prolonged sound mark that spells the long
+// vowel of a loanword, and the voiced marks the halfwidth forms leave
+// standing alone.
+//
+// None of them belongs to a script. Unicode gives them Script=Common,
+// because ー is written after hiragana as readily as after katakana, and
+// that answer is right for a property table and wrong for a word
+// boundary: it made ー a boundary on both sides of the search at once,
+// so データ was cut into デ and タ — two runs of one character, which
+// fragmentQuery can only ask for as the prefixes デ:* and タ:*.
+//
+// **That is most of a data team's vocabulary.** テーブル, ロード,
+// パーティション, カレンダー, レポート, ユーザー, サービスアカウント:
+// each was a prefix scan rather than a lookup, and the corpus answered
+// every one of them with all of itself — the eight katakana probes over
+// examples/demo each returned all twelve concepts, the right one first
+// and eleven trailing it on a shared first character. Migration 0036
+// exists so a two-character Japanese term stops reading the table, and
+// for every word with a long vowel in it the mark had quietly given
+// that back.
+//
+// ・ is deliberately not here. It separates words rather than joining
+// them (サービス・アカウント is two names), which is what a boundary
+// is for.
+func joiningMark(r rune) bool {
+	switch r {
+	case 'ー', // U+30FC prolonged sound mark
+		'ｰ', // U+FF70 halfwidth prolonged sound mark
+		'ﾞ', // U+FF9E halfwidth voiced mark
+		'ﾟ': // U+FF9F halfwidth semi-voiced mark
+		return true
+	}
+	return false
 }
 
 // contentChar reports whether r is the kind of character a Japanese

--- a/internal/store/searchtsv_integration_test.go
+++ b/internal/store/searchtsv_integration_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-	"unicode"
 
 	"github.com/na0fu3y/ochakai/internal/domain"
 	"github.com/na0fu3y/ochakai/internal/testdb"
@@ -49,10 +48,12 @@ func TestCJKClassAgreesWithGo(t *testing.T) {
 	ctx := context.Background()
 	s := newSearchStore(t, ctx)
 
-	goSaysCJK := func(r rune) bool {
-		return unicode.Is(unicode.Han, r) ||
-			unicode.Is(unicode.Hiragana, r) || unicode.Is(unicode.Katakana, r)
-	}
+	// The predicate itself, not a restatement of it. Migration 0042
+	// added characters that belong to none of the three scripts (the
+	// marks written inside a word), and a test that listed the scripts
+	// here would have gone on agreeing with a class the query side had
+	// stopped using.
+	goSaysCJK := scriptWithoutSpaces
 	// The planes these scripts live in, plus latin, Cyrillic and
 	// punctuation to catch a class that matches too much.
 	spans := [][2]rune{
@@ -231,6 +232,63 @@ func explainJapaneseLookup(t *testing.T, ctx context.Context, s *Store) string {
 		t.Fatal(err)
 	}
 	return strings.Join(plan, "\n")
+}
+
+// TestLoanwordIsLookedUpNotPrefixScanned pins what migration 0042
+// bought: a katakana word with a long vowel in it is one term, so a
+// search for it finds the concept that says it and not every concept
+// that happens to start with the same character.
+//
+// Before 0042, データ was two runs of one character — ー was a boundary
+// on both sides of the search — and one-character runs are asked for as
+// prefixes (fragmentQuery). So デ:* reached デプロイ, デフォルト and
+// every other word beginning デ, and the candidate set was most of the
+// corpus. The right concept still ranked first, which is why nothing
+// caught this: the scorer was never what was broken.
+//
+// The assertion is on the neighbour rather than on the target. A test
+// that only checked that データ finds the データ concept passed before
+// this migration too.
+func TestLoanwordIsLookedUpNotPrefixScanned(t *testing.T) {
+	ctx := context.Background()
+	s := newSearchStore(t, ctx)
+	run := testdb.Unique(t, "loanword")
+	actor := domain.Actor{Kind: domain.ActorHuman, Name: "test"}
+
+	// Two concepts sharing nothing but the first character of the word
+	// each is about, which is the whole of what a prefix could match on.
+	for id, body := range map[string]string{
+		"wanted":    "データセットの権限は読み取りだけである。",
+		"neighbour": "デプロイの手順は別に書いてある。",
+	} {
+		k := &domain.Knowledge{
+			Type: domain.TypeInsights, ID: run + "/" + id,
+			Title: id, Body: body, Status: domain.StatusStable, CreatedBy: actor,
+		}
+		if err := s.Create(ctx, k, false); err != nil {
+			t.Fatalf("create %s: %v", k.ID, err)
+		}
+	}
+
+	hits, err := s.SearchLexical(ctx, "データ", Filter{Prefixes: []string{run}}, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ids := make([]string, 0, len(hits))
+	for _, h := range hits {
+		ids = append(ids, strings.TrimPrefix(h.ID, run+"/"))
+	}
+	if len(ids) != 1 || ids[0] != "wanted" {
+		t.Errorf("searching データ returned %v; want just the concept that says it. "+
+			"A neighbour here means the query is asking for the prefix デ:* rather "+
+			"than looking the word up — migration 0042 is what makes ー part of it", ids)
+	}
+
+	// The halfwidth spelling of the same defect: the voiced mark used to
+	// split the run it is written inside.
+	if got := queryFragments("ﾃﾞｰﾀ"); len(got) != 1 {
+		t.Errorf("ﾃﾞｰﾀ cut into %v; a halfwidth loanword is one run, not one per mark", got)
+	}
 }
 
 // TestEnglishSearchStems pins the recall ILIKE could not have: a plural


### PR DESCRIPTION
<!-- Keep PRs small and focused. Link the issue or design doc, if there is one. -->

## What and why

First item off the backlog the eval harness (#695) surfaced. It started as "close the orthography gap", and the measurement sent it somewhere better — the write-up below keeps that order, because the wrong first hypothesis is why the right one is trustworthy.

**The hypothesis that failed.** Orthography was the weakest dimension (lexical 0.67), so the plan was NFKC width folding (full-width `ＢｉｇＱｕｅｒｙ`, half-width kana). Five katakana loanword cases were added first, to show a defect existed. All five ranked 1, MRR 1.00. On a twelve-concept corpus where every term appears in exactly one concept, ranking cannot see a tokenizer defect — the right answer wins even when the query has degraded to a prefix scan.

**What the probe found instead.** Scoring hides it; the candidate set does not. Eight katakana queries against `examples/demo`, before this change:

```
データ  10 hits   テーブル 10   ロード 10   フィード 10
パーティション 10   レポート 10   ページ 10   コード 10      ← the whole corpus, every time
```

ー belongs to no script. Unicode gives the prolonged sound mark `Script=Common` — it is written after hiragana as readily as after katakana — and migration 0036 pinned its window-cutting class to Go's `unicode.Han/Hiragana/Katakana`. So **both sides of the lexical search treated ー as a word boundary**: `データ` was two runs of one character each, and a one-character run can only be asked for as a prefix (`fragmentQuery`), so the query became `デ:*` OR `タ:*` — reaching デプロイ, デフォルト, and everything else beginning デ.

That is most of the vocabulary a data team writes in: テーブル, ロード, パーティション, カレンダー, レポート, ユーザー, サービスアカウント. Migration 0036 exists so a two-character Japanese term stops reading the table; for every word with a long vowel in it, the mark had quietly given that back. The halfwidth voiced marks are the same defect in the other spelling — `ﾃﾞｰﾀ` split at both ﾞ and ｰ.

**After:** the same eight queries return **2.6 hits on average** (10 → 2, 2, 1, 3, 5, 2, 2, 4), each still with the right concept first.

`・` deliberately stays out: it separates words rather than joining them (サービス・アカウント is two names), which is what a boundary is for.

### Numbers

| | before | after |
|---|---|---|
| katakana probe hits (mean of 8, `examples/demo`) | 10.0 | **2.6** |
| lexical recall@10 / MRR (61 cases) | 1.00 / 0.82 | 1.00 / **0.83** |
| — question dimension | 0.76 | **0.79** |
| fused recall@10 / MRR | 1.00 / 0.80 | 1.00 / 0.80 |

Floors rise to 0.80 (lexical) and 0.77 (fused). **The one-point MRR move is the honest size of what the golden set can see, and it is much smaller than what the fix bought** — twelve concepts cannot charge for the nine wrong answers sitting underneath a right one. That limit is now written into the harness's comments rather than left as a number nobody questioned.

### Two things worth a reviewer's eye

- **The class string is edited byte-exactly.** The CJK compatibility ideographs inside it (U+F900, U+FA6D, U+FA70, U+FAD9) NFC-normalize to unified ideographs; retyping them turns two ranges descending and makes the whole regex invalid (`invalid character range`, on every write). Migration 0042 was built by splicing 0036's own bytes and applying two substring edits.
- **`TestCJKClassAgreesWithGo` now pins against `store.scriptWithoutSpaces` itself**, not against a restatement of the three script tables — a restatement would have gone on agreeing with a class the query side had stopped using, which is exactly how the two halves could drift apart again.

`TestLoanwordIsLookedUpNotPrefixScanned` asserts on the *neighbour*, not the target: reverting the fix makes it report `[wanted neighbour]`, and a test that only checked that データ finds the データ concept passed before this change too.

No surface change; no new key, wire field or stored round trip. This is index and tokenization work, so it takes a PR description rather than a numbered record (the `design-doc` skill's own line on query and index work). Migration 0042 recomputes the index for every stored object, as 0040 did — the CHANGELOG entry says so, since it lands at the first start after upgrading.

## Checks

CI runs the same script; make it pass locally first (CONTRIBUTING.md has the
context, including the store integration test and the fuzz targets).

- [x] `scripts/check` is clean — add `--db` when the change touches the store (`core` incl. the store integration tests against a throwaway PostgreSQL 16, and `lint`, both green here; Docker and `govulncheck` are CI's to verify in this environment)
- [x] Behavior changes come with tests (`TestLoanwordIsLookedUpNotPrefixScanned`, verified to fail before the fix; five golden-set cases; the pinning test now reads the real predicate)

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — untouched
- [x] The change lands on every surface it belongs on — it is one ranking/index change behind every surface at once, and adds none
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens a surface? No — no endpoint, tool, command or variable

## Design docs

- [x] Alters an accepted decision? No. No record states where a word boundary falls; 0080 §4 says the lexical half splits a query into fragments and stays true. Index and query work belongs in this description
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmF42nZ26ztXudQnqrwzZ4)_