### PR TITLE
Scope the curation guards, and stop trusting a filename from the wire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,27 @@ last entry.
 
 ### Fixed
 
+- **`put_concept` no longer says a ruling exists outside the caller's
+  scope.** On a deployment with an access policy (design doc 0109), the
+  two guards MCP's `put_concept` runs before it writes — the ones that
+  refuse to replace or revive knowledge a human has ruled on — read the
+  ledger without the scope check the write itself has. Against an id
+  outside the caller's grant they answered "cannot replace `<id>`: it is
+  rejected" instead of the 404 that hides the address, so an agent could
+  learn that a concept exists there, or existed, and that somebody
+  verified, rejected or deprecated it. The concept's content was never
+  reachable and no write ever landed; what leaked was the address and
+  the ruling. Both are scoped now, and §6's exhaustiveness walk covers
+  them, which is why they were the two it did not. A deployment with no
+  access rules — every deployment before 0109 and every one that has not
+  written a policy since — was never affected.
+- **`ochakai get --download` checks the filenames it is handed.** A
+  server names the files it hands back, and the client wrote them under
+  the download directory without asking whether the name was one path
+  segment. Any ochakai holds every filename to that rule on the way in,
+  so this could only fire for an answer that did not come from one — but
+  believing such an answer would have put bytes wherever the name
+  pointed. The name is checked now and a refusal names it.
 - **Halfwidth katakana and fullwidth latin are found by a question
   spelled normally, and the reverse.** They are what a system upstream
   of the reader writes — a warehouse export from something fixed-width,

--- a/cmd/ochakai/client.go
+++ b/cmd/ochakai/client.go
@@ -882,6 +882,16 @@ func cmdGet(ctx context.Context, args []string) error {
 			return err
 		}
 		for _, att := range k.Files {
+			// The name decides where the bytes land, and it arrives from
+			// the server — so it is checked here rather than trusted,
+			// exactly as extractTarGz checks the paths in an archive. A
+			// server holds every name to one segment (domain.ValidFileName)
+			// on the way in, so this can only fire for an answer that did
+			// not come from an ochakai; the cost of believing one would be
+			// a write outside the directory the caller named.
+			if !domain.ValidFileName(att.Name) {
+				return fmt.Errorf("refusing to save %q: the server named a file that is not one path segment", att.Name)
+			}
 			data, _, err := c.File(ctx, att.Path)
 			if err != nil {
 				return fmt.Errorf("file %s: %w", att.Name, err)

--- a/cmd/ochakai/client_test.go
+++ b/cmd/ochakai/client_test.go
@@ -1512,3 +1512,40 @@ func TestUnknownCommandSaysWhatIsWrong(t *testing.T) {
 		}
 	}
 }
+
+// TestGetDownloadRefusesAnEscapingName pins the one place a client writes
+// files where the server chose the names. A server holds every file name
+// to a single path segment, so this can only fire for an answer that did
+// not come from an ochakai — which is exactly when believing it would put
+// bytes outside the directory the caller named.
+func TestGetDownloadRefusesAnEscapingName(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/bundle/{path...}", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(domain.View{
+			ID: "metrics/revenue", Document: "---\ntype: Metric\n---\n\nbody\n",
+			Files: []domain.File{{
+				Name: "../escaped.txt", Path: "metrics/note.txt",
+				MediaType: "text/plain", Size: 3,
+			}},
+		})
+	})
+	mux.HandleFunc("GET /api/v1/bundle/metrics/note.txt", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("pwn"))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	dir := t.TempDir()
+	into := filepath.Join(dir, "files")
+	err := cmdGet(context.Background(), []string{"metrics/revenue", "--download", into, "--url", srv.URL})
+	if err == nil {
+		t.Fatal("cmdGet saved a file the server named ../escaped.txt, want a refusal")
+	}
+	if !strings.Contains(err.Error(), "one path segment") {
+		t.Errorf("error does not say what is wrong: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "escaped.txt")); !os.IsNotExist(err) {
+		t.Errorf("escaped.txt was written outside the download directory")
+	}
+}

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -7,7 +7,12 @@ services:
     build:
       context: ..
     ports:
-      - "8080:8080"
+      # Loopback, not every interface. OCHAKAI_MODE=dev below authenticates
+      # nobody and refuses nothing, so a published 8080 is an anonymous,
+      # writable knowledge base offered to whatever network the machine is
+      # on — a comment saying "local only" is not what keeps it local.
+      # http://localhost:8080 is unchanged for whoever is running it.
+      - "127.0.0.1:8080:8080"
     environment:
       OCHAKAI_DATABASE_URL: postgres://ochakai:ochakai@db:5432/ochakai?sslmode=disable
       OCHAKAI_MODE: dev # local only: all requests act as human:anonymous

