### PR TITLE
Give the web UI the affordances a documentation service keeps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,24 @@ last entry.
 
 ## [Unreleased]
 
+### Added
+
+- **The web UI reads the way a documentation service does — three
+  affordances, no new API.** All three are the curation surface doing
+  its own job (design doc 0067 §1: search, browse, rulings, history)
+  over endpoints that already existed, so REST, MCP and the CLI are
+  untouched. Ctrl+K (⌘K on a Mac) opens a **quick-open palette** from
+  any page: type, arrows, Enter, and the concept is open — nothing typed
+  lists by demand, the same `sort=usage` the search view lands on, and a
+  last row hands the words to the full search view. A long body's
+  overview tab now opens with its **outline** (目次) — every heading
+  gets an anchor id, drawn from the rendered body rather than by parsing
+  the markdown twice. And the history tab shows each revision as a
+  **diff** against the one before it, `+n −n` beside the change, with
+  the unchanged middle elided and the full document still one disclosure
+  away — what a reviewer deciding whether to verify actually needs from
+  a revision is the three lines that moved.
+
 ## [0.27.3] - 2026-08-25
 
 ### Added

--- a/internal/webui/jstest/diff.test.js
+++ b/internal/webui/jstest/diff.test.js
@@ -1,0 +1,65 @@
+// What a revision changed, as the history tab tells it.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { diffHTML, diffLines, diffStats } from '../static/js/diff.js';
+
+const ops = (a, b) => diffLines(a, b).map(o => o.op + ':' + o.text);
+
+test('an edit in the middle leaves the rest alone', () => {
+  assert.deepEqual(ops('a\nb\nc', 'a\nx\nc'), ['same:a', 'del:b', 'add:x', 'same:c']);
+});
+
+test('an added and a removed line are told apart', () => {
+  assert.deepEqual(ops('a\nb', 'a\nb\nc'), ['same:a', 'same:b', 'add:c']);
+  assert.deepEqual(ops('a\nb\nc', 'a\nc'), ['same:a', 'del:b', 'same:c']);
+});
+
+test('the first revision is all additions', () => {
+  // The oldest revision has nothing before it; its diff is the document,
+  // with no phantom deletion for the empty side.
+  assert.deepEqual(ops('', 'a\nb'), ['add:a', 'add:b']);
+  assert.deepEqual(diffStats(diffLines('', 'a\nb')), { added: 2, removed: 0 });
+});
+
+test('identical documents are no change at all', () => {
+  assert.deepEqual(ops('a\nb', 'a\nb'), ['same:a', 'same:b']);
+  assert.equal(diffHTML('a\nb', 'a\nb'), '');
+});
+
+test('a moved block is an alignment, not a rewrite', () => {
+  // The LCS keeps the longest run: b/c stay, a moves.
+  assert.deepEqual(ops('a\nb\nc', 'b\nc\na'), ['del:a', 'same:b', 'same:c', 'add:a']);
+});
+
+test('stats count the changed lines only', () => {
+  assert.deepEqual(diffStats(diffLines('a\nb\nc', 'a\nx\ny\nc')), { added: 2, removed: 1 });
+});
+
+test('the rendering keeps context and elides the rest', () => {
+  const before = ['head', '1', '2', '3', '4', '5', '6', '7', '8', 'tail'].join('\n');
+  const after = ['head', '1', '2', '3', '4', '5', '6', '7', '8', 'TAIL'].join('\n');
+  const html = diffHTML(before, after, 2);
+  // The change and its two context lines are there; the head is elided
+  // with a count, so a reader knows how much sits between.
+  assert.match(html, /<span class="ln del">- tail<\/span>/);
+  assert.match(html, /<span class="ln add">\+ TAIL<\/span>/);
+  assert.match(html, /<span class="ln same"> {2}8<\/span>/);
+  assert.match(html, /<span class="ln skip">⋯ 7 行<\/span>/);
+  assert.ok(!html.includes('head'));
+});
+
+test('what a writer typed arrives escaped, never as markup', () => {
+  const html = diffHTML('x', '<img src=x onerror=alert(1)>');
+  assert.ok(!html.includes('<img'));
+  assert.match(html, /&lt;img/);
+});
+
+test('a rewrite past the alignment budget is stated as a replacement', () => {
+  const before = Array.from({ length: 600 }, (_, i) => 'a' + i).join('\n');
+  const after = Array.from({ length: 600 }, (_, i) => 'b' + i).join('\n');
+  const d = diffLines(before, after);
+  assert.equal(diffStats(d).added, 600);
+  assert.equal(diffStats(d).removed, 600);
+});

