### PR TITLE
Bring the dogfood instance up at session start, and say when it is not

### DIFF
--- a/.claude/hooks/ochakai-recall.sh
+++ b/.claude/hooks/ochakai-recall.sh
@@ -29,9 +29,21 @@ case $prompt in
 /*) exit 0 ;; # slash commands are not knowledge questions
 esac
 
-hits=$(ochakai search "$prompt" --limit "${OCHAKAI_RECALL_LIMIT:-8}" --json 2>/dev/null) || exit 0
-
 session=$(printf '%s' "$input" | jq -r '.session_id // empty' 2>/dev/null) || session=""
+
+if ! hits=$(ochakai search "$prompt" --limit "${OCHAKAI_RECALL_LIMIT:-8}" --json 2>/dev/null); then
+	# Down. Say so once per session rather than never: for a fortnight
+	# this hook's silence read as "nothing relevant" while the instance
+	# was simply not running. session-start.sh brings it up when Docker
+	# is there; this is the line for when it could not.
+	[ -n "$session" ] || exit 0
+	marker="${TMPDIR:-/tmp}/ochakai-down-$session"
+	[ -e "$marker" ] && exit 0
+	: >"$marker" 2>/dev/null || true
+	printf 'The dogfood ochakai instance at %s is not answering, so this session has no recall and no write-back (kb/README.md). `docker compose -f deploy/compose.yaml up -d` brings it up; say so to the user rather than working as if there were nothing to recall.\n' "$OCHAKAI_URL"
+	exit 0
+fi
+
 if [ -n "$session" ]; then
 	# The search answered, so the write-back nudge has somewhere to send
 	# the agent — even when the answer was empty.

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,32 +1,113 @@
 #!/bin/sh
-# session-start: SessionStart hook — make the store tests runnable in the
-# Claude Code cloud environment, and say what still cannot be checked there.
+# session-start: SessionStart hook. Two environments, two jobs:
 #
-# That environment ships the docker CLI without a daemon, and starting
-# dockerd does not help: its egress policy answers 403 for Docker Hub's
-# blob CDN, so pgvector/pgvector:pg17 can never be pulled and the store
-# integration tests would silently skip for the whole session.
+# - On a contributor's machine, bring the dogfood instance up
+#   (kb/README.md). The loop's other two hooks are silent by design when
+#   nothing answers on :8080, and a Docker restart leaves the compose
+#   stack down — so for most of its first fortnight the loop was
+#   installed and not running, and nobody could tell from inside a
+#   session. `docker compose up -d` is idempotent and the stack binds
+#   loopback only, so starting it is safe to repeat; a machine with no
+#   Docker daemon is left alone, and the note says so.
+# - In the Claude Code cloud environment, make the store tests runnable,
+#   and say what still cannot be checked there.
+#
+# The cloud half: that environment ships the docker CLI without a daemon,
+# and starting dockerd does not help: its egress policy answers 403 for
+# Docker Hub's blob CDN, so pgvector/pgvector:pg17 can never be pulled and
+# the store integration tests would silently skip for the whole session.
 # `scripts/check --db` already falls back to a cluster built from the
 # machine's own PostgreSQL; what that fallback needs and a stock image
 # lacks is pgvector beside it. One package, installed here rather than
 # per session, because the container image is cached once this completes.
 #
-# Only the cloud environment is touched (CLAUDE_CODE_REMOTE) — a hook that
-# installed system packages on a contributor's laptop would be a bug. It
-# is idempotent, and it fails silently: a hook must never be the reason a
-# session refuses to start.
+# Only the cloud environment has packages installed (CLAUDE_CODE_REMOTE) —
+# a hook that installed system packages on a contributor's laptop would be
+# a bug. Both halves are idempotent, and both fail silently: a hook must
+# never be the reason a session refuses to start.
 #
 # shellcheck disable=SC2016 # the notes below are prose: the backticks are
 # Markdown, and $HTTPS_PROXY is a command for the agent to run, not for
 # this script to expand.
 set -eu
 
-[ "${CLAUDE_CODE_REMOTE:-}" = "true" ] || exit 0
 command -v jq >/dev/null 2>&1 || exit 0
+
+# say prints one note for the agent and exits. Everything else this
+# script writes goes to a log, never to stdout: stdout is the hook's JSON
+# reply.
+say() {
+	jq -nc --arg t "$1" '{
+		hookSpecificOutput: {
+			hookEventName: "SessionStart",
+			additionalContext: $t,
+		},
+	}'
+	exit 0
+}
 
 # Everything below is written to a log, never to stdout: stdout is the
 # hook's JSON reply.
 log=${TMPDIR:-/tmp}/ochakai-session-start.log
+
+# --- A contributor's machine: the dogfood instance -------------------
+
+: "${OCHAKAI_URL:=http://localhost:8080}"
+
+# concepts prints how many concepts the instance holds, or nothing if it
+# is not answering.
+concepts() {
+	curl -sf -m 3 "$OCHAKAI_URL/api/v1/stats" 2>/dev/null | jq -r '.concepts.total // empty' 2>/dev/null
+}
+
+dogfood_local() {
+	root=$(cd "$(dirname "$0")/../.." && pwd)
+	compose="$root/deploy/compose.yaml"
+	[ -f "$compose" ] || exit 0
+	verb="is up"
+	if ! n=$(concepts) || [ -z "$n" ]; then
+		# Not answering. Only Docker can bring it up, and only when the
+		# port is free: something else on :8080 is not ours to replace.
+		command -v docker >/dev/null 2>&1 || exit 0
+		docker info >/dev/null 2>&1 || say "The dogfood ochakai instance is down and Docker is not running, so this session has no recall and no write-back (kb/README.md). Start Docker and run \`docker compose -f deploy/compose.yaml up -d\` to have both."
+		if nc -z localhost 8080 >/dev/null 2>&1; then
+			say "Something answers on :8080 that is not ochakai (no /api/v1/stats), so the dogfood instance was not started; this session has no recall and no write-back."
+		fi
+		{
+			echo "=== $(date -u +%FT%TZ) docker compose up -d ($compose)"
+			docker compose -f "$compose" up -d
+		} >>"$log" 2>&1 || say "\`docker compose -f deploy/compose.yaml up -d\` failed (see $log), so this session has no recall and no write-back (kb/README.md)."
+		i=0
+		until n=$(concepts) && [ -n "$n" ]; do
+			i=$((i + 1))
+			[ "$i" -lt 25 ] || say "The dogfood instance is starting in the background (docker compose, see $log) and was not answering yet; recall begins with the first prompt it answers."
+			sleep 1
+		done
+		verb="was started"
+	fi
+	# Seed an empty instance from the bundle in git — but only a bundle
+	# that carries no verified key. Import re-records a document's
+	# verification as the importer's own (design doc 0043 §3.2), which is
+	# why kb/README.md leaves import to a person; a bundle of drafts
+	# verifies nothing, so loading it rules on nothing.
+	if [ "$n" = 0 ]; then
+		if grep -rqE '^verified(_at)?:' "$root/kb/bundle"; then
+			say "The dogfood ochakai instance $verb at $OCHAKAI_URL and is empty, and kb/bundle carries verified keys — loading it is a ruling, so a person runs \`ochakai import kb/bundle\` (kb/README.md). Until then recall has nothing to find."
+		fi
+		command -v ochakai >/dev/null 2>&1 || say "The dogfood ochakai instance $verb at $OCHAKAI_URL and is empty, and there is no ochakai CLI on PATH to load kb/bundle with (\`go install ./cmd/ochakai\`, then \`ochakai import kb/bundle\`)."
+		{
+			echo "=== $(date -u +%FT%TZ) ochakai import kb/bundle"
+			OCHAKAI_URL=$OCHAKAI_URL ochakai import "$root/kb/bundle"
+		} >>"$log" 2>&1 || say "The dogfood ochakai instance $verb at $OCHAKAI_URL and is empty; loading kb/bundle failed (see $log)."
+		n=$(concepts) || n=0
+		verb="$verb and was loaded from kb/bundle as drafts (nothing verified, so nothing ruled on)"
+	fi
+	say "The dogfood ochakai instance $verb at $OCHAKAI_URL: $n concepts (kb/README.md). Recall runs on each prompt; fetch with the ochakai MCP get_concept tool, never the CLI."
+}
+
+[ "${CLAUDE_CODE_REMOTE:-}" = "true" ] || dogfood_local
+
+# --- The cloud environment: the store tests --------------------------
 
 docker_note='Two things this environment cannot check, both because of its
 egress policy rather than anything in the tree:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -273,6 +273,13 @@ sessions off the CLI write commands, which the dev instance would record
 as the anonymous human — agent writes go through the MCP tools, whose
 connection carries the process identity
 ([kb/bundle/policies/ai-human-identity.md](kb/bundle/policies/ai-human-identity.md)).
+On a contributor's machine the session-start hook also brings that
+instance up — `docker compose up -d` when Docker is running and nothing
+answers on :8080, and a first load of `kb/bundle` when the instance is
+empty and the bundle carries no `verified:` key, so that nothing is
+ruled on. Both loop hooks stay silent by design when the instance is
+down, which for a fortnight read as "nothing relevant" while the stack
+was simply not running; recall now says so once per session instead.
 That deny list is the one permissions entry that is not a personal
 choice; everything else about permissions belongs in
 `.claude/settings.local.json`, which is not tracked.

--- a/kb/README.md
+++ b/kb/README.md
@@ -15,6 +15,12 @@ ochakai use http://localhost:8080
 ochakai import kb/bundle
 ```
 
+Claude Code のセッションでは `.claude/hooks/session-start.sh` がこれを
+代わりに行う — Docker が動いていれば compose を上げ、インスタンスが
+**空で、かつバンドルに `verified:` キーが一つも無いとき**だけ import
+する(draft しか無いバンドルの読み込みは何も裁定しない)。バンドルが
+検証を運ぶようになったら、import は下の規則どおり人の手に戻る。
+
 そこから先 — 誰がどの identity で書くか、レビューの回し方、ここへの
 書き戻し — は
 [skills/run-the-dogfood-loop](bundle/skills/run-the-dogfood-loop.md) と


### PR DESCRIPTION
## What and why

Item 5 of the 2026-08-23 process review. The dogfood loop ([kb/README.md](kb/README.md)) was installed on 08-08 with hooks that are silent by design when the instance is down — and a Docker restart leaves the compose stack down. Brought up today, `deploy_pgdata` held **zero concepts**: for a fortnight the loop was configured and not running, and from inside a session that was indistinguishable from "nothing relevant to recall". The nine concepts existed only in git.

- **`.claude/hooks/session-start.sh`** gains a half for a contributor's machine (the cloud half is unchanged): when Docker is running and `:8080` is quiet, `docker compose -f deploy/compose.yaml up -d` (idempotent, binds loopback only), wait for `/health`, report the concept count to the agent. A port held by something that is not ochakai, a stopped Docker, or a failed compose each get a one-line note instead.
- **First load.** An empty instance is loaded from `kb/bundle` — *only* when the bundle carries no `verified:` key. Import re-records a document's verification as the importer's own (0043 §3.2), which is why kb/README leaves import to a person; a bundle of drafts verifies nothing, so loading it rules on nothing. A bundle that does carry verifications is left to a person and the note says so. The nine concepts arrived as `draft` / `unverified`, `created` 9.
- **`.claude/hooks/ochakai-recall.sh`** says once per session when the instance is not answering, rather than never.
- kb/README.md and CONTRIBUTING say what the hook does.

Exercised on this machine: up-and-empty → loaded 9; stopped → started in 4.6 s and reported 9; recall with a dead URL → one note, then silence. The identity-policy concept itself is untouched: a three-line edit to it moved the search eval's reach ceiling (10.54 → 10.56), so the rule's exception lives in kb/README.md, which already owns the out-of-bundle statement of it.

## Checks

- [x] `scripts/check core` — no Go change; `TestSearchEvalIntegration` run against a throwaway pgvector, ok
- [x] Behavior changes come with tests — hook behavior exercised by hand (above); no ochakai behavior changes
- [x] CHANGELOG — contributor tooling only

## Surfaces and contract

- [x] N/A — DOC 27 unchanged; kb/README.md grows 6 lines within DOC-LINES slack (surface_test passes)

## Design docs

- [x] No accepted decision is altered
- [x] Commit messages and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)