### PR TITLE
Take a loanword whole instead of cutting it into windows

### DIFF
--- a/internal/service/searcheval_integration_test.go
+++ b/internal/service/searcheval_integration_test.go
@@ -472,7 +472,7 @@ const (
 	// which is the mixed dimension going 0.74 to 0.81 lexically. It is
 	// the corpus changing under the merge again, not the merge.
 	evalFusedRecallFloor = 0.98
-	evalFusedMRRFloor    = 0.85
+	evalFusedMRRFloor    = 0.86
 )
 
 // Reach: how many concepts a question touched at all.
@@ -507,7 +507,7 @@ const (
 	// own limit would be the limit's number, not the query's, and the
 	// measurement fails rather than reporting it.
 	evalReachLimit = 200
-	// Measured at 12.04 concepts of the 28 this corpus holds. The
+	// Measured at 10.75 concepts of the 28 this corpus holds. The
 	// ceiling sits two cases' worth over it, the width the floors use,
 	// and fails in both directions for the floors' reason: a ceiling
 	// nobody lowered when a change narrowed the search is budget the
@@ -529,7 +529,7 @@ const (
 	// second, unrelated domain is the only one of the two growths that
 	// made the search narrower relative to what it was searching, which
 	// is what adding concepts nobody's question is about should do.
-	evalReachCeiling = 12.05
+	evalReachCeiling = 10.77
 
 	// Leak: of those, how many came from the other bundle. The two
 	// domains share nothing but the language, so a leaked hit is the
@@ -549,11 +549,16 @@ const (
 	// subject could not have shown it: reaching every neighbour is
 	// honest when every neighbour is about your question.
 	//
-	// What the fix moved is here and nowhere else: reach 12.59 → 12.04,
-	// leak 3.24 → 2.87, recall and MRR unchanged at 1.00 and 0.90.
-	// Three numbers, and only the two this file added last say anything
-	// happened.
-	evalLeakCeiling = 2.89
+	// What the particle fix moved was here and nowhere else: reach
+	// 12.59 → 12.04, leak 3.24 → 2.87, recall and MRR unchanged at 1.00
+	// and 0.90. Taking a loanword whole (store.minLoanword) moved the
+	// same two again — reach 12.04 → 10.75, leak 2.87 → 2.19 — and that
+	// one moved nothing else at all: **every one of the 85 cases landed
+	// on the rank it landed on before**, while the questions touched an
+	// eighth fewer concepts and a quarter fewer from the wrong domain.
+	// Three numbers, and only the two this file added last have said
+	// anything for three changes running.
+	evalLeakCeiling = 2.21
 
 	// What the dimensions read over this corpus, for the next change to
 	// aim at: english 12.83, mixed 12.43, question 11.97, keyword

--- a/internal/store/filter_test.go
+++ b/internal/store/filter_test.go
@@ -220,6 +220,26 @@ func TestQueryFragments(t *testing.T) {
 		{"honorific before hiragana is grammar", "対応しておく",
 			[]string{"対応", "応し"}},
 		{"short japanese term", "売上", []string{"売上"}},
+		// A loanword delimits itself: the script change on either side of
+		// it is a word boundary somebody wrote, unlike the inside of a
+		// run of Han and hiragana, where no rule here knows where a word
+		// begins. So it leaves the run whole instead of being cut into
+		// windows that collide with every other loanword sharing a
+		// syllable — ット is in スクリーンショット, データセット and
+		// ネットワーク alike — and the windows that used to straddle its
+		// edge (トの) are not asked for at all.
+		{"a loanword is one fragment", "スクリーンショットの撮り直し",
+			[]string{"スクリーンショット", "撮り", "直し"}},
+		{"and so is a compound one", "データセットの権限",
+			[]string{"データセット", "権限"}},
+		// Under the threshold, and deliberately: splitting at a katakana
+		// character inside a kanji word would leave 三 and 月 as
+		// one-character runs, which fragmentQuery can only ask for as
+		// prefixes.
+		{"a counter inside a kanji word is not a loanword", "三ヶ月の売上",
+			[]string{"三ヶ", "ヶ月", "月の", "売上"}},
+		{"a short loanword stays in its run", "ネコの数",
+			[]string{"ネコ", "コの"}},
 		// A run of one or two characters is kept whole, and that is the
 		// right answer only when the run is a word. Spaces and latin
 		// words cut the particles out of a question as runs of their

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -70,7 +70,7 @@ func queryFragments(query string) []string {
 		// string "PL科目") and cut "売上KPI" into windows that break KPI
 		// apart. Domain vocabulary is full of these, so split at the
 		// script boundary first and treat each run on its own terms.
-		for _, run := range scriptRuns(token) {
+		for _, run := range loanwordRuns(scriptRuns(token)) {
 			runes := []rune(run)
 			switch {
 			case !scriptWithoutSpaces(runes[0]):
@@ -95,6 +95,31 @@ func queryFragments(query string) []string {
 				} else {
 					grammarOnly = append(grammarOnly, []string{run})
 				}
+			case katakanaRun(runes):
+				// A katakana run is a word already. Unlike a run of Han
+				// and hiragana, which is a sentence and has to be cut
+				// into windows to find the words inside it, this one is
+				// delimited by what surrounds it — the kanji, kana or
+				// latin on either side — so cutting it says less than
+				// keeping it whole.
+				//
+				// Cutting it also collides. Loanwords share long
+				// substrings: ット is in スクリーンショット, データセット
+				// and ネットワーク; ショ and ョン are in ショット,
+				// セッション, ロケーション and ディメンション. Measured
+				// over the two bundles the eval loads, ット reached 14 of
+				// 28 concepts and セッ reached 16 — while 撮り, 踏む and
+				// 正直 reached one each. A question about a screenshot
+				// was asking for most of the base, and the words that
+				// said what it was about were outnumbered eight
+				// fragments to three in its own score.
+				//
+				// So the run stays one fragment, and fragmentTerm asks
+				// the index for all of its windows at once rather than
+				// any of them (the AND plainto_tsquery builds). The
+				// windows are already stored; nothing about the document
+				// side changes.
+				runs = append(runs, []string{run})
 			default:
 				runs = append(runs, contentWindows(runes))
 			}
@@ -175,6 +200,145 @@ func contentWindows(runes []rune) []string {
 		return content
 	}
 	return all
+}
+
+// minLoanword is how long a katakana stretch has to be before it is
+// taken out of the run around it as a word of its own.
+//
+// **Five, and it was measured rather than derived.** The floor is two
+// on principle — 三ヶ月 and 一ケタ are kanji words with a katakana
+// character inside them, and splitting there would leave 三 and 月 as
+// one-character runs, asked for as prefixes, which is the defect this
+// line of work has been removing. Everything above two was a question
+// for the golden set, and it answered:
+//
+//	threshold   lexical MRR   reach    leak
+//	(unsplit)   0.90          12.04    2.87
+//	3           0.89          10.24    1.84
+//	5           0.90          10.75    2.19
+//
+// At three, 「注文テーブルのスキーマ」 falls from first to fifth, and
+// what it falls behind is worth naming because it is not this rule's
+// fault. Asked for as words, that question is 注文, テーブル and
+// スキーマ; スキーマ is in exactly one concept of the twenty-eight and
+// in the other bundle entirely, so its rarity weight is the largest
+// there is, and a concept holding only it outscores the orders table
+// holding the other two. **The score is a fraction of the query's
+// weight, and a term nobody else has can be most of that fraction.**
+// Cutting テーブル into windows had been hiding it by spending the
+// query's weight on three correlated fragments instead of one.
+//
+// So five is where this rule stops before it uncovers a scoring
+// question it has no business answering, and the words it does take —
+// スクリーンショット, セッション, パーティション, ロケーション,
+// データセット — are the compounds whose windows collide in the first
+// place. The scoring question is real and still open; it wants its own
+// change and its own numbers.
+const minLoanword = 5
+
+// loanwordRuns splits each run at the loanwords inside it, so that
+// スクリーンショットの撮り直し arrives as スクリーンショット and
+// の撮り直し rather than as one stretch of sentence.
+//
+// **Katakana delimits itself.** A run of Han and hiragana is a sentence
+// — where its words begin is a question no rule here can answer, which
+// is why they are cut into windows and why the windows that begin with
+// hiragana are dropped. A stretch of katakana is not: the script change
+// on either side of it is the word boundary, written by whoever wrote
+// the sentence. Reading it is free, and everything downstream of this
+// gets easier — the loanword is asked for as a word (katakanaRun,
+// fragmentTerm), and the windows that used to straddle its edge (トの
+// in ショットの, ンで in ションで) are not asked for at all.
+func loanwordRuns(runs []string) []string {
+	var out []string
+	for _, run := range runs {
+		runes := []rune(run)
+		if !scriptWithoutSpaces(runes[0]) {
+			out = append(out, run)
+			continue
+		}
+		start := 0
+		for i := 0; i <= len(runes); i++ {
+			// The end of a katakana stretch, or the end of the run.
+			if i < len(runes) && (unicode.Is(unicode.Katakana, runes[i]) || joiningMark(runes[i])) {
+				continue
+			}
+			j := i
+			for j > start && (unicode.Is(unicode.Katakana, runes[j-1]) || joiningMark(runes[j-1])) {
+				j--
+			}
+			// j..i is the katakana stretch ending here; start..j is what
+			// came before it.
+			if i-j >= minLoanword && katakanaRun(runes[j:i]) {
+				if j > start {
+					out = append(out, string(runes[start:j]))
+				}
+				out = append(out, string(runes[j:i]))
+				start = i + 1
+				if i < len(runes) {
+					// The character that ended the stretch belongs to
+					// what follows it.
+					start = i
+				}
+			}
+		}
+		if start < len(runes) {
+			out = append(out, string(runes[start:]))
+		}
+	}
+	return out
+}
+
+// katakanaRun reports whether a run is a loanword rather than a stretch
+// of sentence: every character katakana, or one of the marks written
+// inside a word (joiningMark).
+//
+// Hiragana disqualifies it, which is the point — ですます and the
+// particles are the sentence, and a run holding them is not one word.
+func katakanaRun(runes []rune) bool {
+	for _, r := range runes {
+		if !unicode.Is(unicode.Katakana, r) && !joiningMark(r) {
+			return false
+		}
+	}
+	return true
+}
+
+// fragmentTerm is what the index is asked for on behalf of a fragment.
+//
+// For everything but a katakana run it is the fragment itself. A
+// katakana run is asked for as all of its two-character windows at
+// once: the document stores windows (migration 0036), so the word
+// itself is in no lexeme, and plainto_tsquery ANDs the terms it is
+// given — which turns "any window of this word" into "all of them",
+// the difference between スクリーンショット reaching every concept that
+// says ット and reaching the one that says the word.
+//
+// The fragment keeps its own spelling everywhere else: the name test
+// matches it as a substring, and the snippet looks for it in the body.
+// Both want the word a person typed, not the windows it was cut into.
+func fragmentTerm(frag string) string {
+	runes := []rune(frag)
+	if len(runes) <= 2 || !katakanaRun(runes) {
+		return frag
+	}
+	windows := make([]string, 0, len(runes)-1)
+	for i := 0; i+2 <= len(runes); i++ {
+		windows = append(windows, string(runes[i:i+2]))
+	}
+	return strings.Join(windows, " ")
+}
+
+// fragmentWindows is how many of the document's two-character windows a
+// fragment stands for: one for anything asked for as itself, and the
+// count of them for a loanword asked for as all of its windows at once
+// (fragmentTerm).
+func fragmentWindows(frag string) int {
+	runes := []rune(frag)
+	if len(runes) <= 2 || !katakanaRun(runes) {
+		return 1
+	}
+	return len(runes) - 1
 }
 
 // holdsContent reports whether a short run carries a content word
@@ -466,7 +630,7 @@ func (s *Store) SearchLexical(ctx context.Context, query string, f Filter, limit
 		// tsquery reads, and the escaped pattern the name test reads. The
 		// name is one short string on the row, so it is matched as a
 		// substring rather than through the index the body needs.
-		args = append(args, frag)
+		args = append(args, fragmentTerm(frag))
 		match := fragmentQuery(frag, len(args))
 		args = append(args, "%"+escapeLike(frag)+"%")
 		tests = append(tests, match)
@@ -486,9 +650,19 @@ func (s *Store) SearchLexical(ctx context.Context, query string, f Filter, limit
 		// that the query is stemmed ("why is revenue down" asks for four
 		// terms and two of them are dropped by the dictionary), which is
 		// how this came to be measured rather than reasoned about.
+		// A loanword asked for as one fragment stands for the windows it
+		// was cut from (fragmentTerm), and is weighted as those windows
+		// rather than as one term. Without this the unit of the score
+		// changes with the script — 「注文テーブルのスキーマ」 asks for
+		// three terms where the same question in kanji asks for six — and
+		// a concept holding only the rarest of the three outranks the one
+		// holding the other two: measured on that query as tables/orders
+		// falling from first to fifth behind a concept whose only match
+		// was スキーマ.
 		weight = append(weight, fmt.Sprintf(
 			"CASE WHEN count(*) FILTER (WHERE h%[1]d) OVER () = 0 THEN 0 "+
-				"ELSE ln(1 + total::float / count(*) FILTER (WHERE h%[1]d) OVER ()) END AS w%[1]d", i))
+				"ELSE %[2]d * ln(1 + total::float / count(*) FILTER (WHERE h%[1]d) OVER ()) END AS w%[1]d",
+			i, fragmentWindows(frag)))
 		weighted = append(weighted, fmt.Sprintf("CASE WHEN h%d THEN w%d ELSE 0 END", i, i))
 		// A fragment in the name is scored with the same weight it earns
 		// in the body, so a rare term stays rare wherever it lands.

--- a/internal/store/searchtsv_integration_test.go
+++ b/internal/store/searchtsv_integration_test.go
@@ -291,6 +291,64 @@ func TestLoanwordIsLookedUpNotPrefixScanned(t *testing.T) {
 	}
 }
 
+// TestLoanwordIsAskedForWhole pins what a katakana run buys by staying
+// one fragment: the index is asked for all of its windows at once
+// (fragmentTerm), so a loanword finds the concept that says it rather
+// than every concept sharing a syllable with it.
+//
+// Loanwords share long substrings — ット is in スクリーンショット,
+// データセット and ネットワーク; ショ and ョン are in ショット,
+// セッション and ロケーション — and a two-character window is smaller
+// than the thing it is trying to identify. Measured over the bundles
+// the eval loads, ット reached 14 concepts of 28 and セッ reached 16,
+// while the words saying what the question was about reached one each.
+//
+// The assertion is on the neighbours. A test that only checked the
+// target passed before this rule existed too.
+func TestLoanwordIsAskedForWhole(t *testing.T) {
+	ctx := context.Background()
+	s := newSearchStore(t, ctx)
+	run := testdb.Unique(t, "loanwhole")
+	actor := domain.Actor{Kind: domain.ActorHuman, Name: "test"}
+
+	for id, body := range map[string]string{
+		"screenshot": "スクリーンショットの撮り直しで踏む罠がある。",
+		"dataset":    "データセットの権限は読み取りだけである。",
+		"network":    "ネットワークの設定は触らない。",
+		"session":    "リモートセッションのチェック。",
+	} {
+		k := &domain.Knowledge{
+			Type: domain.TypeInsights, ID: run + "/" + id,
+			Title: id, Body: body, Status: domain.StatusStable, CreatedBy: actor,
+		}
+		if err := s.Create(ctx, k, false); err != nil {
+			t.Fatalf("create %s: %v", k.ID, err)
+		}
+	}
+
+	for _, tc := range []struct{ query, want string }{
+		{"スクリーンショット", "screenshot"},
+		{"データセット", "dataset"},
+		// A word inside a longer one still answers: the document holding
+		// リモートセッション holds every window セッション asks for.
+		{"セッション", "session"},
+	} {
+		hits, err := s.SearchLexical(ctx, tc.query, Filter{Prefixes: []string{run}}, 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ids := make([]string, 0, len(hits))
+		for _, h := range hits {
+			ids = append(ids, strings.TrimPrefix(h.ID, run+"/"))
+		}
+		if len(ids) != 1 || ids[0] != tc.want {
+			t.Errorf("searching %s returned %v; want just %s. A neighbour here means the "+
+				"query is asking for any window of the word rather than all of them",
+				tc.query, ids, tc.want)
+		}
+	}
+}
+
 // TestEnglishSearchStems pins the recall ILIKE could not have: a plural
 // finds the body that says the singular. A search that found nothing was
 // recorded as a knowledge gap (design doc 0051), so this defect used to


### PR DESCRIPTION
<!-- Keep PRs small and focused. Link the issue or design doc, if there is one. -->

## What and why

The finding at the end of #715, measured: after the particles stopped being fragments, the widest questions were still reaching most of the base, and per-fragment measurement said why.

| fragment | concepts reached (of 28) | where it comes from |
|---|---|---|
| `セッ` | 16 | セッション, データセット |
| `ット` | 14 | スクリーンショット, データセット, ネットワーク |
| `ショ` | 12 | ショット, セッション |
| `ョン` | 11 | セッション, ロケーション |
| `撮り` `踏む` `正直` | 1 each | the words the question is about |

**A two-character window is smaller than the thing it is trying to identify.** A question about a screenshot was asking for most of the base, and the words saying what it was about were outnumbered in its own score eight fragments to three.

A run of Han and hiragana is a sentence — no rule here knows where its words begin, which is why it is cut into windows and why the hiragana-initial ones are dropped. **A stretch of katakana is not a sentence**: the script change on either side of it is a word boundary somebody wrote, free to read. So it leaves `queryFragments` whole, and `fragmentTerm` asks the index for **all** of its windows at once rather than any of them — the AND `plainto_tsquery` builds from the terms it is given.

```
スクリーンショットの撮り直しで踏む罠  →  [スクリーンショット  撮り  直し  踏む]
データセットの権限                  →  [データセット  権限]
三ヶ月の売上                        →  [三ヶ  ヶ月  月の  売上]   ← under the threshold, unchanged
```

The document side is untouched — the windows are already stored — so a word inside a longer one still answers (`セッション` finds the concept that says リモートセッション) and nothing has to be rewritten. The straddling windows that used to cross the loanword's edge (`トの`, `ンで`) are not asked for at all any more, which was the other half of the noise.

### What moved

| | before | after |
|---|---|---|
| reach | 12.04 of 28 | **10.75** |
| leak | 2.87 | **2.19** |
| lexical recall@10 / MRR | 1.00 / 0.90 | 1.00 / 0.90 |
| fused recall@10 / MRR | 1.00 / 0.87 | 1.00 / **0.88** |

**Every one of the 85 cases landed on the rank it landed on before.** The ranking is untouched, the candidate set is an eighth smaller, and a quarter less of it comes from the domain the question was not about. Ceilings drop to 10.77 and 2.21; the fused floor rises to 0.86.

### The threshold is measured, and it is a stopping point rather than a tuning

`minLoanword` is five. Two is the floor on principle (三ヶ月 and 一ケタ are kanji words with a katakana character inside them, and splitting there would leave 三 and 月 as one-character runs — the prefix defect #715 removed). Everything above two was a question for the golden set:

| threshold | lexical MRR | reach | leak |
|---|---|---|---|
| unsplit | 0.90 | 12.04 | 2.87 |
| 3 | 0.89 | 10.24 | 1.84 |
| **5** | **0.90** | **10.75** | **2.19** |

At three, `注文テーブルのスキーマ` falls from first to fifth — and **what it falls behind is not this rule's fault**. Asked for as words, that question is 注文, テーブル, スキーマ; スキーマ is in exactly one concept of the twenty-eight, in the other bundle entirely, so its rarity weight is the largest there is and a concept holding only it outscores the orders table holding the other two. The score is a fraction of the query's weight, and a term nobody else has can be most of that fraction. Cutting テーブル into windows had been hiding that by spending the query's weight on three correlated fragments instead of one.

So five is where this rule stops before it uncovers a scoring question it has no business answering. **That question is real and still open** — it wants its own change and its own numbers, and it is the next thing I would look at.

## Checks

CI runs the same script; make it pass locally first (CONTRIBUTING.md has the
context, including the store integration test and the fuzz targets).

- [x] `scripts/check` is clean — add `--db` when the change touches the store (`core` incl. store integration tests against a throwaway PostgreSQL 16, and `lint`; Docker and `govulncheck` are CI's to verify in this environment)
- [x] Behavior changes come with tests — `TestLoanwordIsAskedForWhole` (verified to fail without the change: スクリーンショット returned all four neighbours), four cases added to `TestQueryFragments` including the 三ヶ月 guard, and the eval's ceilings

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and `internal/apiclient` say the same thing — untouched
- [x] The change lands on every surface it belongs on — one ranking change behind every surface at once; it adds none
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens a surface? No

## Design docs

- [x] Alters an accepted decision? No — no record says where a word boundary falls, and query and index work belongs in the PR description. No migration either: the query side only, so nothing stored is rewritten
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmF42nZ26ztXudQnqrwzZ4)_