### PR TITLE
Give the eval a second domain, and measure what leaks between them

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,24 +193,31 @@ and cheap to delete once it has been read.
 The standing measurement is `TestSearchEvalIntegration`
 (`internal/service/searcheval_integration_test.go`): a golden set of
 questions, each paired with the concept a good ranking puts in front of
-the reader, scored as recall@10 and MRR over the shipped `examples/demo`
-bundle. It runs the set twice — lexical only, which is the search a
-deployment without Vertex AI gets, and lexical fused with a vector
-ranking from the stand-in encoder beside it, which is the configuration
-every Google Cloud deployment runs (design doc 0080 §1.1). The stand-in
-is deterministic, so the fused half needs no API key and reaches no
-network.
+the reader, scored as recall@10 and MRR over one base holding two of the
+bundles this repository ships — `examples/demo` and `kb/bundle`,
+twenty-eight concepts across two domains that share nothing but the
+language they are written in. It runs the set twice — lexical only,
+which is the search a deployment without Vertex AI gets, and lexical
+fused with a vector ranking from the stand-in encoder beside it, which
+is the configuration every Google Cloud deployment runs (design doc 0080
+§1.1). The stand-in is deterministic, so the fused half needs no API key
+and reaches no network.
 
 Beside recall@10 and MRR it reports **reach**: how many concepts each
 question touched at all, meaned over the set. Ranking numbers read one
 position and are blind to what arrives under it — migration 0042 was
 found outside this harness because every katakana question had degraded
 from a lookup to a prefix scan while recall stayed 1.00 and those cases
-stayed at rank 1. Reach carries a ceiling that fails in both directions,
-like the floors, and is read *with* the recall floor: recall says
-nothing fell out, reach says how much came with it. It is measured on
-the lexical list alone — cosine is never zero, so a fused reach would be
-the corpus size for every query.
+stayed at rank 1. Beside it, and the reason the base holds two bundles
+rather than one, is **leak**: how many of the concepts a question
+reached came from the domain it was not about, which is the search
+matching on Japanese rather than on subject. A corpus about one subject
+cannot ask that question — there, reaching every neighbour is honest.
+Both carry a ceiling that fails in both directions, like the floors, and
+reach is read *with* the recall floor: recall says nothing fell out,
+reach says how much came with it. It is measured on the lexical list
+alone — cosine is never zero, so a fused reach would be the corpus size
+for every query.
 
 Each case is labelled with the dimension of query behaviour it
 exercises — natural questions, keyword lookups, warehouse English