--- a/internal/service/access_integration_test.go
+++ b/internal/service/access_integration_test.go
@@ -142,6 +142,43 @@ func TestScopeRefusesAWriteItAllowsAReadOfIntegration(t *testing.T) {
 	}
 }
 
+// TestScopeHidesARulingOutsideItIntegration is the case the reflection
+// walk below cannot reach: the curation guards MCP's put_concept runs
+// ahead of the write only speak when a human has ruled on the id, so a
+// fixture whose out-of-scope concept is an ordinary draft passes without
+// ever asking the question. Both of their refusals name the id and say a
+// human ruled on it — which is the read 0109 §4 answers with a 404.
+func TestScopeHidesARulingOutsideItIntegration(t *testing.T) {
+	f := newAccessFixture(t)
+	if _, err := f.svc.Reject(f.adminCtx, f.theirs, "not ours", f.admin); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.svc.RefuseIfCurated(f.readCt, f.theirs, "replace"); !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("RefuseIfCurated on a ruled-on concept outside the scope returned %v, want ErrNotFound", err)
+	}
+	// And again once the ruling is a tombstone, which is the other guard:
+	// GetTombstone reads a row Get cannot see, so it needs the check of
+	// its own.
+	if err := f.svc.Delete(f.adminCtx, f.theirs, f.admin, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.svc.RefuseIfRevivingCurated(f.readCt, f.theirs); !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("RefuseIfRevivingCurated on a deleted ruling outside the scope returned %v, want ErrNotFound", err)
+	}
+	// The surface that calls both: put_concept lands here for an id it
+	// found free, and the answer must be the same 404.
+	_, err := f.svc.CreateKeepingCurated(f.readCt,
+		&domain.Knowledge{Type: "Metric", ID: f.theirs, Title: "x"}, f.reader)
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("CreateKeepingCurated outside the scope returned %v, want ErrNotFound", err)
+	}
+	// Inside the read scope but outside the write scope, both guards say
+	// the thing the caller already knows.
+	if _, err := f.svc.RefuseIfCurated(f.readCt, f.shared, "replace"); !errors.Is(err, ErrForbidden) {
+		t.Errorf("RefuseIfCurated on a readable, unwritable concept returned %v, want ErrForbidden", err)
+	}
+}
+
 // TestScopeNarrowsEveryListingIntegration walks the answers assembled
 // from more than one query — the ones the search filter does not reach —
 // because those are where a boundary leaks by omission rather than by
