### PR TITLE
Measure what a question reaches, not only where the answer lands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,9 @@ last entry.
   runs of one character, asked for as the prefixes `デ:*` and `タ:*`,
   and that is most of the vocabulary a data team writes in: テーブル,
   ロード, パーティション, カレンダー, レポート, ユーザー. Measured over
-  `examples/demo`, each of eight katakana probes returned all twelve
-  concepts — the right one first and eleven trailing it on a shared
-  first character; they now return 2.6 on average. The halfwidth voiced
+  `examples/demo`, a katakana question touched 11.00 of the 12 concepts
+  in the base — the right one first, and the rest trailing it on a
+  shared first character; it now touches 2.60. The halfwidth voiced
   marks (ﾞ ﾟ) and halfwidth ｰ join for the same reason. **Migration 0042
   recomputes the search index for every stored object**, so the first
   start after upgrading writes once per row before it serves; a base of

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,6 +201,17 @@ every Google Cloud deployment runs (design doc 0080 §1.1). The stand-in
 is deterministic, so the fused half needs no API key and reaches no
 network.
 
+Beside recall@10 and MRR it reports **reach**: how many concepts each
+question touched at all, meaned over the set. Ranking numbers read one
+position and are blind to what arrives under it — migration 0042 was
+found outside this harness because every katakana question had degraded
+from a lookup to a prefix scan while recall stayed 1.00 and those cases
+stayed at rank 1. Reach carries a ceiling that fails in both directions,
+like the floors, and is read *with* the recall floor: recall says
+nothing fell out, reach says how much came with it. It is measured on
+the lexical list alone — cosine is never zero, so a fused reach would be
+the corpus size for every query.
+
 Each case is labelled with the dimension of query behaviour it
 exercises — natural questions, keyword lookups, warehouse English
 inside a Japanese sentence, English questions, spelling variants,

--- a/internal/service/searcheval_integration_test.go
+++ b/internal/service/searcheval_integration_test.go
@@ -101,6 +101,12 @@ const (
 	dimShort       = "short"       // two-character terms below trigram
 )
 
+// evalDimensions is the order the per-dimension lines are reported in,
+// and the list both reports read: a dimension named here with no cases
+// under it fails the run rather than printing an empty line.
+var evalDimensions = []string{dimQuestion, dimKeyword, dimMixed, dimEnglish,
+	dimKatakana, dimOrthography, dimSynonyms, dimShort}
+
 // evalCases is the golden set. Keep queries phrased as questions and
 // keywords a data agent would send — the point is aboutness, not exact
 // title matches (those are pinned separately by the name-bonus tests in
@@ -377,6 +383,67 @@ const (
 	evalFusedMRRFloor    = 0.77
 )
 
