### PR TITLE
Put the release lessons where the next release reads them

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -61,7 +61,15 @@ them, so a forgotten bump is a red test rather than a stale page:
 the hits rather than replacing them.
 
 Read the unreleased entries as you go and confirm they match what
-actually landed (`git log v<prev>..origin/main --oneline`). A missing
+actually landed. The commits that go missing are the ones that widen no
+surface — a search fix, a ranking change — because nothing counts them;
+`git log v<prev>..origin/main --stat` and a look at every PR that moved
+a non-test file under `internal/` is the sweep that found #709, #715 and
+#716 after the fact. The `changelog` workflow now asks this of every PR,
+so a miss here means somebody labeled one `no-changelog`; read those.
+Then check that nothing landed *below* `## [Unreleased]`: a PR branched
+before the previous release and merged after it drops its entry into the
+section that was just tagged, and git raises no conflict. A missing
 entry is much cheaper to fix now than after the tag.
 
 Run `scripts/check` and open the PR. Merge it before tagging.
@@ -74,9 +82,16 @@ tag message and release body.
 
 ```bash
 git fetch origin && git checkout -B rel origin/main
-git tag -a vX.Y.Z -F -
+git tag -a vX.Y.Z --cleanup=verbatim -F notes.md
 git push origin vX.Y.Z
 ```
+
+**`--cleanup=verbatim` is not optional.** Without it git strips every
+line that starts with `#` as a comment — and the release notes are
+Markdown, so `## 検索` and every heading under it vanish silently. The
+tag looks fine in `git tag -l`; the gap shows on the Releases page.
+v0.26.3 was tagged twice for this reason. Read the result back before
+pushing: `git tag -l --format='%(contents)' vX.Y.Z | head -20`.
 
 Pushing runs [release.yaml](../../../.github/workflows/release.yaml): one
 job publishes the multi-arch image to GHCR with SBOM and provenance, the
@@ -149,6 +164,19 @@ curl -s https://proxy.golang.org/github.com/na0fu3y/ochakai/@latest
 
 `./ochakai version` must print the tag — a mismatch means the ldflags
 wiring broke, and it is the one failure the automation cannot see.
+
+If `gh attestation verify oci://…` hangs — it does on some networks,
+and so does `docker pull`, while a plain `curl` to the registry answers
+— do not wait on it. Read the manifest digest over HTTP and ask the
+attestation store directly; one hit is the same proof:
+
+```bash
+token=$(curl -s "https://ghcr.io/token?scope=repository:na0fu3y/ochakai:pull" | jq -r .token)
+digest=$(curl -sI -H "Authorization: Bearer $token" \
+  -H "Accept: application/vnd.oci.image.index.v1+json" \
+  https://ghcr.io/v2/na0fu3y/ochakai/manifests/X.Y.Z | tr -d '\r' | awk 'tolower($1)=="docker-content-digest:" {print $2}')
+gh api "repos/na0fu3y/ochakai/attestations/$digest" --jq '.attestations | length'   # expect 1
+```
 
 ## Why the ceremony
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,6 +9,10 @@ context, including the store integration test and the fuzz targets).
 
 - [ ] `scripts/check` is clean — add `--db` when the change touches the store
 - [ ] Behavior changes come with tests
