### PR TITLE
Keep a claim's timestamps as the document wrote them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,19 @@ last entry.
 
 ### Fixed
 
+- **A claim keeps the timestamps the document wrote.** A received
+  document's trust family is kept as its own claim under `received:`
+  ([0075](docs/design/0075-the-bundle-is-the-address-space.md) §3.1) —
+  but YAML types an unquoted date-time, and rendering that back had to
+  pick a spelling again: `at: 2026-07-01T00:00:00Z` was stored as the
+  bare date `2026-07-01`, and `at: 2026-07-01 09:30:00` as
+  `2026-07-01T09:30:00Z`. A claim now carries the text as written, which
+  is what a claim is for. Only documents from another producer were
+  affected — this instance's own export form quotes its timestamps, so
+  the export → review → import loop is unchanged — and a claim already
+  stored keeps the spelling it landed with, because the bytes it arrived
+  in are gone; re-importing the bundle it came from restores it.
+
 - **A katakana word with a long vowel in it is one search term.**
   ー belongs to no script — Unicode calls it Common, because it is
   written after hiragana as readily as after katakana — so both halves

--- a/internal/okf/raw.go
+++ b/internal/okf/raw.go
@@ -253,6 +253,7 @@ func MoveServerKeys(raw []byte) (doc []byte, claimed []string, claim map[string]
 		if !serverOwnedKeys[pairs[i].Value] {
 			continue
 		}
+		keepTimestampText(pairs[i+1])
 		var v any
 		if err := pairs[i+1].Decode(&v); err != nil {
 			continue
@@ -272,6 +273,29 @@ func MoveServerKeys(raw []byte) (doc []byte, claimed []string, claim map[string]
 	}
 	out := appendFrontmatter(stripped, block)
 	return out, claimed, ClaimOf(out)
+}
+
+// keepTimestampText makes every timestamp under n decode as the text it
+// was written as, by retagging it a string in place.
+//
+// A claim is what the document asserted (design doc 0075 §3.1), and a
+// timestamp is the one scalar that cannot survive the trip through Go: a
+// node YAML resolves to time.Time has to be given a spelling again on the
+// way out, and the value alone no longer says which one it arrived in.
+// So `at: 2026-07-01T00:00:00Z` came back out as the bare date
+// `2026-07-01` (yamlScalar reads a zero clock as a date, which is what
+// keeps `stale_after: 2026-12-31` a day rather than an instant), and
+// `at: 2026-07-01 09:30:00` came back out in the T form. Neither is what
+// the document said. Retagging costs nothing else: the node already holds
+// the written text, and a claim is stored as text anyway (textify).
+func keepTimestampText(n *yaml.Node) {
+	// !!timestamp is what YAML resolves an unquoted date or date-time to.
+	if n.Kind == yaml.ScalarNode && n.Tag == "!!timestamp" {
+		n.Tag = "!!str"
+	}
+	for _, c := range n.Content {
+		keepTimestampText(c)
+	}
 }
 
 // ClaimOf reads ClaimKey back out of a document, which is how a caller

--- a/internal/okf/raw_test.go
+++ b/internal/okf/raw_test.go
@@ -193,6 +193,48 @@ func TestForeignTrustFamilyBecomesAClaim(t *testing.T) {
 	}
 }
 