--- a/internal/service/searcheval_integration_test.go
+++ b/internal/service/searcheval_integration_test.go
@@ -19,14 +19,23 @@ import (
 
 // This file is the search evaluation harness (issue #528): a golden set
 // of questions with the concept each one is expected to surface, scored
-// as recall@k and MRR over the shipped demo bundle. Ranking changes land
-// with these numbers in the PR; the floors below pin the current
-// baseline so a regression fails instead of shipping quietly.
+// as recall@k and MRR over the bundles this repository ships. Ranking
+// changes land with these numbers in the PR; the floors below pin the
+// current baseline so a regression fails instead of shipping quietly.
 //
-// The corpus is examples/demo — the same eighteen concepts the quick
-// start loads — imported under a run-unique prefix so a shared test
-// database neither collides nor pollutes, plus one Japanese concept
-// defined inline.
+// **The corpus is two bundles and one base**, imported under a
+// run-unique prefix so a shared test database neither collides nor
+// pollutes: examples/demo, the eighteen concepts the quick start loads,
+// plus kb/bundle, the nine concepts of ochakai's own development
+// knowledge, plus one Japanese concept defined inline.
+//
+// The second bundle is here because one was not a base, it was a topic.
+// Every question asked of examples/demo alone is a question about a
+// shop asked of a corpus entirely about that shop, so sharing 売上 with
+// every neighbour is the normal condition and no measurement can
+// separate "matched the subject" from "matched Japanese". With two
+// domains it can, and the separation has a number: leak, below. It
+// found a defect on the first run.
 //
 // The supplement used to be the only Japanese here, because the demo had
 // none and the two-character windows a Japanese question is cut into
@@ -100,6 +109,17 @@ const (
 	dimSynonyms    = "synonyms"    // names only the synonyms key holds
 	dimShort       = "short"       // two-character terms below trigram
 )
+
+// evalKBPrefix is the path segment the project's own bundle is loaded
+// under, and so the test for which domain a concept or a hit belongs
+// to. A real base is not one topic — this one is a shop's analytics and
+// ochakai's own development knowledge, sharing nothing but the language
+// they are written in.
+const evalKBPrefix = "kb"
+
+// inKB reports whether an id relative to the run prefix is in the
+// project's own bundle rather than the shop's.
+func inKB(id string) bool { return strings.HasPrefix(id, evalKBPrefix+"/") }
 
 // evalDimensions is the order the per-dimension lines are reported in,
 // and the list both reports read: a dimension named here with no cases
@@ -268,6 +288,50 @@ var evalCases = []evalCase{
 	// supplement below, in a corpus with no other home for it; 粗利 and
 	// 定価 are the demo's own, a couple of sentences in the products
 	// concept about which price column means what.
+	// The project's own bundle, in the same base (evalKBPrefix). These
+	// are the questions a developer asks ochakai about ochakai, and they
+	// are here for two reasons.
+	//
+	// One is what they are made of: real developer Japanese, written by
+	// whoever learned the thing, with the English of the trade left
+	// standing inside it — MCP, testdb.Unique, DOC-LINES, ICU. The demo
+	// is prose about a store, and however carefully it is written it is
+	// written by somebody who knew a search would read it.
+	//
+	// The other is what they are asked *against*. Every case above is a
+	// question about a store, asked of a base that is entirely about
+	// that store, where sharing 売上 with every neighbour is the normal
+	// condition. A base holding two unrelated domains is what a team
+	// actually has, and it is the only arrangement in which a question
+	// can be asked whether it stayed in its own — which is the leak
+	// measured below.
+	//
+	// Two of them are deliberately words the store also uses. 行数 is a
+	// row count over there and a page's length here; 書き戻す is an
+	// outcome reported there and a concept landing in kb/ here. Same
+	// characters, unrelated subjects — which is the whole question a
+	// two-domain base is able to ask.
+	{query: "ツールは少ないほうが安いのか", want: "kb/insights/mcp-bytes-not-tool-count", dim: dimQuestion},
+	{query: "semantica との比較", want: "kb/insights/mcp-bytes-not-tool-count", dim: dimQuestion},
+	{query: "テストの id はどこから取るか", want: "kb/insights/store-tests-shared-db", dim: dimQuestion},
+	{query: "自前の名前空間", want: "kb/insights/store-tests-shared-db", dim: dimKeyword},
+	{query: "日本語にすると行数は減るか", want: "kb/insights/translation-costs-lines", dim: dimQuestion},
+	{query: "見出しを訳すとリンクが死ぬ", want: "kb/insights/translation-costs-lines", dim: dimQuestion},
+	{query: "AI が verify を打ってよいか", want: "kb/policies/ai-human-identity", dim: dimQuestion},
+	{query: "匿名で記録されてしまう", want: "kb/policies/ai-human-identity", dim: dimQuestion},
+	{query: "Docker が無い環境でインスタンスを立てる", want: "kb/skills/dogfood-instance-without-docker", dim: dimMixed},
+	{query: "リモートセッションで正直に言えるチェック", want: "kb/skills/remote-session-checks", dim: dimQuestion},
+	{query: "スクリーンショットの撮り直しで踏む罠", want: "kb/skills/webui-screenshots", dim: dimQuestion},
+	{query: "ダークスキーム", want: "kb/skills/webui-screenshots", dim: dimKatakana},
+	{query: "文書から concept を起こす線引き", want: "kb/skills/extract-into-kb",
+		accept: []string{"kb/skills/remote-session-checks"}, dim: dimMixed},
+	{query: "学びをどこに書き戻すか", want: "kb/skills/run-the-dogfood-loop", dim: dimQuestion},
+	// The trade's English, inside the base that is written in Japanese
+	// around it — the same shape as the warehouse's column names above,
+	// arrived at from the other domain.
+	{query: "testdb.Unique", want: "kb/insights/store-tests-shared-db", dim: dimEnglish},
+	{query: "DOC-LINES", want: "kb/insights/translation-costs-lines", dim: dimEnglish},
+	{query: "ICU ロケール", want: "kb/skills/webui-screenshots", dim: dimMixed},
 	{query: "解約率", want: "ja/metrics/kaiyakuritsu", dim: dimShort},
 	{query: "解約の分母", want: "ja/metrics/kaiyakuritsu", dim: dimShort},
 	{query: "粗利", want: "tables/products", dim: dimShort},
@@ -385,7 +449,7 @@ const (
 	// to rank 2 is 0.007 here, so a floor closer than that fails on
 	// noise.
 	evalRecallFloor = 0.98
-	evalMRRFloor    = 0.85
+	evalMRRFloor    = 0.88
 	// Fused: the same questions with the stand-in encoder on, measured
 	// at 1.00 / 0.87. This floor is the one that catches the verified
 	// addend going back to 0.002 — that constant is the kind that gets
@@ -443,7 +507,7 @@ const (
 	// own limit would be the limit's number, not the query's, and the
 	// measurement fails rather than reporting it.
 	evalReachLimit = 200
-	// Measured at 10.54 concepts of the 19 this corpus holds. The
+	// Measured at 12.59 concepts of the 28 this corpus holds. The
 	// ceiling sits two cases' worth over it, the width the floors use,
 	// and fails in both directions for the floors' reason: a ceiling
 	// nobody lowered when a change narrowed the search is budget the
@@ -457,13 +521,37 @@ const (
 	// one point across that fix where reach moved by nine concepts,
 	// which is the whole argument for measuring this at all.
 	//
-	// **It moves when the corpus does, and it did.** The thelook rewrite
-	// replaced twelve concepts with nineteen, so the number here is not
-	// comparable with the 6.25 above: as a share of the base it went
-	// from 52% to 56%. A monolingual corpus about one store shares its
-	// common fragments across everything in it, and eighteen concepts
-	// have more of each other to reach than eleven did.
-	evalReachCeiling = 10.56
+	// **It moves when the corpus does, and it has twice.** The thelook
+	// rewrite replaced twelve concepts with nineteen (10.54, 56% of the
+	// base, against 6.25 and 52% before it), and kb/bundle then took it
+	// to twenty-eight (12.59, 45%). None of the three is comparable with
+	// the others as an absolute count; what the share says is that a
+	// second, unrelated domain is the only one of the two growths that
+	// made the search narrower relative to what it was searching, which
+	// is what adding concepts nobody's question is about should do.
+	evalReachCeiling = 12.61
+
+	// Leak: of those, how many came from the other bundle. The two
+	// domains share nothing but the language, so a leaked hit is the
+	// search matching on Japanese rather than on subject.
+	//
+	// Measured at 3.24 concepts, and **the widest case is the finding
+	// this second bundle was added to produce**: 「AI が verify を
+	// 打ってよいか」 reaches 18 of the store's concepts, and the demo's
+	// own 「department は2値か」 reaches all 28 in the base. Both are
+	// the defect migration 0042 fixed for vocabulary, still standing for
+	// grammar: queryFragments keeps a run of one or two characters whole
+	// without asking whether it holds a content character, so the
+	// particles が, は and の arrive as fragments and fragmentQuery asks
+	// for a one-character run as a prefix. が:* matches nearly every
+	// Japanese document in the base. contentWindows drops hiragana-only
+	// windows for exactly this reason — "they match nearly every entry"
+	// — and the short-run branch above it never asks.
+	//
+	// The number ships before the fix, which is the order the records
+	// follow (design doc 0089 §4). Reach and leak are both baselined
+	// with the defect in them; the change that closes it moves both.
+	evalLeakCeiling = 3.25
 
 	// What the dimensions read over this corpus, for the next change to
 	// aim at: english 12.83, mixed 12.43, question 11.97, keyword
@@ -538,14 +626,13 @@ regression spends without moving anything anybody reads.`,
 	}
 }
 
-// loadDemoBundle imports every document under examples/demo with the
-// run-unique prefix prepended to its path-derived id, and returns the
-// number imported. Root-relative links inside the bodies keep pointing
-// at the unprefixed ids; that leaves the link graph dangling, which the
-// lexical ranking this harness measures does not read.
-func loadDemoBundle(t *testing.T, ctx context.Context, svc *Service, prefix string, actor domain.Actor) int {
+// loadBundle imports every document under a bundle root with the given
+// id prefix prepended to its path-derived id, and returns the number
+// imported. Root-relative links inside the bodies keep pointing at the
+// unprefixed ids; that leaves the link graph dangling, which the lexical
+// ranking this harness measures does not read.
+func loadBundle(t *testing.T, ctx context.Context, svc *Service, root, prefix string, actor domain.Actor) int {
 	t.Helper()
-	root := filepath.Join("..", "..", "examples", "demo")
 	n := 0
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil || d.IsDir() || filepath.Ext(path) != ".md" {
@@ -571,7 +658,7 @@ func loadDemoBundle(t *testing.T, ctx context.Context, svc *Service, prefix stri
 		return nil
 	})
 	if err != nil {
-		t.Fatalf("load demo bundle: %v", err)
+		t.Fatalf("load bundle %s: %v", root, err)
 	}
 	return n
 }
@@ -582,8 +669,16 @@ func TestSearchEvalIntegration(t *testing.T) {
 	actor := domain.Actor{Kind: domain.ActorHuman, Name: "eval"}
 	prefix := uid(t, "svceval")
 
-	if n := loadDemoBundle(t, ctx, svc, prefix, actor); n < 18 {
+	if n := loadBundle(t, ctx, svc, filepath.Join("..", "..", "examples", "demo"), prefix, actor); n < 18 {
 		t.Fatalf("demo bundle shrank to %d documents; the golden set assumes the quick-start eighteen", n)
+	}
+	// The project's own bundle, in the same base. Two unrelated domains
+	// under one search is what a team's base actually looks like, and it
+	// is the only arrangement in which the leak measurement below means
+	// anything (evalKBPrefix).
+	if n := loadBundle(t, ctx, svc, filepath.Join("..", "..", "kb", "bundle"),
+		prefix+"/"+evalKBPrefix, actor); n < 9 {
+		t.Fatalf("kb bundle shrank to %d documents; the golden set assumes nine", n)
 	}
 	for id, doc := range japaneseSupplement {
 		d, _, err := okf.Parse([]byte(doc))
@@ -616,7 +711,9 @@ func TestSearchEvalIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("count the corpus: %v", err)
 	}
-	checkEvalReach(t, measureReach(t, ctx, svc, prefix, len(corpus.Hits)), evalReachCeiling)
+	reach, leak := measureReach(t, ctx, svc, prefix, len(corpus.Hits))
+	checkEvalCeiling(t, "reach", reach, evalReachCeiling)
+	checkEvalCeiling(t, "leak", leak, evalLeakCeiling)
 
 	// The same questions with the vector half on, which is the
 	// configuration a Google Cloud deployment runs.
@@ -631,16 +728,33 @@ func TestSearchEvalIntegration(t *testing.T) {
 // The worst case is logged by name. A mean says the search narrowed;
 // the question sitting at the top of it says what to look at next, and
 // that is the line that sent this harness to the prolonged sound mark.
-func measureReach(t *testing.T, ctx context.Context, svc *Service, prefix string, corpus int) float64 {
+func measureReach(t *testing.T, ctx context.Context, svc *Service, prefix string, corpus int) (reach, leak float64) {
 	t.Helper()
 	filter := store.Filter{Prefixes: []string{prefix}}
 	type tally struct{ cases, reached int }
 	byDim := map[string]*tally{}
 	total, worst, worstQuery := 0, 0, ""
+	leaked, leakWorst, leakWorstQuery := 0, 0, ""
 	for _, c := range evalCases {
 		hits, err := svc.Store.SearchLexical(ctx, c.query, filter, evalReachLimit)
 		if err != nil {
 			t.Fatalf("reach %q: %v", c.query, err)
+		}
+		// How far outside its own domain the question went. The two
+		// bundles share nothing but the language they are written in, so
+		// a hit from the other one is the search matching on Japanese
+		// rather than on subject — the failure the demo alone cannot
+		// show, because there every concept is about the same shop and
+		// a wide reach is honest.
+		crossed := 0
+		for _, h := range hits {
+			if inKB(strings.TrimPrefix(h.ID, prefix+"/")) != inKB(c.want) {
+				crossed++
+			}
+		}
+		leaked += crossed
+		if crossed > leakWorst {
+			leakWorst, leakWorstQuery = crossed, c.query
 		}
 		if len(hits) >= evalReachLimit {
 			t.Fatalf("%q reached %d concepts, filling the limit this is measured at: "+
@@ -665,22 +779,24 @@ func measureReach(t *testing.T, ctx context.Context, svc *Service, prefix string
 	}
 	mean := float64(total) / float64(len(evalCases))
 	t.Logf("reach = %.2f concepts of %d (widest: %q at %d), lexical only", mean, corpus, worstQuery, worst)
-	return mean
+	leak = float64(leaked) / float64(len(evalCases))
+	t.Logf("leak  = %.2f concepts from the other domain (widest: %q at %d)", leak, leakWorstQuery, leakWorst)
+	return mean, leak
 }
 
-// checkEvalReach holds the reach to its ceiling in both directions, the
-// way checkEvalFloors holds a floor: over it is the widening the
-// ceiling exists to catch, and further under it than
+// checkEvalCeiling holds a measured width to its ceiling in both
+// directions, the way checkEvalFloors holds a floor: over it is the
+// widening the ceiling exists to catch, and further under it than
 // evalFloorSlackCases allows is a ceiling nobody lowered when the
 // search narrowed.
-func checkEvalReach(t *testing.T, got, ceiling float64) {
+func checkEvalCeiling(t *testing.T, name string, got, ceiling float64) {
 	t.Helper()
 	slack := evalFloorSlackCases / float64(len(evalCases))
 	switch {
 	case got > ceiling:
-		t.Errorf(`reach rose to %.2f concepts, over the %.2f ceiling: a change widened what every
+		t.Errorf(`%s rose to %.2f concepts, over the %.2f ceiling: a change widened what every
 question touches. Recall and MRR can both be unmoved while this happens — the right
-answer stays where it was and more wrong ones arrive under it.`, got, ceiling)
+answer stays where it was and more wrong ones arrive under it.`, name, got, ceiling)
 	case ceiling-got > slack:
 		// Rounded down, which is the floors' rule read in the other
 		// direction: a floor is advised upward and a ceiling downward,
@@ -688,10 +804,10 @@ answer stays where it was and more wrong ones arrive under it.`, got, ceiling)
 		// number. Rounding a ceiling up advises a value that fails this
 		// same check on the next run.
 		want := math.Floor((got+slack)*100) / 100
-		t.Errorf(`reach measures %.2f concepts against a ceiling of %.2f — %.1f cases' worth of room,
+		t.Errorf(`%s measures %.2f concepts against a ceiling of %.2f — %.1f cases' worth of room,
 wider than the %d evalFloorSlackCases this file allows. Lower the ceiling to at most
 %.2f in the PR that earned it.`,
-			got, ceiling, (ceiling-got)*float64(len(evalCases)), evalFloorSlackCases, want)
+			name, got, ceiling, (ceiling-got)*float64(len(evalCases)), evalFloorSlackCases, want)
 	}
 }
 


### PR DESCRIPTION
<!-- Keep PRs small and focused. Link the issue or design doc, if there is one. -->

> **Rebased onto the thelook rewrite.** This PR was first measured against the previous demo bundle; #705–#707 replaced it with the thelook_ecommerce ontology while this was open, so everything below is re-measured on the current corpus. The kb cases and the leak measurement carried over unchanged — they are about the other domain — and the finding got sharper, not weaker.

## What and why

**One bundle was not a base, it was a topic.** Every question in the golden set was a question about a store asked of a corpus entirely about that store, so sharing 売上 with every neighbour was the normal condition, and nothing here could separate *matched the subject* from *matched Japanese*. #702 was invisible to recall and MRR for that reason, and #704's reach could not say whether 10.54 of 19 was a wide search or an honest one.

`kb/bundle` is the second domain — **in the same base, not beside it**. Nine concepts of ochakai's own development knowledge, sharing nothing with the store but the language. It is small (the corpus goes to 28) and that is not what it is for:

- **It is not written for a search to read.** Real developer Japanese with the English of the trade standing inside it — MCP, `testdb.Unique`, `DOC-LINES`, ICU — written by whoever learned the thing. The demo, however carefully written, was written by someone who knew this harness existed.
- **It does not churn.** Two commits in the last hundred and thirty touch `kb/bundle`, so a golden set can be pinned to it without failing on somebody else's knowledge-writing.
- **It is a domain a question can leave.** That is the point. Two of its questions even use words the store also uses in unrelated senses — 行数 is a row count there and a page's length here, 書き戻す is an outcome reported there and a concept landing in `kb/` here.

### Leak: of the concepts a question reached, how many came from the domain it was not about

Measured at **3.24 of 12.59 reached**, and it found a defect on its first run:

| query | reaches |
|---|---|
| `department は2値か` (a demo case) | **all 28 concepts in the base** |
| `AI が verify を打ってよいか` | 18 of the store's concepts, from a kb question |

Both are the defect #702 fixed for vocabulary, still standing for grammar:

```
AI が verify を打ってよいか  →  [AI  が  verify  打っ]
department は2値か          →  [department  は  2  値か]
お盆                      →  [お盆]        ← correct: 盆 is a content character
```

`queryFragments` keeps a run of one or two characters whole **without asking whether it holds a content character**, so the particles が, は and の arrive as fragments, and `fragmentQuery` asks for a one-character run as a prefix. `が:*` matches nearly every Japanese document in the base. `contentWindows` drops hiragana-only windows for exactly this reason — *"they match nearly every entry"* — and the short-run branch above it never asks.

**The number ships before the mechanism** (design doc 0089 §4), so reach and leak are baselined *with* the defect in them, and the change that closes it moves both. That is the order #702 and #704 followed, and it is why this PR does not also contain the fix.

### The new baseline (85 cases, 28 concepts, two domains)

| | measured | floor / ceiling |
|---|---|---|
| lexical recall@10 / MRR | 1.00 / 0.90 | 0.98 / 0.88 |
| fused recall@10 / MRR | 1.00 / 0.87 | 0.98 / 0.85 |
| reach | 12.59 of 28 | ≤ 12.61 |
| **leak** | **3.24** | ≤ 3.25 |

MRR *rose* because the kb questions name things that exist in exactly one place. What got harder is not visible in MRR at all — which is the argument for having the other two numbers. Leak takes the same two-sided ceiling reach has.

As a **share of the base**, reach went 52% (twelve concepts) → 56% (the thelook rewrite's nineteen) → **45%** here. A second, unrelated domain is the only one of the two growths that made the search narrower relative to what it was searching, which is what adding concepts nobody's question is about should do.

Per dimension, lexical MRR: question 0.91, keyword 0.95, mixed 0.87, english 0.74, katakana 1.00, orthography 0.61, synonyms 1.00, short 1.00.

## Checks

CI runs the same script; make it pass locally first (CONTRIBUTING.md has the
context, including the store integration test and the fuzz targets).

- [x] `scripts/check` is clean — add `--db` when the change touches the store (`core` incl. store integration tests against a throwaway PostgreSQL 16, and `lint`; Docker and `govulncheck` are CI's to verify in this environment)
- [x] Behavior changes come with tests — this PR is a test

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and `internal/apiclient` say the same thing — untouched
- [x] The change lands on every surface it belongs on — it touches none
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens a surface? No — one integration test and the contributor docs. `kb/bundle` is read as a fixture; nothing in it changes

## Design docs

- [x] Alters an accepted decision? No — a measurement over bundles the repository already ships
- [x] Commit messages and code comments are in English