### PR TITLE
Name a subtree archive in Japanese too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,23 @@ last entry.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A subtree archive names itself in Japanese too.** The filename half
+  of design doc 0127 folded every non-ASCII character to a hyphen, so
+  the two shapes it exists to prevent came back for the directories
+  this product's first audience actually has: `営業` arrived as
+  `ochakai-okf-.tar.gz`, one hyphen from the whole-base backup's name,
+  and `teams/成長` arrived as `ochakai-okf-teams.tar.gz` — **an archive
+  of one directory under the name of every directory beside it.** Those
+  characters are percent-encoded now, and the unescaped name travels
+  beside them in `filename*` (RFC 6266), which is the one browsers
+  prefer. **The whole base and a subtree the ASCII name already spelled
+  exactly send the byte-identical header they sent in 0.27.0**, and the
+  root `index.md`'s `bundle_scope` — the other half of 0127, which was
+  correct throughout — is unchanged. No endpoint, parameter or header
+  name is added.
+
 ## [0.27.0] - 2026-08-23
 
 ### Added

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -589,6 +589,9 @@ paths:
         carries `bundle_scope` in its frontmatter and a sentence naming
         what is missing, and the `Content-Disposition` filename is
         `ochakai-okf-<subtree>.tar.gz` rather than `ochakai-okf.tar.gz`.
+        A subtree spelled outside ASCII is percent-encoded there and
+        carried unescaped in `filename*` (RFC 6266), so the name never
+        folds away to `ochakai-okf-.tar.gz` or to a wider subtree's.
         Deeper `index.md` files are unchanged — what a subtree archive
         lacks is above them, not below. A whole-base archive is exactly
         what it was.

--- a/internal/restapi/restapi.go
+++ b/internal/restapi/restapi.go
@@ -34,6 +34,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/na0fu3y/ochakai/internal/domain"
 	"github.com/na0fu3y/ochakai/internal/httpauth"
@@ -58,21 +59,83 @@ const exportBatch = 100
 // archiveFilename names an archive after the subtree it carries, with
 // the path's separators folded to hyphens so the name is one word on
 // every filesystem. The whole bundle is "ochakai-okf.tar.gz", unchanged.
