### PR TITLE
Stop asking for the particles a question is made of

### DIFF
--- a/internal/service/searcheval_integration_test.go
+++ b/internal/service/searcheval_integration_test.go
@@ -507,7 +507,7 @@ const (
 	// own limit would be the limit's number, not the query's, and the
 	// measurement fails rather than reporting it.
 	evalReachLimit = 200
-	// Measured at 12.59 concepts of the 28 this corpus holds. The
+	// Measured at 12.04 concepts of the 28 this corpus holds. The
 	// ceiling sits two cases' worth over it, the width the floors use,
 	// and fails in both directions for the floors' reason: a ceiling
 	// nobody lowered when a change narrowed the search is budget the
@@ -529,29 +529,31 @@ const (
 	// second, unrelated domain is the only one of the two growths that
 	// made the search narrower relative to what it was searching, which
 	// is what adding concepts nobody's question is about should do.
-	evalReachCeiling = 12.61
+	evalReachCeiling = 12.05
 
 	// Leak: of those, how many came from the other bundle. The two
 	// domains share nothing but the language, so a leaked hit is the
 	// search matching on Japanese rather than on subject.
 	//
-	// Measured at 3.24 concepts, and **the widest case is the finding
-	// this second bundle was added to produce**: 「AI が verify を
-	// 打ってよいか」 reaches 18 of the store's concepts, and the demo's
-	// own 「department は2値か」 reaches all 28 in the base. Both are
-	// the defect migration 0042 fixed for vocabulary, still standing for
-	// grammar: queryFragments keeps a run of one or two characters whole
-	// without asking whether it holds a content character, so the
-	// particles が, は and の arrive as fragments and fragmentQuery asks
-	// for a one-character run as a prefix. が:* matches nearly every
-	// Japanese document in the base. contentWindows drops hiragana-only
-	// windows for exactly this reason — "they match nearly every entry"
-	// — and the short-run branch above it never asks.
+	// Measured at 2.87 concepts, against 3.24 when this measurement
+	// arrived — **and the difference is the defect it was added to
+	// find.** 「AI が verify を打ってよいか」 reached 18 of the store's
+	// concepts and the demo's own 「department は2値か」 reached all 28
+	// in the base, because queryFragments kept a run of one or two
+	// characters whole without asking whether it held a content
+	// character: the particles が and は arrived as fragments, and
+	// fragmentQuery asks for a one-character run as a prefix, so が:*
+	// matched nearly every Japanese document there was. It was migration
+	// 0042's defect — a boundary in the wrong place — standing for
+	// grammar rather than for vocabulary, and one corpus about one
+	// subject could not have shown it: reaching every neighbour is
+	// honest when every neighbour is about your question.
 	//
-	// The number ships before the fix, which is the order the records
-	// follow (design doc 0089 §4). Reach and leak are both baselined
-	// with the defect in them; the change that closes it moves both.
-	evalLeakCeiling = 3.25
+	// What the fix moved is here and nowhere else: reach 12.59 → 12.04,
+	// leak 3.24 → 2.87, recall and MRR unchanged at 1.00 and 0.90.
+	// Three numbers, and only the two this file added last say anything
+	// happened.
+	evalLeakCeiling = 2.89
 
 	// What the dimensions read over this corpus, for the next change to
 	// aim at: english 12.83, mixed 12.43, question 11.97, keyword

--- a/internal/store/filter_test.go
+++ b/internal/store/filter_test.go
@@ -220,6 +220,31 @@ func TestQueryFragments(t *testing.T) {
 		{"honorific before hiragana is grammar", "対応しておく",
 			[]string{"対応", "応し"}},
 		{"short japanese term", "売上", []string{"売上"}},
+		// A run of one or two characters is kept whole, and that is the
+		// right answer only when the run is a word. Spaces and latin
+		// words cut the particles out of a question as runs of their
+		// own — が, は, を — and fragmentQuery asks for a
+		// one-character run as a prefix, so が arrived as が:* and
+		// matched nearly every Japanese document in the base. It is the
+		// rule contentWindows applies to the runs long enough to be
+		// cut, reaching the ones that are not.
+		{"a particle between latin words is not a fragment",
+			"AI が verify を打ってよいか", []string{"AI", "verify", "打っ"}},
+		{"a particle against a digit is not a fragment",
+			"department は2値か", []string{"department", "2", "値か"}},
+		// Kept, because the run is the word rather than a window of one:
+		// asking whether a content character is *in* it, not whether it
+		// begins it.
+		{"a two-character word is still a fragment", "与信の判断",
+			[]string{"与信", "信の", "判断"}},
+		{"an honorific two-character word survives", "お茶 を 出す",
+			[]string{"お茶", "出す"}},
+		// The whole-query fallback: a question with nowhere else to look
+		// asks for its grammar rather than asking for nothing. This is
+		// contentWindows' own fallback, applied across the query.
+		{"a grammar-only query keeps its runs", "か", []string{"か"}},
+		{"grammar-only runs survive when nothing else does", "の と は",
+			[]string{"の", "と", "は"}},
 		{"mixed scripts", "revenue 売上高", []string{"revenue", "売上", "上高"}},
 		{"punctuation only falls back to the query", "???", []string{"???"}},
 		{"duplicate windows collapse", "ををを", []string{"をを"}},

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -55,7 +55,11 @@ func queryFragments(query string) []string {
 	// falls evenly across the query instead of truncating its tail. A
 	// question often names its subject last ("〜の件で、直近の原価率は?"),
 	// and cutting in reading order would drop exactly that.
-	var runs [][]string
+	//
+	// A short run holding no content character is collected apart from
+	// the rest and used only when nothing else survives (grammarOnly
+	// below).
+	var runs, grammarOnly [][]string
 	for _, token := range strings.FieldsFunc(query, func(r rune) bool {
 		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
 	}) {
@@ -68,12 +72,42 @@ func queryFragments(query string) []string {
 		// script boundary first and treat each run on its own terms.
 		for _, run := range scriptRuns(token) {
 			runes := []rune(run)
-			if !scriptWithoutSpaces(runes[0]) || len(runes) <= 2 {
+			switch {
+			case !scriptWithoutSpaces(runes[0]):
 				runs = append(runs, []string{run})
-				continue
+			case len(runes) <= 2:
+				// Short enough to be a word of its own — 売上, 与信 — or
+				// short enough to be nothing but grammar. Which it is
+				// decides whether it is asked for at all: a run this
+				// short is kept whole, and fragmentQuery asks for a
+				// one-character run as a prefix, so が arrives as が:*
+				// and matches nearly every Japanese document there is.
+				//
+				// This is the rule contentWindows already applies to the
+				// runs long enough to be cut ("they match nearly every
+				// entry"), reaching the runs that are not. It was
+				// measured by the leak the golden set gained with a
+				// second domain: 「AI が verify を打ってよいか」 asked
+				// for が and touched 18 concepts of a store it has
+				// nothing to do with.
+				if holdsContent(runes) {
+					runs = append(runs, []string{run})
+				} else {
+					grammarOnly = append(grammarOnly, []string{run})
+				}
+			default:
+				runs = append(runs, contentWindows(runes))
 			}
-			runs = append(runs, contentWindows(runes))
 		}
+	}
+
+	// A query that is nothing but grammar — ください, か — asks for it
+	// rather than asking for nothing, which is contentWindows' own
+	// fallback applied to the whole query instead of to one run. The
+	// two have to agree: a question is dropped from the fragments only
+	// when the question has somewhere else to look.
+	if len(runs) == 0 {
+		runs = grammarOnly
 	}
 
 	var out []string
@@ -141,6 +175,20 @@ func contentWindows(runes []rune) []string {
 		return content
 	}
 	return all
+}
+
+// holdsContent reports whether a short run carries a content word
+// rather than spelling grammar. Any content character in it answers —
+// the run is the word here, not a window of one, so the
+// first-character rule contentWindows uses would drop ヶ月 and お盆
+// for where the content sits rather than for whether it is there.
+func holdsContent(runes []rune) bool {
+	for _, r := range runes {
+		if contentChar(r) {
+			return true
+		}
+	}
+	return false
 }
 
 // QueryTerms extracts the terms of a query — the names a compound


### PR DESCRIPTION
<!-- Keep PRs small and focused. Link the issue or design doc, if there is one. -->

## What and why

The fix the baseline in #713 was written for. That PR shipped the number; this is the mechanism (design doc 0089 §4).

`queryFragments` keeps a run of one or two characters whole **without asking whether it holds a content character**. Spaces and latin words cut the particles out of a Japanese question as runs of their own, and `fragmentQuery` asks for a one-character run as a prefix — so `が` arrived as `が:*` and matched nearly every Japanese document in the base.

```
AI が verify を打ってよいか   →  [AI  が  verify  打っ]      →  [AI  verify  打っ]
department は2値か           →  [department  は  2  値か]   →  [department  2  値か]
お盆                         →  [お盆]                       →  [お盆]        (unchanged)
ください                     →  [くだ  ださ  さい]           →  [くだ  ださ  さい]  (unchanged)
```

It is migration #702's defect — a boundary in the wrong place — standing for grammar rather than for vocabulary. `contentWindows` already drops hiragana-only windows for exactly this reason (*"they match nearly every entry"*); the branch above it, for the runs too short to be cut, never asked.

Two rules keep it honest:

- **Content anywhere in the run, not at its head.** Here the run *is* the word rather than a window of one, so 与信 and お茶 keep the fragment they are.
- **A query with nothing else to look for falls back to its grammar.** ください and か still ask for themselves rather than for nothing — `contentWindows`' own fallback, applied across the query instead of within one run.

### What moved

| | before | after |
|---|---|---|
| reach | 12.59 of 28 | **12.04** |
| leak | 3.24 | **2.87** |
| recall@10 lexical / fused | 1.00 / 1.00 | 1.00 / 1.00 |
| MRR lexical / fused | 0.90 / 0.87 | 0.90 / 0.87 |

**Only the two numbers #704 and #713 added say anything happened.** Recall and MRR are flat to two decimals — the right answer was always first; the change is what stopped arriving underneath it. The ceilings are lowered to 12.05 and 2.89 in this PR, which is the two-sided check doing its job.

The two questions that named the defect were `AI が verify を打ってよいか`, which reached 18 concepts of a store it has nothing to do with, and the demo's own `department は2値か`, which reached all 28 in the base.

### Note on a non-reproducible failure

One `scripts/check core` run failed in `internal/service` while I was finishing this, and I could not reproduce it: 3 clean `go test -race ./...` runs, one clean `scripts/check core`, and `-count=3` over `internal/service` and `internal/store` since. I have no diagnosis, so I am flagging it rather than calling it a flake — if CI shows anything in that package, it is worth looking at rather than re-running.

## Checks

CI runs the same script; make it pass locally first (CONTRIBUTING.md has the
context, including the store integration test and the fuzz targets).

- [x] `scripts/check` is clean — add `--db` when the change touches the store (`core` incl. store integration tests against a throwaway PostgreSQL 16, and `lint`; Docker and `govulncheck` are CI's to verify in this environment — see the note above)
- [x] Behavior changes come with tests — six cases added to `TestQueryFragments` (particles between latin words and against a digit; a two-character word and an honorific one surviving; the grammar-only query fallback), plus the eval's reach and leak ceilings

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and `internal/apiclient` say the same thing — untouched
- [x] The change lands on every surface it belongs on — one ranking change behind every surface at once; it adds none
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens a surface? No

## Design docs

- [x] Alters an accepted decision? No — no record says where a word boundary falls, and query and index work belongs in the PR description. No migration either: this is the query side only, so nothing stored has to be rewritten
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmF42nZ26ztXudQnqrwzZ4)_