--- a/internal/webui/jstest/outline.test.js
+++ b/internal/webui/jstest/outline.test.js
@@ -1,0 +1,62 @@
+// The outline: ids on rendered headings, and the table of contents
+// drawn from them.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { headingAnchor, headingAnchors, TOC_MIN, tocHTML } from '../static/js/outline.js';
+import { md } from '../static/js/markdown.js';
+
+test('an anchor is the heading in the URL, Japanese included', () => {
+  assert.equal(headingAnchor('検証の順番'), '検証の順番');
+  assert.equal(headingAnchor('How To Read'), 'how-to-read');
+  // esc() wrote entities; the anchor holds the character they meant,
+  // minus the punctuation that cannot travel in a fragment.
+  assert.equal(headingAnchor('A &amp; B'), 'a--b');
+});
+
+test('every heading in a rendered body gains an id', () => {
+  const { html, headings } = headingAnchors(md('# 定義\n\n## 検証の順番\n\nprose'));
+  assert.match(html, /<h1 id="定義">定義<\/h1>/);
+  assert.match(html, /<h2 id="検証の順番">検証の順番<\/h2>/);
+  assert.deepEqual(headings.map(h => [h.level, h.id]), [[1, '定義'], [2, '検証の順番']]);
+});
+
+test('two sections with one name stay two anchors', () => {
+  const { headings } = headingAnchors('<h2>例</h2><h2>例</h2><h2>例</h2>');
+  assert.deepEqual(headings.map(h => h.id), ['例', '例-2', '例-3']);
+});
+
+test('a heading a writer typed as markup cannot match', () => {
+  // md() escapes prose, so a literal <h2> arrives as entities and the
+  // outline sees no heading in it.
+  const { headings } = headingAnchors(md('prose with <h2>fake</h2> inside'));
+  assert.deepEqual(headings, []);
+});
+
+test('inline markup stays in the heading and out of the anchor', () => {
+  const { html, headings } = headingAnchors(md('## `sql` の読み方'));
+  assert.match(html, /<h2 id="sql-の読み方"><code>sql<\/code> の読み方<\/h2>/);
+  assert.equal(headings[0].text, 'sql の読み方');
+});
+
+test('the outline waits for a document long enough to need one', () => {
+  const two = [{ level: 2, text: 'a', id: 'a' }, { level: 2, text: 'b', id: 'b' }];
+  assert.equal(tocHTML(two), '');
+  assert.ok(two.length < TOC_MIN);
+  const three = [...two, { level: 3, text: 'c', id: 'c' }];
+  const html = tocHTML(three);
+  assert.match(html, /<summary>目次<\/summary>/);
+  // Levels indent relative to the shallowest heading present.
+  assert.match(html, /<li class="lv0"><a href="#a">a<\/a><\/li>/);
+  assert.match(html, /<li class="lv1"><a href="#c">c<\/a><\/li>/);
+});
+
+test('the outline stops at h3', () => {
+  const headings = [
+    { level: 2, text: 'a', id: 'a' }, { level: 2, text: 'b', id: 'b' },
+    { level: 3, text: 'c', id: 'c' }, { level: 4, text: 'd', id: 'd' },
+  ];
+  const html = tocHTML(headings);
+  assert.ok(!html.includes('#d'));
+});

--- a/internal/webui/static/app.css
+++ b/internal/webui/static/app.css
@@ -91,6 +91,51 @@ pre code { background: none; padding: 0; }
 }
 .topbar .spacer { flex: 1; }
 
