### PR TITLE
The line surgery declines the frontmatter it cannot address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,66 @@ last entry.
   read-only rule is unchanged too: on a frozen deployment the whole
   editor is absent, as it was.
 
+### Fixed
+
+- **A frontmatter this instance's keys could not be appended to no
+  longer breaks the document.** The trust family ochakai publishes
+  (`generated` / `verified` / `created_by`) is appended to a stored
+  document's frontmatter as lines, and the lines were written at column
+  0 whatever column the frontmatter was at. A mapping indented by a
+  space — unusual YAML, and valid YAML — is *ended* by a key less
+  indented than itself, so what came back out of `GET` with
+  `Accept: text/markdown`, out of `ochakai get`, and out of a bundle
+  export was a document that no longer parsed, carrying keys the write
+  path could then no longer take off again. The same append ran on the
+  way in, where it stored such a document in a form that no longer
+  parsed and dropped the claim it had just taken out of it.
+
+  The line surgery beside it had the same shape of fault twice more, and
+  both times what was lost was a key the writer owned rather than one of
+  ours. A flow mapping's keys do not have lines of their own, so taking
+  out "the lines this key occupies" took the neighbour with it:
+  `{type: Metric, generated: x}` arrived with a type and was stored
+  without one. And the parser counts a bare carriage return as a line
+  break where the surgery counts only `\n`, so a frontmatter holding one
+  was numbered a line ahead of where the cut landed — `generated` was
+  read on one line and a *different* line was removed.
+
+  The keys are now written at the frontmatter mapping's own column, and
+  the append checks its own work: it goes on only if taking it off again
+  gives back the document that came in. A frontmatter whose lines do not
+  answer to keys is not addressed at all — a flow mapping, one numbered
+  in line breaks the cut does not count, and one carrying a `...` or
+  `--- ` marker, where the mapping stops before the block does — and one
+  the keys cannot be appended to is left exactly as it arrived: no
+  surgery in either direction — nothing is taken out of it on the way in and
+  nothing is put back on the way out, so it still round-trips byte for
+  byte, and what it loses is only this instance's provenance *in the
+  markdown export*. Every other reader of provenance is unaffected: the
+  JSON representations, the trust tier and `trust=` read the ledgers,
+  never the document. Nothing ochakai writes and nothing written by hand
+  in the ordinary way is one of these shapes, so no stored document
+  moves — the only documents this reaches are the ones it was
+  corrupting.
+
+- **Normalizing a stored document is idempotent, so sending back what a
+  read handed you answers `unchanged`.** The two normalizations a write
+  applies — CRLF to LF, and exactly one newline at the end (design doc
+  0075 §3) — did not hold on a text whose carriage returns sat against a
+  line ending. `\r\r\n` had its CRLF replaced and was left holding a new
+  one, and a document ending in a bare CR kept it and had a newline
+  appended after it: both stored a CRLF, out of a document the CRLF rule
+  had just been applied to, and only the *next* normalization folded it.
+  The user-visible effect was a `PUT` of the exact bytes a read returned
+  answering `plan: updated` and writing a second revision of identical
+  content.
+
+  **This moves the content hash of a stored document that ends in a bare
+  CR or contains a `\r\r\n`** — the first write after upgrading rewrites
+  it once, with the carriage returns gone, and settles there. A carriage
+  return in the middle of a line is nobody's line ending and still
+  stays.
+
 ## [0.27.1] - 2026-08-23
 
 ### Fixed

--- a/internal/okf/raw.go
+++ b/internal/okf/raw.go
@@ -65,14 +65,57 @@ const ClaimKey = "received"
 // exactly one newline. Nothing else — no NFC normalization of the
 // content, which design doc 0022 applies to keys (ids, filenames, link
 // targets, queries) and deliberately not to what a writer wrote.
