### PR TITLE
Let the loop's numbers be asked about a period and a path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,28 @@ last entry.
 
 ## [Unreleased]
 
+### Added
+
+- **The loop's numbers on the review page can be asked about a period
+  and a path.** `GET /api/v1/stats` has taken `days` and `prefix` all
+  along (design doc 0069 §5); the page asked for neither, so the only
+  reading a browser offered was the last 30 days over the whole base —
+  a team sharing a deployment could not see its own month, and nobody
+  could look back over a quarter without the CLI. Two controls sit above
+  the numbers now, and the numbers are drawn as two bands: what the base
+  *is*, and what happened *inside the window* — the split design doc
+  0069 §5 already made field by field, which is what makes it visible
+  that the period moves the second band and not the first. Two flow
+  numbers the wire carried and the page did not draw join them: concepts
+  created, and outcomes reported worked and failed. **Scoped, the
+  unanswered searches beside them are still the whole instance's** and
+  cannot be otherwise — a search that found nothing found it nowhere, so
+  there is no id to scope it by (0069 §5.1) — and the reading says so
+  rather than letting that number pass as the team's. Nothing is added
+  to the wire: no endpoint, no parameter, no word. The review trend
+  stays the one shape with no axes that design doc 0095 §3 gave it, and
+  the queue depths a curator works from are untouched.
+
 ### Fixed
 
 - **`put_concept` no longer says a ruling exists outside the caller's

--- a/internal/webui/jstest/smoke.mjs
+++ b/internal/webui/jstest/smoke.mjs
@@ -332,6 +332,31 @@ try {
   await check('the current tab says so to a reader who cannot see it',
     await waitFor(`!!document.querySelector('#topnav a[data-route="review"][aria-current="page"]')`), shown);
 
+  // The window and the scope are the stats call's own two parameters, so
+  // these two checks are the round trip: the page asks, the server
+  // answers about that period and that path, and the band redraws. A
+  // control that changed nothing on screen would pass every check above
+  // this one.
+  await waitFor(`!!document.querySelector('#loop-days')`);
+  await evalJS(`(() => { const d = document.querySelector('#loop-days'); if (!d) return;
+    d.value = '7'; d.dispatchEvent(new Event('change', { bubbles: true })); })()`);
+  // The band names the window the server answered about (window_days),
+  // not the one the control asked for — a page that drew its own request
+  // back would say 7 whatever came back.
+  await check('the flow numbers can be asked about another period',
+    await waitFor(`${textOf('#loop-stats')}.includes('直近 7 日に起きたこと')`), shown);
+
+  // examples/demo keeps its metrics under metrics/, and a scope the base
+  // does not have would draw the same note over nothing at all.
+  await evalJS(`(() => { const p = document.querySelector('#loop-prefix'); if (!p) return;
+    p.value = 'metrics'; p.dispatchEvent(new Event('input', { bubbles: true })); })()`);
+  // Scoped, the misses beside the other numbers are still the whole
+  // instance's and cannot be anything else (design doc 0069 §5.1) — so
+  // the reading says which of its numbers did not narrow.
+  await check('a scoped reading says what it could not scope',
+    await waitFor(`(() => { const t = ${textOf('#loop-stats')};
+      return t.includes('答えの無かった検索だけは絞れません') && t.includes('/metrics'); })()`), shown);
+
   // The access policy (design doc 0109 §5). The tab is absent until the
   // server answers for it, so this is also the check that the probe ran
   // at all: CI's deployment has no policy and names no administrators,

--- a/internal/webui/static/app.css
+++ b/internal/webui/static/app.css
@@ -344,6 +344,16 @@ table.rules .flag { text-align: center; width: 3.2rem; padding-right: 0; }
 .stat-tiles .tile { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: .9rem 1rem; }
 .tile .num { font-size: 1.7rem; font-weight: 700; }
 .tile .lbl { color: var(--muted); font-size: .82rem; }
+/* The loop's numbers are of two kinds and are read differently: a state
+   is how the base stands now, a flow is what happened inside the window
+   the reader picked (design doc 0069 §5). One band each, so the window
+   control visibly moves the second and leaves the first alone. */
+.tile-band { color: var(--muted); font-size: .82rem; margin: .2rem 0 .35rem; }
+/* The two bands are read as one table of numbers, so their columns
+   have to line up: auto-fill keeps the tracks the shorter band would
+   otherwise swallow, and a state tile stays the width of the flow
+   tile under it. */
+.stat-tiles.band { grid-template-columns: repeat(auto-fill, minmax(9rem, 1fr)); }
 
 /* ---- markdown body ---- */
 .md h1, .md h2, .md h3, .md h4, .md h5, .md h6 { line-height: 1.3; margin: 1.1em 0 .4em; }

--- a/internal/webui/static/index.html
+++ b/internal/webui/static/index.html
@@ -15,11 +15,11 @@
      action and tree drag & drop), the draft review queue (sort=usage),
      the two feeds that empty by verifying — reported wrong (sort=failed)
      and verification age (sort=verified_at), reachable from the review