+// Reach: how many concepts a question touched at all.
+//
+// recall@k and MRR both read one position — where the right answer
+// landed — and are blind to what came with it. Migration 0042 was found
+// outside this harness for exactly that reason: ー was a word boundary,
+// every katakana question had degraded from a lookup to a prefix scan,
+// and the golden set said 1.00 recall and MRR 1.00 on those cases,
+// because the right concept was still first. What was wrong sat
+// underneath it, and no number here could see it.
+//
+// Reach is that number. It is the length of the lexical list — every
+// concept that matched a fragment at all, which is the floor the
+// ranking is built on ("matched something", not a score threshold:
+// design doc 0068 §3). A question that reaches the whole corpus has
+// ranked it, not searched it, and the reader under a byte budget
+// (design doc 0093) pays for the difference.
+//
+// **Lexical only, and that is not a gap to close later.** Cosine is
+// never zero, so the vector half reaches every concept in the corpus by
+// construction; a fused reach would be the corpus size for every query
+// on every run and would measure nothing at all.
+//
+// **Read it with the recall floor, never alone.** Reach falls to 1.00
+// if the search stops finding anything, and it is the recall floor —
+// not this ceiling — that says the answers are still there. The two
+// numbers are one measurement: recall says nothing fell out, reach says
+// how much came with it.
+const (
+	// High enough that nothing is truncated by it: a reach that hit its
+	// own limit would be the limit's number, not the query's, and the
+	// measurement fails rather than reporting it.
+	evalReachLimit = 200
+	// Measured at 6.25 concepts of the 12 this corpus holds. The
+	// ceiling sits two cases' worth over it, the width the floors use,
+	// and fails in both directions for the floors' reason: a ceiling
+	// nobody lowered when a change narrowed the search is budget the
+	// next widening spends without moving a number anybody reads.
+	//
+	// **It was checked against the defect it was written for.** On the
+	// tree before migration 0042 the same set measures 7.44, which
+	// fails this ceiling, and the katakana line reads 11.00 of 12 —
+	// every loanword question touching all but one concept in the base.
+	// recall and MRR over that tree are 1.00 and 0.82, against 1.00 and
+	// 0.83 after: the ranking numbers moved by one point where reach
+	// moved by nine concepts, which is the whole argument for measuring
+	// this at all.
+	//
+	// It moves when the corpus does, as the floors do — a thirteenth
+	// concept is another concept every common fragment can reach.
+	evalReachCeiling = 6.27
+
+	// What the dimensions read after 0042, for the next change to aim
+	// at: question 8.48, english 6.67, orthography 5.67, mixed 5.00,
+	// keyword 4.91, katakana 2.60, synonyms 2.00, short 1.33. The
+	// question line is the widest and the least alarming — a natural
+	// question carries many fragments and a twelve-concept corpus about
+	// one shop shares most of them — while english and orthography are
+	// wide *and* rank worst (MRR 0.69 and 0.67), which is where the two
+	// measurements agree that something is unfinished.
+)
+
 // evalFloorSlackCases is how far a floor may sit under what was measured
 // before that gap is itself a failure, counted in cases.
 //
@@ -507,10 +574,89 @@ func TestSearchEvalIntegration(t *testing.T) {
 	})
 	checkEvalFloors(t, lexical, recall, mrr, evalRecallFloor, evalMRRFloor)
 
+	// What the ranking numbers above cannot see: how much each question
+	// touched on its way to the answer.
+	corpus, err := svc.SearchOrList(ctx, "", "verified_at", "", filter, 1000)
+	if err != nil {
+		t.Fatalf("count the corpus: %v", err)
+	}
+	checkEvalReach(t, measureReach(t, ctx, svc, prefix, len(corpus.Hits)), evalReachCeiling)
+
 	// The same questions with the vector half on, which is the
 	// configuration a Google Cloud deployment runs.
 	fusedRecall, fusedMRR := scoreFusedGoldenSet(t, ctx, svc, prefix)
 	checkEvalFloors(t, "fused", fusedRecall, fusedMRR, evalFusedRecallFloor, evalFusedMRRFloor)
