### PR TITLE
Release v0.26.3

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Version
       description: Output of `ochakai version`, or the image tag you deployed.
-      placeholder: "0.26.2"
+      placeholder: "0.26.3"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ last entry.
 
 ## [Unreleased]
 
+## [0.26.3] - 2026-08-22
+
 ### Added
 
 - **The loop's numbers on the review page can be asked about a period
@@ -159,6 +161,34 @@ last entry.
   so this could only fire for an answer that did not come from one — but
   believing such an answer would have put bytes wherever the name
   pointed. The name is checked now and a refusal names it.
+- **A Japanese question stops asking for the particles it is made of.**
+  `queryFragments` kept a run of one or two characters whole without
+  asking whether it held a content character, and a one-character run
+  was asked for as a prefix — so a question written with spaces or latin
+  words in it (`AI が verify を打ってよいか`) sent `が:*` to the index,
+  which matches nearly every Japanese document there is. `contentWindows`
+  had dropped hiragana-only windows for exactly this reason since 0089
+  §4; the branch above it never asked. A run that *is* a word keeps its
+  fragment wherever the content character sits in it (与信, お茶), and a
+  query with nothing else to look for still asks for its grammar
+  (ください, か) rather than for nothing.
+- **A katakana word is asked for whole instead of cut into windows.** A
+  run of Han and hiragana is a sentence nobody here can find the word
+  boundaries in, which is why it is cut into two-character windows — but
+  **a stretch of katakana is not a sentence**, and the script change on
+  either side of it is a word boundary somebody wrote. A question about
+  a スクリーンショット was spending most of its weight on セッ, ット and
+  ショ — fragments belonging to データセット and セッション — and reaching
+  most of the base. A katakana run of five characters or more now leaves
+  the query whole and asks the index for all of its windows at once
+  rather than any of them. The stored side is untouched, so a word
+  inside a longer one still answers (`セッション` finds リモートセッション)
+  and nothing has to be rewritten.
+- **Neither of the two above moves a ranking**: over the golden set
+  every case landed on the rank it already had, and what changed is what
+  stopped arriving underneath it — the candidate set is a seventh
+  smaller and a third less of it comes from the domain the question was
+  not about. Both are query-side, so no migration and no re-embedding.
 - **Halfwidth katakana and fullwidth latin are found by a question
   spelled normally, and the reverse.** They are what a system upstream
   of the reader writes — a warehouse export from something fixed-width,
@@ -5028,7 +5058,8 @@ worth naming: SQL injection in `compile_sql` through undeclared field
 pass-through, fixed in 0.8.0 — v0.7.0 and earlier are affected. Details
 are in git history.
 
-[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.26.2...HEAD
+[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.26.3...HEAD
+[0.26.3]: https://github.com/na0fu3y/ochakai/compare/v0.26.2...v0.26.3
 [0.26.2]: https://github.com/na0fu3y/ochakai/compare/v0.26.1...v0.26.2
 [0.26.1]: https://github.com/na0fu3y/ochakai/compare/v0.26.0...v0.26.1
 [0.26.0]: https://github.com/na0fu3y/ochakai/compare/v0.25.0...v0.26.0

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -74,7 +74,7 @@ info:
     is a security defect, shipped in the next release with no deprecation
     window (SECURITY.md). MCP, the CLI and the stored shape stay unstable
     while the major version is 0 and may still change in a minor release.
-  version: 0.26.2
+  version: 0.26.3
   license:
     name: MIT
 servers:

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -77,7 +77,7 @@ export IMAGE=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:$VERSION
 `:latest` ではなくバージョンを固定し、再デプロイを意識的な判断にする。
 `gh` CLI が無ければ
 [リリースページ](https://github.com/na0fu3y/ochakai/releases)から番号
-を読み、手で設定する — `export VERSION=0.26.2`。
+を読み、手で設定する — `export VERSION=0.26.3`。
 
 (このガイドは 0.9.0 以降を前提にしている。それより前のリリースは
 [retract](https://go.dev/ref/mod#go-mod-file-retract) 済みでサポート外

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -5,7 +5,7 @@ region     = "us-central1"
 
 # Pin a released version, not "latest", so a redeploy is a decision:
 # https://github.com/na0fu3y/ochakai/releases
-image_tag = "0.26.2"
+image_tag = "0.26.3"
 
 # Who can reach ochakai. This is the whole access-control surface — whoever
 # reaches it can read and write everything. Never allUsers.


### PR DESCRIPTION
## What and why

Release preparation for **v0.26.3**. No **BREAKING** entry stands in the
unreleased section, so this is a patch bump.

Sixteen PRs landed since v0.26.2. The section cuts as written, with one
correction: **two search changes shipped without a changelog entry.**
[#715](https://github.com/na0fu3y/ochakai/pull/715) (a question stopped
asking for its own particles) and
[#716](https://github.com/na0fu3y/ochakai/pull/716) (a katakana word is
asked for whole rather than as two-character windows) both change what
comes back from a search — the same kind of thing v0.26.2 recorded twice
under *Fixed* (the long vowel, the honorific prefix) — and neither
touched `CHANGELOG.md` on the way in. They are added here, with a third
bullet saying what the pair did and did not move: no ranking changed
over the golden set, and both are query-side, so no migration and no
re-embedding. Everything else that landed already has its entry, and the
one migration in this release (0043, the NFKC reindex) is named in the
entry that causes it.

The five files that carry a version:

- `CHANGELOG.md` — `[Unreleased]` → `[0.26.3] - 2026-08-22`, a fresh
  empty `[Unreleased]`, and the compare links repointed
- `api/openapi.yaml` — `info.version`
- `.github/ISSUE_TEMPLATE/bug_report.yml` — the placeholder
- `deploy/cloudrun/README.md` — the hand-set `export VERSION=`
- `deploy/terraform/terraform.tfvars.example` — `image_tag`, which is
  applied rather than read, so a stale pin deploys the stale image

`mcpserver.RetiredToolNames` and `retiredCommands` are both empty — no
rename window closes with this release.

## Checks

- [x] `scripts/check` is clean — the store tests skipped (no local
      PostgreSQL; nothing here touches the store, and CI runs them)
- [x] Behavior changes come with tests — none; this is a version bump
      and changelog prose. `TestReleaseVersionsAgree`,
      `TestARetiredNameLastsOneRelease` and `TestManualLinksResolve`
      pass

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver` and
      `internal/apiclient` say the same thing — only `info.version` moves
- [x] The change lands on every surface it belongs on — it adds none
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens a surface? No

## Design docs

- [x] Alters an accepted decision? No
- [x] Commit messages and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)
