### PR TITLE
Say the property, not only where it is bought (C2, C8)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ too**: the manual has a ceiling on its line count, so explaining a fold
 at length is a decision like any other.
 
 That document opens with the **eight conditions** ochakai exists to
-satisfy — the knowledge stays the user's, Google Cloud with no secrets,
+satisfy — the knowledge stays the user's, secret-zero on Google Cloud,
 OKF v0.2, no forward-deployed engineer, usable from Claude Code, a small
 embeddable REST API, a measurable improvement loop, and being one of the
 best choices available to a Japanese-speaking user weighing similar

--- a/docs/surface.md
+++ b/docs/surface.md
@@ -24,13 +24,13 @@ ochakai を使う人が払うのは実装の行数ではなく**表面**であ�
 | id | 条件 |
 |---|---|
 | C1 | 資産は利用者のもの — 丸ごと出て、丸ごと戻り、求められれば消える([0009](design/0009-provenance-portability.md)・[0031](design/0031-purge.md)・[0075](design/0075-the-bundle-is-the-address-space.md)) |
-| C2 | Google Cloud、secret なし — Cloud Run IAM と Cloud SQL IAM で、トークンもパスワードも置かない([0065](design/0065-identity-and-provenance.md)・[0003](design/0003-gcp-only.md)) |
+| C2 | secret を一つも置かないこと — その性質を Cloud Run IAM と Cloud SQL IAM が無設定で買う([0065](design/0065-identity-and-provenance.md)・[0003](design/0003-gcp-only.md))。**性質と買い方は同じではない**: OIDC 発行者を名指したデプロイは Google Cloud の外でも secret を増やさずに誰が呼んでいるかを答え([0086](design/0086-a-second-way-to-say-who-is-calling.md))、そこではデータベースの資格情報が運用者の仕事に戻る |
 | C3 | 形式は Open Knowledge Format v0.2 — 保存もワイヤも往復も OKF で、その横に第二の形式を発明しない([0075](design/0075-the-bundle-is-the-address-space.md)) |
 | C4 | No FDE — デプロイは自分でできて、必要な操作には自分で打てるコマンドがある([0067](design/0067-four-faces-and-what-they-decline.md)) |
 | C5 | Claude Code から使える — MCP over HTTP と、それを話せないクライアントのための stdio 橋([0067](design/0067-four-faces-and-what-they-decline.md) §3) |
 | C6 | 利用者が自分の Web サービスに埋められる小さな REST API — OpenAPI 一枚で、クライアントライブラリを要らなくする([0081](design/0081-what-ochakai-is-and-what-it-refuses-to-hold.md)・[0067](design/0067-four-faces-and-what-they-decline.md) §1) |
 | C7 | 人間の改善ループが測れる — 検証・結果報告・キューの長さ・答えの無かった問いを、推測ではなく数で持つ([0069](design/0069-the-loop-and-what-measures-it.md)) |
-| C8 | 日本語話者にとって、類似サービスと比較したときの最適な選択肢の一つであること — trigram 索引は二文字の日本語語を引けず、埋め込みは Google Cloud 上で既定である([0080](design/0080-search-and-how-a-deployment-embeds.md)) |
+| C8 | 日本語話者にとって、類似サービスと比較したときの最適な選択肢の一つであること — 二文字の日本語語が索引で引け(移行 `0036`)、書き手が与えた別名も索引に入り([0105](design/0105-a-concept-answers-to-its-other-names.md))、埋め込みは既定でデプロイのリージョンで走る([0080](design/0080-search-and-how-a-deployment-embeds.md) §1.2) |
 
 **どれにも当たらない提案は、三つの問いに進むまでもなく no である。**
 逆は成り立たない — 条件に当たることは必要条件であって十分条件では


### PR DESCRIPTION
## What and why

`docs/surface.md` の八つの条件は、**提案を測るときに実際に読まれる物差し**である。その二行が、このリポジトリが既に知っていることから離れていた。しかも**誰も落とせない** — `cmd/ochakai/surface_test.go` が読むのは九つの数える節であってこの表ではないので、条件が古くなっても失敗するテストが一つも無い。

決定は一つも動かない。動かしたのは、条件が自分の根拠として何を名指すかだけである。

### C2 — 一行に二つの主張が畳まれていた

旧: `Google Cloud、secret なし — Cloud Run IAM と Cloud SQL IAM で、トークンもパスワードも置かない`

これは**性質**(長期 secret をどこにも置かない)と、**それを無設定で買う機構**(Cloud Run IAM + Cloud SQL IAM)を一つの文にしている。`docs/positioning.md`「ochakai が負けるところ」は既に正確に割っており(「C2 の secret-zero という性質は Cloud Run IAM と Cloud SQL IAM で無設定に買われている」)、粗いのは物差しの側だけだった。