+}
+
+// measureReach reports the mean number of concepts a question reached,
+// with a line per dimension beside it — the same shape the scorer
+// reports, so the two are read together.
+//
+// The worst case is logged by name. A mean says the search narrowed;
+// the question sitting at the top of it says what to look at next, and
+// that is the line that sent this harness to the prolonged sound mark.
+func measureReach(t *testing.T, ctx context.Context, svc *Service, prefix string, corpus int) float64 {
+	t.Helper()
+	filter := store.Filter{Prefixes: []string{prefix}}
+	type tally struct{ cases, reached int }
+	byDim := map[string]*tally{}
+	total, worst, worstQuery := 0, 0, ""
+	for _, c := range evalCases {
+		hits, err := svc.Store.SearchLexical(ctx, c.query, filter, evalReachLimit)
+		if err != nil {
+			t.Fatalf("reach %q: %v", c.query, err)
+		}
+		if len(hits) >= evalReachLimit {
+			t.Fatalf("%q reached %d concepts, filling the limit this is measured at: "+
+				"raise evalReachLimit, or the number is the limit's and not the query's",
+				c.query, len(hits))
+		}
+		total += len(hits)
+		if len(hits) > worst {
+			worst, worstQuery = len(hits), c.query
+		}
+		d := byDim[c.dim]
+		if d == nil {
+			d = &tally{}
+			byDim[c.dim] = d
+		}
+		d.cases++
+		d.reached += len(hits)
+	}
+	for _, dim := range evalDimensions {
+		d := byDim[dim]
+		t.Logf("  %-11s reach = %.2f concepts", dim, float64(d.reached)/float64(d.cases))
+	}
+	mean := float64(total) / float64(len(evalCases))
+	t.Logf("reach = %.2f concepts of %d (widest: %q at %d), lexical only", mean, corpus, worstQuery, worst)
+	return mean
+}
+
+// checkEvalReach holds the reach to its ceiling in both directions, the
+// way checkEvalFloors holds a floor: over it is the widening the
+// ceiling exists to catch, and further under it than
+// evalFloorSlackCases allows is a ceiling nobody lowered when the
+// search narrowed.
+func checkEvalReach(t *testing.T, got, ceiling float64) {
+	t.Helper()
+	slack := evalFloorSlackCases / float64(len(evalCases))
+	switch {
+	case got > ceiling:
+		t.Errorf(`reach rose to %.2f concepts, over the %.2f ceiling: a change widened what every
+question touches. Recall and MRR can both be unmoved while this happens — the right
+answer stays where it was and more wrong ones arrive under it.`, got, ceiling)
+	case ceiling-got > slack:
+		// Rounded down, which is the floors' rule read in the other
+		// direction: a floor is advised upward and a ceiling downward,
+		// because both have to stay on the measurement's side of the
+		// number. Rounding a ceiling up advises a value that fails this
+		// same check on the next run.
+		want := math.Floor((got+slack)*100) / 100
+		t.Errorf(`reach measures %.2f concepts against a ceiling of %.2f — %.1f cases' worth of room,
+wider than the %d evalFloorSlackCases this file allows. Lower the ceiling to at most
+%.2f in the PR that earned it.`,
+			got, ceiling, (ceiling-got)*float64(len(evalCases)), evalFloorSlackCases, want)
+	}
 }
 
 // rank is the position of the first acceptable concept — want, or one of