-     queue and #/search/reported-wrong — how much each queue is holding
-     (design doc 0049), how the loop is going and what it could not
-     answer (design doc 0051), the access policy for an administrator —
-     who may read and write under which directory (design doc 0109) —
-     and OKF export.
+     queue and #/search/reported-wrong — how much each queue is holding,
+     how the loop is going over a period and under a path, and what it
+     could not answer (design doc 0069), the access policy for an
+     administrator — who may read and write under which directory
+     (design doc 0109) — and OKF export.
      A starting point for building your own UI. -->
 <html lang="ja">
 <head>

--- a/internal/webui/static/js/views/review.js
+++ b/internal/webui/static/js/views/review.js
@@ -9,17 +9,26 @@ import { esc } from '../escape.js';
 import { actorStr, daysSince, displayTitle, entryHash, fmtAge } from '../format.js';
 import { descHTML } from '../markdown.js';
 import { queueStrip, refreshQueues } from '../queues.js';
-import { refreshTree } from '../tree.js';
+import { knownDirs, refreshTree } from '../tree.js';
 import { icon } from '../vocab.js';
-import { explore } from './explore.js';
+import { debounce, explore } from './explore.js';
 
 // A draft with zero search hits, older than this, is flagged stale — the
 // inventory case (nobody's finding it; a candidate to drop). Sort=usage
 // already sinks these to the bottom; the toggle isolates them.
 export const STALE_DAYS = 14;
+// The windows the flow numbers can be asked about — `days` on the stats
+// call, whose default is the 30 this page opens with. 180 is the
+// server's ceiling and not a round number chosen here: the raw events
+// behind the outcome and miss counts are pruned after it, so a longer
+// window would answer with less than it was asked for (design doc 0069
+// §3), and asking for one is a 400.
+export const STATS_WINDOWS = [7, 30, 90, 180];
 // loaded and cursor walk the draft queue a page at a time (design doc
 // 0050 §2.1): the queue is a ledger, so it has an end rather than a cap.
-export const review = { staleOnly: false, loaded: [], cursor: '' };
+// days and prefix are what the loop's numbers above it are asked about;
+// both are parameters the stats call already takes.
+export const review = { staleOnly: false, loaded: [], cursor: '', days: 30, prefix: '' };
 
 export function viewReview() {
   view.innerHTML = `
@@ -37,6 +46,16 @@ export function viewReview() {
     <a href="#/search/verification-age">検証の古さ</a>(検証が古いものから順)です。検証し直すと、前者からは消え、
     後者では最後尾に回ります。三つ目の <a href="#/search/stale">期限切れ</a> は、書き手が宣言した期限を過ぎた
     concept を並べます。こちらは検証では片付かず、concept を編集して期限を宣言し直すと消えます。</p>
+    <div class="toolbar" style="margin:.2rem 0 .5rem">
+      <label class="check">窓
+        <select id="loop-days" aria-label="流れの数を数える窓">${STATS_WINDOWS.map(d =>
+          `<option value="${d}"${d === review.days ? ' selected' : ''}>直近 ${d} 日</option>`).join('')}</select></label>
+      <label class="check">範囲
+        <input type="text" id="loop-prefix" list="loop-dirs" placeholder="全体" aria-label="パスで数を絞る"
+               title="このパスの下にある concept だけを数える(例: teams/growth)"
+               value="${esc(review.prefix)}" style="width:9rem"></label>
+      <datalist id="loop-dirs"></datalist>
+    </div>
     <div id="loop-stats"></div>
     <div class="toolbar">
       <label class="check"><input type="checkbox" id="r-stale" ${review.staleOnly ? 'checked' : ''}>
@@ -46,15 +65,32 @@ export function viewReview() {
     </div>
     <div id="review-results"><div class="empty">…</div></div>`;
   $('#r-stale').addEventListener('change', () => { review.staleOnly = $('#r-stale').checked; runReview(); });
+  // The directories the tree has loaded, offered as completions — the
+  // same list the move dialog completes against, and the reason the
+  // scope is typed as a path rather than picked from a fixed menu:
+  // which prefixes mean a team is the base's own business.
+  $('#loop-dirs').innerHTML = knownDirs().map(p => `<option value="${esc(p)}">`).join('');
+  $('#loop-days').addEventListener('change', e => { review.days = Number(e.target.value); loadLoopStats(); });
+  $('#loop-prefix').addEventListener('input', e => {
+    review.prefix = e.target.value.replace(/^\/+|\/+$/g, '').trim();
+    debounce(loadLoopStats, 250);
+  });
   refreshQueues();
   runReview();
   loadLoopStats();
 }
 
