### PR TITLE
Let the toolchain hold the idioms, and put the attestations where a scanner looks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Line endings are LF in the repository, on every machine that clones it.
+#
+# Two files here are goldens a test regenerates and compares byte for byte
+# — docs/cli.md (TestCLIReferenceIsCurrent) and api/openapi.frozen.txt —
+# and two are shell scripts CI executes, scripts/check and scripts/mcpb. A
+# Windows checkout with core.autocrlf at its default would rewrite all four
+# on the way in, so `-update` would report a whole-file diff and a script
+# would fail on its shebang. This is what keeps a contributor's platform
+# out of the diff.
+* text=auto eol=lf
+
+# The only binaries tracked here: four web UI screenshots and the MCP
+# bundle's icon. Named so git neither converts nor tries to diff them.
+*.png binary

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,11 +3,28 @@ on:
   push:
     branches: [main]
   pull_request:
+  # govulncheck is the one job that answers a question the repository does
+  # not ask: whether somebody else published a vulnerability against a
+  # dependency this tree already pinned. That answer changes on days
+  # nothing is committed here, so it is also on a clock — the same shape
+  # scorecard.yaml already uses, and the reason every other job below
+  # declines a scheduled run.
+  schedule:
+    - cron: "17 3 * * 2"
+# Read-only, and nothing below asks for more: no job here pushes, comments
+# or publishes. `persist-credentials: false` on every checkout is the
+# other half — without it the job's token is left in `.git/config`, where
+# any later step (a build script, a tool run from the tree) can read it.
+# The two together are what makes a compromised step in this file cost
+# nothing.
 permissions:
   contents: read
 jobs:
   test:
     runs-on: ubuntu-latest
+    # A scheduled run is govulncheck's alone; this job answers only to a
+    # commit.
+    if: github.event_name != 'schedule'
     services:
       postgres:
         image: pgvector/pgvector:pg17
@@ -23,6 +40,8 @@ jobs:
           --health-retries 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false # see the note above `permissions`
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
@@ -64,8 +83,13 @@ jobs:
           key: test-go-${{ hashFiles('go.sum') }}-${{ github.run_id }}
   lint:
     runs-on: ubuntu-latest
+    # A scheduled run is govulncheck's alone; this job answers only to a
+    # commit.
+    if: github.event_name != 'schedule'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false # see the note above `permissions`
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
@@ -113,6 +137,9 @@ jobs:
   # the page would then be tested against instead of the real one.
   webui:
     runs-on: ubuntu-latest
+    # A scheduled run is govulncheck's alone; this job answers only to a
+    # commit.
+    if: github.event_name != 'schedule'
     services:
       postgres:
         image: pgvector/pgvector:pg17
@@ -128,10 +155,22 @@ jobs:
           --health-retries 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false # see the note above `permissions`
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: false # same shared-key problem as in the test job
+      # Named, because this job is the one place a Node version decides
+      # anything: `scripts/check ui` passes a glob to `node --test`, and
+      # the smoke below drives Chrome over the DevTools Protocol with
+      # Node's own global WebSocket. Both are recent enough that the
+      # runner image's default has already moved under them once. 24 is
+      # the line under long-term support; there is no package.json to say
+      # it in, so it is said here.
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
       # The unit half first: it is the part that fails for a reason in
       # the code rather than a reason in the plumbing.
       - run: scripts/check ui
@@ -176,6 +215,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false # see the note above `permissions`
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
@@ -186,8 +227,13 @@ jobs:
   # This job runs README.md's own steps verbatim.
   quickstart:
     runs-on: ubuntu-latest
+    # A scheduled run is govulncheck's alone; this job answers only to a
+    # commit.
+    if: github.event_name != 'schedule'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false # see the note above `permissions`
       # --build: the compose file also names a published `image:`, and
       # without --build compose is free to reuse that instead of building
       # the commit under test. The point of this job is to catch a break

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,8 +42,9 @@ jobs:
           restore-keys: |
             test-go-${{ hashFiles('go.sum') }}-
             test-go-
-      # gofmt, go vet, go test -race, and the CGO_ENABLED=0 build. Run
-      # through the script contributors run so the two cannot drift.
+      # gofmt, go vet, go fix -diff, go test -race, and the CGO_ENABLED=0
+      # build. Run through the script contributors run so the two cannot
+      # drift.
       - run: scripts/check core
         env:
           OCHAKAI_TEST_DATABASE_URL: postgres://t:t@localhost:55433/t?sslmode=disable

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,57 @@
+# CodeQL: the one analysis in this repository that follows a value from
+# where it arrives to where it is used.
+#
+# The linters in .golangci.yml are deliberately local — each reads one
+# function and reports nothing on a clean tree (design doc 0035 §3.1).
+# That rule is what keeps them trustworthy, and it is also their ceiling:
+# none of them can see a request parameter reach a SQL string, because the
+# two are in different packages. ochakai builds SQL and serves HTTP, so
+# that is the question worth asking of it, and CodeQL's taint analysis is
+# what asks it.
+#
+# It also answers OpenSSF Scorecard, which recognises CodeQL, Sonar and
+# Snyk and scored this repository 0 on SAST while golangci-lint and
+# govulncheck both ran — the same shape as Signed-Releases, where the work
+# was done and the scanner looked elsewhere. Findings land in this
+# repository's code-scanning tab beside Scorecard's own SARIF.
+#
+# 0035 §3.1's rule applies here too: if this reports on a clean tree,
+# it comes out. It does not gate a merge — a required status check is a
+# promise about a tool whose query set moves on GitHub's schedule, not
+# this repository's.
+name: codeql
+on:
+  push:
+    branches: [main]
+  pull_request:
+  # Query packs are updated by GitHub, so a finding can appear on a week
+  # nothing was committed — the same reason govulncheck runs on a clock.
+  schedule:
+    - cron: "41 4 * * 3"
+permissions:
+  contents: read
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout
+      security-events: write # upload the results to code scanning
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      # The toolchain go.mod names, so CodeQL extracts against the same
+      # standard library the build uses rather than the runner's default.
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: false # same shared-key problem as in ci.yaml
+      - uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          languages: go
+          # `security-extended` over the default `security`: this is not a
+          # merge gate, so a lower-confidence finding costs a read rather
+          # than a blocked pull request.
+          queries: security-extended
+      - uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+      - uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,16 @@ jobs:
       id-token: write
       attestations: write
     steps:
+      # persist-credentials: false on both jobs' checkouts. Neither pushes
+      # with git — this one talks to GHCR with the registry login below,
+      # and `binaries` uses `gh`, which reads GH_TOKEN from the
+      # environment — so the token left in `.git/config` would be readable
+      # by every later step and used by none of them. That matters most in
+      # `binaries`, which runs goreleaser over the tree with
+      # `contents: write` in scope.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
@@ -64,6 +73,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           # goreleaser derives the version from the tag and walks the
           # history to find the previous one; a shallow clone has
           # neither.
@@ -127,13 +137,42 @@ jobs:
           gh release edit "$TAG" --notes-file "$RUNNER_TEMP/notes.md"
       # The image carries provenance; the archives people actually
       # download should too.
-      - uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+      - id: attest
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: |
             dist/*.tar.gz
             dist/*.zip
             dist/*.mcpb
             dist/checksums.txt
+      # The same attestations, beside the archives rather than only in
+      # GitHub's attestation store. This adds no guarantee — `gh
+      # attestation verify` already reads the store — it adds a
+      # *reachable* one, for the two readers that cannot: an OSS review
+      # walking release assets (OpenSSF Scorecard's Signed-Releases looks
+      # for a `.intoto.jsonl`, and scored this repository 0 while every
+      # artifact above was attested), and anyone verifying without
+      # reaching github.com, who now has `gh attestation verify <file>
+      # --bundle <this>` offline.
+      #
+      # `.intoto.jsonl` is what the file is rather than a name chosen to
+      # be found: the action appends one JSON bundle per line as it
+      # attests each subject, and emits the eight above as one file.
+      #
+      # Scorecard averages over the last five releases, so this moves the
+      # score across five tags rather than at the next one.
+      - name: Attach the attestation bundle
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          BUNDLE: ${{ steps.attest.outputs.bundle-path }}
+        run: |
+          set -euo pipefail
+          # ochakai_X.Y.Z, the spelling every other asset uses — the tag
+          # without its leading v, the way scripts/mcpb names the bundle.
+          name="ochakai_${TAG#v}.intoto.jsonl"
+          cp "$BUNDLE" "$RUNNER_TEMP/$name"
+          gh release upload "$TAG" "$RUNNER_TEMP/$name" --clobber
       # Publishing is last, because a published release is immutable
       # here: GitHub answers 422 to an asset upload against one, and
       # everything above this line is an addition to what goreleaser

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,6 +24,13 @@ builds:
       - CGO_ENABLED=0
     flags:
       - -trimpath
+    # Without this the binaries carry the build's wall clock, so the same
+    # tag rebuilt tomorrow produces different archives and a different
+    # checksums.txt — and "verify the checksum yourself" stops being
+    # something a reader can act on. The commit's own timestamp is the one
+    # value that is a property of the tag rather than of the runner.
+    # -trimpath above removes the other half, the build machine's paths.
+    mod_timestamp: "{{ .CommitTimestamp }}"
     # main.version is the only variable the source lets us stamp; see
     # cmd/ochakai/main.go. .Tag rather than .Version because .Version
     # strips the leading "v", and every other path that reports a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,38 @@ last entry.
   accumulating (the SDK never expires an idle one), and a deployment is
   free to run more than one instance, which sessions in one instance's
   memory had ruled out.
+- **The MCP tools say whether a retry is safe, and that the world they
+  reach is closed.** Two hints were left at their spec defaults, and both
+  defaults were wrong here. `openWorldHint` defaults to true — "this call
+  goes somewhere unbounded" — where every tool on this surface reads or
+  writes this deployment's own base and reaches nothing else; it is false
+  on all six now. `idempotentHint` is where the two writes stop being one
+  thing: `put_concept` is a replace at an address, so the same document
+  written twice lands the same concept and an identical write is recorded
+  as no revision at all, while `report_outcome` is another outcome every
+  time it is called, which is the point — a client that retried it would
+  move a counter the curator reads. They no longer share an annotation.
+  Nothing an operator sets changes, no tool is added or removed, and the
+  hints are annotations rather than schema, so no counted surface moves.
+- **`scripts/check core` runs `go fix -diff`**, and the tree it now holds
+  still. Since Go 1.26 `go fix` is not the pre-1.0 API renamer its name
+  comes from: it runs the modernizers, and `-diff` prints the patch
+  instead of applying it, exiting non-zero when it is not empty — the
+  shape design doc 0035 §3.1 asks of a check, silent on a clean tree, so
+  a finding always means new code written in an older idiom. Unlike the
+  linter there is no version to pin, because it ships with the toolchain
+  `go.mod` already names. Applying it once touched twelve files and
+  changed no behaviour: `new(expr)` for the four `&x`-returning helpers,
+  which are gone now that their callers say it directly; `reflect.Pointer`
+  for `reflect.Ptr`; one `if` that was spelling `min`; a loop-variable
+  copy Go 1.22 made redundant; and embedded struct literals written as
+  the fields they set. What it did *not* report is worth as much, because
+  the fixers for those ran as well: `slicessort` read twelve
+  `sort.Slice` and `sort.SliceStable` calls and left every one, and
+  `stringsseq` left all eight `range strings.Split` loops — seven range
+  over an index, which a value-only iterator cannot hand back. Both had
+  been proposed as sweeps by a reading of the tree; the tool is what
+  settled them.
 
 ## [0.26.3] - 2026-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,47 @@ last entry.
   been proposed as sweeps by a reading of the tree; the tool is what
   settled them.
 
+### Security
+
+- **A release carries its attestations as a file beside the archives**,
+  `ochakai_X.Y.Z.intoto.jsonl`. The archives and the image have carried
+  provenance attestations for a long time, but the attestations lived only
+  in GitHub's attestation store, which `gh attestation verify` reads and
+  two readers cannot: an OSS
+  review that walks release assets — OpenSSF Scorecard's Signed-Releases
+  scored this repository 0 while every artifact was signed — and anyone
+  verifying without reaching github.com, who now has `gh attestation
+  verify <file> --bundle <this>` offline. The guarantee is unchanged; what
+  changed is that it is reachable. The upload happens before the release
+  is published, for the reason the step above it already gives.
+- **Both base images are pinned by digest as well as tag.** A tag is a
+  name its owner can repoint — `nonroot` is rebuilt in place — so the same
+  commit built twice was not necessarily the same image. Dependabot reads
+  the tag-and-digest pair and opens the pull request that moves both, so
+  the pin is a value somebody bumps in a commit rather than one that goes
+  stale.
+- **The release archives are byte-reproducible.** goreleaser stamped the
+  build's wall clock into the binaries, so rebuilding a tag produced
+  different archives and a different `checksums.txt`; they now carry the
+  commit's own timestamp, which is a property of the tag rather than of
+  the runner. `-trimpath` was already removing the other half.
+- **No workflow leaves its token in the checkout.** `persist-credentials:
+  false` on every one of them now — it was set on the Scorecard job alone
+  and missing from the other eight, none of which pushes with git: the
+  release jobs talk to GHCR through the registry login and to `gh`, which
+  reads its token from the environment. The token in `.git/config` was
+  readable by every later step and used by none of them.
+- **govulncheck runs weekly as well as on every commit**, because a
+  vulnerability published against an already-pinned dependency arrives on
+  somebody else's schedule. The other four jobs in that file decline a
+  scheduled run.
+- **CodeQL analyses the Go on push, on pull requests and weekly.** The
+  linters in `.golangci.yml` are local by design and none of them can see
+  a request parameter reach a SQL string; this is the analysis that
+  follows a value across packages. It reports into code scanning beside
+  Scorecard's SARIF and does not gate a merge. Design doc 0035 §3.1's
+  rule applies to it too: if it reports on a clean tree, it comes out.
+
 ## [0.26.3] - 2026-08-22
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,15 @@
 # Requires BuildKit: on the legacy builder (plain gcr.io/cloud-builders/docker
 # on Cloud Build, or docker without DOCKER_BUILDKIT=1) the next line fails
 # with `failed to parse platform : "" is an invalid component`.
-FROM --platform=$BUILDPLATFORM golang:1.27.0 AS build
+#
+# Both bases carry a digest as well as a tag. A tag is a name its owner can
+# repoint, so the same commit built twice is not necessarily the same
+# image; the digest is what makes "this Dockerfile" and "that image" the
+# same statement. The tag stays beside it because it is what a reader
+# recognises, and because dependabot's docker ecosystem reads the pair and
+# opens the pull request that moves both — the digest below is a value
+# somebody has to bump, and the point is that bumping it is a commit.
+FROM --platform=$BUILDPLATFORM golang:1.27.0@sha256:65b6f280bf050ec5af12716857e8ea8439d694dbba8f31ceeb7630670071f2bb AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
@@ -16,8 +24,9 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -trimpath -ldflags=
 # The Debian version is named rather than left off: distroless resolves a
 # bare tag to whatever it currently considers newest, which would move
 # this image's base on a day nobody chose. debian13 is where that default
-# points today.
-FROM gcr.io/distroless/static-debian13:nonroot
+# points today, and the digest holds it still even there — `nonroot` is
+# rebuilt in place, so the tag alone names a moving target.
+FROM gcr.io/distroless/static-debian13:nonroot@sha256:1c2c046bc09ed40fad370b599a0b1ae7987f55b01e247cf27a7c27cd97e5bbc7
 COPY --from=build /ochakai /ochakai
 USER nonroot
 ENTRYPOINT ["/ochakai"]

--- a/cmd/ochakai/client_test.go
+++ b/cmd/ochakai/client_test.go
@@ -1347,8 +1347,8 @@ func TestGetPrintsTheRulingAndWhy(t *testing.T) {
 // prints the reason (design doc 0104 §3).
 func TestPrintHitsNamesTurnedDownRowsWithoutChangingThem(t *testing.T) {
 	page := &apiclient.SearchResult{Hits: []domain.SearchHit{
-		{Summary: domain.Summary{ID: "metrics/a", Status: domain.StatusDraft, Title: "A", Rejected: true}, Score: 1},
-		{Summary: domain.Summary{ID: "metrics/b", Status: domain.StatusStable, Title: "B"}, Score: 0.5},
+		{ID: "metrics/a", Status: domain.StatusDraft, Title: "A", Rejected: true, Score: 1},
+		{ID: "metrics/b", Status: domain.StatusStable, Title: "B", Score: 0.5},
 	}}
 	stdout, stderr := capture(t, func() { printHits(page, "") })
 	for _, want := range []string{"ochakai://metrics/a\tdraft\tA", "ochakai://metrics/b\tstable\tB"} {
@@ -1383,7 +1383,7 @@ func TestPrintHitsNamesTurnedDownRowsWithoutChangingThem(t *testing.T) {
 func TestPrintHitsLeadsWithTheOrderingKeyOnlyWhenThereIsOne(t *testing.T) {
 	verified := time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC)
 	hit := domain.SearchHit{
-		Summary: domain.Summary{ID: "metrics/revenue", Status: domain.StatusStable, Title: "売上", StaleAfter: "2026-12-31", VerifiedAt: &verified},
+		ID: "metrics/revenue", Status: domain.StatusStable, Title: "売上", StaleAfter: "2026-12-31", VerifiedAt: &verified,
 		// A lexical deployment's score, well above RRF's ~1/60 ceiling:
 		// whichever scale it is on, it must not reach the line.
 		Score: 1.73,

--- a/cmd/ochakai/style_test.go
+++ b/cmd/ochakai/style_test.go
@@ -19,13 +19,11 @@ var ansi = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 // rather than a second output format nobody can grep.
 func TestStyledLineStripsBackToThePlainOne(t *testing.T) {
 	page := &apiclient.SearchResult{Hits: []domain.SearchHit{{
-		Summary: domain.Summary{
-			ID:          "metrics/revenue",
-			Status:      domain.StatusStable,
-			Title:       "売上",
-			Description: "完了した注文の合計",
-		},
-		Snippet: "…返品を差し引く…",
+		ID:          "metrics/revenue",
+		Status:      domain.StatusStable,
+		Title:       "売上",
+		Description: "完了した注文の合計",
+		Snippet:     "…返品を差し引く…",
 	}}}
 
 	plain, _ := capture(t, func() { printHits(page, "") })

--- a/internal/apiclient/apiclient_test.go
+++ b/internal/apiclient/apiclient_test.go
@@ -37,7 +37,7 @@ func TestSearchBuildsQueryAndDecodesHits(t *testing.T) {
 		}
 		got = r.URL.Query()
 		_ = json.NewEncoder(w).Encode(map[string]any{"hits": []domain.SearchHit{
-			{Summary: domain.Summary{Type: domain.TypeMetrics, ID: "revenue", Title: "売上"}, Score: 0.9},
+			{Type: domain.TypeMetrics, ID: "revenue", Title: "売上", Score: 0.9},
 		}})
 	})
 	page, err := c.Search(context.Background(), SearchParams{
@@ -84,7 +84,7 @@ func TestSearchUsageSortDecodesUsage(t *testing.T) {
 	c := newTestPair(t, func(w http.ResponseWriter, r *http.Request) {
 		got = r.URL.Query()
 		_ = json.NewEncoder(w).Encode(map[string]any{"hits": []domain.SearchHit{
-			{Summary: domain.Summary{Type: domain.TypeInsights, ID: "draft-a", Title: "草案"},
+			{Type: domain.TypeInsights, ID: "draft-a", Title: "草案",
 				Usage: &domain.Usage{SearchHits: 7, Fetches: 2}},
 		}})
 	})
@@ -190,7 +190,7 @@ func TestBacklinksAsksTheSearchFaceWithLinksTo(t *testing.T) {
 			t.Error("a reverse lookup sent a query; it has no text to rank by")
 		}
 		_ = json.NewEncoder(w).Encode(map[string]any{"hits": []domain.SearchHit{
-			{Summary: domain.Summary{Type: domain.TypeInsights, ID: "revenue-reading", Title: "売上の読み方"}},
+			{Type: domain.TypeInsights, ID: "revenue-reading", Title: "売上の読み方"},
 		}})
 	})
 	entries, err := c.Backlinks(context.Background(), "metrics/revenue", 0)

--- a/internal/domain/knowledge_test.go
+++ b/internal/domain/knowledge_test.go
@@ -93,7 +93,7 @@ func TestSameContent(t *testing.T) {
 			Description: "monthly revenue", Tags: []string{"sales"},
 			Status: StatusStable, StatusNote: "checked",
 			Sources: []Source{
-				{Resource: "policies/revenue.md", ID: "rev", UsageCount: intp(0)},
+				{Resource: "policies/revenue.md", ID: "rev", UsageCount: new(0)},
 				{Resource: "https://example.test/ga4", LastModified: "2026-05-30"},
 			},
 			UsageWindow: &UsageWindow{From: "2026-06-01", To: "2026-06-30"},
@@ -174,8 +174,6 @@ func TestSameContent(t *testing.T) {
 	}
 }
 
-func intp(n int) *int { return &n }
-
 // The OKF v0.2 families carry their own shape rules (SPEC §5.1, §10.2).
 // domain holds the predicate; service turns a false into a 400 and the
 // bundle parser turns it into a note (design doc 0036 §3.4).
@@ -188,8 +186,8 @@ func TestOKFFamilyValidation(t *testing.T) {
 		"a resource is enough":        {true, func() bool { return Source{Resource: "policies/rev.md"}.Valid() }},
 		"source date must be a date":  {false, func() bool { return Source{Resource: "r", LastModified: "2026-06"}.Valid() }},
 		"source date may be absent":   {true, func() bool { return Source{Resource: "r"}.Valid() }},
-		"usage_count may not be < 0":  {false, func() bool { return Source{Resource: "r", UsageCount: intp(-1)}.Valid() }},
-		"usage_count may be 0":        {true, func() bool { return Source{Resource: "r", UsageCount: intp(0)}.Valid() }},
+		"usage_count may not be < 0":  {false, func() bool { return Source{Resource: "r", UsageCount: new(-1)}.Valid() }},
+		"usage_count may be 0":        {true, func() bool { return Source{Resource: "r", UsageCount: new(0)}.Valid() }},
 		"per-source window is dated":  {false, func() bool { return Source{Resource: "r", UsageWindow: &UsageWindow{From: "nope"}}.Valid() }},
 		"parameter needs a name":      {false, func() bool { return Parameter{Type: "integer"}.Valid() }},
 		"parameter needs a type":      {false, func() bool { return Parameter{Name: "year"}.Valid() }},

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -395,7 +395,7 @@ func newServer(svc *service.Service, version string, retired []RetiredToolName) 
 	// together — the merge is where the saving actually was.
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "put_concept",
-		Annotations: nonDestructive,
+		Annotations: replacingWrite,
 		Description: "Write a concept: created if the id is free, replaced if it is taken.\n" +
 			"The document you send is the whole concept — a key you leave out is cleared, so on a " +
 			"replace, get_concept first and send back what you are not changing. Every change is " +
@@ -496,7 +496,7 @@ func newServer(svc *service.Service, version string, retired []RetiredToolName) 
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "report_outcome",
-		Annotations: nonDestructive,
+		Annotations: recordingWrite,
 		Description: "Report whether knowledge you acted on actually worked — the last edge of the " +
 			"write-back loop. After running an attested computation, or SQL you wrote from a " +
 			"metric definition, report worked, or failed with what went wrong in note: failed " +
@@ -538,14 +538,39 @@ var writeTools = []string{"put_concept", "report_outcome"}
 // never change a concept (they may bump usage counters — telemetry the hint
 // deliberately ignores). Writes are non-destructive because history is kept
 // as revisions, and no tool on this surface is destructive — the one that
-// was, delete_concept, left with design doc 0076. The values are immutable
-// and shared across tools.
+// was, delete_concept, left with design doc 0076. The values are
+// immutable: readOnly is shared by the four reads, and the two writes
+// each have their own, for the reason below.
+//
+// openWorldHint is false on all six, and it is the one hint whose default
+// is wrong here: the spec's own example for a closed world is a memory
+// tool, and every tool on this surface reads or writes this deployment's
+// own base and reaches nothing else. Left unsaid it defaults to true,
+// which would tell a client these calls go somewhere unbounded — the
+// opposite of what ochakai refuses to do (design doc 0081: no LLM, no
+// SQL, and the only hosts it contacts are Google Cloud APIs in the
+// caller's own project).
+//
+// idempotentHint is where the two writes stop being one thing, so they no
+// longer share a value. put_concept is a replace at an address: the same
+// document written twice lands the same concept, and an identical write
+// is recorded as no revision at all. report_outcome is not — every call
+// is another outcome, which is the point (design doc 0069: the loop is
+// measured by how often knowledge was used and how often it failed), so a
+// client that retried it would move a counter the curator reads. The
+// hint says which of the two a retry is safe on, and that is exactly the
+// question a retry has to answer.
 var (
-	readOnly       = &mcp.ToolAnnotations{ReadOnlyHint: true}
-	nonDestructive = &mcp.ToolAnnotations{DestructiveHint: boolPtr(false)}
+	readOnly = &mcp.ToolAnnotations{ReadOnlyHint: true, OpenWorldHint: new(false)}
+	// A write whose repeat lands the same concept.
+	replacingWrite = &mcp.ToolAnnotations{
+		DestructiveHint: new(false), IdempotentHint: true, OpenWorldHint: new(false),
+	}
+	// A write whose repeat is a second record.
+	recordingWrite = &mcp.ToolAnnotations{
+		DestructiveHint: new(false), OpenWorldHint: new(false),
+	}
 )
-
-func boolPtr(b bool) *bool { return &b }
 
 // parseKnowledgeURI extracts the concept id from a canonical knowledge URI
 // (ochakai://<id>). ok is false when the URI lacks the scheme or what

--- a/internal/okf/parse.go
+++ b/internal/okf/parse.go
@@ -357,7 +357,9 @@ func parseDoc(doc []byte) (*Doc, string, []string, error) {
 		setAttr(ClaimKey, claim)
 	}
 
-	return &Doc{Verified: hasVerified, Claimed: claimed, Knowledge: domain.Knowledge{
+	return &Doc{
+		Verified:    hasVerified,
+		Claimed:     claimed,
 		Type:        typ,
 		ID:          fm.id,
 		Title:       fm.title,
@@ -377,7 +379,7 @@ func parseDoc(doc []byte) (*Doc, string, []string, error) {
 		Attrs:       attrs,
 		Body:        strings.TrimSpace(body),
 		Doc:         string(stored),
-	}}, fm.typ, notes, nil
+	}, fm.typ, notes, nil
 }
 
 // The v0.2 family readers. All of them follow the same rule: never reject

--- a/internal/restapi/openapi_schema_test.go
+++ b/internal/restapi/openapi_schema_test.go
@@ -144,7 +144,7 @@ func (d *specDoc) lookup(t *testing.T, path string) *specSchema {
 // fields it never emits left out.
 func jsonFields(t *testing.T, typ reflect.Type) map[string]bool {
 	t.Helper()
-	for typ.Kind() == reflect.Ptr {
+	for typ.Kind() == reflect.Pointer {
 		typ = typ.Elem()
 	}
 	if typ.Kind() != reflect.Struct {
@@ -152,7 +152,6 @@ func jsonFields(t *testing.T, typ reflect.Type) map[string]bool {
 	}
 	out := map[string]bool{}
 	for field := range typ.Fields() {
-		field := field
 		if !field.IsExported() {
 			continue
 		}

--- a/internal/service/cursor.go
+++ b/internal/service/cursor.go
@@ -127,7 +127,10 @@ func cursorKeys(sort string, h domain.SearchHit) []*string {
 	case "verified_at":
 		return []*string{cursorTime(h.VerifiedAt)}
 	case "stale_after":
-		return []*string{cursorText(h.StaleAfter)}
+		// A pointer to the text, never nil: an empty ordering value is
+		// still a value and not a NULL, and the feeds that order by text
+		// only list rows that have one.
+		return []*string{new(h.StaleAfter)}
 	case "usage":
 		u := usageOf(h)
 		return []*string{cursorCount(u.Recent.Fetches), cursorCount(u.Fetches), cursorTime(&h.CreatedAt)}
@@ -168,10 +171,6 @@ func cursorCount(n int64) *string {
 	s := strconv.FormatInt(n, 10)
 	return &s
 }
-
-// cursorText carries a text ordering key. An empty one is still a value,
-// not a NULL — the feeds that order by text only list rows that have it.
-func cursorText(s string) *string { return &s }
 
 // nextCursor returns the cursor for the page after hits, or "" when the
 // listing ended. more says whether the store had a row beyond the page:

--- a/internal/service/cursor_test.go
+++ b/internal/service/cursor_test.go
@@ -25,14 +25,14 @@ func TestCursorRoundTrip(t *testing.T) {
 	}{
 		{sort: "verified_at", keys: []*string{&at}, id: "metrics/revenue"},
 		{sort: "verified_at", keys: []*string{nil}, id: "glossary/completed-order"},
-		{sort: "usage", keys: []*string{ptr("74"), &at}, id: "insights/seasonality"},
-		{sort: "failed", keys: []*string{ptr("3"), ptr("0"), nil}, id: "queries/broken"},
+		{sort: "usage", keys: []*string{new("74"), &at}, id: "insights/seasonality"},
+		{sort: "failed", keys: []*string{new("3"), new("0"), nil}, id: "queries/broken"},
 		{sort: "source", keys: nil, id: "tables/shop-orders"},
 		// An id with the separator the encoding joins on, and one with a
 		// character base64url has to survive.
-		{sort: "stale_after", keys: []*string{ptr("2026-12-31")}, id: "a/b?c+d"},
+		{sort: "stale_after", keys: []*string{new("2026-12-31")}, id: "a/b?c+d"},
 		// An empty ordering value is a value, not an absent one.
-		{sort: "stale_after", keys: []*string{ptr("")}, id: "x"},
+		{sort: "stale_after", keys: []*string{new("")}, id: "x"},
 	} {
 		enc := encodeCursor(tc.sort, tc.keys, tc.id)
 		got, err := decodeCursor(enc, tc.sort, len(tc.keys))
@@ -64,7 +64,7 @@ func TestCursorRoundTrip(t *testing.T) {
 // a position here.
 func TestCursorRefusals(t *testing.T) {
 	var inputErr *InvalidInputError
-	usage := encodeCursor("usage", []*string{ptr("74"), ptr("2026-07-14T02:33:41Z")}, "insights/seasonality")
+	usage := encodeCursor("usage", []*string{new("74"), new("2026-07-14T02:33:41Z")}, "insights/seasonality")
 
 	for _, tc := range []struct {
 		name, cursor, sort, want string
@@ -114,7 +114,7 @@ func TestSearchRefusesACursor(t *testing.T) {
 func TestCursorKeysMatchTheOrder(t *testing.T) {
 	at := time.Date(2026, 7, 14, 2, 33, 41, 19778000, time.UTC)
 	hit := domain.SearchHit{
-		Summary: domain.Summary{ID: "metrics/revenue", StaleAfter: "2026-12-31", VerifiedAt: &at, CreatedAt: at},
+		ID: "metrics/revenue", StaleAfter: "2026-12-31", VerifiedAt: &at, CreatedAt: at,
 		// search_hits and fetches differ on purpose: the usage feed ranks
 		// by reads, and a cursor built from the listings it was ranked by
 		// until now would pass every other assertion here.
@@ -148,13 +148,13 @@ func TestCursorKeysMatchTheOrder(t *testing.T) {
 
 	// A feed whose ordering value is absent carries the absence, which is
 	// the never-verified tail of two of them.
-	unverified := domain.SearchHit{Summary: domain.Summary{ID: "x"}, Usage: &domain.Usage{}}
+	unverified := domain.SearchHit{ID: "x", Usage: &domain.Usage{}}
 	if k := cursorKeys("verified_at", unverified); len(k) != 1 || k[0] != nil {
 		t.Errorf("a never-verified entry's cursor key = %v, want the absent one", k)
 	}
 	// A listing whose hits carry no usage object at all must still produce
 	// a position rather than panic: score-0 listings share one wire shape.
-	if k := cursorKeys("usage", domain.SearchHit{Summary: domain.Summary{ID: "x"}}); len(k) != 3 || *k[0] != "0" {
+	if k := cursorKeys("usage", domain.SearchHit{ID: "x"}); len(k) != 3 || *k[0] != "0" {
 		t.Errorf("a hit with no usage totals = %v, want a zero position", k)
 	}
 }
@@ -163,7 +163,7 @@ func TestCursorKeysMatchTheOrder(t *testing.T) {
 // nothing behind it must not hand one out, or every walk gains a trailing
 // request that returns nothing (design doc 0050 §2.3).
 func TestNextCursorOnlyWhenMoreFollows(t *testing.T) {
-	hits := []domain.SearchHit{{Summary: domain.Summary{ID: "a", StaleAfter: "2026-01-01"}}}
+	hits := []domain.SearchHit{{ID: "a", StaleAfter: "2026-01-01"}}
 	if got := nextCursor("stale_after", hits, false); got != "" {
 		t.Errorf("the last page handed out a cursor: %q", got)
 	}
@@ -174,8 +174,6 @@ func TestNextCursorOnlyWhenMoreFollows(t *testing.T) {
 		t.Error("a page with more behind it handed out no cursor")
 	}
 }
-
-func ptr(s string) *string { return &s }
 
 // encodeRaw builds a cursor body the encoder would never produce, for the
 // refusals that a well-formed one cannot reach.
@@ -231,7 +229,7 @@ func TestBrowseCursorCarriesBothRunsAndItsDirectory(t *testing.T) {
 		!strings.Contains(err.Error(), "sales") || !strings.Contains(err.Error(), "glossary") {
 		t.Errorf("a cursor from another directory = %v, want a refusal naming both", err)
 	}
-	if _, err := decodeBrowseCursor(encodeCursor("usage", []*string{ptr("7"), ptr("x")}, "sales/"), "sales/"); err == nil {
+	if _, err := decodeBrowseCursor(encodeCursor("usage", []*string{new("7"), new("x")}, "sales/"), "sales/"); err == nil {
 		t.Error("a cursor from the usage feed resumed a level")
 	}
 	// The root has no name of its own, so the refusal gives it one rather

--- a/internal/service/embed_test.go
+++ b/internal/service/embed_test.go
@@ -44,7 +44,7 @@ func TestReembedCursorEmpty(t *testing.T) {
 
 func TestReembedCursorRefusals(t *testing.T) {
 	var inputErr *InvalidInputError
-	listingCursor := encodeCursor("usage", []*string{ptr("74"), ptr("2026-07-14T02:33:41Z")}, "insights/seasonality")
+	listingCursor := encodeCursor("usage", []*string{new("74"), new("2026-07-14T02:33:41Z")}, "insights/seasonality")
 
 	for _, tc := range []struct {
 		name, cursor string

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -52,7 +52,7 @@ func TestCheckedLimit(t *testing.T) {
 }
 
 func hit(id string, status domain.Status) domain.SearchHit {
-	return domain.SearchHit{Summary: domain.Summary{Type: domain.TypeMetrics, ID: id, Status: status}}
+	return domain.SearchHit{Type: domain.TypeMetrics, ID: id, Status: status}
 }
 
 // verifiedHit is hit plus a confirmation. The rank boost keys off the

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -810,10 +810,7 @@ func efSearch(limit int) int {
 		defaultEF = 40   // pgvector's own default
 		maxEF     = 1000 // pgvector's ceiling
 	)
-	ef := max(4*limit, defaultEF)
-	if ef > maxEF {
-		ef = maxEF
-	}
+	ef := min(max(4*limit, defaultEF), maxEF)
 	return ef
 }
 

--- a/scripts/check
+++ b/scripts/check
@@ -2,13 +2,14 @@
 # check: run the checks CI runs, in the order CI runs them.
 #
 #   scripts/check          everything (core, ui, lint, vuln)
-#   scripts/check core     gofmt, go vet, go test -race, CGO_ENABLED=0 build
+#   scripts/check core     gofmt, go vet, go fix -diff, go test -race,
+#                          CGO_ENABLED=0 build
 #   scripts/check ui       the web UI's own tests (node --test)
 #   scripts/check lint     golangci-lint
 #   scripts/check vuln     govulncheck
 #   scripts/check --db …   run a throwaway PostgreSQL for the store tests
 #
-# CI's test job runs `scripts/check core`, so those four stay identical by
+# CI's test job runs `scripts/check core`, so those five stay identical by
 # construction. The lint and vuln jobs run their tools directly — lint via
 # the golangci-lint action, which installs a released binary instead of
 # building one from source — so this script takes the linter version from
@@ -198,6 +199,19 @@ run_core() {
 	}
 	step "go vet"
 	go vet ./...
+	# `go fix` since Go 1.26 is not the pre-1.0 API renamer its name comes
+	# from: it runs the modernizers — new(expr), min/max, range-over-int,
+	# SplitSeq, wg.Go, slices and maps — and `-diff` prints the patch
+	# instead of applying it, exiting non-zero when it is not empty. That
+	# is the shape design doc 0035 §3.1 asks of a check: on a clean tree
+	# it says nothing, so a finding always means new code written in an
+	# older idiom. Unlike golangci-lint there is no version to pin — it
+	# ships with the toolchain go.mod already names.
+	step "go fix -diff"
+	go fix -diff ./... || {
+		echo "check: the fixes above are what \`go fix ./...\` would apply" >&2
+		exit 1
+	}
 	step "go test -race"
 	if [ -z "${OCHAKAI_TEST_DATABASE_URL:-}" ]; then
 		# Named rather than "store tests": four packages need a database,


### PR DESCRIPTION
## What and why

Two commits, no new capability in either. Both are cases where the work
was already done and something could not see it.

**`go fix -diff` joins `scripts/check core`** ([a065561](https://github.com/na0fu3y/ochakai/commit/a065561)).
Since Go 1.26 `go fix` runs the modernizers rather than the pre-1.0 API
renamer its name comes from, and `-diff` exits non-zero when the patch is
not empty — the shape 0035 §3.1 asks of a check, silent on a clean tree.
There is no version to pin: it ships with the toolchain `go.mod` already
names, so unlike golangci-lint it cannot drift into a second file.

Applying it once touched twelve files and changed no behaviour. The four
`&x`-returning helpers are deleted, their callers saying `new(expr)`
directly; `cursorText`'s doc comment moves to the one call site, where what
it explains still applies.

**What it declined is the more useful half.** `slicessort` read twelve
`sort.Slice`/`SliceStable` calls and left every one; `stringsseq` left all
eight `range strings.Split` loops, seven of which range over an index a
value-only iterator cannot hand back. Both had been proposed here as
sweeps, from reading the tree rather than running the tool. Same for
`encoding/json/v2`: it is GA in 1.27 and the v1 API is already running on
it in a `go 1.27` module, so there is nothing to migrate.

**Two MCP annotation hints whose spec defaults were wrong here.**
`openWorldHint` defaults to *true* — "this call goes somewhere unbounded" —
where every tool reads or writes this deployment's own base and reaches
nothing else; the spec's own example of a closed world is a memory tool.
`idempotentHint` is where the two writes stop being one thing, so they no
longer share an annotation: `put_concept` is a replace at an address and an
identical write is recorded as no revision at all, while `report_outcome` is
another outcome every time, which is the point (0069) — a client that
retried it would move a counter the curator reads.

**Six supply-chain gaps** ([9c202b4](https://github.com/na0fu3y/ochakai/commit/9c202b4)),
the same shape as each other. Every archive has been attested for a long
time, but only into GitHub's attestation store, which `gh attestation
verify` reads and two readers cannot: an OSS review walking release assets
(Scorecard's Signed-Releases scored this repository **0/10** while every
artifact was signed) and anyone verifying without reaching github.com. The
bundle is attached as `ochakai_X.Y.Z.intoto.jsonl` — what the file is, not a
name chosen to be found — before the release is published, for the reason
the step above it already gives (v0.21.0). Alongside: both base images
pinned by digest as well as tag, `mod_timestamp` so a rebuilt tag produces
the same archives, `persist-credentials: false` on the eight checkouts that
lacked it, govulncheck weekly, CodeQL, `.gitattributes`, and Node 24 named
in the web UI job.

### One thing that does not sit right, and is deliberately not fixed here

**The MCP byte budget cannot see annotations.** `residentBytes` counts
names, descriptions, both schemas and the instructions — not the
annotations, which a client also holds for the whole conversation. So the
~530 bytes this PR adds are real and invisible to the ceiling, which is the
same blind spot 0103 closed for output schemas.

Closing it would take the measured total from 11,788 to roughly 12,300 and
force `MCP-BYTES` 12,000 → 12,500. `docs/surface.md` says raising a ceiling
is a decision said out loud, and this repository's own habit when the
resident bytes went over was to doubt the addition rather than the ceiling
(0113 dropped a type instead). Neither belongs inside a cleanup PR, so the
measurement is left alone and named here instead.

## Checks

- [x] `scripts/check --db` is clean — core, ui (57), golangci-lint 0 issues, govulncheck 0
- [x] Behavior changes come with tests — no behaviour changes; the existing
      `TestMCPStaysUnderItsResidentByteCap`, the annotation assertions and
      the whole store suite cover what moved

Also verified outside the script, because CI is the only other place these run:

- `goreleaser check` validates the config
- every workflow file parses (through the repo's own YAML library)
- the image builds and runs on the pinned digests, on a Debian 13 distroless base
- `actions/attest-build-provenance` exposes `bundle-path` **at the SHA this file pins**,
  and writes one JSON bundle per line — so `.intoto.jsonl` is accurate
- Scorecard's accepted suffixes read from its own probe source, not from memory
- no tracked file contains CRLF, and `git add --renormalize` moves nothing but this PR

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver` and
      `internal/apiclient` still say the same thing — no operation, tool,
      command or variable is added, renamed or removed
- [x] Lands on every surface it belongs on. Annotations exist only on MCP:
      they are how that protocol says what REST says with its method and the
      CLI with its command name, so there is nothing to mirror
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens no counted surface. REST 12 / MCP 6 / CLI 25 / ENV 15 / DOC 27
      are all unchanged, and annotations are not schema — which is exactly
      the sentence the section above is uneasy about

## Design docs

- [x] Not applicable. The hints refine annotations that landed without a
      numbered record (CHANGELOG only), and 0081, 0069 and 0035 already hold
      the decisions this leans on — nothing accepted is altered
- [x] Commit messages and code comments are in English