+- [ ] Behavior changes have a line under `## [Unreleased]` in `CHANGELOG.md`
+      — the `changelog` workflow checks for one when a non-test file under
+      `internal/` or `cmd/` moves; if this change is not behavior, label the
+      PR `no-changelog` and say why above
 
 ## Surfaces and contract
 

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -1,0 +1,68 @@
+# A behavior change that widens no surface passes every check this
+# repository has — surface_test.go counts entries, frozenwire_test.go
+# watches the wire, and a search fix that changes which concepts come
+# back touches neither. Three of those shipped without a CHANGELOG entry
+# in two consecutive releases (#709 in 0.26.2, #715 and #716 in 0.26.3),
+# each found by hand during release prep. A trap sprung three times is a
+# check, not a reminder (design doc 0035).
+#
+# Its own workflow rather than a job in ci.yaml so that adding or removing
+# the `no-changelog` label re-runs this and only this.
+name: changelog
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+permissions:
+  contents: read
+jobs:
+  entry:
+    runs-on: ubuntu-latest
+    # The label is the way out for a change that is behavior on paper and
+    # not in practice — a comment rewrite, a rename under internal/ — and
+    # it is visible on the PR, which a skipped check is not.
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changelog') }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          # The merge-base is what the diff is against; a shallow clone
+          # has no history to find it in.
+          fetch-depth: 0
+      - name: A behavior change carries a CHANGELOG entry, under Unreleased
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -eu
+          # What counts as behavior: anything under internal/ or cmd/ that
+          # is not a test. The web UI's sources live under internal/ too,
+          # which is deliberate — #514 was a UI change nobody wrote down.
+          behavior=$(git diff --name-only "$BASE...$HEAD" -- internal cmd |
+            grep -Ev '_test\.go$|^internal/webui/jstest/|/testdata/' || true)
+          if [ -z "$behavior" ]; then
+            echo "no behavior change under internal/ or cmd/; nothing to write down"
+            exit 0
+          fi
+          if git diff --quiet "$BASE...$HEAD" -- CHANGELOG.md; then
+            printf '::error file=CHANGELOG.md::This PR changes behavior but adds no CHANGELOG entry. Add one under ## [Unreleased], or label the PR no-changelog and say why in the description.\n'
+            printf 'Behavior files changed:\n%s\n' "$behavior"
+            exit 1
+          fi
+          # The entry has to land above the first released heading. A PR
+          # branched before a release and merged after it puts its lines
+          # into the section that was just tagged — git sees no conflict,
+          # and the entry is then in a release it was not part of.
+          released=$(git show "$HEAD:CHANGELOG.md" | grep -nE '^## \[[0-9]' | head -1 | cut -d: -f1)
+          [ -n "$released" ] || exit 0 # no released section yet; nothing to land under
+          # Added lines below that heading are stray — except the compare
+          # links at the very bottom, which a release PR adds to legitimately.
+          stray=$(git diff -U0 "$BASE...$HEAD" -- CHANGELOG.md |
+            awk -v r="$released" '
+              /^@@/ { split($3, a, /[+,]/); below = (a[2] + 0 > r); next }
+              /^\+\+\+/ { next }
+              below && /^\+/ && !/^\+\[[^]]+\]: / { print }')
+          if [ -n "$stray" ]; then
+            printf '::error file=CHANGELOG.md,line=%s::This PR edits CHANGELOG.md below the first released heading (line %s). Move the entry under ## [Unreleased] — it is probably sitting in the section that was tagged after this branch was cut.\n' "$released" "$released"
+            exit 1
+          fi
+          echo "CHANGELOG entry present under Unreleased"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1115,6 +1115,13 @@ out from a review costs you the time you spent writing it, not only the
 time it takes to read.
 
 - Keep PRs small and focused; include tests for behavior changes.
+- A behavior change gets a line under `## [Unreleased]` in
+  `CHANGELOG.md`. The `changelog` workflow fails a PR that moves a
+  non-test file under `internal/` or `cmd/` without touching the
+  changelog, and one whose entry landed below the first released
+  heading (a branch cut before a release, merged after it); the
+  `no-changelog` label is the way out when the change is not behavior,
+  and the description says why.
 - A PR that widens a surface — a REST operation, an MCP tool, a CLI
   command, an environment variable — names which of
   [docs/surface.md](docs/surface.md)'s eight conditions it serves, updates
@@ -1166,8 +1173,12 @@ commits are English:
 
 ```sh
 git fetch origin && git checkout -B rel origin/main
-git tag -a v0.14.0 -F -   # then push: git push origin v0.14.0
+git tag -a v0.14.0 --cleanup=verbatim -F notes.md   # then push: git push origin v0.14.0
 ```
+
+`--cleanup=verbatim` because the notes are Markdown: without it git
+drops every `#`-led line as a comment, and the headings are gone before
+anyone reads the tag.
 
 Pushing the tag runs [release.yaml](.github/workflows/release.yaml): one
 job publishes the multi-arch image to GHCR with SBOM and provenance, the


### PR DESCRIPTION
## What and why

Three release lessons had been living in an agent's memory file rather than in the repository, and one of them was relearned three times: a behavior change that widens no surface — a search fix, a ranking change — passes every check here (surface_test counts entries, frozenwire_test watches the wire) and can ship without a CHANGELOG entry. #709 did in 0.26.2; #715 and #716 did in 0.26.3; each was caught by hand during release prep. This is the first item of the 2026-08-23 process review: lessons go back into the repo, and a trap sprung three times becomes a check.

- **`.github/workflows/changelog.yaml`** — fails a PR that moves a non-test file under `internal/` or `cmd/` without touching `CHANGELOG.md`, and a PR whose changelog lines landed *below* the first released heading (a branch cut before a release and merged after it drops its entry into the section just tagged, with no conflict). The `no-changelog` label is the way out, visible on the PR. Its own workflow so that labeling re-runs only this check. Run against history: passes on every recent merge, fails on #709 and #715, and treats the release-prep PR's compare links as legitimate.
- **`.claude/skills/release/SKILL.md`** — `--cleanup=verbatim` on the tag command (git otherwise strips `#`-led lines, i.e. every Markdown heading; v0.26.3 was tagged twice for this), the `--stat` sweep for uncounted behavior changes, and the HTTP + `gh api` route for verifying the image attestation when `gh attestation verify oci://` hangs (verified today against 0.26.3).
- **CONTRIBUTING.md**, **PR template** — the same two facts where a contributor reads them.

No surface widens; no design decision changes.

## Checks

- [x] `scripts/check` is clean — no Go or UI files change
- [x] Behavior changes come with tests — the workflow's script was run against real history (above)
- [x] CHANGELOG — not ochakai behavior; contributor tooling only

## Surfaces and contract

- [x] N/A — no wire, CLI, MCP, env or doc surface changes

## Design docs

- [x] No accepted decision is altered
- [x] Commit messages and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)