+/* ---- quick open (Ctrl+K) ---- */
+.palette-btn {
+  font: inherit; cursor: pointer; display: inline-flex; align-items: center; gap: .45rem;
+  background: var(--code-bg); border: 1px solid var(--border); border-radius: 8px;
+  color: var(--muted); padding: .3rem .7rem; white-space: nowrap;
+}
+.palette-btn:hover { border-color: var(--accent); color: var(--text); }
+.palette-btn kbd {
+  font-family: inherit; font-size: .74rem; border: 1px solid var(--border);
+  border-radius: 4px; padding: 0 .3rem; background: var(--surface); color: var(--muted);
+}
+/* On a phone the shortcut is not real; the button shrinks to its icon. */
+@media (max-width: 800px) { .palette-btn kbd { display: none; } }
+#palette {
+  width: min(36rem, 92vw); border: 1px solid var(--border); border-radius: 12px;
+  padding: 0; background: var(--surface); color: var(--text); box-shadow: var(--shadow-hover);
+  /* Near the top, like every service's palette: the eye is already
+     there, and results growing downward never push the input away. */
+  margin: 10vh auto auto;
+}
+#palette::backdrop { background: rgba(0, 0, 0, .35); }
+#palette-q {
+  border: none; border-bottom: 1px solid var(--border); border-radius: 12px 12px 0 0;
+  font-size: 1.02rem; padding: .8rem 1rem;
+}
+#palette-q:focus { outline: none; }
+#palette-list { max-height: 22rem; overflow-y: auto; padding: .3rem; }
+#palette-list .empty { padding: 1.2rem 0; }
+.palette-row {
+  display: flex; align-items: center; gap: .55rem; cursor: pointer;
+  padding: .45rem .7rem; border-radius: 8px;
+}
+.palette-row.active { background: var(--accent-weak); }
+.palette-row .palette-title {
+  font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.palette-row .palette-id {
+  color: var(--muted); font-size: .8rem; flex: 1; min-width: 0;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.palette-hint {
+  border-top: 1px solid var(--border); color: var(--muted);
+  font-size: .78rem; padding: .4rem .9rem;
+}
+
 /* ---- layout: persistent tree sidebar + content pane ---- */
 .shell { display: grid; grid-template-columns: 17rem minmax(0, 1fr); }
 /* The topbar toggle collapses the sidebar for reading room; the choice
@@ -315,6 +360,18 @@ input[type=date]:not(:focus):invalid, input[type=date]:not(:focus):placeholder-s
 }
 .tabs button:hover { color: var(--text); }
 .tabs button.active { color: var(--accent-strong); border-bottom-color: var(--accent); }
+/* A revision's diff (diff.js): a line each, colored the way the page
+   already colors states — additions in verified's green, deletions in
+   rejected's red — and the elisions quiet, because they are the part
+   that did not change. */
+pre.diff { padding: .4rem 0; }
+.diff .ln { display: block; padding: 0 .9rem; white-space: pre-wrap; word-break: break-all; }
+.diff .ln.add { background: var(--verified-bg); color: var(--verified-fg); }
+.diff .ln.del { background: var(--rejected-bg); color: var(--rejected-fg); }
+.diff .ln.skip { color: var(--muted); text-align: center; user-select: none; }
+.diffstat { font-size: .8rem; margin-left: .3rem; white-space: nowrap; }
+.diffstat .add { color: var(--verified-fg); }
+.diffstat .del { color: var(--rejected-fg); }
 table.kv { border-collapse: collapse; width: 100%; }
 table.kv td { border-bottom: 1px solid var(--border); padding: .45rem .6rem .45rem 0; vertical-align: top; }
 table.kv td.k { color: var(--muted); width: 11rem; white-space: nowrap; }
@@ -375,6 +432,19 @@ table.rules.edit tr.invalid > td { background: var(--rejected-bg); }
 
 /* ---- markdown body ---- */
 .md h1, .md h2, .md h3, .md h4, .md h5, .md h6 { line-height: 1.3; margin: 1.1em 0 .4em; }
+/* An anchored heading lands below the sticky top bar, not under it. */
+.md [id] { scroll-margin-top: 4.2rem; }
+/* The outline (outline.js): the document's own shape, above the body,
+   for the documents long enough to need a map. */
+.toc {
+  border: 1px solid var(--border); border-radius: 10px; background: var(--surface);
+  padding: .45rem .95rem; margin: .9rem 0; font-size: .9rem; max-width: 30rem;
+}
+.toc summary { cursor: pointer; font-weight: 600; color: var(--muted); }
+.toc ol { list-style: none; margin: .35rem 0 .3rem; padding: 0; }
+.toc li { padding: .12rem 0; }
+.toc li.lv1 { padding-left: 1rem; }
+.toc li.lv2 { padding-left: 2rem; }
 .md h1 { font-size: 1.3rem; } .md h2 { font-size: 1.15rem; } .md h3 { font-size: 1rem; }
 /* h4 and below stop growing and start leaning on weight and colour:
    past the third level a document is showing structure, not shouting. */

--- a/internal/webui/static/index.html
+++ b/internal/webui/static/index.html
@@ -15,7 +15,9 @@
      action and tree drag & drop), the draft review queue (sort=usage),
      the two feeds that empty by verifying — reported wrong (sort=failed)
      and verification age (sort=verified_at), reachable from the review
-     queue and #/search/reported-wrong — how much each queue is holding,
+     queue and #/search/reported-wrong — a quick-open palette (Ctrl+K)
+     over the same search, an outline with heading anchors on long
+     bodies, revision diffs in the history tab, how much each queue is holding,
      how the loop is going over a period and under a path, and what it
      could not answer (design doc 0069), the access policy for an
      administrator — who may read and write under which directory
@@ -40,6 +42,11 @@
     <a href="#/access" data-route="access" id="nav-access" hidden>アクセス</a>
   </nav>
   <span class="spacer"></span>
+  <!-- The door documentation services keep: jump to an entry from
+       anywhere. The button is the discoverable half; the shortcut it
+       names is the fast one, and palette.js swaps the hint to ⌘K where
+       the keyboard has one. -->
+  <button id="palette-btn" class="palette-btn" title="どこからでもナレッジを検索して開けます" aria-label="クイックオープン"><span aria-hidden="true">🔍</span><kbd>Ctrl+K</kbd></button>
 </header>
 <div class="shell" id="shell">
   <aside class="sidebar">
@@ -82,6 +89,16 @@
     <main id="view" tabindex="-1"></main>
   </div>
 </div>
+<!-- The quick-open palette (palette.js). A native <dialog>, because
+     showModal() is the focus trap and the Esc handling — the page has no
+     framework to reimplement either in. Empty until opened; the list is
+     written by the module from /api/v1/search. -->
+<dialog id="palette" aria-label="クイックオープン">
+  <input type="text" id="palette-q" placeholder="ナレッジを検索して移動…" autocomplete="off"
+         role="combobox" aria-expanded="true" aria-autocomplete="list" aria-controls="palette-list" aria-label="ナレッジを検索">
+  <div id="palette-list" role="listbox" aria-label="候補"></div>
+  <div class="palette-hint">↑↓ で選択 · Enter で開く · Esc で閉じる</div>
+</dialog>
 <!-- Every save, refusal and failure is announced here, so it is a live
      region: a screen reader gets told what a sighted reader sees flash
      past. polite, not assertive — it reports, it does not interrupt. -->

--- a/internal/webui/static/js/diff.js
+++ b/internal/webui/static/js/diff.js
@@ -1,0 +1,105 @@
+// What changed between two revisions of a document, line by line. The
+// history tab holds every revision whole (design doc 0046 §3.5), and a
+// reviewer deciding whether to verify wants the three lines that moved,
+// not two full documents to read side by side — which is how every wiki
+// shows its history, and why this one does too.
+//
+// Pure text in, pure markup out: nothing here touches the network or the
+// document, so a test can hold it.
+
+import { esc } from './escape.js';
+
+// Above this many changed lines a side, the quadratic middle would cost
+// more than the answer is worth; the fallback below states the change as
+// a replacement, which for a rewrite that big is also the truth.
+const LCS_MAX = 500;
+
+// diffLines compares two documents and returns every line once, in
+// order, marked same / add / del. Common prefix and suffix are peeled
+// first — most edits touch a few lines in the middle of an unchanged
+// document — and the middle is aligned on a longest common subsequence.
+export function diffLines(before, after) {
+  // An empty document has no lines — not one empty line. It matters at
+  // the oldest revision, whose diff is against nothing: the whole
+  // document is additions, with no phantom deletion in front.
+  const split = s => String(s ?? '') === '' ? [] : String(s).split('\n');
+  const a = split(before);
+  const b = split(after);
+  let lo = 0;
+  while (lo < a.length && lo < b.length && a[lo] === b[lo]) lo++;
+  let aHi = a.length, bHi = b.length;
+  while (aHi > lo && bHi > lo && a[aHi - 1] === b[bHi - 1]) { aHi--; bHi--; }
+  const ops = [];
+  for (let i = 0; i < lo; i++) ops.push({ op: 'same', text: a[i] });
+  const mid = lcsOps(a.slice(lo, aHi), b.slice(lo, bHi));
+  ops.push(...mid);
+  for (let i = aHi; i < a.length; i++) ops.push({ op: 'same', text: a[i] });
+  return ops;
+}
+
+// The aligned middle: deletions before additions, because a change reads
+// as "this went, that came". Past LCS_MAX a side, the whole middle is
+// one replacement.
+function lcsOps(a, b) {
+  if (!a.length || !b.length || a.length > LCS_MAX || b.length > LCS_MAX) {
+    return [...a.map(text => ({ op: 'del', text })), ...b.map(text => ({ op: 'add', text }))];
+  }
+  // len[i][j]: the longest common subsequence of a[i:] and b[j:].
+  const w = b.length + 1;
+  const len = new Int32Array((a.length + 1) * w);
+  for (let i = a.length - 1; i >= 0; i--) {
+    for (let j = b.length - 1; j >= 0; j--) {
+      len[i * w + j] = a[i] === b[j]
+        ? len[(i + 1) * w + j + 1] + 1
+        : Math.max(len[(i + 1) * w + j], len[i * w + j + 1]);
+    }
+  }
+  const ops = [];
+  let i = 0, j = 0;
+  while (i < a.length && j < b.length) {
+    if (a[i] === b[j]) { ops.push({ op: 'same', text: a[i] }); i++; j++; }
+    else if (len[(i + 1) * w + j] >= len[i * w + j + 1]) ops.push({ op: 'del', text: a[i++] });
+    else ops.push({ op: 'add', text: b[j++] });
+  }
+  while (i < a.length) ops.push({ op: 'del', text: a[i++] });
+  while (j < b.length) ops.push({ op: 'add', text: b[j++] });
+  return ops;
+}
+
+// The two numbers a history row leads with.
+export function diffStats(ops) {
+  let added = 0, removed = 0;
+  for (const o of ops) {
+    if (o.op === 'add') added++;
+    else if (o.op === 'del') removed++;
+  }
+  return { added, removed };
+}
+
+// diffHTML renders the changed hunks with `context` unchanged lines
+// around each, eliding the rest — the whole document is one disclosure
+// away, so what the diff owes the reader is only the change. Two
+// unchanged documents return nothing, and the caller says so in words.
+export function diffHTML(before, after, context = 2) {
+  const ops = diffLines(before, after);
+  if (!ops.some(o => o.op !== 'same')) return '';
+  // keep[i]: this line is a change or sits within `context` of one.
+  const keep = new Array(ops.length).fill(false);
+  for (let i = 0; i < ops.length; i++) {
+    if (ops[i].op === 'same') continue;
+    for (let k = Math.max(0, i - context); k <= Math.min(ops.length - 1, i + context); k++) keep[k] = true;
+  }
+  const MARK = { same: ' ', add: '+', del: '-' };
+  let out = '', skipped = 0;
+  const flushSkip = () => {
+    if (skipped) out += `<span class="ln skip">⋯ ${skipped} 行</span>`;
+    skipped = 0;
+  };
+  for (let i = 0; i < ops.length; i++) {
+    if (!keep[i]) { skipped++; continue; }
+    flushSkip();
+    out += `<span class="ln ${ops[i].op}">${MARK[ops[i].op]} ${esc(ops[i].text)}</span>`;
+  }
+  flushSkip();
+  return `<pre class="diff mono">${out}</pre>`;
+}

--- a/internal/webui/static/js/main.js
+++ b/internal/webui/static/js/main.js
@@ -2,6 +2,7 @@
 
 import { markPosture } from './api.js';
 import { $ } from './dom.js';
+import { initPalette } from './palette.js';
 import { refreshQueues } from './queues.js';
 import { route } from './router.js';
 import { refreshTree } from './tree.js';
@@ -25,4 +26,5 @@ refreshTree();
 refreshQueues();
 markPosture();
 markAccessTab();
+initPalette();
 route();

--- a/internal/webui/static/js/outline.js
+++ b/internal/webui/static/js/outline.js
@@ -1,0 +1,71 @@
+// The outline of a rendered body: ids on the headings the renderer drew,
+// and the table of contents built from them. Documentation services show
+// long pages this way — the shape first, the prose under it — and a
+// knowledge base whose bodies are runbooks and metric definitions reads
+// the same way.
+//
+// It reads the renderer's own output rather than the markdown, because
+// the renderer already decided what is a heading and what is a `#` in a
+// code fence; deciding twice is how the two drift. The shape it matches
+// is exactly what md() emits — `<hN>` with no attributes — so nothing a
+// writer typed can match it: a `<h2>` in their prose arrives escaped.
+
+import { esc } from './escape.js';
+
+// The entities esc() writes, undone for the anchor only: a heading
+// "A & B" should anchor as A-B, not A-amp-B. The visible text keeps the
+// escaped form, because it is already HTML.
+const unescape = s => s
+  .replace(/&lt;/g, '<').replace(/&gt;/g, '>')
+  .replace(/&quot;/g, '"').replace(/&#39;/g, "'")
+  .replace(/&amp;/g, '&');
+
+// An anchor a reader can see in the URL: the heading's own words, with
+// whitespace as hyphens and markup punctuation dropped. Japanese stays
+// itself — an id may hold any character but spaces, and 「検証の順番」
+// is a better anchor than a transliteration nobody typed.
+export function headingAnchor(text) {
+  return unescape(text)
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/[<>&"'#%?]/g, '')
+    .toLowerCase();
+}
+
+// headingAnchors gives every heading in a rendered body an id and
+// returns the outline beside the marked-up html. Ids are deduplicated
+// the way filenames are (-2, -3, …), so two sections with one name stay
+// two anchors; an empty heading gets no id and stays out of the outline.
+export function headingAnchors(html) {
+  const taken = new Map();
+  const headings = [];
+  const out = String(html ?? '').replace(/<h([1-6])>([\s\S]*?)<\/h\1>/g, (m, level, inner) => {
+    const text = inner.replace(/<[^>]*>/g, '').trim();
+    const base = headingAnchor(text);
+    if (!base) return m;
+    const n = (taken.get(base) || 0) + 1;
+    taken.set(base, n);
+    const id = n === 1 ? base : `${base}-${n}`;
+    headings.push({ level: Number(level), text, id });
+    return `<h${level} id="${esc(id)}">${inner}</h${level}>`;
+  });
+  return { html: out, headings };
+}
+
+// How many headings make an outline worth its height: below this a
+// reader sees the whole shape by scrolling once, and the box would only
+// push the prose down.
+export const TOC_MIN = 3;
+
+// tocHTML draws the outline as a disclosure above the body — h1 to h3,
+// because past that a document is showing structure to the section it is
+// in, not to the page. Nothing to draw returns nothing: the box is for
+// documents long enough to need a map.
+export function tocHTML(headings) {
+  const items = (headings || []).filter(h => h.level <= 3);
+  if (items.length < TOC_MIN) return '';
+  const top = Math.min(...items.map(h => h.level));
+  return '<details class="toc" open><summary>目次</summary><ol>'
+    + items.map(h => `<li class="lv${h.level - top}"><a href="#${esc(h.id)}">${h.text}</a></li>`).join('')
+    + '</ol></details>';
+}

--- a/internal/webui/static/js/palette.js
+++ b/internal/webui/static/js/palette.js
@@ -1,0 +1,135 @@
+// The quick-open palette: Ctrl+K (⌘K) from anywhere, type, Enter, and
+// the entry is open. Documentation services all keep this door — a
+// reader who knows what they want should not have to walk to the search
+// page to name it — and it is a read, so it belongs to every deployment,
+// read-only ones included.
+//
+// It is a client of the same /api/v1/search the search view uses, with
+// the same empty-query behavior: nothing typed lists by demand
+// (sort=usage), which is this page's version of "recent pages" — the
+// entries this base is actually asked for.
+
+import { api } from './api.js';
+import { $ } from './dom.js';
+import { esc } from './escape.js';
+import { displayTitle, entryHash } from './format.js';
+import { icon } from './vocab.js';
+import { debounce, explore, viewExplore } from './views/explore.js';
+
+const dialog = () => $('#palette');
+
+// The rows the palette holds: concept hits, plus one synthetic row that
+// hands the query to the full search view — the palette jumps, the
+// search view explains, and a query that needs filters or a snippet
+// belongs there.
+let rows = [];
+let active = 0;
+
+function render() {
+  const list = $('#palette-list');
+  const q = $('#palette-q').value.trim();
+  const attrs = i => `class="palette-row${i === active ? ' active' : ''}"${i === active ? ' id="palette-active"' : ''} role="option" aria-selected="${i === active}" data-i="${i}"`;
+  const items = rows.map((r, i) => r.search
+    ? `<div ${attrs(i)}>
+         <span class="type-ico" aria-hidden="true">🔍</span>
+         <span class="palette-title">「${esc(q)}」を検索</span><span class="palette-id">結果の一覧と絞り込みを開きます</span>
+       </div>`
+    : `<div ${attrs(i)}>
+         <span class="type-ico" aria-hidden="true">${icon(r.hit.type)}</span>
+         <span class="palette-title">${esc(displayTitle(r.hit))}</span>
+         <span class="palette-id mono">${esc(r.hit.id)}</span>
+         <span class="badge ${esc(r.hit.status)}">${esc(r.hit.status)}</span>
+       </div>`).join('');
+  list.innerHTML = items || `<div class="empty">${q ? '一致するナレッジが見つかりません。' : 'まだナレッジがありません。'}</div>`;
+  list.querySelectorAll('.palette-row').forEach(el => {
+    el.addEventListener('click', () => go(Number(el.dataset.i)));
+    // Hover moves the selection the way the arrows do, so the keyboard
+    // and the pointer never disagree about which row Enter would open.
+    el.addEventListener('mousemove', () => {
+      if (active === Number(el.dataset.i)) return;
+      active = Number(el.dataset.i);
+      render();
+    });
+  });
+  const marked = list.querySelector('.palette-row.active');
+  if (marked) marked.scrollIntoView({ block: 'nearest' });
+  $('#palette-q').setAttribute('aria-activedescendant', marked ? 'palette-active' : '');
+}
+
+async function load() {
+  const q = $('#palette-q').value.trim();
+  const my = load._seq = (load._seq || 0) + 1;
+  try {
+    const p = q ? 'q=' + encodeURIComponent(q) : 'sort=usage';
+    const { hits = [] } = await api(`/api/v1/search?${p}&limit=8`);
+    if (my !== load._seq || !dialog().open) return; // a newer keystroke answered
+    rows = hits.map(hit => ({ hit }));
+    if (q) rows.push({ search: true });
+    active = 0;
+    render();
+  } catch (e) {
+    if (my !== load._seq || !dialog().open) return;
+    $('#palette-list').innerHTML = `<div class="error-banner" role="alert">検索に失敗しました: ${esc(e.message)}</div>`;
+  }
+}
+
+function go(i) {
+  const r = rows[i];
+  if (!r) return;
+  dialog().close();
+  if (r.search) {
+    // Hand the words to the search view the way its own box would. A
+    // hash set to its current value fires no hashchange, so the view is
+    // redrawn directly when it is already the route.
+    explore.q = $('#palette-q').value.trim();
+    if (location.hash === '#/search') viewExplore();
+    else location.hash = '#/search';
+    return;
+  }
+  location.hash = entryHash(r.hit);
+}
+
+export function openPalette() {
+  const d = dialog();
+  if (d.open) return;
+  d.showModal();
+  const input = $('#palette-q');
+  input.value = '';
+  input.focus();
+  rows = [];
+  active = 0;
+  load();
+}
+
+export function initPalette() {
+  const d = dialog();
+  const input = $('#palette-q');
+  // ⌘K where the keyboard has a ⌘; Ctrl+K everywhere else. The button's
+  // hint follows the machine it is shown on.
+  if (/Mac|iP(hone|ad|od)/.test(navigator.platform || '')) {
+    const kbd = $('#palette-btn kbd');
+    if (kbd) kbd.textContent = '⌘K';
+  }
+  window.addEventListener('keydown', e => {
+    if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key.toLowerCase() === 'k') {
+      e.preventDefault();
+      d.open ? d.close() : openPalette();
+    }
+  });
+  $('#palette-btn').addEventListener('click', openPalette);
+  // A click on the backdrop is a click on the <dialog> itself — its box
+  // only ever receives clicks on its children.
+  d.addEventListener('click', e => { if (e.target === d) d.close(); });
+  input.addEventListener('input', () => debounce(load, 150));
+  input.addEventListener('keydown', e => {
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      if (!rows.length) return;
+      active = (active + (e.key === 'ArrowDown' ? 1 : rows.length - 1)) % rows.length;
+      render();
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      go(active);
+    }
+  });
+}

--- a/internal/webui/static/js/router.js
+++ b/internal/webui/static/js/router.js
@@ -25,7 +25,17 @@ export function route() {
   // footnote landed on the home page, which is worse than the marker
   // not being a link.
   const hash = location.hash;
-  if (hash && !hash.startsWith('#/')) return;
+  if (hash && !hash.startsWith('#/')) {
+    // Except at boot: an anchor is all the URL holds then — the route it
+    // jumped within is gone — and returning without rendering left the
+    // whole page blank. The home page is the honest answer to an address
+    // that names a place inside a document it does not name.
+    if (!route._rendered) {
+      route._rendered = true;
+      viewHome();
+    }
+    return;
+  }
   if (unsaved && unsaved() && !confirm('保存していない変更を破棄しますか？')) {
     // Put the URL back; replaceState does not re-fire hashchange.
     history.replaceState(null, '', route._current || '#/');

--- a/internal/webui/static/js/views/detail.js
+++ b/internal/webui/static/js/views/detail.js
@@ -4,10 +4,12 @@
 import { applyStatus, liftRejection, moveEntry, rejectEntry, verifyEntry } from '../actions.js';
 import { BASE, api, toast } from '../api.js';
 import { hitCard } from '../cards.js';
+import { diffHTML, diffLines, diffStats } from '../diff.js';
 import { $, view } from '../dom.js';
 import { esc } from '../escape.js';
 import { actorStr, conceptURL, crumbTrail, displayTitle, fmtDate, fmtSize, idPath, isVerified, lastVerification, trustOf } from '../format.js';
 import { descHTML, md } from '../markdown.js';
+import { headingAnchors, tocHTML } from '../outline.js';
 import { knownDirs, refreshTree, revealInTree } from '../tree.js';
 import { STATUSES, icon } from '../vocab.js';
 
@@ -202,10 +204,18 @@ export async function viewDetail(id) {
     // Sources sit under the prose they support rather than in a tab of
     // their own: OKF's own model is body footnotes keyed to source ids, so
     // whoever is reading the body is exactly who needs the list.
-    overview: () => `
+    overview: () => {
+      // The body with its outline: ids on the headings, and a table of
+      // contents when there are enough of them to need a map. The
+      // description stays out of both — its headings describe, they do
+      // not structure the document.
+      const body_ = docBody ? headingAnchors(md(docBody, resolveFile, resolveEntry)) : { html: '', headings: [] };
+      return `
       ${entry.description ? descHTML(entry.description, 'lead') : ''}
-      ${docBody ? `<div class="md">${md(docBody, resolveFile, resolveEntry)}</div>` : ''}
-      ${!entry.description && !docBody ? '<div class="empty">description も本文もありません。</div>' : ''}`,
+      ${tocHTML(body_.headings)}
+      ${docBody ? `<div class="md">${body_.html}</div>` : ''}
+      ${!entry.description && !docBody ? '<div class="empty">description も本文もありません。</div>' : ''}`;
+    },
     // The document, whole and unrendered. It replaced tabs that each
     // redrew a slice of the frontmatter in some other shape — which is
     // the duplication document-first exists to remove, and the reason
@@ -324,17 +334,28 @@ export async function viewDetail(id) {
       // ?history is the object's own ledger, at the object's own address
       // (design doc 0046 §3.5); the log.md beside it is the directory's.
       const { revisions } = await api('/api/v1/bundle/' + idPath(entry.id) + '.md?history&limit=200');
-      const rows = (revisions || []).map(r => `
+      // Newest first, so a revision's neighbor below is what it changed
+      // from — the oldest diffs against nothing, and is the document.
+      const revs = revisions || [];
+      const rows = revs.map((r, i) => {
+        const stats = diffStats(diffLines((revs[i + 1] || {}).document || '', r.document || ''));
+        const diff = diffHTML((revs[i + 1] || {}).document || '', r.document || '');
+        return `
         <tr>
           <td class="k mono">#${r.rev}</td>
           <td>
-            <div><strong>${esc(r.change)}</strong> · ${esc(actorStr(r.changed_by))} · ${esc(fmtDate(r.changed_at))}</div>
+            <div><strong>${esc(r.change)}</strong> · ${esc(actorStr(r.changed_by))} · ${esc(fmtDate(r.changed_at))}
+              <span class="diffstat"><span class="add">+${stats.added}</span> <span class="del">−${stats.removed}</span></span></div>
+            ${diff
+              ? `<details${i === 0 ? ' open' : ''}><summary style="cursor:pointer;color:var(--muted);font-size:.84rem">差分</summary>${diff}</details>`
+              : `<div class="provenance">ドキュメントに変更はありません。</div>`}
             <details><summary style="cursor:pointer;color:var(--muted);font-size:.84rem">ドキュメント</summary>
               <pre>${esc(r.document || '')}</pre></details>
           </td>
-        </tr>`).join('');
+        </tr>`;
+      }).join('');
       return () => `
-        <p class="provenance" style="margin:0 0 .8rem">すべての変更を新しい順に並べています。誰が変えたのかと、そのときのドキュメントです。</p>
+        <p class="provenance" style="margin:0 0 .8rem">すべての変更を新しい順に並べています。誰が何を変えたのかを差分で、そのときの全文をドキュメントで確かめられます。</p>
         <table class="kv">${rows}</table>`;
     },
   };


### PR DESCRIPTION
<!-- Keep PRs small and focused. Link the issue or design doc, if there is one. -->

## What and why

The web UI is being used enough to deserve the affordances every documentation / wiki service keeps, so this PR adds three — and **no new API**: all three are clients of endpoints that already exist, which is the answer to "APIも新設検討" that this repo's own rules point at. Each one is the curation surface doing one of its four jobs better (design doc 0067 §1: search, browse, rulings, history viewing), serving C7 (the review loop's human side) and C5 (usable curation from a browser):

