### PR TITLE
Release v0.27.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Version
       description: Output of `ochakai version`, or the image tag you deployed.
-      placeholder: "0.27.1"
+      placeholder: "0.27.2"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ last entry.
 
 ## [Unreleased]
 
+## [0.27.2] - 2026-08-24
+
 ### Added
 
 - **The web UI edits frontmatter in fields again, and still saves a
@@ -5659,7 +5661,8 @@ worth naming: SQL injection in `compile_sql` through undeclared field
 pass-through, fixed in 0.8.0 — v0.7.0 and earlier are affected. Details
 are in git history.
 
-[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.27.1...HEAD
+[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.27.2...HEAD
+[0.27.2]: https://github.com/na0fu3y/ochakai/compare/v0.27.1...v0.27.2
 [0.27.1]: https://github.com/na0fu3y/ochakai/compare/v0.27.0...v0.27.1
 [0.27.0]: https://github.com/na0fu3y/ochakai/compare/v0.26.3...v0.27.0
 [0.26.3]: https://github.com/na0fu3y/ochakai/compare/v0.26.2...v0.26.3

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -82,7 +82,7 @@ info:
     is a security defect, shipped in the next release with no deprecation
     window (SECURITY.md). MCP, the CLI and the stored shape stay unstable
     while the major version is 0 and may still change in a minor release.
-  version: 0.27.1
+  version: 0.27.2
   license:
     name: MIT
 servers:

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -77,7 +77,7 @@ export IMAGE=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:$VERSION
 `:latest` ではなくバージョンを固定し、再デプロイを意識的な判断にする。
 `gh` CLI が無ければ
 [リリースページ](https://github.com/na0fu3y/ochakai/releases)から番号
-を読み、手で設定する — `export VERSION=0.27.1`。
+を読み、手で設定する — `export VERSION=0.27.2`。
 
 (このガイドは 0.9.0 以降を前提にしている。それより前のリリースは
 [retract](https://go.dev/ref/mod#go-mod-file-retract) 済みでサポート外

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -5,7 +5,7 @@ region     = "us-central1"
 
 # Pin a released version, not "latest", so a redeploy is a decision:
 # https://github.com/na0fu3y/ochakai/releases
-image_tag = "0.27.1"
+image_tag = "0.27.2"
 
 # Who can reach ochakai. This is the whole access-control surface — whoever
 # reaches it can read and write everything. Never allUsers.


### PR DESCRIPTION
0.27.1 の次。未リリース欄に **BREAKING** がないのでパッチを上げる。

版番号を持つ四つのファイルを 0.27.2 に揃え、`## [Unreleased]` を
`## [0.27.2] - 2026-08-24` として切り出し、新しい空の Unreleased と
compare リンクを足しただけ。コードは動かしていない。

- `mcpserver.RetiredToolNames` と `retiredCommands` は本番側が空のまま
  — 今回消す窓はない
- `git log v0.27.1..origin/main` の 6 PR のうち、CHANGELOG に載るのは
  #763 / #764 / #766 / #767 の四つ。#762 と #765 は `examples/demo/`
  の日本語の手入れで、面は動いていない
- CHANGELOG への追記は `## [Unreleased]` 直下の一箇所だけ — 0.27.1 の
  節に落ちたエントリはない

面は広がらないので、docs/surface.md の三つの問いは今回は問われない。

`scripts/check` は緑。`TestReleaseVersionsAgree` と
`TestARetiredNameLastsOneRelease` も通る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)