### PR TITLE
Let an honorific prefix begin a content window

### DIFF
--- a/internal/store/filter_test.go
+++ b/internal/store/filter_test.go
@@ -202,6 +202,23 @@ func TestQueryFragments(t *testing.T) {
 		{"latin infix", "EC売上高", []string{"EC", "売上", "上高"}},
 		{"all-kana query keeps its windows", "ください",
 			[]string{"くだ", "ださ", "さい"}},
+		// An honorific prefix is the exception to "a content word does
+		// not begin with hiragana": お盆 and ご要望 are words, and the
+		// window that spells them is the only one that finds them —
+		// 盆の and 望の depend on the particle the document happened to
+		// use. Without this, 「お盆」 finds the entry and 「お盆は」 does
+		// not, which is the difference between a term and a question.
+		{"honorific prefix keeps its window", "お盆の影響",
+			[]string{"お盆", "盆の", "影響"}},
+		{"honorific prefix in a question", "ご要望の件",
+			[]string{"ご要", "要望", "望の"}},
+		// Only お and ご, and only before a content character: ぜ売
+		// (なぜ売上) is still a straddling fragment, and おく (〜しておく)
+		// is still grammar.
+		{"other hiragana still straddles", "なぜ売上が下がる",
+			[]string{"売上", "上が", "下が"}},
+		{"honorific before hiragana is grammar", "対応しておく",
+			[]string{"対応", "応し"}},
 		{"short japanese term", "売上", []string{"売上"}},
 		{"mixed scripts", "revenue 売上高", []string{"revenue", "売上", "上高"}},
 		{"punctuation only falls back to the query", "???", []string{"???"}},

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -120,13 +120,20 @@ func queryFragments(query string) []string {
 //
 // A run with no content character at all — an all-kana query like
 // ください — keeps every window, or it would match nothing.
+//
+// The honorific prefixes are the exception to the first-character rule,
+// because お盆 and ご要望 are content words that do begin with hiragana.
+// Their window is the only fragment that finds them: the one after it
+// (盆の, 望の) carries whichever particle the document happened to use,
+// so 「お盆」 found an entry and 「お盆は」 found nothing until this
+// branch existed.
 func contentWindows(runes []rune) []string {
 	all := make([]string, 0, len(runes))
 	var content []string
 	for i := 0; i+2 <= len(runes); i++ {
 		w := string(runes[i : i+2])
 		all = append(all, w)
-		if contentChar(runes[i]) {
+		if contentChar(runes[i]) || honorific(runes[i], runes[i+1]) {
 			content = append(content, w)
 		}
 	}
@@ -220,6 +227,19 @@ func scriptWithoutSpaces(r rune) bool {
 // grammar around it.
 func contentChar(r rune) bool {
 	return unicode.Is(unicode.Han, r) || unicode.Is(unicode.Katakana, r)
+}
+
+// honorific reports whether first and second spell a content word behind
+// an honorific prefix — お盆, ご要望 — which is the one shape in which a
+// word begins with hiragana.
+//
+// Both conditions carry weight. Restricting it to お and ご keeps ぜ売
+// (なぜ売上) a straddling fragment, and requiring a content character
+// after keeps おく (〜しておく) grammar: without the second test every
+// hiragana-to-kanji boundary in a question would become a fragment, which
+// is what the first-character rule exists to exclude.
+func honorific(first, second rune) bool {
+	return (first == 'お' || first == 'ご') && contentChar(second)
 }
 
 // fragmentQuery renders the tsquery that finds one fragment in


### PR DESCRIPTION
Fixes #708.

## What and why

`contentWindows` keeps only the two-character windows that begin with a content character (Han or Katakana), on the rule that Japanese grammar is written in hiragana and content words are not. **お盆 and ご要望 are the shape that rule does not cover**: content words that do begin with hiragana.

The window spelling such a word was dropped from every query, so the only fragment left to find it was the next one along — `盆の`, `望の` — which carries whichever particle the document happened to use. Observable result, against `examples/demo`, whose `insights/reading-revenue` has お盆 in the body:

```
ochakai search "お盆"       → 1 hit
ochakai search "お盆は"     → 0 hits   ← one particle, and it is gone
ochakai search "お盆の影響"  → 0 hits
ochakai search "お盆 影響"   → 1 hit   ← a space puts it back
```

That is the difference between a term and a question, and the question is the shape an agent sends.

**The fix keeps a window that begins with お or ご when a content character follows.** Both conditions carry weight: restricting it to those two prefixes keeps `ぜ売` (なぜ売上) a straddling fragment, and requiring a content character after keeps `おく` (〜しておく) grammar. Without the second test, every hiragana-to-kanji boundary in a question would become a fragment, which is what the first-character rule exists to exclude.

### Measured, not argued

Lexical-only (`OCHAKAI_EMBEDDINGS=off`) against a 20-concept base (`examples/demo` + `kb/bundle`), over 22 Japanese questions an agent would plausibly send — the harness from https://github.com/na0fu3y/ochakai/issues/699#issuecomment-5356397720:

| | before | after |
|---|---|---|
| top-1 | 13/22 (59%) | 14/22 (64%) |
| top-3 | 21/22 (95%) | **22/22 (100%)** |
| MRR | 0.77 | 0.81 |
| 0 件で返った質問 | 1 | 0 |

**Every other question's rank and hit count is unchanged.** The one that moved is the one that was broken.

### What it costs, named

The new branch admits politeness formulas as fragments. Probing real code with natural questions:

```
ご覧のとおり売上は落ちている  -> ["ご覧" "覧の" "売上" "上は" "落ち"]
お客様からの問い合わせ件数    -> ["お客" "客様" "様か" "問い" "合わ" "件数"]
対応しておく必要はあるか      -> ["対応" "応し" "必要" "要は"]   ← おく stays out
```

`ご覧` in 「ご覧のとおり」 is discourse framing, not the subject of the question, and it is now a fragment. Since scoring weights rare fragments highest, a politeness formula that is rare in the base could pull rank — the same failure mode the original comment warns about. On this base nothing moved, but this base has no such text; **a larger corpus is where that would show**, and it is the thing to watch if the ranking ever looks odd around 「お世話になっております」-shaped prose. I judged the recall it buys worth naming the cost rather than widening the rule further.

## Checks

- [x] `scripts/check` is clean — `scripts/check --db core` (all packages incl. the store integration tests) and `scripts/check lint` (0 issues) both pass. Note the store tests ran against **PostgreSQL 16.13**, not the pgvector/pgvector:pg17 CI uses; `scripts/check vuln` is unverifiable in this environment (the proxy refuses vuln.go.dev, which is the host being blocked, not a finding)
- [x] Behavior changes come with tests — `TestQueryFragments` gains four cases: the two honorific shapes that were broken, and the two that must stay excluded (`ぜ売`, `しておく`). The two exclusion cases passed before the change, which is what says the fix is narrow

## Surfaces and contract

- [x] No surface change: `contentWindows` is unexported and internal to `internal/store`. REST, MCP, CLI and the web UI all reach it through the same `search`, and none of their shapes change
- [x] `api/openapi.frozen.txt` untouched
- [x] Nothing to add to `docs/surface.md` — no endpoint, tool, command or variable

## Design docs

- [ ] **Not applicable, and this is the judgment worth a reviewer's eye.** I read this as an internal change that leaves the outside contract unchanged — search still returns hits ranked, and 0080's decision (how a deployment embeds, and that Japanese is cut into two-character windows) is unaltered; what changes is that one class of word is no longer dropped on the way in. If you read the set of fragments a query becomes as itself observable, this belongs in 0080's lineage instead and I will write the doc
- [x] Commit messages and code comments are in English

## How it was found

Not by reading the code. It surfaced as the single 0-hit question while measuring lexical-only search for #699 — with embeddings on, the semantic side would likely have covered it, so the deployments that would have kept hitting this are exactly the ones off Google Cloud (design doc 0086's OIDC path), where lexical is all there is.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L6Tu4wtbTZiKQ5epBa9jfL)_