### PR TITLE
Release 0.27.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Version
       description: Output of `ochakai version`, or the image tag you deployed.
-      placeholder: "0.27.0"
+      placeholder: "0.27.1"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ last entry.
 
 ## [Unreleased]
 
+## [0.27.1] - 2026-08-23
+
 ### Fixed
 
 - **A subtree archive names itself in Japanese too.** The filename half
@@ -5499,7 +5501,8 @@ worth naming: SQL injection in `compile_sql` through undeclared field
 pass-through, fixed in 0.8.0 — v0.7.0 and earlier are affected. Details
 are in git history.
 
-[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.27.0...HEAD
+[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.27.1...HEAD
+[0.27.1]: https://github.com/na0fu3y/ochakai/compare/v0.27.0...v0.27.1
 [0.27.0]: https://github.com/na0fu3y/ochakai/compare/v0.26.3...v0.27.0
 [0.26.3]: https://github.com/na0fu3y/ochakai/compare/v0.26.2...v0.26.3
 [0.26.2]: https://github.com/na0fu3y/ochakai/compare/v0.26.1...v0.26.2

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -82,7 +82,7 @@ info:
     is a security defect, shipped in the next release with no deprecation
     window (SECURITY.md). MCP, the CLI and the stored shape stay unstable
     while the major version is 0 and may still change in a minor release.
-  version: 0.27.0
+  version: 0.27.1
   license:
     name: MIT
 servers:

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -77,7 +77,7 @@ export IMAGE=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:$VERSION
 `:latest` ではなくバージョンを固定し、再デプロイを意識的な判断にする。
 `gh` CLI が無ければ
 [リリースページ](https://github.com/na0fu3y/ochakai/releases)から番号
-を読み、手で設定する — `export VERSION=0.27.0`。
+を読み、手で設定する — `export VERSION=0.27.1`。
 
 (このガイドは 0.9.0 以降を前提にしている。それより前のリリースは
 [retract](https://go.dev/ref/mod#go-mod-file-retract) 済みでサポート外

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -5,7 +5,7 @@ region     = "us-central1"
 
 # Pin a released version, not "latest", so a redeploy is a decision:
 # https://github.com/na0fu3y/ochakai/releases
-image_tag = "0.27.0"
+image_tag = "0.27.1"
 
 # Who can reach ochakai. This is the whole access-control surface — whoever
 # reaches it can read and write everything. Never allUsers.


### PR DESCRIPTION
0.27.0 の後に入ったのは #760 の一件のみ、BREAKING なしなのでパッチ。

`## [Unreleased]` を `## [0.27.1] - 2026-08-23` に落とし、空の Unreleased と
compare リンクを足したうえで、タグが更新しない5つのファイルを揃えた:
`api/openapi.yaml` の `info.version`、bug_report の placeholder、
`deploy/cloudrun/README.md` の手書き `export VERSION=`、
`deploy/terraform/terraform.tfvars.example` の `image_tag`。

`RetiredToolNames` と `retiredCommands` はどちらも空のまま — このリリースで
閉じる改名の窓はない。`grep -rn 0.27.0` の残りは CHANGELOG と設計記録の
正当な言及だけ。`scripts/check` は通っている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)