これは判断を変える。0086(OIDC 発行者を名指したデプロイが自分で検証する)は、**性質を保ったまま買い方を外した**提案である。粗い読み方では「Google Cloud」としか書かれていないので、0086 は条件違反として提案の段階で落ちる。実際には通っており、しかも secret は一つも増えていない。

新しい行は性質を先に置き、どこで買うかを続け、Google Cloud の外ではデータベースの資格情報が運用者の仕事に戻ることまで言う。0003 の「それ以外の実行環境をサポートしない」は動かない — 支えるスコープの話であって、性質の話ではないからである。

### C8 — 根拠が入れ替わっていたのに、文が古いまま残っていた

旧: `… — trigram 索引は二文字の日本語語を引けず、埋め込みは Google Cloud 上で既定である`

後半は真だが、**前半が後半の理由として書かれている**。その因果は `internal/store/migrations/0036_lexical_search_is_indexed.sql`(2026-08-15)以降成立しない。二文字窓を tsvector の lexeme にしたので字句索引は自分で `売上` を引けるようになり、`pg_trgm` は生きたコードから消えて 0016 のコメントに歴史として残るだけになっている。

代金は字面ではなかった。**[0114](``https://github.com/na0fu3y/ochakai/blob/main/docs/design/0114-a-degraded-ranking-says-so.md)(2026-08-17)がこの行を根拠として引いている**:``

> そして誰が困るかは C8 が決めている。**trigram の索引は二文字の日本語語を引けない**([surface.md](../surface.md) C8、0080)。日本語のデプロイで埋め込みが落ちるということは、検索が「ほぼ何も返さない」に近づくということであり…

0114 の決定(退化した順位はそう名乗る)は正しく、ここでは触らない。ただしその**深刻さの見積もりは、書かれた二日前に既に古くなっていた文から受け継がれている** — 字句だけでも日本語は引けるので、失うのは意味での一致であって「ほぼ何も返さない」ではない。記録は書き換えないので、直せるのは引かれた側だけである。

もう一つの実害は前向きの側にある。いまの書きぶりは「日本語検索を改善する」提案に対して**「字句索引を直せ」と読める**。もう直っている。

新しい行は、**今日真で、外から確かめられる三つ**を名指す — 二文字の日本語語が索引で引ける(移行 `0036`)、書き手が与えた別名が索引に入る(``[0105](https://github.com/na0fu3y/ochakai/blob/main/docs/design/0105-a-concept-answers-to-its-other-names.md))、埋め込みが既定でデプロイのリージョンで走る([0080](https://github.com/na0fu3y/ochakai/blob/main/docs/design/0080-search-and-how-a-deployment-embeds.md)`` §1.2)。

### CLAUDE.md

同じ条件の一行要約が、C2 と同じ理由でプラットフォームを先に置いていた(`Google Cloud with no secrets` → `secret-zero on Google Cloud`)。冒頭の段落はもともと正確なので、そちらは触っていない。

### 表面を広げるか

**広げない。** 追加した REST 操作・MCP ツール・CLI コマンド・環境変数は無い。`docs/surface.md` の変更は**行数中立**(表の一行を一行に置き換えただけ)なので、`DOC` の 27 も `DOC-LINES` も動かない。三つの問いは、表面を足す PR のためのものなので該当しない。

## Checks

- [x] `scripts/check` is clean — add `--db` when the change touches the store
- [x] Behavior changes come with tests

`scripts/check core`(gofmt / go vet / `go test -race` / `CGO_ENABLED=0` build)と `scripts/check lint`(0 issues)がローカルで green。ドキュメントのみの変更なのでストアには触っておらず、`--db` は要らない。`scripts/check vuln` はこの環境の egress ポリシーが vuln.go.dev を拒むため実行できていない(脆弱性の検出ではなくプロキシの拒否) — CI が回す。

振る舞いの変更が無いのでテストの追加も無い。**逆に、この PR が見つけた穴のほうを記録しておく**: 八つの条件は `cmd/ochakai/surface_test.go` の検査対象外で、条件が現在形で間違っていても何も落ちない。今回のような drift を機械が捕まえる方法は思いついていないので(条件は散文で、その真偽は外の世界にある)、ここでは塞いでいない。

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, `internal/apiclient` が同じことを言う — 触っていない
- [x] 面ごとに載る/載らないの判断 — 該当なし(コードの変更が無い)
- [x] `api/openapi.frozen.txt` は無変更
- [x] 表面を広げないので `docs/surface.md` の数は動かない(行数中立)

## Design docs

- [x] 受け入れ済みの決定を変えないので、番号付きドキュメントは無い。0003・0065・0080・0086・0105 のいずれも決定は不変で、変わったのは条件表がそれらを引くときの精度だけである(0048: 外形の変わらない変更は PR の説明で足りる)
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y8pPvwv8kXTqrPXQEXfNEJ)_