-// The loop as the instance sees it (design doc 0051), on the page where
-// the person who runs it already is. Four numbers and the questions that
-// came back empty — not a dashboard: what a curator can act on this
-// morning, which is what the queues below are for.
+// The loop as the instance sees it (design doc 0069 §5), on the page
+// where the person who runs it already is. A handful of numbers and the
+// questions that came back empty — not a dashboard: what a curator can
+// act on this morning, which is what the queues below are for.
+//
+// They come in two kinds and are read differently, so they are drawn as
+// two bands rather than one row: a *state* is how the base stands right
+// now, a *flow* is what happened inside the window (design doc 0069 §5
+// says which is which, field by field). Split, the window control
+// visibly moves the second band and leaves the first alone; mixed, the
+// reader had to know the schema to tell which numbers just changed.
 //
 // sparkline draws the review trend: eight weeks of verifications, oldest
 // first (design doc 0095). Inline SVG rather than a chart library — this
@@ -88,13 +124,24 @@ function sparkline(weeks) {
 export async function loadLoopStats() {
   const out = $('#loop-stats');
   if (!out) return;
+  // The window and the scope are both parameters the stats call already
+  // takes, so asking a narrower question adds nothing to the wire. days
+  // is sent only when it is not the server's own default, which keeps
+  // the plain "how is it going" call the same one it always was.
+  const p = new URLSearchParams();
+  if (review.days !== 30) p.set('days', review.days);
+  if (review.prefix) p.append('prefix', review.prefix);
+  const query = p.toString();
+  // Rapid changes to either control leave earlier answers in flight; the
+  // last one asked for is the one drawn, whichever returns first.
+  const my = loadLoopStats._seq = (loadLoopStats._seq || 0) + 1;
   let s;
-  try { s = await api('/api/v1/stats'); } catch (e) {
-    if (out !== $('#loop-stats')) return;
+  try { s = await api('/api/v1/stats' + (query ? '?' + query : '')); } catch (e) {
+    if (my !== loadLoopStats._seq || out !== $('#loop-stats')) return;
     out.innerHTML = `<div class="error-banner" role="alert">loop の数字を読み込めませんでした: ${esc(e.message)}</div>`;
     return;
   }
-  if (out !== $('#loop-stats')) return;
+  if (my !== loadLoopStats._seq || out !== $('#loop-stats')) return;
   const trust = s.concepts?.trust || {};
   const confirmed = (trust['human-reviewed'] || 0) + (trust['machine-confirmed'] || 0);
   const gaps = s.misses?.recording ? (s.misses.queries || []) : [];
@@ -107,15 +154,32 @@ export async function loadLoopStats() {
   // past, and this one is worth stopping at — nothing else on any
   // surface says a concept is half in the index (design doc 0089).
   const truncated = s.embedding?.enabled ? (s.embedding.truncated ?? 0) : 0;
-  out.innerHTML = `
-    <div class="stat-tiles" style="max-width:52rem;margin:.2rem 0 1rem">
+  // Every number keyed by a concept honors the scope — the tallies, the
+  // queues, the verifications, the outcomes, the shape. `misses` does
+  // not and cannot: a search that found nothing found it nowhere, so
+  // there is no id to scope it by (design doc 0069 §5.1). Wherever one
+  // is drawn beside a scoped number, it says which it is.
+  const scoped = !!review.prefix;
+  out.innerHTML = (scoped ? `
+    <p style="max-width:48rem;margin:0 0 .8rem;color:var(--muted);font-size:.9rem">
+      <code>/${esc(review.prefix)}</code> の下だけを数えています。<strong>答えの無かった検索だけは絞れません</strong> —
+      何も返さなかった検索には concept の id が無いので、どこで訊かれたかを言えないからです。その数と一覧は
+      インスタンス全体のものです。下のキューの帯と draft の一覧も絞っていません。</p>` : '') + `
+    <div class="tile-band">いまの姿</div>
+    <div class="stat-tiles band" style="max-width:52rem;margin:0 0 1rem">
       <div class="tile"><div class="num">${s.concepts?.total ?? 0}</div><div class="lbl">concept</div></div>
       <div class="tile"><div class="num">${confirmed}</div><div class="lbl">誰かが確認した</div></div>
-      <div class="tile"><div class="num">${s.review?.verifications ?? 0}</div><div class="lbl">直近 ${s.window_days} 日の検証</div></div>
-      <div class="tile"><div class="num">${s.misses?.recording ? (s.misses.count ?? 0) : '–'}</div>
-        <div class="lbl">何も見つからなかった検索</div></div>
+    </div>
+    <div class="tile-band">直近 ${s.window_days} 日に起きたこと</div>
+    <div class="stat-tiles band" style="max-width:52rem;margin:0 0 1rem">
+      <div class="tile"><div class="num">${s.concepts?.created ?? 0}</div><div class="lbl">増えた concept</div></div>
+      <div class="tile"><div class="num">${s.review?.verifications ?? 0}</div><div class="lbl">検証</div></div>
+      <div class="tile"><div class="num">${s.outcomes?.worked ?? 0} / ${s.outcomes?.failed ?? 0}</div>
+        <div class="lbl">うまくいった / 失敗の報告</div></div>
       <div class="tile"><div class="num">${s.outcomes?.concepts_reported ?? 0}/${s.outcomes?.concepts_used ?? 0}</div>
         <div class="lbl">使われた concept のうち結果が返ってきたもの</div></div>
+      <div class="tile"><div class="num">${s.misses?.recording ? (s.misses.count ?? 0) : '–'}</div>
+        <div class="lbl">何も見つからなかった検索${scoped ? '(全体)' : ''}</div></div>
     </div>` + sparkline(s.review?.weekly) + (dropped ? `
     <p style="max-width:48rem;margin:0 0 1.2rem;color:var(--muted);font-size:.9rem">
       この ${s.window_days} 日で、記録されたあと失われた観測が ${dropped} 件あります。
@@ -127,10 +191,10 @@ export async function loadLoopStats() {
       見つかりません — 語句そのものが含まれていれば字句検索は当てます。長すぎる concept を
       分けるか、より広い窓のモデルに移すかのどちらかです。</p>` : '') + (gaps.length ? `
     <details style="max-width:48rem;margin:0 0 1.2rem">
-      <summary style="cursor:pointer;color:var(--muted)">答えの無かった検索 — 次に書くもの</summary>
+      <summary style="cursor:pointer;color:var(--muted)">答えの無かった検索 — 次に書くもの${scoped ? '(全体)' : ''}</summary>
       <p style="color:var(--muted);font-size:.9rem;margin:.5rem 0">直近 ${s.window_days} 日で何も返さなかった検索を、
       多く訊かれたものから順に並べています。誰かが片付けるキューではありません: 答えになる concept が書かれれば、
-      この一覧からは自然に消えます。</p>
+      この一覧からは自然に消えます。${scoped ? 'この一覧だけは範囲の指定を受けません — 何も見つからなかった検索は、どこで訊かれたかを言えないからです。' : ''}</p>
       ${gaps.map(g => `<div style="display:flex;gap:.6rem;align-items:baseline;padding:.25rem 0">
         <span class="badge">${g.count}×</span>
         <a href="#/search" class="mono" data-gap="${esc(g.query)}">${esc(g.query)}</a></div>`).join('')}

--- a/internal/webui/webui_test.go
+++ b/internal/webui/webui_test.go
@@ -491,7 +491,7 @@ func TestADescriptionIsRenderedAsTheMarkdownItIs(t *testing.T) {
 	}
 }
 
-// The loop strip is the human side of design doc 0051: the review page
+// The loop strip is the human side of design doc 0069 §5: the review page
 // is where the person who runs the loop already is, so the instance's
 // numbers are drawn there rather than on a page of their own.
 //


### PR DESCRIPTION
The review page called `GET /api/v1/stats` with no parameters, so the only reading a browser offered was **the last 30 days over the whole base**. Both `days` and `prefix` have been on that call since design doc [0069](docs/design/0069-the-loop-and-what-measures-it.md) §5 — the page never passed them.

Now: a window control (7 / 30 / 90 / 180 — 180 is the server's ceiling, past which raw events are pruned) and a path scope completed against the directories the tree has loaded. The numbers are drawn as two bands, *what the base is* and *what happened inside the window*, which is the split 0069 §5 already makes field by field; drawing it is what makes it visible that the period moves the second band and not the first. Two flow numbers the wire carried and the page did not draw join them: **concepts created**, and **outcomes reported worked / failed**.

## The three questions (docs/surface.md)

**1. Who got stuck.** Second-hand, and I am saying so rather than dressing it up: a user of this instance asked for "a dashboard you can actually look back with". Asked what that meant, four questions came back — *is review moving*, *how much did the base grow and get used last month*, *how does my team's corner look*, and *how did the queues pile up*. The first was already answered by the trend; the middle two were answerable from numbers the wire already sent and the page threw away; the fourth is not answerable at all (below).

**2. Can an existing surface cover it?** It is covered — that is the point. `stats` takes both parameters, and `ochakai stats --days --prefix` answers all of this from a terminal today. What was missing was a browser reading of an existing answer, which is the Web UI's job as a curation surface ([0067](docs/design/0067-four-faces-and-what-they-decline.md) §1). **No endpoint, parameter, vocabulary word or environment variable is added**, so no count in [docs/surface.md](docs/surface.md) moves.

**3. What folds away.** Nothing, and this is the honest half: the Web UI is not counted, so a page can grow without any number saying so. What holds it is the prose — the review trend stays the one shape with no axes [0095](docs/design/0095-the-loop-has-a-shape.md) §3 gave it, and no second chart is added. The eight weeks follow the scope but **not** the window: a shape whose length changes cannot be compared with itself (0095 §2).

## What this deliberately does not do

- **Queue depth over time.** Nothing snapshots how deep a queue was last month, and a trend rebuilt from revisions would be a number that looks right and is not (0095 §1). Adding the snapshot table is a periodic moving part 0095 §4 declines. The page says nothing about this — a permanent "cannot be shown" line is one more thing to read past.
- **Scoping the queues below.** `#/search/reported-wrong` and friends have no scoped route, and a count that disagrees with what opening it shows is worse than no count. The scope note says the strip and the draft list are not narrowed.
- **`misses` under a scope.** It cannot be: a search that found nothing found it nowhere, so there is no id to scope by (0069 §5.1). Scoped, the miss tile and the gap list say `(全体)` and the note says why — otherwise the instance's number would pass as the team's.

No design record: the wire, the stored form, identity and the Google Cloud dependencies are all unchanged, and 0095's decision about the shape is untouched. No manual page either — nothing a `docs/` page documents behaves differently.

## Verification

- `scripts/check core ui` (with a throwaway PostgreSQL) and `scripts/check lint` — clean.
- The browser smoke gains the two round trips this rests on: the window redraws from the `window_days` the **server echoed** (not the value the control asked for), and a scoped reading names what it could not scope. 25/25 checks pass locally against `examples/demo`.
- Driven by hand at 7 / 30 / 90 / 180 days and under `metrics`.

Two design doc citations 0069 superseded (0049, 0051) are corrected where they sat, in the page's own comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)