### PR TITLE
Start the web UI where the knowledge is, not where the bundle is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,25 @@ last entry.
 
 ## [Unreleased]
 
+### Changed
+
+- **The web UI starts where the knowledge does.** A caller granted one
+  directory (design doc 0109) opened the page on a root holding one
+  directory holding one directory, and two clicks stood between them and
+  their own knowledge every time it loaded. The sidebar and the home
+  listing now walk past the levels that hold **one directory and nothing
+  else**, and both begin at the first level with something to choose
+  between. A line above the tree names the path walked and links back to
+  the bundle's root.
+
+  It hides nothing: the step is taken only when the level has no concepts
+  and no files of its own, so what is skipped is a corridor rather than a
+  room. Ids are unchanged everywhere — a walked page still spells
+  `teams/growth/metrics/revenue` in full, because a second spelling of an
+  address is what this must not buy. An administrator whose base lives
+  under a single directory gets the same walk for the same reason, and no
+  setting turns it on or off.
+
 ### Security
 
 - **Both web-UI commands refuse a cross-site write.** `ochakai ui` has

--- a/internal/webui/jstest/descend.test.js
+++ b/internal/webui/jstest/descend.test.js
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { MAX_DESCENT, descendSingleRoad, isCorridor } from '../static/js/descend.js';
+
+// A level as the browse endpoint answers one.
+const level = (dirs = [], concepts = [], files = []) =>
+  ({ dirs: dirs.map(name => ({ name, count: 1 })), concepts, files });
+
+// A tree given as a map of prefix -> level, which is what the walk reads.
+const loader = tree => async p => {
+  if (!(p in tree)) throw new Error(`no level at ${p}`);
+  return tree[p];
+};
+
+test('a corridor is one directory and nothing else', () => {
+  assert.equal(isCorridor(level(['teams'])), true);
+  assert.equal(isCorridor(level(['teams', 'glossary'])), false, 'two doors is a choice');
+  assert.equal(isCorridor(level(['teams'], [{ id: 'note' }])), false, 'a concept here is a room');
+  assert.equal(isCorridor(level(['teams'], [], [{ path: 'a.csv' }])), false, 'so is a file');
+  assert.equal(isCorridor(level()), false, 'an empty level goes nowhere');
+});
+
+test('the walk stops where there is something to choose between', async () => {
+  const tree = {
+    'teams/': level(['growth']),
+    'teams/growth/': level(['metrics', 'queries']),
+  };
+  const { level: at, prefix } = await descendSingleRoad(level(['teams']), '', loader(tree));
+  assert.equal(prefix, 'teams/growth/');
+  assert.deepEqual(at.dirs.map(d => d.name), ['metrics', 'queries']);
+});
+
+test('a level holding knowledge of its own is where the walk ends', async () => {
+  const tree = { 'teams/': level(['growth'], [{ id: 'teams/charter' }]) };
+  const { prefix } = await descendSingleRoad(level(['teams']), '', loader(tree));
+  assert.equal(prefix, 'teams/', 'descending past teams/ would have hidden its concept');
+});
+
+test('a base with nothing to walk stays at the root', async () => {
+  const { prefix } = await descendSingleRoad(level(['a', 'b']), '', loader({}));
+  assert.equal(prefix, '');
+  const empty = await descendSingleRoad(level(), '', loader({}));
+  assert.equal(empty.prefix, '');
+});
+
+test('a level that cannot be read ends the walk where it stands', async () => {
+  // The corridor says there is a door; opening it fails. The page must
+  // still render what it already has, at the deepest level it read.
+  const { level: at, prefix } = await descendSingleRoad(level(['teams']), '', loader({}));
+  assert.equal(prefix, '');
+  assert.deepEqual(at.dirs.map(d => d.name), ['teams']);
+});
+
+test('the walk is bounded', async () => {
+  // A corridor with no end: every level answers with one more door.
+  const endless = async p => level([String(p.split('/').length)]);
+  const { prefix } = await descendSingleRoad(level(['1']), '', endless);
+  assert.equal(prefix.split('/').filter(Boolean).length, MAX_DESCENT);
+});

--- a/internal/webui/static/app.css
+++ b/internal/webui/static/app.css
@@ -268,6 +268,10 @@ input[type=date]:not(:focus):invalid, input[type=date]:not(:focus):placeholder-s
 }
 .weak-matches .card { opacity: .75; }
 .truncation-note { color: var(--muted); font-size: .86rem; text-align: center; padding: .8rem 0; }