+//
+// This is the ASCII half of the name, and it is only half because an id
+// is any valid UTF-8 (domain.validSegment) — which for this product's
+// first audience means the subtree is usually spelled in Japanese
+// (C8). Folding those characters to hyphens the way the unsafe ASCII
+// ones are folded is what design doc 0127 exists to prevent: "営業"
+// left nothing behind and came out as "ochakai-okf-.tar.gz", one
+// hyphen from the whole-base name, and "teams/成長" came out as
+// "ochakai-okf-teams.tar.gz" — an archive of one directory claiming to
+// be the archive of every directory beside it. So a character that is
+// not ASCII is percent-encoded rather than dropped: it stays uglier
+// than the Japanese, and it stays true. archiveDisposition puts the
+// unescaped name beside this one for the clients that can read it.
 func archiveFilename(prefix string) string {
 	if prefix == "" {
 		return "ochakai-okf.tar.gz"
 	}
-	safe := strings.Map(func(r rune) rune {
+	var safe strings.Builder
+	for _, r := range prefix {
 		switch {
 		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-':
-			return r
+			safe.WriteRune(r)
 		case r >= 'A' && r <= 'Z':
-			return r + ('a' - 'A')
+			safe.WriteRune(r + ('a' - 'A'))
+		case r < utf8.RuneSelf:
+			safe.WriteByte('-')
 		default:
-			return '-'
+			pctEncode(&safe, string(r))
 		}
-	}, prefix)
-	return "ochakai-okf-" + strings.Trim(safe, "-") + ".tar.gz"
+	}
+	name := strings.Trim(safe.String(), "-")
+	if name == "" {
+		// Every character folded away, which ASCII alone can still do:
+		// a directory named "_" leaves nothing. The name has to keep
+		// saying "part of a base" even when it can no longer say which
+		// part, because the whole point is that it is not the backup.
+		name = "subtree"
+	}
+	return "ochakai-okf-" + name + ".tar.gz"
+}
+
+// archiveDisposition is the whole Content-Disposition header: the ASCII
+// name every client understands, and — where it would say more — the
+// exact one, as RFC 6266's filename* (which browsers have preferred over
+// filename since IE9).
+//
+// Emitted only where the fold lost something, so the whole base and a
+// subtree the ASCII name already spells exactly send the byte-identical
+// header they sent before. No header name is added: filename* is a
+// parameter of a Content-Disposition that is already counted
+// (docs/surface.md, HEADER).
+func archiveDisposition(prefix string) string {
+	disp := `attachment; filename="` + archiveFilename(prefix) + `"`
+	if prefix == "" {
+		return disp
+	}
+	exact := "ochakai-okf-" + strings.ReplaceAll(prefix, "/", "-") + ".tar.gz"
+	if exact == archiveFilename(prefix) {
+		return disp
+	}
+	var enc strings.Builder
+	pctEncode(&enc, exact)
+	return disp + "; filename*=UTF-8''" + enc.String()
+}
+
+// pctEncode writes s percent-encoded to everything outside RFC 3986's
+// unreserved set, which is a subset of RFC 8187's attr-char and so is
+// safe both inside filename* and inside a quoted filename.
+func pctEncode(b *strings.Builder, s string) {
+	const unreserved = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~"
+	for _, c := range []byte(s) {
+		if strings.IndexByte(unreserved, c) >= 0 {
+			b.WriteByte(c)
+			continue
+		}
+		fmt.Fprintf(b, "%%%02X", c)
+	}
 }
 
 func writeBundleArchive(w http.ResponseWriter, r *http.Request, svc *service.Service, prefix string) {
@@ -143,8 +206,7 @@ func writeBundleArchive(w http.ResponseWriter, r *http.Request, svc *service.Ser
 	// The name says what is inside, because the person who meets this
 	// archive again is reading a filename rather than unpacking it
 	// (design doc 0127). A whole base keeps the name it has always had.
-	w.Header().Set("Content-Disposition",
-		`attachment; filename="`+archiveFilename(prefix)+`"`)
+	w.Header().Set("Content-Disposition", archiveDisposition(prefix))
 	tgz := okf.NewTarGzWriter(w, time.Now())
 	written := make(map[string]bool, len(ids)+len(indexes))
 	fail := func(what string, err error) {

--- a/internal/restapi/restapi_integration_test.go
+++ b/internal/restapi/restapi_integration_test.go
@@ -3877,4 +3877,29 @@ func TestRESTIntegrationASubtreeArchiveSaysItIsOne(t *testing.T) {
 	if !carried {
 		t.Errorf("the subtree archive is missing its own concept: %v", paths)
 	}
+
+	// A subtree spelled the way this product's first audience spells one.
+	// An id is any valid UTF-8, and folding those characters out of the
+	// filename took 0127's own half of the promise back out with them:
+	// the name said nothing, or worse, said the name of the directory
+	// above.
+	jp := root + "/営業/売上"
+	putDoc(t, srv.URL, jp+"/実績", []byte("---\ntype: Metric\ntitle: 実績\n---\n\nbody\n"), false).Body.Close()
+	removeEntries(t, srv, jp+"/実績")
+	disp, index, paths = read(t, "/"+jp)
+	if strings.Contains(disp, `filename="ochakai-okf-.tar.gz"`) || !strings.Contains(disp, "%E5%96%B6%E6%A5%AD") {
+		t.Errorf("a Japanese subtree arrived as %q, want a name that is its own", disp)
+	}
+	if !strings.Contains(disp, `filename*=UTF-8''`) {
+		t.Errorf("a Japanese subtree carries no exact name: %q", disp)
+	}
+	if got := archiveFilename(root + "/営業"); strings.Contains(disp, `filename="`+got+`"`) {
+		t.Errorf("the archive of %q arrived under the name of %q: %q", jp, root+"/営業", disp)
+	}
+	if !strings.Contains(index, `bundle_scope: "`+jp+`"`) {
+		t.Errorf("the root index carries no bundle_scope:\n%s", index)
+	}
+	if !slices.Contains(paths, jp+"/実績.md") {
+		t.Errorf("the subtree archive is missing its own concept: %v", paths)
+	}
 }

--- a/internal/restapi/restapi_test.go
+++ b/internal/restapi/restapi_test.go
@@ -743,3 +743,57 @@ func TestAcceptIsReadAsASetOfNames(t *testing.T) {
 		})
 	}
 }