@@ -581,8 +727,7 @@ func scoreGoldenSet(t *testing.T, config, prefix string, search func(query strin
 	}
 	recall = float64(found) / float64(len(evalCases))
 	mrr /= float64(len(evalCases))
-	for _, dim := range []string{dimQuestion, dimKeyword, dimMixed, dimEnglish,
-		dimKatakana, dimOrthography, dimSynonyms, dimShort} {
+	for _, dim := range evalDimensions {
 		d := byDim[dim]
 		if d == nil {
 			t.Fatalf("dimension %s has no cases; drop it from this list or give it one", dim)

--- a/internal/store/migrations/0042_a_long_vowel_is_inside_the_word.sql
+++ b/internal/store/migrations/0042_a_long_vowel_is_inside_the_word.sql
@@ -10,12 +10,12 @@
 -- character each — asked for as the prefixes デ:* and タ:*, and stored
 -- as the lone lexeme デ.
 --
--- Measured over examples/demo before this migration: each of the eight
--- katakana probes (データ, テーブル, ロード, フィード, パーティション,
--- レポート, ページ, コード) returned all twelve concepts. The right one
--- ranked first — the scorer is not what was broken — and eleven
--- unrelated concepts followed it with a non-zero score, on the strength
--- of a shared first character. That is the corpus reading itself, which
+-- Measured over examples/demo before this migration: a katakana
+-- question reached 11.00 of the 12 concepts in the base, and reaches
+-- 2.60 after it (the harness reports this as the katakana dimension's
+-- reach). The right one ranked first either way — the scorer is not
+-- what was broken — and the rest followed it with a non-zero score, on
+-- the strength of a shared first character. That is the corpus reading itself, which
 -- is the cost 0036 exists to have removed, and it applies to most of
 -- the vocabulary a data team writes in.
 --

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -234,9 +234,9 @@ func scriptWithoutSpaces(r rune) bool {
 // **That is most of a data team's vocabulary.** テーブル, ロード,
 // パーティション, カレンダー, レポート, ユーザー, サービスアカウント:
 // each was a prefix scan rather than a lookup, and the corpus answered
-// every one of them with all of itself — the eight katakana probes over
-// examples/demo each returned all twelve concepts, the right one first
-// and eleven trailing it on a shared first character. Migration 0036
+// every one of them with most of itself — over examples/demo a katakana
+// question reached 11.00 of the base's 12 concepts, the right one first
+// and the rest trailing it on a shared first character. Migration 0036
 // exists so a two-character Japanese term stops reading the table, and
 // for every word with a long vowel in it the mark had quietly given
 // that back.


### PR DESCRIPTION
<!-- Keep PRs small and focused. Link the issue or design doc, if there is one. -->

## What and why

Item 3 of the backlog #702 left: the harness could not see the defect #702 fixed.

recall@k and MRR both read **one position** — where the right answer landed — and are blind to what arrives under it. When ー was a word boundary and every katakana question had degraded from a lookup to a prefix scan, this harness reported recall 1.00 with all five katakana cases at rank 1. The defect was found with a probe written by hand, run once, and thrown away. That is the part this PR fixes.

**Reach** is that probe made standing: the length of the lexical list — every concept that matched a fragment at all, which is the floor the ranking sits on (design doc 0068 §3: "matched something", not a score threshold). A question that reaches the whole corpus has ranked it rather than searched it, and the caller under a byte budget (0093) pays for the difference.

### It was checked against the defect it was written for

Same golden set, same corpus; the only difference is the tree.

| | before 0042 | after 0042 |
|---|---|---|
| **reach (mean of 61 cases)** | **7.44** — fails the 6.27 ceiling | **6.25** |
| — katakana dimension | **11.00 of 12 concepts** | **2.60** |
| — mixed | 7.00 | 5.00 |
| — keyword | 5.64 | 4.91 |
| recall@10 | 1.00 | 1.00 |
| MRR (lexical) | 0.82 | 0.83 |

Nine concepts of reach against one point of MRR. The ranking numbers were never going to carry that, and now something does.

### Design

- **Two-sided ceiling**, like the floors: over it is the widening it exists to catch; more than `evalFloorSlackCases` under it is a ceiling nobody lowered when a change narrowed the search. The rounding goes the other way from a floor's — a floor is advised upward and a ceiling downward, because both have to stay on the measurement's side of the number.
- **Read with the recall floor, never alone.** Reach falls to 1.00 if search stops finding anything; the recall floor is what says the answers are still there. Recall says nothing fell out, reach says how much came with it — one measurement in two numbers.
- **Lexical only, deliberately.** Cosine is never zero, so the vector half reaches every concept by construction; a fused reach would report the corpus size on every run and measure nothing.
- **Per dimension, and the widest question by name.** A mean says the search narrowed; the question at the top of it says what to look at next. That line is what sent the last PR to the prolonged sound mark.

After 0042 the dimensions read: question 8.48, english 6.67, orthography 5.67, mixed 5.00, keyword 4.91, katakana 2.60, synonyms 2.00, short 1.33. English and orthography are wide *and* rank worst (MRR 0.69, 0.67) — the two measurements agreeing on where the next change belongs.

### A correction to #702

Three numbers in #702 came from the hand-run probe, which was capped at `limit 10` and ran without the inline supplement — so "each of eight katakana probes returned all twelve concepts" was the cap talking, not the search. The standing measurement gives the honest figures: **11.00 of 12 before, 2.60 after**. The CHANGELOG entry, migration 0042's note and the comment in `search.go` are corrected here to cite the measurement the test now computes and holds, rather than a probe nobody can re-run.

## Checks

CI runs the same script; make it pass locally first (CONTRIBUTING.md has the
context, including the store integration test and the fuzz targets).

- [x] `scripts/check` is clean — add `--db` when the change touches the store (`core` incl. store integration tests against a throwaway PostgreSQL 16, and `lint`; Docker and `govulncheck` are CI's to verify in this environment)
- [x] Behavior changes come with tests — this PR is a test, and it was validated by running it against the pre-0042 tree, where it fails as designed

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and `internal/apiclient` say the same thing — untouched
- [x] The change lands on every surface it belongs on — it touches none; the diff is one integration test, contributor docs, and three corrected numbers
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens a surface? No

## Design docs

- [x] Alters an accepted decision? No — a measurement of existing behaviour, plus a correction to numbers written in prose
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmF42nZ26ztXudQnqrwzZ4)_