### PR TITLE
Fold the haystack and the query to one spelling of a character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,22 @@ last entry.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Halfwidth katakana and fullwidth latin are found by a question
+  spelled normally, and the reverse.** They are what a system upstream
+  of the reader writes — a warehouse export from something fixed-width,
+  an IME that yields ＢｉｇＱｕｅｒｙ mid-sentence, a CSV that came
+  through a mainframe — and each spelling used to be its own island:
+  「データセット」 found only the normally-written document, 「ﾃﾞｰﾀｾｯﾄ」
+  only the halfwidth one, and neither ever found the other. That was
+  recall, not ranking: the document could not be found at all. Both
+  sides now fold with NFKC, the compatibility normalization the standard
+  defines for this, and the two implementations are pinned against each
+  other over 7,377 code points. **Migration 0043 recomputes the search
+  index for every stored object**, so the first start after upgrading
+  writes once per row before it serves.
+
 ## [0.26.2] - 2026-08-21
 
 ### Fixed

--- a/internal/service/search.go
+++ b/internal/service/search.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/text/unicode/norm"
+
 	"github.com/na0fu3y/ochakai/internal/domain"
 	"github.com/na0fu3y/ochakai/internal/embed"
 	"github.com/na0fu3y/ochakai/internal/store"
@@ -156,7 +158,10 @@ func namedBy(h domain.SearchHit, names []string) bool {
 	if i := strings.LastIndexByte(seg, '/'); i >= 0 {
 		seg = seg[i+1:]
 	}
-	title, seg := domain.Normalize(h.Title), domain.Normalize(seg)
+	// Folded as the store folds the query it compares against
+	// (migration 0043), or a concept named ｵｰﾀﾞｰ would keep the sort key
+	// the store's own scorer gave it and lose it here.
+	title, seg := norm.NFKC.String(h.Title), norm.NFKC.String(seg)
 	for _, name := range names {
 		if strings.EqualFold(title, name) || strings.EqualFold(seg, name) {
 			return true

--- a/internal/service/searcheval_integration_test.go
+++ b/internal/service/searcheval_integration_test.go
@@ -332,6 +332,14 @@ var evalCases = []evalCase{
 	{query: "testdb.Unique", want: "kb/insights/store-tests-shared-db", dim: dimEnglish},
 	{query: "DOC-LINES", want: "kb/insights/translation-costs-lines", dim: dimEnglish},
 	{query: "ICU ロケール", want: "kb/skills/webui-screenshots", dim: dimMixed},
+	// The same word the reader types and the document spells another
+	// way. Until the index and the query agree on one spelling of a
+	// character, these are two islands: a normally-written question
+	// cannot reach a halfwidth-written document and the reverse holds
+	// too, so what fails here is recall rather than rank.
+	{query: "オーダー", want: "ja/ops/export-notes", dim: dimOrthography},
+	{query: "エクスポート", want: "ja/ops/export-notes", dim: dimOrthography},
+	{query: "ETL", want: "ja/ops/export-notes", dim: dimOrthography},
 	{query: "解約率", want: "ja/metrics/kaiyakuritsu", dim: dimShort},
 	{query: "解約の分母", want: "ja/metrics/kaiyakuritsu", dim: dimShort},
 	{query: "粗利", want: "tables/products", dim: dimShort},
@@ -352,6 +360,25 @@ var japaneseSupplement = map[string]string{
 		"status: draft\n" +
 		"---\n\n" +
 		"解約率は月初時点の有効契約数を分母に取る。日割りはしない。\n",
+	// A concept written the way a system upstream of the reader writes:
+	// halfwidth katakana and fullwidth latin, which is what a warehouse
+	// export, an IME mid-sentence and anything that came through a
+	// fixed-width system produce. No shipped bundle is written this way
+	// — they are written by people who type carefully — which is
+	// exactly why the supplement carries it (the 解約率 argument: a
+	// shape the bundles cannot exercise).
+	//
+	// The questions asking for it below are spelled normally, because
+	// that is how the reader asks.
+	"ja/ops/export-notes": "---\n" +
+		"type: Insight\n" +
+		"title: ｴｸｽﾎﾟｰﾄの綴り\n" +
+		"description: 基幹から届く抽出ファイルの表記ゆれ\n" +
+		"tags: [ops]\n" +
+		"status: draft\n" +
+		"---\n\n" +
+		"基幹の ｴｸｽﾎﾟｰﾄ は ｵｰﾀﾞｰ 区分を半角で書く。ＥＴＬ を通しても\n" +
+		"綴りはそのまま残るので、読む側で揃えることになる。\n",
 }
 
 // evalVerified is the one concept the harness confirms before scoring.
@@ -449,7 +476,7 @@ const (
 	// to rank 2 is 0.007 here, so a floor closer than that fails on
 	// noise.
 	evalRecallFloor = 0.98
-	evalMRRFloor    = 0.88
+	evalMRRFloor    = 0.89
 	// Fused: the same questions with the stand-in encoder on, measured
 	// at 1.00 / 0.87. This floor is the one that catches the verified
 	// addend going back to 0.002 — that constant is the kind that gets
@@ -472,7 +499,7 @@ const (
 	// which is the mixed dimension going 0.74 to 0.81 lexically. It is
 	// the corpus changing under the merge again, not the merge.
 	evalFusedRecallFloor = 0.98
-	evalFusedMRRFloor    = 0.86
+	evalFusedMRRFloor    = 0.87
 )
 
 // Reach: how many concepts a question touched at all.
@@ -507,7 +534,7 @@ const (
 	// own limit would be the limit's number, not the query's, and the
 	// measurement fails rather than reporting it.
 	evalReachLimit = 200
-	// Measured at 10.75 concepts of the 28 this corpus holds. The
+	// Measured at 10.52 concepts of the 29 this corpus holds. The
 	// ceiling sits two cases' worth over it, the width the floors use,
 	// and fails in both directions for the floors' reason: a ceiling
 	// nobody lowered when a change narrowed the search is budget the
@@ -529,7 +556,7 @@ const (
 	// second, unrelated domain is the only one of the two growths that
 	// made the search narrower relative to what it was searching, which
 	// is what adding concepts nobody's question is about should do.
-	evalReachCeiling = 10.77
+	evalReachCeiling = 10.54
 
 	// Leak: of those, how many came from the other bundle. The two
 	// domains share nothing but the language, so a leaked hit is the
@@ -556,9 +583,12 @@ const (
 	// one moved nothing else at all: **every one of the 85 cases landed
 	// on the rank it landed on before**, while the questions touched an
 	// eighth fewer concepts and a quarter fewer from the wrong domain.
-	// Three numbers, and only the two this file added last have said
-	// anything for three changes running.
-	evalLeakCeiling = 2.21
+	// Three numbers, and only the two this file added last had said
+	// anything for three changes running — until migration 0043, where
+	// recall moved instead: three questions that could not find their
+	// concept at all, because the document spelled it ｵｰﾀﾞｰ and the
+	// question spelled it オーダー.
+	evalLeakCeiling = 2.14
 
 	// What the dimensions read over this corpus, for the next change to
 	// aim at: english 12.83, mixed 12.43, question 11.97, keyword

--- a/internal/store/migrations/0043_one_spelling_of_a_character.sql
+++ b/internal/store/migrations/0043_one_spelling_of_a_character.sql
@@ -1,0 +1,44 @@
+-- The index and the query agree on one spelling of a character.
+--
+-- Halfwidth katakana and fullwidth latin are what a system upstream of
+-- the reader produces: a warehouse export written by something
+-- fixed-width, an IME that yields ＢｉｇＱｕｅｒｙ mid-sentence, a CSV
+-- that came through a mainframe. Nothing in the lexical search folded
+-- them, so each spelling was its own island — measured, on a base
+-- holding one document of each: 「データセット」 found only the
+-- normally-written one, 「ﾃﾞｰﾀｾｯﾄ」 only the halfwidth one, and neither
+-- ever found the other. That is recall, not rank: the document could
+-- not be found at all.
+--
+-- NFKC is the fold, applied once to the haystack before either pass
+-- cuts it. It is the compatibility normalization the standard defines
+-- for exactly this — ｦ-ﾟ to their fullwidth kana, Ａ-Ｚ to ASCII, ㍿ to
+-- 株式会社 — and Postgres and Go implement the same one: 7,377 code
+-- points across ASCII, kana, CJK compatibility and the halfwidth and
+-- fullwidth block agree between normalize(…, NFKC) and Go's
+-- golang.org/x/text/unicode/norm, which TestNFKCAgreesWithGo pins so
+-- the query side and the document side cannot drift apart.
+--
+-- The query side folds in store.queryFragments and store.QueryTerms.
+-- What does not fold is the whole-query bonus (SearchLexical): it asks
+-- whether the question appears in the haystack verbatim, which is a
+-- question about the raw text, and folding it would put a normalize()
+-- over a multi-kilobyte body on every candidate row for a bonus that is
+-- already a tiebreaker.
+
+CREATE OR REPLACE FUNCTION ochakai_search_tsv(p_text text) RETURNS tsvector
+LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT AS $$
+    SELECT strip(
+        to_tsvector('english', regexp_replace(
+            regexp_replace(
+                regexp_replace(f.folded, '[' || ochakai_cjk_class() || ']+', ' ', 'g'),
+                '[^[:alnum:]]+', ' ', 'g'),
+            '[^[:space:]]{255}[^[:space:]]{255}[^[:space:]]*', ' ', 'g'))
+        || to_tsvector('simple', ochakai_cjk_bigrams(f.folded)))
+    FROM (SELECT normalize(p_text, NFKC)) AS f(folded)
+$$;
+
+-- The lexemes already stored were cut before the fold. Assigning
+-- search_text to itself is how every migration since 0016 has asked the
+-- trigger to run, and the generated tsvector column follows it (0036).
+UPDATE object SET search_text = search_text WHERE id IS NOT NULL;

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -12,6 +12,7 @@ import (
 	"unicode"
 
 	"github.com/jackc/pgx/v5"
+	"golang.org/x/text/unicode/norm"
 
 	"github.com/na0fu3y/ochakai/internal/domain"
 )
@@ -51,6 +52,11 @@ const maxQueryFragments = 24
 // index entries are the same two characters the query is. What each
 // fragment becomes on the way there is fragmentQuery.
 func queryFragments(query string) []string {
+	// One spelling of a character, as the haystack holds it (migration
+	// 0043): ﾃﾞｰﾀｾｯﾄ and データセット are the same word, and until both
+	// sides folded, a question in either spelling could not reach a
+	// document in the other at all.
+	query = norm.NFKC.String(query)
 	// Fragments are collected per run and then interleaved, so the cap
 	// falls evenly across the query instead of truncating its tail. A
 	// question often names its subject last ("〜の件で、直近の原価率は?"),
@@ -378,7 +384,9 @@ func holdsContent(runes []rune) bool {
 // query is the name whole — the reach the rule had before terms existed
 // — and a name with hiragana inside it (売り上げ) likewise.
 func QueryTerms(query string) []string {
-	runes := []rune(query)
+	// Folded as queryFragments folds, and for its reason: a name is
+	// matched against the same haystack.
+	runes := []rune(norm.NFKC.String(query))
 	var terms []string
 	seen := map[string]bool{}
 	start, hasContent := -1, false
@@ -541,6 +549,14 @@ func fragmentQuery(frag string, n int) string {
 const (
 	filenameText = `regexp_replace(k.id, '^.*/', '')`
 	nameText     = `k.title || ' ' || ` + filenameText
+	// The same two, as the query is spelled by the time it is compared
+	// to them (migration 0043). A concept filed at ｵｰﾀﾞｰ.md is named
+	// オーダー by whoever filed it there, and the reader types it the
+	// way they type it. Both are short strings on a row the scan
+	// already has.
+	foldedName     = `normalize(` + nameText + `, NFKC)`
+	foldedTitle    = `normalize(k.title, NFKC)`
+	foldedFilename = `normalize(` + filenameText + `, NFKC)`
 )
 
 // SearchLexical ranks entries by how much of the query they contain and
@@ -612,16 +628,16 @@ func (s *Store) SearchLexical(ctx context.Context, query string, f Filter, limit
 	// (「EC事業の継続率を計算して」) is the name of nothing, but it names
 	// EC事業 and 継続率, and the definitions it asks for must not lose to
 	// the reports that merely say all its words (QueryTerms).
-	args = append(args, escapeLike(query))
+	args = append(args, escapeLike(norm.NFKC.String(query)))
 	nameTests := []string{fmt.Sprintf(
-		"k.title ILIKE $%[1]d OR "+filenameText+" ILIKE $%[1]d", len(args))}
+		foldedTitle+" ILIKE $%[1]d OR "+foldedFilename+" ILIKE $%[1]d", len(args))}
 	for _, term := range QueryTerms(query) {
 		if strings.EqualFold(term, query) {
 			continue // the whole-query test above already asks this
 		}
 		args = append(args, escapeLike(term))
 		nameTests = append(nameTests, fmt.Sprintf(
-			"k.title ILIKE $%[1]d OR "+filenameText+" ILIKE $%[1]d", len(args)))
+			foldedTitle+" ILIKE $%[1]d OR "+foldedFilename+" ILIKE $%[1]d", len(args)))
 	}
 	frags := queryFragments(query)
 	var hit, weight, weighted, named, weights, tests []string
@@ -705,7 +721,7 @@ func (s *Store) SearchLexical(ctx context.Context, query string, f Filter, limit
 							THEN 1 ELSE 0 END AS named,
 						(SELECT max(v.at) FROM knowledge_verification v
 							WHERE v.id = k.id) AS last_verified
-					FROM object k, LATERAL (SELECT `+nameText+` AS name) nm
+					FROM object k, LATERAL (SELECT `+foldedName+` AS name) nm
 					WHERE k.search_tsv @@ (%[8]s) AND %[9]s
 				) c
 			) w

--- a/internal/store/searchtsv_integration_test.go
+++ b/internal/store/searchtsv_integration_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/text/unicode/norm"
+
 	"github.com/na0fu3y/ochakai/internal/domain"
 	"github.com/na0fu3y/ochakai/internal/testdb"
 )
@@ -107,6 +109,126 @@ func TestCJKClassAgreesWithGo(t *testing.T) {
 		}
 		if mismatched > 8 {
 			t.Errorf("...and %d more disagreements in U+%04X..U+%04X", mismatched-8, span[0], span[1])
+		}
+	}
+}
+
+// TestNFKCAgreesWithGo pins the fold migration 0043 put on the haystack
+// against the one store.queryFragments puts on the query.
+//
+// Two implementations of one standard, and they have to be the same
+// implementation for the search to work at all: the document's lexemes
+// are cut from normalize(…, NFKC) in SQL, and the fragments looked up
+// in them are cut from norm.NFKC in Go. A character either side folds
+// differently is a term nobody can find — the failure 0043 exists to
+// remove, arriving from the other direction.
+//
+// The blocks are the ones a fold changes: latin and its fullwidth
+// forms, the kana, the CJK compatibility squares (㍿, ㌔), and the
+// halfwidth and fullwidth block itself.
+func TestNFKCAgreesWithGo(t *testing.T) {
+	ctx := context.Background()
+	s := newSearchStore(t, ctx)
+
+	spans := [][2]rune{
+		{0x0020, 0x0500}, // ASCII, latin-1, latin extended
+		{0x2000, 0x30FF}, // punctuation, CJK symbols, the kana
+		{0x3200, 0x33FF}, // enclosed CJK letters, compatibility squares
+		{0xFB00, 0xFFEF}, // ligatures through halfwidth and fullwidth forms
+	}
+	compared, mismatched := 0, 0
+	for _, span := range spans {
+		var chars []string
+		for r := span[0]; r <= span[1]; r++ {
+			if r >= 0xD800 && r <= 0xDFFF {
+				continue // surrogates are not characters
+			}
+			chars = append(chars, string(r))
+		}
+		rows, err := s.pool.Query(ctx,
+			`SELECT c, normalize(c, NFKC) FROM unnest($1::text[]) AS c`, chars)
+		if err != nil {
+			t.Fatalf("normalize U+%04X..U+%04X: %v", span[0], span[1], err)
+		}
+		for rows.Next() {
+			var char, sqlFolded string
+			if err := rows.Scan(&char, &sqlFolded); err != nil {
+				rows.Close()
+				t.Fatal(err)
+			}
+			compared++
+			goFolded := norm.NFKC.String(char)
+			if goFolded == sqlFolded {
+				continue
+			}
+			mismatched++
+			if mismatched <= 8 {
+				t.Errorf("U+%04X (%q): Go folds to %q, the database to %q — "+
+					"a query fragment and the document's lexemes would not meet",
+					[]rune(char)[0], char, goFolded, sqlFolded)
+			}
+		}
+		err = rows.Err()
+		rows.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if mismatched > 8 {
+		t.Errorf("...and %d more disagreements", mismatched-8)
+	}
+	if compared < 7000 {
+		t.Fatalf("compared only %d code points; the spans stopped covering the fold", compared)
+	}
+}
+
+// TestOneSpellingOfACharacter is what the fold buys: a question and a
+// document written in different compatibility forms of the same word
+// find each other.
+//
+// Halfwidth katakana and fullwidth latin are what a system upstream of
+// the reader writes — a warehouse export, an IME mid-sentence, a CSV
+// that came through something fixed-width. Before migration 0043 each
+// spelling was its own island: neither of the two documents below could
+// be found by a question spelled the other way, which is recall rather
+// than rank.
+func TestOneSpellingOfACharacter(t *testing.T) {
+	ctx := context.Background()
+	s := newSearchStore(t, ctx)
+	run := testdb.Unique(t, "spelling")
+	actor := domain.Actor{Kind: domain.ActorHuman, Name: "test"}
+
+	for id, body := range map[string]string{
+		"halfwidth": "基幹の ｴｸｽﾎﾟｰﾄ は ｵｰﾀﾞｰ 区分を半角で書く。",
+		"fullwidth": "ＥＴＬ を通しても綴りはそのまま残る。",
+	} {
+		k := &domain.Knowledge{
+			Type: domain.TypeInsights, ID: run + "/" + id,
+			Title: id, Body: body, Status: domain.StatusStable, CreatedBy: actor,
+		}
+		if err := s.Create(ctx, k, false); err != nil {
+			t.Fatalf("create %s: %v", k.ID, err)
+		}
+	}
+
+	for _, tc := range []struct{ query, want string }{
+		{"オーダー", "halfwidth"},    // asked normally, written halfwidth
+		{"ｴｸｽﾎﾟｰﾄ", "halfwidth"}, // and asked the way it is written
+		{"ETL", "fullwidth"},     // asked in ASCII, written fullwidth
+		{"ＥＴＬ", "fullwidth"},
+	} {
+		hits, err := s.SearchLexical(ctx, tc.query, Filter{Prefixes: []string{run}}, 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(hits) != 1 || !strings.HasSuffix(hits[0].ID, "/"+tc.want) {
+			ids := make([]string, 0, len(hits))
+			for _, h := range hits {
+				ids = append(ids, strings.TrimPrefix(h.ID, run+"/"))
+			}
+			t.Errorf("searching %s returned %v; want just %s — the two spellings of a "+
+				"character have to reach the same lexeme (migration 0043)",
+				tc.query, ids, tc.want)
 		}
 	}
 }


### PR DESCRIPTION
<!-- Keep PRs small and focused. Link the issue or design doc, if there is one. -->

## What and why

The hypothesis this whole line of work started from, five changes ago — and it took until now to have the instruments to state it as a defect rather than a hunch.

Halfwidth katakana and fullwidth latin are what a system *upstream of the reader* writes: a warehouse export from something fixed-width, an IME that yields ＢｉｇＱｕｅｒｙ mid-sentence, a CSV that came through a mainframe. Nothing in the lexical search folded them, so each spelling was its own island. Measured on a base holding one document of each:

```
データセット  finds [normal]        ﾃﾞｰﾀｾｯﾄ    finds [halfwidth]
BigQuery      finds [normal]        ＢｉｇＱｕｅｒｙ  finds [fullwidth]
オーダー      finds [normal]        ← the halfwidth document says ｵｰﾀﾞｰ, and is invisible
```

Neither ever found the other. **That is recall, not rank: the document could not be found at all.**

### The number, before the mechanism

No shipped bundle is written that way — they are written by people who type carefully — so the supplement carries it, which is what the supplement is for (the 解約率 argument: a shape the bundles cannot exercise). One concept written the way an export writes it, and three questions spelled the way a reader asks:

| | before | after |
|---|---|---|
| `オーダー` → the export concept | **miss** | rank 1 |
| `エクスポート` | **miss** | rank 1 |
| `ETL` (the document says ＥＴＬ) | **miss** | rank 1 |
| lexical recall@10 / MRR | **0.97** / 0.87 | **1.00** / 0.91 |
| fused recall@10 / MRR | 0.97 / 0.85 | 1.00 / 0.88 |
| orthography dimension MRR | 0.61 | **0.89**, 6 of 6 found |
| reach / leak | 10.75 / 2.19 | 10.52 / 2.12 |

Recall failing its floor is the strongest signal this harness has, and it is the first time in this series that it has been the number to move — #702, #715 and #716 were all invisible to recall and MRR both.

`ＢｉｇＱｕｅｒｙの実行` goes from third to first. That case was the original hypothesis: the fullwidth word matched nothing, so the question was really `の実行` and tied two concepts about running things.

### How

NFKC — the compatibility normalization the standard defines for exactly this. Migration 0043 applies it to the haystack once, before either pass cuts it, and rewrites what is already stored the way 0040 and 0042 did. `queryFragments` and `QueryTerms` fold the query the same way, and the name comparisons fold both sides: a concept filed at `ｵｰﾀﾞｰ.md` is named オーダー by whoever filed it there.

**The two implementations have to be one implementation.** `TestNFKCAgreesWithGo` walks 7,377 code points across latin, the kana, the CJK compatibility squares and the halfwidth/fullwidth block, holding `normalize(…, NFKC)` to `golang.org/x/text/unicode/norm`. They agree today, at zero disagreements; a character that stopped agreeing would be a term nobody could find — this same defect arriving from the other side. It is the `TestCJKClassAgreesWithGo` pattern, for the second boundary the two halves share.

**What does not fold**: the whole-query bonus. It asks whether the question appears in the haystack *verbatim* — a question about the raw text — and folding it would put a `normalize()` over a multi-kilobyte body on every candidate row, for what is already a tiebreaker. Named as a limit in the migration rather than left to be discovered.

Not fixed here, and worth naming: 「売り上げの定義」 still ranks third. Okurigana (売り上げ for 売上) is not a compatibility variant — no fold reaches it, and the product's answer for it today is the writer's own `synonyms` key (design doc 0105).

## Checks

CI runs the same script; make it pass locally first (CONTRIBUTING.md has the
context, including the store integration test and the fuzz targets).

- [x] `scripts/check` is clean — add `--db` when the change touches the store (`core` incl. store integration tests against a throwaway PostgreSQL 16, and `lint`; Docker and `govulncheck` are CI's to verify in this environment)
- [x] Behavior changes come with tests — `TestOneSpellingOfACharacter` (verified to fail without the migration: both queries return nothing), `TestNFKCAgreesWithGo`, the supplement concept and its three golden cases, and the eval's floors and ceilings

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and `internal/apiclient` say the same thing — untouched
- [x] The change lands on every surface it belongs on — one search change behind every surface at once; it adds none
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens a surface? No

## Design docs

- [x] Alters an accepted decision? No — no record says which spellings of a character the index folds, and index and query work belongs in the PR description. The stored *document* is untouched: 0043 rewrites the derived search index, not the OKF round trip, and a concept written in halfwidth comes back out of `export` exactly as it went in
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmF42nZ26ztXudQnqrwzZ4)_