+
+// An archive's filename is one of the two places design doc 0127 has it
+// say which part of a base it is, and it is the one that lands before
+// anybody opens anything. An id is any valid UTF-8, so for this
+// product's first audience the subtree is usually spelled in Japanese —
+// and folding those characters away took the filename's half of 0127
+// back out in exactly that case.
+func TestAnArchiveNamesTheSubtreeItCarriesInAnySpelling(t *testing.T) {
+	// The two shapes that made this a defect rather than an ugly name:
+	// a name that says nothing, and a name that says something wider.
+	whole := archiveFilename("")
+	for _, prefix := range []string{"営業", "営業/売上", "日本語", "_", "-"} {
+		got := archiveFilename(prefix)
+		if got == whole || got == "ochakai-okf-.tar.gz" {
+			t.Errorf("archiveFilename(%q) = %q, which a whole-base backup is kept under", prefix, got)
+		}
+	}
+	for _, c := range []struct{ prefix, wider string }{
+		{"teams/成長", "teams"},
+		{"チーム/growth", "growth"},
+	} {
+		if got := archiveFilename(c.prefix); got == archiveFilename(c.wider) {
+			t.Errorf("archiveFilename(%q) = %q, the name of %q — an archive of one directory "+
+				"claiming to be the archive of every directory beside it",
+				c.prefix, got, c.wider)
+		}
+	}
+
+	// The exact name travels for the clients that read RFC 6266, and
+	// the ASCII half stays unambiguous for the ones that do not.
+	disp := archiveDisposition("teams/成長")
+	if !strings.Contains(disp, `filename*=UTF-8''ochakai-okf-teams-%E6%88%90%E9%95%B7.tar.gz`) {
+		t.Errorf("Content-Disposition carries no exact name: %q", disp)
+	}
+	if !strings.Contains(disp, `filename="ochakai-okf-teams-%E6%88%90%E9%95%B7.tar.gz"`) {
+		t.Errorf("the ASCII half is not the subtree it carries: %q", disp)
+	}
+
+	// What shipped for the whole base and for a subtree the ASCII name
+	// already spelled exactly is what keeps shipping, byte for byte:
+	// this fixes the case that was broken and moves nothing else. A
+	// prefix the fold only changed the case of gains the exact spelling
+	// beside it, which is the same rule and not a second one.
+	for _, c := range []struct{ prefix, want string }{
+		{"", `attachment; filename="ochakai-okf.tar.gz"`},
+		{"teams/growth", `attachment; filename="ochakai-okf-teams-growth.tar.gz"`},
+		{"teams/growth-eu", `attachment; filename="ochakai-okf-teams-growth-eu.tar.gz"`},
+		{"Teams", `attachment; filename="ochakai-okf-teams.tar.gz"; filename*=UTF-8''ochakai-okf-Teams.tar.gz`},
+	} {
+		if got := archiveDisposition(c.prefix); got != c.want {
+			t.Errorf("archiveDisposition(%q) = %q, want %q", c.prefix, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## What and why

Found while verifying v0.27.0. The **filename half of design doc 0127 does not work for non-ASCII subtrees**, which for this product's first audience (C8) is the ordinary case: `archiveFilename` folded every character outside `[a-z0-9-]` to a hyphen, and an id is any valid UTF-8 (`domain.validSegment`).

Both shapes 0127 exists to prevent came back:

| prefix | v0.27.0 | this PR (`filename=` / `filename*` decoded) |
|---|---|---|
| `teams/growth` | `ochakai-okf-teams-growth.tar.gz` | unchanged |
| `営業/売上` | `ochakai-okf-.tar.gz` | `…-%E5%96%B6%E6%A5%AD-%E5%A3%B2%E4%B8%8A.tar.gz` / `ochakai-okf-営業-売上.tar.gz` |
| `teams/成長` | **`ochakai-okf-teams.tar.gz`** | `ochakai-okf-teams-%E6%88%90%E9%95%B7.tar.gz` / `…-teams-成長.tar.gz` |

The third row is the reason this is a defect rather than an ugly name: an archive of one directory arrived **under the name of every directory beside it**. The first is one hyphen from the whole-base backup's name — the exact confusion 0127 was written against.

Not a security issue, and nothing was disclosed that should not have been: `svc.MayArchive` gates the endpoint correctly before the snapshot is taken, and the other half of 0127 — the root `index.md`'s `bundle_scope` — was correct throughout and is untouched. What failed is the half that reaches the person restoring the archive *before* they open it.

Non-ASCII characters are percent-encoded now rather than dropped, and the unescaped name travels beside them in `filename*` (RFC 6266), which browsers prefer over `filename`. A prefix that folds away entirely (`_`, `-`) becomes `ochakai-okf-subtree.tar.gz` — it can stop saying *which* part, but not that it is one.

**Nothing else moves.** The whole base and a subtree the ASCII name already spelled exactly send the byte-identical header they sent in 0.27.0. A prefix the fold only changed the case of gains the exact spelling beside it, which is the same rule and not a second one.

## Checks

- [x] `scripts/check` is clean — `core` and `lint` (0 issues) green; `--db` green except `TestWhatPostgresCanIndexAboveTheBMP`, which fails on this machine's **PostgreSQL 16** and is unrelated to this change (README requires 17; CI's pg17 and pg18 both pass it)
- [x] Behavior changes come with tests — a unit test over the naming and the whole header, and the 0127 integration test now archives a Japanese subtree end to end. Both assert the regression directly: a name must not equal the whole-base name, and must not equal a wider subtree's
- [x] Behavior changes have a line under `## [Unreleased]` in `CHANGELOG.md`

## Surfaces and contract

- [x] `api/openapi.yaml` gains the two sentences that say what the filename does with a non-ASCII subtree; `internal/restapi` matches. `internal/apiclient` needs nothing — it does not read `Content-Disposition`
- [x] The change lands on every surface it belongs on. It is **REST-only, deliberately**: the archive's other caller is `ochakai export`, which writes to stdout or a directory and never reads the header, so there is nothing for the CLI to carry. MCP and the Web UI do not serve archives
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens no surface. No endpoint, parameter, flag or environment variable is added, and **`HEADER` stays at 13**: that dimension counts header *names* on the wire, `Content-Disposition` is already one of them, and `filename*` is a parameter of it — the same reason `docs/surface.md` gives for an addition to a response body not appearing there

## Design docs

- [x] Not applicable — no accepted decision is altered. This is a rule inside 0127's area, and the parent record plus the CHANGELOG answer it in three months ([0128](https://github.com/na0fu3y/ochakai/blob/main/docs/design/0128-a-number-is-for-an-area-not-a-rule-inside-it.md)). 0127 already states the intended behavior; this makes the code do it
- [x] Commit messages and code comments are in English

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nzwtu4HmMx78STdBxp6JoM)_