### PR TITLE
Release 0.26.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Version
       description: Output of `ochakai version`, or the image tag you deployed.
-      placeholder: "0.26.1"
+      placeholder: "0.26.2"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ last entry.
 
 ## [Unreleased]
 
+## [0.26.2] - 2026-08-21
+
 ### Fixed
 
 - **A claim keeps the timestamps the document wrote.** A received
@@ -51,6 +53,26 @@ last entry.
   recomputes the search index for every stored object**, so the first
   start after upgrading writes once per row before it serves; a base of
   a few thousand concepts takes seconds, and nothing else is affected.
+
+- **An honorific prefix no longer takes the word behind it out of the
+  query.** Japanese is cut into two-character windows, and a window was
+  kept only when it began with a content character — grammar is written
+  in hiragana, and that rule holds right up until the content word
+  itself begins with one. お盆 and ご要望 are that shape: the window
+  spelling the word was dropped from every query, leaving only the next
+  window along (`盆の`, `望の`), which carries whichever particle the
+  document happened to use. `ochakai search "お盆"` found the concept
+  and `ochakai search "お盆は"` found nothing — one particle, and the
+  question was gone. A window beginning お or ご now survives when a
+  content character follows it, and both halves of that test carry
+  weight: `おく` (〜しておく) has to stay grammar. Measured lexical-only
+  over 22 Japanese questions against a 20-concept base, top-3 recall
+  goes 21/22 to 22/22 and MRR 0.77 to 0.81, and no other question's
+  rank moved. **This is the query side only** — the stored index has
+  always kept every window — so nothing is reindexed for it. The cost,
+  named: a politeness formula (`ご覧のとおり`) is now a fragment too,
+  and scoring weights rare fragments highest, so a base holding a lot
+  of polite prose is where to watch the ranking.
 
 ### Changed
 
@@ -4854,7 +4876,8 @@ worth naming: SQL injection in `compile_sql` through undeclared field
 pass-through, fixed in 0.8.0 — v0.7.0 and earlier are affected. Details
 are in git history.
 
-[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.26.1...HEAD
+[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.26.2...HEAD
+[0.26.2]: https://github.com/na0fu3y/ochakai/compare/v0.26.1...v0.26.2
 [0.26.1]: https://github.com/na0fu3y/ochakai/compare/v0.26.0...v0.26.1
 [0.26.0]: https://github.com/na0fu3y/ochakai/compare/v0.25.0...v0.26.0
 [0.25.0]: https://github.com/na0fu3y/ochakai/compare/v0.24.1...v0.25.0

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -74,7 +74,7 @@ info:
     is a security defect, shipped in the next release with no deprecation
     window (SECURITY.md). MCP, the CLI and the stored shape stay unstable
     while the major version is 0 and may still change in a minor release.
-  version: 0.26.1
+  version: 0.26.2
   license:
     name: MIT
 servers:

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -77,7 +77,7 @@ export IMAGE=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:$VERSION
 `:latest` ではなくバージョンを固定し、再デプロイを意識的な判断にする。
 `gh` CLI が無ければ
 [リリースページ](https://github.com/na0fu3y/ochakai/releases)から番号
-を読み、手で設定する — `export VERSION=0.26.1`。
+を読み、手で設定する — `export VERSION=0.26.2`。
 
 (このガイドは 0.9.0 以降を前提にしている。それより前のリリースは
 [retract](https://go.dev/ref/mod#go-mod-file-retract) 済みでサポート外

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -5,7 +5,7 @@ region     = "us-central1"
 
 # Pin a released version, not "latest", so a redeploy is a decision:
 # https://github.com/na0fu3y/ochakai/releases
-image_tag = "0.26.1"
+image_tag = "0.26.2"
 
 # Who can reach ochakai. This is the whole access-control surface — whoever
 # reaches it can read and write everything. Never allUsers.


### PR DESCRIPTION
## What and why

0.26.2 のリリース準備。`[Unreleased]` を `## [0.26.2] - 2026-08-21` に閉じ、
版番号を持つ他の四ファイル（OpenAPI の `info.version`、bug report テンプレート
の placeholder、デプロイガイドの手書き `export VERSION=`、Terraform 例の
`image_tag`）を追随させる。`TestReleaseVersionsAgree` がこの四つを見ている。

**patch 版なのは、未リリース節に `BREAKING` が一つも無いため**（`grep -c` で 0）。
デモバンドルの入れ替えは同梱の例データの id が変わるだけで、契約は動いていない。

**未記載だった修正を一件足した。** `git log v0.26.1..origin/main` を突き合わせた
ところ、[#709](https://github.com/na0fu3y/ochakai/pull/709)（お盆・ご要望のような
接頭辞つき内容語が全クエリから落ちていた）が `internal/store/search.go` を触って
いるのに CHANGELOG に無かった。検索の当たり方が変わる、アップグレードする人が
知りたい種類の修正なので Fixed に追記した。クエリ側だけの変更で索引は全窓を
保持し続けているため、再索引も移行も要らない旨も併記してある。

他の未記載コミットは意図的にそのまま：
[#710](https://github.com/na0fu3y/ochakai/pull/710) /
[#711](https://github.com/na0fu3y/ochakai/pull/711) は `docs/positioning.md` と
`docs/faq.md` の散文、[#695](https://github.com/na0fu3y/ochakai/pull/695) /
[#704](https://github.com/na0fu3y/ochakai/pull/704) は検索評価ハーネスと
CONTRIBUTING で、いずれも外から観測できる変化ではない。

`mcpserver.RetiredToolNames` と `retiredCommands` はどちらも空なので、この
リリースで閉じる改名の猶予窓は無い。

## Checks

- [x] `scripts/check` is clean — `scripts/check`（lint 0 issues、govulncheck
  0 vulnerabilities）と `scripts/check --db core`（Postgres 込み）の両方が緑
- [x] Behavior changes come with tests — コードの変更は無く、版番号と散文のみ。
  `TestReleaseVersionsAgree` が四ファイルの一致を、
  `TestARetiredNameLastsOneRelease` が空の改名表を見ている

## Surfaces and contract

- [x] `api/openapi.yaml` の変更は `info.version` の一行のみ。`internal/restapi`、
  `internal/mcpserver`、`internal/apiclient` に対応する変更は無い
- [x] 面は増減しない
- [x] `api/openapi.frozen.txt` is untouched
- [x] `docs/surface.md` に足すものは無い — エンドポイントもツールもコマンドも
  変数も増えていない

## Design docs

- [x] Not applicable — 決定は動いていない
- [x] Commit messages and code comments are in English