+//
+// Carriage returns are cut wherever a line ending would be left holding
+// one, which is what makes those two rules hold at all. Replacing "\r\n"
+// in "\r\r\n" leaves a CR against the new LF, and trimming only newlines
+// off a text ending in a bare CR puts the appended one right after it —
+// both store a CRLF out of a document the first rule was applied to.
+//
+// It is the same thing as saying the function is idempotent, and that is
+// the property a writer depends on: PUTting back the bytes a read handed
+// it is normalizing what is already normalized, and the answer it is owed
+// is `unchanged` rather than a second revision of identical content.
+//
+// A carriage return that is nobody's line ending — one in the middle of a
+// line — is the writer's, and stays.
 func NormalizeText(raw []byte) []byte {
-	s := strings.TrimPrefix(string(raw), "\ufeff")
-	s = strings.ReplaceAll(s, "\r\n", "\n")
-	s = strings.TrimRight(s, "\n")
+	s := foldCRLF(strings.TrimPrefix(string(raw), "\ufeff"))
+	s = strings.TrimRight(s, "\n\r")
 	if s == "" {
 		return nil
 	}
 	return []byte(s + "\n")
+}
+
+// foldCRLF turns every CRLF into an LF, taking with it the carriage
+// returns run up against one: after it, no CR in the text is followed by
+// an LF, which a single pass of strings.ReplaceAll cannot say.
+func foldCRLF(s string) string {
+	if !strings.Contains(s, "\r") {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	cr := 0 // carriage returns held back until what follows them is known
+	for i := range len(s) {
+		switch s[i] {
+		case '\r':
+			cr++
+		case '\n':
+			cr = 0 // they were the front of this line ending
+			b.WriteByte('\n')
+		default:
+			for ; cr > 0; cr-- {
+				b.WriteByte('\r')
+			}
+			b.WriteByte(s[i])
+		}
+	}
+	for ; cr > 0; cr-- {
+		b.WriteByte('\r')
+	}
+	return b.String()
 }
 
 // splitFrontmatter cuts a normalized document into the text inside its
@@ -176,16 +219,14 @@ type lineRange struct{ from, to int }
 // that key is going away too, in which case the blank line between them
 // separates nothing and goes with them.
 //
-// Frontmatter that does not parse as a mapping yields nothing: a document
-// that cannot be read is one no write path stores, and guessing at its
-// shape here could only damage it.
+// Frontmatter the surgery cannot address yields nothing (mappingKeys):
+// a document whose shape cannot be read in lines is one to leave exactly
+// as it arrived, since guessing at it could only damage it.
 func ownedKeyRanges(fm string, lines int, owned func(string) bool) []lineRange {
-	var root yaml.Node
-	if err := yaml.Unmarshal([]byte(fm), &root); err != nil ||
-		len(root.Content) == 0 || root.Content[0].Kind != yaml.MappingNode {
+	pairs, ok := mappingKeys(fm)
+	if !ok {
 		return nil
 	}
-	pairs := root.Content[0].Content
 	all := strings.Split(fm, "\n")
 	var out []lineRange
 	for i := 0; i+1 < len(pairs); i += 2 {
@@ -209,6 +250,78 @@ func ownedKeyRanges(fm string, lines int, owned func(string) bool) []lineRange {
 	}
 	return out
 }
+
+// mappingKeys reads a frontmatter block's top-level keys. It is the
+// precondition the removal here rests on, since the removal works in
+// whole lines: ok is false for a block whose lines do not answer to
+// keys, and four shapes are that block.
+//
+// One that is not a mapping at all has no keys to address.
+//
+// A *flow* mapping — `{type: Metric, generated: x}` — has keys that do
+// not own their lines: one line can hold two of them and one key can be
+// half a line, so "the lines this key occupies" is not something that
+// can be taken out. Doing it anyway stored a document that arrived
+// saying `type: Metric` with no type at all, and cut another one off
+// mid-mapping at `{type: Metric,`. A flow *value* under a block key is
+// addressable and stays so: it is the key's own line and its
+// continuations, which is what a line range already means here.
+//
+// A block carrying a line break the parser counts and this file does not
+// is numbered in lines that are not the ones being cut — every range
+// here is a line number the parser reported, applied to lines split on
+// "\n". A frontmatter holding a bare carriage return was numbered a line
+// ahead of the cut, so `generated` was read on one line and a *different*
+// line was removed.
+//
+// A document marker ends the mapping before the block ends, so a key
+// written at the end of the block joins nothing. That one is the append
+// failing rather than the removal, and it is still the removal that has
+// to decline it: what a stored document must never hold is a key one
+// direction can take out and the other cannot put back, since then the
+// export form and the document it was made from differ by a key nobody
+// appended.
+//
+// Everything ochakai writes and everything an author writes by hand is
+// the addressable case; the rest arrives, is stored byte for byte, and
+// comes back out, which is what the bundle promises it (design doc 0075
+// §1). What it does not get is the surgery — no key is taken out of it
+// on the way in and none is put back on the way out.
+func mappingKeys(fm string) (pairs []*yaml.Node, ok bool) {
+	var root yaml.Node
+	if err := yaml.Unmarshal([]byte(fm), &root); err != nil ||
+		len(root.Content) == 0 || root.Content[0].Kind != yaml.MappingNode {
+		return nil, false
+	}
+	m := root.Content[0]
+	if m.Style&yaml.FlowStyle != 0 || strings.ContainsAny(fm, yamlLineBreaks) ||
+		hasDocumentMarker(fm) {
+		return nil, false
+	}
+	return m.Content, true
+}
+
+// hasDocumentMarker reports whether any line of a block is YAML's
+// start-of-document or end-of-document marker. Both have to sit at
+// column 0 to be one, which is why the lines are read as they come
+// rather than trimmed.
+func hasDocumentMarker(fm string) bool {
+	for line := range strings.SplitSeq(fm, "\n") {
+		for _, m := range []string{"---", "..."} {
+			if line == m || strings.HasPrefix(line, m+" ") || strings.HasPrefix(line, m+"\t") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// yamlLineBreaks are the line breaks the YAML parser counts and
+// strings.Split on "\n" does not — a carriage return, and the three
+// Unicode ones. NormalizeText folds every CRLF, so what is left of them
+// in a stored document is deliberate bytes rather than a line ending
+// anybody meant.
+const yamlLineBreaks = "\r\u0085\u2028\u2029"
 
 // MoveServerKeys is what a write path does with the keys this instance
 // owns: it takes them out of the received document's frontmatter, and
@@ -239,12 +352,10 @@ func MoveServerKeys(raw []byte) (doc []byte, claimed []string, claim map[string]
 	if !ok || fm == "" {
 		return stripped, nil, nil
 	}
-	var root yaml.Node
-	if err := yaml.Unmarshal([]byte(fm), &root); err != nil ||
-		len(root.Content) == 0 || root.Content[0].Kind != yaml.MappingNode {
+	pairs, ok := mappingKeys(fm)
+	if !ok {
 		return stripped, nil, nil
 	}
-	pairs := root.Content[0].Content
 	moved := map[string]any{}
 	for i := 0; i+1 < len(pairs); i += 2 {
 		if pairs[i].Value == ClaimKey {
@@ -271,8 +382,19 @@ func MoveServerKeys(raw []byte) (doc []byte, claimed []string, claim map[string]
 	if err != nil {
 		return stripped, nil, nil
 	}
-	out := appendFrontmatter(stripped, block)
-	return out, claimed, ClaimOf(out)
+	out := appendFrontmatter(stripped, block, func(key string) bool { return key == ClaimKey })
+	claim = ClaimOf(out)
+	if claim == nil {
+		// The claim did not go in, so the keys do not come out: what is
+		// stored is the document as it arrived, its own trust family still
+		// in it. Taking a key off a document and failing to put it back
+		// under ClaimKey is the one loss no later release can undo (design
+		// doc 0075 §3.1), and the export form of a document this instance
+		// cannot append to carries no observation to collide with it
+		// (appendFrontmatter).
+		return raw, nil, nil
+	}
+	return out, claimed, claim
 }
 
 // keepTimestampText makes every timestamp under n decode as the text it
@@ -413,12 +535,72 @@ func ClaimNote(keys []string) string {
 // frontmatter, which is where every key this instance adds goes: the
 // stored document is the writer's own bytes, so nothing already in it
 // moves (design doc 0046 §2.2).
-func appendFrontmatter(raw, block []byte) []byte {
+//
+// The block is written at the mapping's own column, because a key less
+// indented than the mapping it is meant to join does not join it. A
+// frontmatter indented by one space is unusual YAML and valid YAML, and
+// appending `generated:` at column 0 ended the mapping instead of
+// extending it — leaving an export form that no longer parses, with keys
+// StripServerKeys could then no longer find.
+//
+// Indentation is not the only shape a line-append cannot extend, and
+// rather than enumerate them here this checks its own work: the block
+// goes on only if stripping owned back off gives the document that came
+// in, which is the property the two operations owe each other stated
+// where it is enforced instead of discovered. It is also why the column
+// is read off the text rather than out of a parse — a guess that is
+// wrong costs the keys, never the document, and it saves an export the
+// parse it would otherwise pay per entry.
+//
+// What cannot be appended to is handed back untouched, as a document
+// with no frontmatter at all already was: inventing a place for the keys
+// would corrupt the file, and an export form missing this instance's
+// observations is a gap in what the markdown says where the alternative
+// is a document that no longer parses. Every other reader of provenance
+// is unaffected — the JSON representations, the ledgers, the trust tier
+// read what this instance recorded, never the document's bytes.
+func appendFrontmatter(raw, block []byte, owned func(string) bool) []byte {
 	fm, rest, ok := splitFrontmatter(string(raw))
 	if !ok {
 		return raw
 	}
-	return []byte("---\n" + fm + string(block) + "---\n" + rest)
+	out := []byte("---\n" + fm + indentBlock(string(block), frontmatterIndent(fm)) + "---\n" + rest)
+	if !bytes.Equal(stripKeys(out, owned), raw) {
+		return raw
+	}
+	return out
+}
+
+// frontmatterIndent is how far a frontmatter block's mapping is indented,
+// read off the first line that is a key rather than a blank or a comment.
+func frontmatterIndent(fm string) int {
+	for line := range strings.SplitSeq(fm, "\n") {
+		trimmed := strings.TrimLeft(line, " ")
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		return len(line) - len(trimmed)
+	}
+	return 0
+}
+
+// indentBlock shifts a rendered block right by n columns, keeping every
+// line's own indentation relative to the block. Blank lines stay blank:
+// trailing spaces are not something to add to a document.
+func indentBlock(block string, n int) string {
+	if n <= 0 || block == "" {
+		return block
+	}
+	pad := strings.Repeat(" ", n)
+	var b strings.Builder
+	for line := range strings.SplitSeq(strings.TrimSuffix(block, "\n"), "\n") {
+		if line != "" {
+			b.WriteString(pad)
+		}
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	return b.String()
 }
 
 // WithServerKeys is the inverse: it appends this instance's observations
@@ -438,7 +620,7 @@ func WithServerKeys(raw []byte, k *domain.Knowledge) ([]byte, error) {
 	// A document with no frontmatter has nowhere for the keys to go, and
 	// inventing a block would corrupt the file — appendFrontmatter hands
 	// such a file back untouched.
-	return appendFrontmatter(raw, owned), nil
+	return appendFrontmatter(raw, owned, func(key string) bool { return serverOwnedKeys[key] }), nil
 }
 
 // serverKeysFor is the trust family this instance would publish for k —

--- a/internal/okf/raw_test.go
+++ b/internal/okf/raw_test.go
@@ -69,9 +69,25 @@ func TestNormalizeText(t *testing.T) {
 		{"a\n\n\n", "a\n"},
 		{"\ufeff---\n", "---\n"},
 		{"", ""},
+		// A document ending in a bare CR: the trailing carriage return goes
+		// with the trailing newlines, or the newline appended after it would
+		// make the CRLF this same function says is not stored.
+		{"a\r", "a\n"},
+		{"a\r\r\n\r", "a\n"},
+		// A carriage return run up against a line ending goes with it: what
+		// one pass of ReplaceAll leaves behind is another CRLF.
+		{"a\r\r\nb\n", "a\nb\n"},
+		{"a\rb\r", "a\rb\n"}, // a CR inside a line is the writer's, and stays
 	} {
-		if got := string(NormalizeText([]byte(tc.in))); got != tc.want {
+		got := string(NormalizeText([]byte(tc.in)))
+		if got != tc.want {
 			t.Errorf("NormalizeText(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+		// And normalizing the normalized changes nothing. A writer PUTting
+		// back the bytes a read handed it is doing exactly that, and the
+		// answer it is owed is `unchanged` rather than a second revision.
+		if again := string(NormalizeText([]byte(got))); again != got {
+			t.Errorf("NormalizeText is not idempotent on %q: %q then %q", tc.in, got, again)
 		}
 	}
 }
@@ -249,6 +265,98 @@ func TestReplaceBodyLeavesFrontmatterAlone(t *testing.T) {
 	}
 }
 
+// A frontmatter mapping may be indented — unusual YAML, and valid YAML.
+// Then column 0 is *outside* it, and the keys this instance appends have
+// to be written at the mapping's own column or they end it instead of
+// extending it. That produced an export form that no longer parsed, and
+// whose keys StripServerKeys could then no longer find; on the way in it
+// stored a document that no longer parsed and dropped the claim it had
+// just taken out of it.
+func TestAnIndentedFrontmatterIsAppendedAtItsOwnColumn(t *testing.T) {
+	in := "---\n  type: Metric\n  generated: {by: human:x}\n---\n\n本文。\n"
+	d, _, err := Parse([]byte(in))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The claim came out of the document and went back under ClaimKey, at
+	// the mapping's indentation, leaving a document that still parses.
+	if d.Attrs[ClaimKey] == nil {
+		t.Fatalf("the claim was dropped: %q", d.Doc)
+	}
+	if !strings.Contains(d.Doc, "\n  received:\n") {
+		t.Errorf("the claim was not written at the mapping's column: %q", d.Doc)
+	}
+	back, _, err := Parse([]byte(d.Doc))
+	if err != nil {
+		t.Fatalf("the stored document no longer parses: %v\n%s", err, d.Doc)
+	}
+	if back.Doc != d.Doc {
+		t.Errorf("the stored document did not survive re-import:\n--- want ---\n%s\n--- got ---\n%s", d.Doc, back.Doc)
+	}
+	// And so does the export form, which is where the failure was found.
+	out, err := WithServerKeys([]byte(d.Doc), testEntry())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := Parse(out); err != nil {
+		t.Fatalf("the export form no longer parses: %v\n%s", err, out)
+	}
+	if got := string(StripServerKeys(out)); got != d.Doc {
+		t.Errorf("round trip lost bytes:\n--- want ---\n%s\n--- got ---\n%s", d.Doc, got)
+	}
+}
+
+// The line surgery cuts a frontmatter into lines and takes keys out of
+// it by line. Three shapes cannot be read that way, and it declines all
+// three rather than damage them — each of them used to lose a key the
+// writer owned, which is worse than losing one of ours. What they get
+// instead is what the bundle promises anything it holds: the bytes come
+// back out (design doc 0075 §1), with no surgery in either direction.
+func TestTheSurgeryDeclinesAFrontmatterItCannotAddress(t *testing.T) {
+	for _, tc := range []struct{ why, in string }{
+		// A flow mapping's keys do not own their lines: one line holds two
+		// of them, so removing "this key's lines" took the neighbour.
+		{"flow mapping", "---\n{type: Metric, generated: x}\n---\n"},
+		{"flow mapping over two lines", "---\n{type: Metric,\n generated: x}\n---\n"},
+		// The parser counts a bare carriage return as a line break and this
+		// file counts only "\n", so the key line numbers and the lines being
+		// cut were out of step: a different line was removed than the one
+		// the key was read on.
+		{"a line break only the parser counts", "---\n\rgenerated: x\ntype: Metric\n---\n"},
+		{"a Unicode line separator", "---\ntype: Metric\u2028title: x\ngenerated: y\n---\n"},
+		// A document marker ends the mapping before the block ends, so a
+		// key appended after it joins nothing — and a removal the export
+		// cannot undo is what leaves a stored document holding one of our
+		// keys.
+		{"an end-of-document marker", "---\ntype: Metric\ngenerated: x\ntitle: t\n...\n---\n"},
+		{"a start-of-document marker", "---\ntype: Metric\n--- \ntitle: t\n---\n"},
+	} {
+		if got := string(StripServerKeys([]byte(tc.in))); got != tc.in {
+			t.Errorf("%s: the strip cut lines it cannot address:\n--- want ---\n%q\n--- got ---\n%q", tc.why, tc.in, got)
+		}
+		d, _, err := Parse([]byte(tc.in))
+		if err != nil {
+			t.Fatalf("%s: Parse(%q): %v", tc.why, tc.in, err)
+		}
+		if d.Type != domain.TypeMetrics {
+			t.Errorf("%s: the writer's own key was lost: %+v", tc.why, d.Knowledge)
+		}
+		if d.Doc != tc.in {
+			t.Errorf("%s: the document was rewritten:\n--- want ---\n%q\n--- got ---\n%q", tc.why, tc.in, d.Doc)
+		}
+		out, err := WithServerKeys([]byte(d.Doc), testEntry())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(out) != tc.in {
+			t.Errorf("%s: keys were appended where they cannot be taken off again:\n%q", tc.why, out)
+		}
+		if got := string(StripServerKeys(out)); got != tc.in {
+			t.Errorf("%s: round trip lost bytes:\n--- want ---\n%q\n--- got ---\n%q", tc.why, tc.in, got)
+		}
+	}
+}
+
 // The property the two operations owe each other, over whatever the
 // fuzzer can produce: appending this instance's keys and taking them off
 // again is the identity on any document ochakai stores (design doc 0035 —
@@ -263,12 +371,36 @@ func FuzzServerKeyRoundTrip(f *testing.F) {
 	f.Add("---\ntype: Metric\nreceived: not a mapping\ncreated_by: human:x\n---\n")
 	f.Add("---\n---\nbody only\n")
 	f.Add("not a document at all\n")
+	// A mapping indented by one space: column 0 is outside it, so keys
+	// appended there end the frontmatter rather than extend it.
+	f.Add("---\n type: 0\n---")
+	f.Add("---\n  type: Metric\n  generated: {by: x}\n---\n")
+	// Flow mappings, whose keys do not own their lines at all.
+	f.Add("---\n{type: Metric, generated: x}\n---\n")
+	f.Add("---\n{type: Metric,\n generated: x}\n---\n")
+	f.Add("---\ntype: Metric\ngenerated: [1,\n 2]\n---\n")         // a flow *value* stays addressable
+	f.Add("---\ntype: Metric\n...\n---\n")                         // frontmatter that ends before its delimiter
+	f.Add("---\ntype: Metric\ngenerated: x\ntitle: t\n...\n---\n") // and one with a key to take out first
+	f.Add("---\ntype: Metric\n--- \ntitle: t\n---\n")
+	f.Add("---\ntype: Metric\n---\nbody\r") // a bare CR at the end (NormalizeText)
+	// Line breaks the parser counts and "\n" splitting does not, which put
+	// the key line numbers and the cut lines out of step.
+	f.Add("---\n\rgenerated: x\ntype: 0\n---\n")
+	f.Add("---\n\rtype:\r 0\n---")
+	f.Add("---\ntype: Metric\u2028title: x\ngenerated: y\n---\n")
 
 	f.Fuzz(func(t *testing.T, raw string) {
+		// Normalizing is idempotent, so a writer sending back the bytes a
+		// read handed it is sending something already stored — which is the
+		// difference between `unchanged` and a second revision.
+		normalized := NormalizeText([]byte(raw))
+		if again := NormalizeText(normalized); !slices.Equal(again, normalized) {
+			t.Fatalf("NormalizeText is not idempotent on %q: %q then %q", raw, normalized, again)
+		}
 		// Only documents ochakai would have stored: the write path parses
 		// before it stores, so a text Parse refuses is not one this
 		// property is about.
-		d, _, err := Parse(NormalizeText([]byte(raw)))
+		d, _, err := Parse(normalized)
 		if err != nil {
 			t.Skip()
 		}

--- a/internal/okf/testdata/fuzz/FuzzServerKeyRoundTrip/1fc2e8ab0ff72385
+++ b/internal/okf/testdata/fuzz/FuzzServerKeyRoundTrip/1fc2e8ab0ff72385
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("---\n\rtype:\r 0\n---")

--- a/internal/okf/testdata/fuzz/FuzzServerKeyRoundTrip/88cdea3fb606d8a6
+++ b/internal/okf/testdata/fuzz/FuzzServerKeyRoundTrip/88cdea3fb606d8a6
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("\r\r\n0")


### PR DESCRIPTION
## What and why

`FuzzServerKeyRoundTrip` failed on `"---\n type: 0\n---"` — a frontmatter
mapping indented by one space. `WithServerKeys` appended `generated:` /
`verified:` / `created_by:` at column 0, which is *less* indented than the
mapping already there, so the export form was YAML that no longer parsed and
`StripServerKeys` could no longer find the keys to take back off. The
export → review → import round trip design doc 0009 promises did not hold.

Probing the family before fixing found **three more shapes with the same root
cause, two of them worse** — silent data loss on the *write* path, all
pre-existing on `main`:

| frontmatter | what `main` does |
|---|---|
| `---\n type: 0\n---` (indented) | export unparseable; on write, stores an unparseable document and **drops the claim** |
| `{type: Metric, generated: x}` (flow) | arrives with a type, **stored without one** |
| bare `\r`, U+0085, U+2028, U+2029 in frontmatter | the parser counts these as line breaks and `strings.Split(s, "\n")` does not, so **a different line is removed than the key that was read** |
| `...` / `--- ` marker | the mapping ends before the block does, so an appended key joins nothing |

**Three options were on the table for the reported bug** — match the
indentation, refuse such a document on the write path, or normalize the
frontmatter's indentation in `NormalizeText`. The last two were declined.
Refusing breaks 0075 §1's central invariant (what goes into the bundle comes
out) over ochakai's own implementation choice, and normalizing means
re-serializing the frontmatter — exactly what 0046 §2.2 / 0075 §3 exist to
prevent — while fixing only one of the four shapes.

So the fix is **one rule instead of four patches**. The removal declines a
frontmatter whose lines do not answer to keys (`mappingKeys`), and the append
**checks its own work**: the block goes on only if stripping it back off gives
the document that came in. That enforces the round-trip property at runtime
rather than leaving it to be discovered by fuzzing, and it does not depend on
having enumerated the shapes correctly. A frontmatter that fails either is
stored exactly as it arrived and gets no surgery in either direction, so it
still round-trips byte for byte; what it gives up is this instance's
provenance in the *markdown export* alone — the JSON representations, the
ledgers and `trust=` read what this instance recorded, never the document's
bytes.

Because the self-check is the gate, the indent is read off the text instead of
a parse: `WithServerKeys` costs one added frontmatter parse, 8.1µs → 26µs per
document (measured), the same as an enumerated gate would have cost.

**Separately, `NormalizeText` was not idempotent.** `strings.TrimRight(s, "\n\r")`
alone was not enough — the fuzzer found `"\r\r\n"` in 0.07s: `ReplaceAll` folds
the CRLF and leaves a *new* one behind, so a stored document could still
contain the CRLF the rule says is not stored, and only the *next* call folded
it. A `PUT` of the exact bytes a read returned therefore answered
`plan: updated` and wrote a second revision of identical content. Replaced with
a single-pass fold that takes the carriage returns run up against a line
ending; a CR mid-line is still the writer's and stays. **This moves the content
hash of a stored document ending in a bare CR or holding a `\r\r\n`** — the
first write after upgrading rewrites it once and settles — which the CHANGELOG
says.

## Checks

- [x] `scripts/check --db` is clean
- [x] Behavior changes come with tests — both fuzz finds are checked in as
      corpus entries, the family as `f.Add` seeds, and the property now also
      asserts the idempotence. `FuzzServerKeyRoundTrip` ran 10 minutes clean
      (27.7M execs, 713 corpus entries) plus a 5-minute re-run after the final
      refactor; `FuzzParse` 150 seconds clean
- [x] Behavior changes have a line under `## [Unreleased]` in `CHANGELOG.md` —
      two, under `### Fixed`

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver` and
      `internal/apiclient` still say the same thing — nothing on the wire moved
- [x] Nothing lands or is withheld per surface: this is one package's internal
      behavior, reached identically from every face that reads or writes a
      document
- [x] `api/openapi.frozen.txt` untouched
- [x] No surface widens — no endpoint, parameter, flag, tool or environment
      variable is added, so `docs/surface.md` is unchanged and its test passes

## Design docs

- [x] Not applicable — **no accepted decision is altered.** Both changes make
      the code do what design doc 0075 §3 and §3.1 already decided: the two
      normalizations (CRLF → LF, exactly one trailing newline), and removing
      the server-owned keys line-wise on the way in and appending them on the
      way out without moving anything else. What was wrong was that the code
      did not hold to them — a bare `\r\r\n` stored a CRLF, and the line
      surgery damaged frontmatter it could not address. Per 0128 that is a rule
      inside an existing area: the parent record plus this PR and the CHANGELOG
      answer it, so it takes no number
- [x] Commit messages and code comments are in English

## For the reviewer

One judgement call worth a second opinion: I stopped short of making the append
*succeed* on a `...`-marked frontmatter, which would mean inserting after the
last key's block rather than at the end of the frontmatter. Declining it keeps
both directions agreeing — and they have to agree, because a stored document
must never hold a server-owned key that the removal can take out and the append
cannot put back, or the export form and the document it was made from differ by
a key nobody appended. The extra machinery would buy only provenance in the
markdown export of a document nothing generates.
