### PR TITLE
Write down where the lexical side ends

### DIFF
--- a/internal/service/searcheval_integration_test.go
+++ b/internal/service/searcheval_integration_test.go
@@ -605,6 +605,38 @@ const (
 	// for.
 )
 
+// **What the english and mixed dimensions are, and what does not move
+// them.** They are the two lowest lines the report prints, and after
+// four changes to the lexical side they are the two that did not
+// improve. It is worth writing down why, because the shape of their
+// loss is not a defect anything here can fix.
+//
+// A question whose content is a warehouse identifier saturates. Asked
+// 「sale_price column」 or 「sale_price はどの表にあるか」 — the
+// Japanese half of which is particles, so both questions are the
+// identifier — six concepts score exactly 1.00: the table that defines
+// the column, and the five computations that use it all contain sale,
+// price and column, so coverage is total for every one of them and the
+// order among them falls to the tie-break, which knows nothing about
+// the question. 「traffic_source は何の値か」 is the same at 0.53, and
+// 「why is revenue down」 puts five concepts at 1.50.
+//
+// Two ways out were measured and neither works. **Frequency** is
+// refused on principle and was measured refusing it: keeping positions
+// and breaking ties with ts_rank moved MRR from 0.85 to 0.84 (migration
+// 0036). **Length** does not separate them either — for
+// 「sale_price column」 the concept that answers is the second shortest
+// of the six, behind one that does not.
+//
+// What separates "defines this column" from "uses this column" is not
+// in the words: both say the identifier, once, in prose that is
+// otherwise about different things. It is the vector half's question,
+// and **this harness cannot answer whether the vector half answers
+// it** — the stand-in encoder shares the lexical side's vocabulary
+// exactly here, which is the limit fakeencoder_test.go states about
+// itself. So these two lines are not a backlog. They are where the
+// lexical side ends.
+
 // evalFloorSlackCases is how far a floor may sit under what was measured
 // before that gap is itself a failure, counted in cases.
 //


### PR DESCRIPTION
<!-- Keep PRs small and focused. Link the issue or design doc, if there is one. -->

## What and why

Comment-only. After four changes to the lexical side (#702, #715, #716, #717), `english` (0.74) and `mixed` (0.87) are the two lowest lines the report prints and the two that never moved. I measured what their loss is made of, and it is not a defect anything on that side can fix — so this records it, in the file whose numbers would otherwise send the next reader to measure it again.

**A question whose content is a warehouse identifier saturates.** Asked `sale_price column`, or `sale_price はどの表にあるか` — whose Japanese half is particles, so both questions *are* the identifier:

```
1. metrics/revenue(1.00)  2. monthly-bookings(1.00)  3. monthly-revenue(1.00)
4. revenue-by-traffic-source(1.00)  5. tables/order-items(1.00)  ← the answer
6. tables/orders(1.00)
```

The table that defines the column and the five computations that use it all contain sale, price and column. Coverage is total for every one, so **the order among them falls to a tie-break that knows nothing about the question** (verification recency, then id). `traffic_source は何の値か` is the same shape at 0.53; `why is revenue down` puts five concepts at 1.50.

Two ways out were measured, and neither works:

- **Frequency** is refused on principle, and was measured refusing it — migration 0036 records that keeping positions and breaking ties with `ts_rank` moved MRR from 0.85 to 0.84.
- **Length** does not separate them: for that query the concept that answers is the *second* shortest of the six, behind one that does not answer.

What separates "defines this column" from "uses this column" is not in the words — both say the identifier once, in prose otherwise about different things. It is the vector half's question, and **this harness cannot say whether the vector half answers it**: the stand-in encoder shares the lexical side's vocabulary exactly there, which is the limit `fakeencoder_test.go` already states about itself.

So those two lines are not a backlog. They are where the lexical side ends, and saying so is worth more than another round of tuning against them — the same reason the records keep what was refused (design doc 0081 §"No を覚えていること").

## Checks

CI runs the same script; make it pass locally first (CONTRIBUTING.md has the
context, including the store integration test and the fuzz targets).

- [x] `scripts/check` is clean — `core` (incl. store integration tests against a throwaway PostgreSQL 16) and `lint`; Docker and `govulncheck` are CI's to verify in this environment
- [x] Behavior changes come with tests — no behavior change; this is a comment in a test file

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and `internal/apiclient` say the same thing — untouched
- [x] The change lands on every surface it belongs on — it touches none
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens a surface? No — one comment

## Design docs

- [x] Alters an accepted decision? No — it records a measurement and two rejected mechanisms
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmF42nZ26ztXudQnqrwzZ4)_