- **Quick-open palette** (`js/palette.js`, Ctrl+K / ⌘K, plus a top-bar button): jump to a concept from any page over the same `GET /api/v1/search` the search view uses. Nothing typed lists by demand (`sort=usage` — this base's own version of "recent pages"); a synthetic last row hands the query to the full search view for filters and snippets. A native `<dialog>`, so `showModal()` is the focus trap and the Esc handling; it is a read, so it stays on read-only deployments.
- **Outline** (`js/outline.js`): headings in the overview tab gain anchor ids, and a body with three or more headings opens with its 目次 (h1–h3). Ids come from the renderer's own output rather than a second parse of the markdown, so nothing a writer typed can inject a heading. A boot on a bare anchor hash now renders the home page instead of a blank one — a latent failure footnote links already had.
- **Revision diffs** (`js/diff.js`): the history tab shows each revision as a line diff against the one before it, `+n −n` beside the change, two context lines kept and the unchanged middle elided; the full document stays one disclosure away. Common prefix/suffix peel first, an LCS aligns the middle, and a rewrite past 500 lines a side is stated as a replacement rather than paid for quadratically. This is the reviewer's half of verify: what changed since the ruling.

The three questions, since the Web UI grew (it is not a counted surface — it has no address space of its own): **who got stuck** — curators using `ochakai ui` daily, per the owner's read of usage; reaching a known concept meant tree-walking or the search page, verifying meant reading two full documents side by side. **Why existing surfaces don't cover it** — they carry the data (search, `?history`) but the page never drew it as a jump, a map, or a change. **What is folded away** — nothing had to be: zero new endpoints, params, headers, tools, commands or variables; the page stays no-build, no-framework, no-CDN.

Verified beyond the unit tests by driving the page in headless Chromium against a stub `/api/v1`: palette keyboard flow (arrows, Enter, Esc, backdrop click), anchor scrolling under the sticky bar, diff rendering and stats, light and dark.

## Checks

- [x] `scripts/check` is clean — `core`, `ui` (93 tests) and `lint` (0 issues) run locally; the store tests need Postgres and run in CI, and nothing here touches the store
- [x] Behavior changes come with tests — `jstest/outline.test.js`, `jstest/diff.test.js`; the Go-side module-embedding and copy guards cover the new modules and strings
- [x] Behavior changes have a line under `## [Unreleased]` in `CHANGELOG.md`

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, `internal/apiclient` — untouched; the change is web-UI-only
- [x] The change lands on every surface it belongs on — it belongs only on the Web UI: the palette, the outline and the diff are renderings of what search and `?history` already answer; MCP/CLI/REST carry the data itself, and staying off them is the deliberate omission (design doc 0067)
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens a surface? No — no REST operation, MCP tool, CLI command or environment variable is added; `docs/surface.md` deliberately does not count the Web UI, and nothing in it moves

## Design docs

- [x] Alters an accepted decision? No — 0067's allocation (the Web UI is search, browse, rulings and history viewing) is exactly what these three implement; no new record
- [x] Commit messages and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JDeb1HtMWyNzq4gseXiTW

---
_Generated by [Claude Code](https://claude.ai/code/session_016JDeb1HtMWyNzq4gseXiTW)_