@@ -283,8 +320,7 @@ func TestEveryWriteIsScopedIntegration(t *testing.T) {
 		"Get": true, "Search": true, "SearchOrList": true, "Revisions": true,
 		"Usage": true, "Browse": true, "Stats": true, "IndexDocument": true,
 		"LogDocument": true, "LogRows": true, "ObjectHistory": true,
-		"GetFile": true, "GetFileMeta": true, "FillFiles": true,
-		"RefuseIfCurated": true, "RefuseIfRevivingCurated": true, "Close": true,
+		"GetFile": true, "GetFileMeta": true, "FillFiles": true, "Close": true,
 		"Policy": true, "RequireAdmin": true,
 		// Whole-bundle operations are refused by RequireAdmin rather than
 		// by an id, and TestPolicyBelongsToAdministratorsIntegration

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -475,8 +475,17 @@ func (s *Service) Plan(ctx context.Context, k *domain.Knowledge, actor domain.Ac
 // tell agents to consult before re-proposing. Nobody notices: unlike a
 // deleted verified concept, a deleted rejection leaves nothing anyone was
 // using.
+//
+// It is a step of a write, so it is scoped like one (design doc 0109 §4).
+// Without that, its refusal was a read of somebody else's subtree: the
+// sentence names the id and says a human ruled on it, which is exactly
+// what a caller outside the scope is meant to receive a 404 for.
 func (s *Service) RefuseIfCurated(ctx context.Context, id, op string) (*string, error) {
-	k, err := s.Store.Get(ctx, domain.Normalize(id))
+	id = domain.Normalize(id)
+	if err := s.mayWrite(ctx, id); err != nil {
+		return nil, err
+	}
+	k, err := s.Store.Get(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -517,8 +526,18 @@ func (s *Service) RefuseIfCurated(ctx context.Context, id, op string) (*string, 
 // revivable in one call. A draft tombstone stays revivable: nobody ruled
 // on it, and reviving an abandoned draft is how a create on a deleted id
 // is supposed to work.
+//
+// Scoped like RefuseIfCurated and for the same reason (design doc 0109
+// §4): a tombstone is still something at an address, and saying a
+// deleted ruling sits at one answers the question the boundary refuses.
+// It runs ahead of create's own guard, so without this the refusal
+// arrived before the 404 that should have replaced it.
 func (s *Service) RefuseIfRevivingCurated(ctx context.Context, id string) error {
-	k, err := s.Store.GetTombstone(ctx, domain.Normalize(id))
+	id = domain.Normalize(id)
+	if err := s.mayWrite(ctx, id); err != nil {
+		return err
+	}
+	k, err := s.Store.GetTombstone(ctx, id)
 	if errors.Is(err, store.ErrNotFound) {
 		// A free id, or a live concept — Create's own ErrAlreadyExists
 		// covers the second case.

--- a/internal/store/move.go
+++ b/internal/store/move.go
@@ -172,7 +172,11 @@ func (s *Store) rewriteReferences(ctx context.Context, tx pgx.Tx, oldID string, 
 		`SELECT `+knowledgeSelectDoc+` FROM object
 		 WHERE deleted_at IS NULL AND (links @> $1 OR attrs->>'model' = $2 OR id = $3)
 		 ORDER BY id FOR UPDATE`,
-		fmt.Sprintf(`[{"target": %q}]`, oldID),
+		// The same containment the reverse lookup asks with, marshalled
+		// rather than formatted: %q spells a Go literal, and the two
+		// disagree for a rune Go writes as \U0001d173 — which no id is
+		// likely to carry, and which JSON has no such escape for.
+		linkContainment(oldID),
 		oldID, newID)
 	if err != nil {
 		return err


### PR DESCRIPTION
## What and why

A security review of the whole tree — auth and identity, the access
policy, the store's SQL, the four faces, the web UI, the client, the
container and the workflows. Most of it held; three things did not, and
one development harness was wider than it said.

**1. The curation guards read outside the caller's scope (design doc
0109 §4).** MCP's `put_concept` runs `RefuseIfCurated` and
`RefuseIfRevivingCurated` before it writes, and both went to the ledger
with no scope check of their own — the write's `mayWrite` ran after
them. Against an id outside the caller's grant they answered

```
cannot replace personnel/salaries from this surface: it is rejected, …
cannot create personnel/salaries from this surface: the id holds a deleted rejected concept, …
```

where §4 says the answer is the 404 that hides the address. What leaked
is the address and the fact that a human ruled on it (verified /
rejected / deprecated); the concept's content was never reachable and no
write ever landed. **A deployment with no access rules — every
deployment before 0109, and every one that has not written a policy
since — is unaffected**, because there is no boundary to cross.

Both guards take `mayWrite` now: an out-of-scope id is `ErrNotFound`,
and a readable-but-unwritable one is the `ErrForbidden` §4 already
prescribes for a write (previously that case got the 400 about the
ruling, which is a less accurate refusal of the same request).

§6's reflection walk over every write listed these two under *reads*,
which is why it did not catch it. They are steps of a write and are
walked as writes now. That walk alone is not enough, though — its
fixture holds an ordinary draft outside the scope, and these guards only
speak for a concept somebody ruled on — so
`TestScopeHidesARulingOutsideItIntegration` rules on it first and asks
all three entry points, `CreateKeepingCurated` included.

**2. A filename from a server decided where bytes landed.** `ochakai get
--download` joined `domain.File.Name` onto the download directory
unchecked. Every ochakai holds a filename to one path segment on the way
in (`domain.ValidFileName`), so only an answer that did not come from
one could carry `..` — but the client is the one thing that points at a
server it does not run, `ochakai use` makes that a one-word decision,
and believing such a name would put bytes wherever it pointed. Checked
now, with the refusal naming the name — the same thing `extractTarGz`
already does for the paths in an archive.

**3. A move built its jsonb by formatting.** `rewriteReferences` spelled
the link containment with `%q`, which is a Go literal and not JSON: the
two disagree for a rune Go escapes as `\U0001d173` — an id no one is
likely to write, and a hand-rolled literal the package already has the
marshalled `linkContainment` for. Not exploitable (the value is bound as
a parameter, so it was never SQL injection); it is the inconsistency
that is worth removing.

**4. The compose harness published dev mode to every interface.**
`deploy/compose.yaml` runs `OCHAKAI_MODE=dev`, which authenticates
nobody and refuses nothing, and published `8080:8080` — an anonymous,
writable knowledge base offered to whatever network the machine is on. A
comment saying "local only" is not what keeps it local. `127.0.0.1:8080:8080`
now; `http://localhost:8080` is unchanged for whoever is running it, and
so is `docker compose exec`.

### What the review found nothing to change in

Recorded because a review that only lists defects reads as if nothing
else was looked at:

- **Identity.** The Cloud Run path takes `X-Serverless-Authorization`
  ahead of `Authorization` — the header Cloud Run actually validates —
  so an authorized caller cannot impersonate through the other one. The
  OIDC verifier checks signature, issuer, audience and expiry, allows
  asymmetric algorithms only, pins the discovery document's own issuer
  against the configured one, bounds what it reads, and rate-limits the
  refetch an unknown `kid` would otherwise trigger. `serve-ui` verifies
  the IAP assertion's signature *and* its issuer, and both proxies drop
  every inbound credential and delegation header before forwarding.
- **The store.** Every filter value is a bound parameter; the only
  interpolated pieces are column qualifiers, placeholder numbers and
  validated ints. `ILIKE` patterns are escaped, so a `%` in a query
  cannot flatten a ranking.
- **The access policy itself.** Administrators come from the
  environment, which is the one place a policy cannot grant itself;
  prefixes match on segment boundaries at both ends; listings are
  narrowed by the filter rather than by dropping rows, so paging stays
  honest; browse counts are scoped in SQL, so a directory row cannot
  carry a count of what the caller cannot see; and a policy that cannot
  be read fails closed.
- **Serving somebody's bytes.** `nosniff` always, inline only for the
  types that cannot execute, `Content-Security-Policy: sandbox` and
  `attachment` for everything else, and SVG and HTML named explicitly.
  The page itself is `default-src 'none'; script-src 'self'` with
  nothing inline, `frame-ancestors 'none'`, and one escape function
  every interpolation goes through.
- **`ochakai ui`.** Loopback bind, plus the Host and Origin guards that
  close DNS rebinding and CSRF against a proxy that signs as the user.
- **Errors and logs.** A 500 answers "internal error" and the reason
  goes to the log; the request log keeps the route and the actor's
  *kind*, never the path or the name.
- **Supply chain.** Distroless nonroot, `CGO_ENABLED=0 -trimpath`,
  read-only default workflow permissions with each job declaring its
  own, actions pinned by SHA, `pull_request` rather than
  `pull_request_target`, SBOM and provenance attestation on the image
  and the archives.

Two things worth an operator's judgement rather than a patch, noted here
and not acted on:

- The shipped recall hook injects search rows — other writers'
  descriptions and snippets — into the agent's prompt. That is what
  design doc 0108 decided it should do, and the trust tier is the answer
  to it; it is worth knowing that pointing a recall hook at an
  `OCHAKAI_MODE=sandbox` deployment (anonymous *and* writable, by
  design) means any stranger can put text in front of your agent.
- `OCHAKAI_ADMINS=*` is spellable, mirroring
  `OCHAKAI_DELEGATING_CALLERS`. Beside an anonymous posture it makes
  every caller an administrator. It is explicit enough to be a choice,
  but it is the one value of that variable that undoes the floor
  under a policy.

## Checks

- [x] `scripts/check core ui lint` is clean, run with `--db`'s database
      (a local PostgreSQL 16 cluster, not the `pgvector/pgvector:pg17`
      CI runs). `scripts/check vuln` could not run in that sandbox — its
      egress policy answers `Forbidden` for `vuln.go.dev`, confirmed
      against the proxy's own status — and CI's `govulncheck` job has
      since passed here, as has `quickstart`, which is the only thing
      that exercises change 4.
- [x] Behavior changes come with tests. Each fails without its fix:
      `TestScopeHidesARulingOutsideItIntegration` and
      `TestEveryWriteIsScopedIntegration` (both entries, once the two
      guards are no longer exempted) for 1, and
      `TestGetDownloadRefusesAnEscapingName` for 2.

## Surfaces and contract

- [x] No endpoint, tool, command or variable moved, so `api/openapi.yaml`,
      `internal/restapi`, `internal/mcpserver` and `internal/apiclient`
      are untouched and still agree.
- [x] Nothing lands on a new surface. The scope fix is enforced in
      `service.Service`, where 0109 §4 put the enforcement point, so
      every face gets it.
- [x] `api/openapi.frozen.txt` is untouched. The refusal that changes
      shape is `put_concept`'s, which is MCP, and the REST statuses
      involved (404, 403) are the ones 0109 already documents.
- [x] No surface is widened, so `docs/surface.md` does not move.

## Design docs

- [x] Not applicable. Design doc 0109 §4 and §6 already state the
      invariant this restores — an out-of-scope read is a 404, a
      readable-but-unwritable write is a 403, and every write is walked
      — so there is no accepted decision being altered and nothing a
      reader could have been depending on. It belongs in this
      description, per 0048.
- [x] Commit messages and code comments are in English.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AoonoHcTMhPq2z85L5z3r