+// A claim is what the document asserted, down to how it spelled its
+// timestamps: YAML types an unquoted date-time, and rendering that back
+// used to hand a midnight instant out as a bare date and the
+// space-separated form out as the T form (design doc 0075 §3.1).
+func TestAClaimKeepsTheTimestampsAsWritten(t *testing.T) {
+	in := "---\ntype: Metric\ntitle: Revenue\n" +
+		"generated:\n  by: human:sato@example.co.jp\n  at: 2026-07-01T00:00:00Z\n" +
+		"verified:\n- by: human:ceo@example.co.jp\n  at: 2026-07-02 09:30:00\n" +
+		"- by: human:cfo@example.co.jp\n  at: 2026-07-03\n---\n\n本文。\n"
+	d, _, err := Parse([]byte(in))
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, ok := d.Attrs[ClaimKey].(map[string]any)
+	if !ok {
+		t.Fatalf("no claim was kept: %#v", d.Attrs)
+	}
+	generated, _ := claim["generated"].(map[string]any)
+	if got := generated["at"]; got != "2026-07-01T00:00:00Z" {
+		t.Errorf("claim.generated.at = %#v, want the instant the document wrote", got)
+	}
+	verified, _ := claim["verified"].([]any)
+	if len(verified) != 2 {
+		t.Fatalf("claim.verified = %#v", claim["verified"])
+	}
+	for i, want := range []string{"2026-07-02 09:30:00", "2026-07-03"} {
+		e, _ := verified[i].(map[string]any)
+		if got := e["at"]; got != want {
+			t.Errorf("claim.verified[%d].at = %#v, want %q", i, got, want)
+		}
+	}
+	// And the stored document says the same thing as the map beside it,
+	// through as many round trips as the bundle is carried.
+	back, _, err := Parse([]byte(d.Doc))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if back.Doc != d.Doc {
+		t.Errorf("a claim did not survive re-import:\n--- want ---\n%s\n--- got ---\n%s", d.Doc, back.Doc)
+	}
+}
+
 // A move rewrites a referring entry's body. Its frontmatter is not what
 // changed, and must come out byte for byte (design doc 0046 §2.2).
 func TestReplaceBodyLeavesFrontmatterAlone(t *testing.T) {


### PR DESCRIPTION
## What and why

A received document's trust family is kept as its own claim under `received:`
(design doc [0075](https://github.com/na0fu3y/ochakai/blob/main/docs/design/0075-the-bundle-is-the-address-space.md) §3.1),
but `MoveServerKeys` decoded each value to `any` first. YAML types an unquoted
date-time, so a claim's timestamps arrived as `time.Time` and had to be given a
spelling again on the way out:

| the document wrote | the claim stored (before) |
|---|---|
| `at: 2026-07-01T00:00:00Z` | `at: "2026-07-01"` |
| `at: 2026-07-01 09:30:00` | `at: "2026-07-01T09:30:00Z"` |

Neither is what the document asserted, which is the one thing a claim is there
to hold. The bare date comes from `yamlScalar` reading a zero clock as a day —
correct for `stale_after: 2026-12-31`, wrong for a midnight instant.

The fix retags the timestamp scalars as strings before decoding: the node
already carries the text as written, and a claim is stored as text anyway
(`textify`). Nothing else changes.

Found while tracing what an imported-then-verified concept looks like on
export. It is a defect against a decision already recorded, not a new decision —
no surface moves and no numbered doc is needed.

**Scope**

- Only documents from another producer are affected. This instance's own export
  form quotes its timestamps, so `export → review → import` still stores the
  same bytes, and `IsObservation` still recognizes an export coming home.
- The v0.1 flat `verified_at:` spelling goes through the same path and is
  covered.
- A claim already stored keeps the spelling it landed with — the bytes it
  arrived in are gone. Re-importing the source bundle restores it.

## Checks

- [x] `scripts/check` is clean — `core`, `core --db` and `lint` all pass here
      (`--db` against the machine's PostgreSQL 16.13, not CI's
      pgvector/pgvector:pg17). `vuln` is not verifiable in this environment:
      the proxy refuses vuln.go.dev, so CI is where that one runs.
- [x] Behavior changes come with tests — `TestAClaimKeepsTheTimestampsAsWritten`
      covers the instant, the space-separated form and a plain date, and fails
      on `main`.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver` and
      `internal/apiclient` are untouched and still agree — the change is inside
      the shared write path.
- [x] It lands wherever a document is written, which is every surface at once:
      `MoveServerKeys` is below REST / MCP / CLI / Web UI.
- [x] `api/openapi.frozen.txt` is untouched.
- [x] No surface is widened — no endpoint, tool, command or variable. Nothing
      to add to `docs/surface.md`.

## Design docs

- [x] Not applicable: this alters no accepted decision. It makes the code say
      what 0075 §3.1 already decided — `received:` records what the document
      asserted.
- [x] Commit messages and code comments are in English.

---
_Generated by [Claude Code](https://claude.ai/code/session_015oENT7psShEJ61Ms8PnqFo)_