+/* Where the tree starts, when that is not the bundle's root. Quiet, and
+   above the first node, because it is context rather than an entry. */
+.walked-from { color: var(--muted); font-size: .8rem; padding: 0 0 .4rem; word-break: break-all; }
+.walked-from a { margin-right: .35rem; }
 .feed-banner {
   background: var(--accent-weak); border: 1px solid var(--border); border-radius: 8px;
   padding: .55rem .9rem; margin-bottom: 1rem; font-size: .92rem; color: var(--accent-strong);

--- a/internal/webui/static/js/descend.js
+++ b/internal/webui/static/js/descend.js
@@ -1,0 +1,48 @@
+// Where the tree starts, when the levels above hold nothing to choose
+// between.
+//
+// A caller granted one directory (design doc 0109) opens the page on a
+// root holding one directory holding one directory, and two clicks stand
+// between them and their own knowledge every time. This walks that
+// corridor once, at load, so the sidebar and the home listing begin where
+// the reader would have arrived anyway.
+//
+// **It hides nothing, and that is the whole of why it is safe**: a step
+// is taken only when the level has exactly one subdirectory, no concepts
+// and no files, so what is skipped is a corridor rather than a room. The
+// prefixes stay whole — a walked path is shown with the way back, and an
+// id is spelled the way it is stored, because a second spelling of an
+// address is what this must not buy (design doc 0075 §2).
+//
+// Kept apart from tree.js so it can be tested as what it is: a function
+// over levels. load(prefix) answers the level at a prefix, and a load
+// that throws ends the walk where it stands — a corridor that cannot be
+// read is as far as this caller gets, and the page still renders.
+
+// MAX_DESCENT bounds the walk. A corridor this long is not a shape
+// anybody navigates by hand, and the bound keeps a boot from becoming one
+// request per segment of some pathological tree.
+export const MAX_DESCENT = 8;
+
+// isCorridor reports whether a level holds one directory and nothing
+// else — the only shape it is safe to walk past.
+export function isCorridor(level) {
+  return (level.dirs || []).length === 1
+    && !(level.concepts || []).length
+    && !(level.files || []).length;
+}
+
+export async function descendSingleRoad(level, prefix, load) {
+  for (let i = 0; i < MAX_DESCENT && isCorridor(level); i++) {
+    const next = prefix + level.dirs[0].name + '/';
+    let deeper;
+    try {
+      deeper = await load(next);
+    } catch {
+      break;
+    }
+    level = deeper;
+    prefix = next;
+  }
+  return { level, prefix };
+}

--- a/internal/webui/static/js/tree.js
+++ b/internal/webui/static/js/tree.js
@@ -2,6 +2,7 @@
 // navigation (design docs 0014, 0016).
 
 import { READ_ONLY, api } from './api.js';
+import { descendSingleRoad } from './descend.js';
 import { $ } from './dom.js';
 import { esc } from './escape.js';
 import { dirHash, displayTitle, idPath } from './format.js';
@@ -12,7 +13,18 @@ import { icon } from './vocab.js';
 // directories, loaded one level per request; the root is the top-level
 // segments. Expanded nodes survive navigation within the session and
 // are restored (re-fetched) on a tree refresh.
-export const browse = { open: new Set() }; // keys: prefix
+export const browse = {
+  open: new Set(), // keys: prefix
+  // root is the level the tree starts at, which is not always the
+  // bundle's root — see descendSingleRoad. Read by the home page so
+  // that what it lists and what the sidebar shows are one answer.
+  root: '',
+  // ready resolves when root holds that answer. The home view renders
+  // from the same boot as the tree and got there first, so reading root
+  // without waiting listed the corridor the sidebar had just walked
+  // past — the two panels disagreeing about where the base begins.
+  ready: Promise.resolve(),
+};
 
 // knownDirs are the directory prefixes the tree has loaded, plus the
 // root — the completions offered where a destination path is typed.
@@ -25,11 +37,24 @@ export function knownDirs() {
 // refreshTree (re)loads the root level; wireNodes then reloads every
 // node restored as open. Called at boot, from the ↻ button, and after
 // writes that change what the tree shows (create, delete, status).
-export async function refreshTree() {
+export function refreshTree() {
+  const done = loadTree();
+  // Every refresh republishes the answer, because a write can turn a
+  // corridor into a room (or back).
+  browse.ready = done.catch(() => {});
+  return done;
+}
+
+async function loadTree() {
   const tree = $('#tree');
   try {
-    const res = await api('/api/v1/bundle/index.md');
-    tree.innerHTML = levelHTML(res, '') || '<div class="empty">まだナレッジがありません。</div>';
+    const walked = await descendSingleRoad(
+      await api('/api/v1/bundle/index.md'), '',
+      p => api(`/api/v1/bundle/${idPath(p.replace(/\/$/, ''))}/index.md`));
+    browse.root = walked.prefix;
+    const body = levelHTML(walked.level, walked.prefix);
+    tree.innerHTML = (walkedFromHTML(walked.prefix) + body)
+      || '<div class="empty">まだナレッジがありません。</div>';
     wireNodes(tree);
     // A deep link may have rendered before the tree existed (boot) or
     // before this refresh; re-reveal the current entry or directory in
@@ -45,6 +70,16 @@ export async function refreshTree() {
   }
 }
 $('#tree-refresh').addEventListener('click', refreshTree);
+
+// walkedFromHTML names the corridor the tree skipped, with the way back
+// to the real root. The tree starting somewhere other than the bundle's
+// root is a thing a reader has to be able to see, and undo: without this
+// line the page would be claiming an address it does not have.
+function walkedFromHTML(prefix) {
+  if (!prefix) return '';
+  return `<div class="walked-from"><a href="${dirHash('')}" title="バンドルの一番上を開きます">/</a>${
+    esc(prefix.replace(/\/$/, ''))} から表示しています</div>`;
+}
 
 export function nodeHTML(prefix, label, count) {
   // The ＋ prefills the editor's ID with this directory — no retyping the

--- a/internal/webui/static/js/views/dir.js
+++ b/internal/webui/static/js/views/dir.js
@@ -6,7 +6,7 @@ import { dirCard, fileCard, hitCard } from '../cards.js';
 import { $, view } from '../dom.js';
 import { esc } from '../escape.js';
 import { crumbTrail, idPath } from '../format.js';
-import { revealInTree } from '../tree.js';
+import { browse, revealInTree } from '../tree.js';
 import { explore } from './explore.js';
 
 // loadDirIndex fetches one browse level and renders it into container
@@ -71,5 +71,15 @@ export function viewHome() {
   $('#home-go').addEventListener('click', () => { explore.q = $('#home-q').value; });
   $('#home-export').addEventListener('click', downloadBundle);
   if (matchMedia('(pointer: fine)').matches) $('#home-q').focus({ preventScroll: true });
-  loadDirIndex($('#home-index'), '', 'まだナレッジがありません。最初のナレッジを作成してください。');
+  // The same level the sidebar starts at: a caller whose knowledge sits
+  // under one directory should not have to walk the corridor twice, once
+  // in each panel (design doc 0075 §2 keeps the address whole either
+  // way). Awaited, because both panels render from one boot and this one
+  // is faster — without it the home page lists the corridor the sidebar
+  // has just walked past.
+  const box = $('#home-index');
+  browse.ready.then(() => {
+    if (!box.isConnected) return; // navigated away while the tree loaded
+    loadDirIndex(box, browse.root, 'まだナレッジがありません。最初のナレッジを作成してください。');
+  });
 }


### PR DESCRIPTION
A caller granted one directory ([0109](https://github.com/na0fu3y/ochakai/blob/main/docs/design/0109-a-directory-has-readers-and-writers.md))
opened the page on a root holding one directory holding one directory.
**Two clicks stood between them and their own knowledge, every time the
page loaded** — and that shape is precisely the one
[0119](https://github.com/na0fu3y/ochakai/blob/main/docs/design/0119-an-operated-fleet-is-deployments-or-directories.md)
describes: an organization living in a directory of a shared deployment.

The sidebar and the home listing now walk past the levels that hold **one
directory and nothing else**, and both begin at the first level with
something to choose between.

## Why it is safe

**It hides nothing.** The step is taken only when the level has exactly
one subdirectory, no concepts and no files — so what is skipped is a
corridor, not a room. That property is also what makes deep links keep
working: if the walk happened, there was nothing at those levels to link
to.

**Ids are untouched.** A walked page still spells
`teams/growth/metrics/revenue` in full, in the tree, the breadcrumbs and
the cards. A second spelling of an address is what this must not buy
([0075](https://github.com/na0fu3y/ochakai/blob/main/docs/design/0075-the-bundle-is-the-address-space.md) §2).

**It is visible and undoable.** A line above the tree names the path
walked and links back to the bundle's root.

**No setting decides it.** The rule reads what the server returned, so it
behaves the same under `ochakai ui` and `serve-ui` — `serve-ui` cannot
hold a per-user setting anyway — and an administrator whose base lives
under a single directory gets the same walk for the same reason.

## No design record

This changes what a page draws, not what any surface carries. No
endpoint, parameter, header, tool, command, flag, variable or vocabulary
word moves.

## Two defects found before shipping, and one only by looking

The walk lives in its own module (`descend.js`) so it can be tested as
what it is — a function over levels. Six tests cover the corridor
predicate, stopping at a room, an unreadable level, and the bound.

- A `res, prefix = level, next` that is JavaScript's comma operator and
  not a tuple assignment. `node --check` passes it happily.
- **The home page raced the tree.** Both panels render from one boot, the
  home listing got there first, and it listed the corridor the sidebar had
  just walked past. **This one had no failing test — it appeared when the
  page was opened and looked at.** The home view now waits for the tree's
  answer, which every refresh republishes, since a write can turn a
  corridor into a room.

## Verified by looking

Against a local instance seeded with `t/acme/{metrics,queries}`: both
panels start at `t/acme/`, the walked line reads `/ t/acme から表示して
います`, and the breadcrumbs and ids stay whole. Putting a concept at
`t/` stops the walk there and shows it in both panels — the "hides
nothing" property, observed rather than assumed. No console errors.

`scripts/check --db` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)