### PR TITLE
Give the reader the affordances a documentation service keeps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,26 @@ last entry.
   away — what a reviewer deciding whether to verify actually needs from
   a revision is the three lines that moved.
 
+- **Four more of them, for the reader rather than the reviewer — still
+  no new API.** Every rendered code block carries a **copy button** (a
+  fenced block in a body, the SQL on a result card, the whole stored
+  document, a past revision), and a concept's header copies its
+  `ochakai://` address: knowledge here is written to be used somewhere
+  else, and selecting a verified query by hand was the last step of
+  reading it. Headings gained **permalinks** — hovering one shows a ¶
+  whose address is `#/k/<id>?h=<heading>`, so a section can be sent
+  rather than described; clicking it puts that address in the bar and on
+  the clipboard without redrawing the page, and opening one lands on the
+  heading. Search results and the palette **mark the words that were
+  typed**, in the title, the description and the snippet, so a hit says
+  why it is one. And a link to a concept that is not there is drawn as a
+  **dead link** rather than as an ordinary one, with the page behind it
+  saying so in its own words — the id, a search for its last segment,
+  and, for whoever may write, the editor with that id already filled in.
+  Only a `not_found` marks a link: a network failure or a refused read
+  says nothing about whether a concept exists, and each neighbour is
+  asked about once per session, four at a time, up to thirty per body.
+
 ## [0.27.3] - 2026-08-25
 
 ### Added

--- a/internal/webui/jstest/format.test.js
+++ b/internal/webui/jstest/format.test.js
@@ -40,6 +40,14 @@ test('the id is decoded segment by segment, after the heading is cut off', () =>
   assert.deepEqual(parseKPath(raw), { id: 'a/q?h=1', heading: '' });
 });
 
+test('a malformed address is a bad address, not an exception', () => {
+  // A truncated or hand-typed escape used to throw URIError out of the
+  // router, which left the previous concept on screen under the new
+  // address. The raw text finds nothing, which is what happened.
+  assert.deepEqual(parseKPath('metrics/revenue?h=%zz'), { id: 'metrics/revenue', heading: '%zz' });
+  assert.deepEqual(parseKPath('metrics/%E3%81'), { id: 'metrics/%E3%81', heading: '' });
+});
+
 test('a directory hash tolerates a trailing slash', () => {
   assert.equal(dirHash('insights/q1'), '#/dir/insights/q1');
   assert.equal(dirHash('insights/q1/'), '#/dir/insights/q1');

--- a/internal/webui/jstest/format.test.js
+++ b/internal/webui/jstest/format.test.js
@@ -5,7 +5,8 @@ import assert from 'node:assert/strict';
 
 import {
   actorStr, conceptURL, crumbTrail, daysSince, dirHash, displayTitle,
-  entryHash, fmtAge, fmtSize, isVerified, lastVerification, trustOf,
+  entryHash, fmtAge, fmtSize, headingHash, isVerified, lastVerification,
+  parseKPath, trustOf,
 } from '../static/js/format.js';
 import { esc } from '../static/js/escape.js';
 
@@ -15,6 +16,28 @@ test('an id keeps its slashes and encodes everything else', () => {
   assert.equal(entryHash({ id: 'metrics/revenue' }), '#/k/metrics/revenue');
   assert.equal(entryHash({ id: 'a b/c#d' }), '#/k/a%20b/c%23d');
   assert.equal(conceptURL('metrics/revenue'), '/api/v1/bundle/metrics/revenue.md');
+});
+
+test('a heading link carries the concept and the section together', () => {
+  assert.equal(headingHash('metrics/revenue', '定義'), '#/k/metrics/revenue?h=%E5%AE%9A%E7%BE%A9');
+  // And comes back apart the same way.
+  assert.deepEqual(parseKPath('metrics/revenue?h=%E5%AE%9A%E7%BE%A9'),
+    { id: 'metrics/revenue', heading: '定義' });
+});
+
+test('a route with no heading is the concept alone', () => {
+  assert.deepEqual(parseKPath('metrics/revenue'), { id: 'metrics/revenue', heading: '' });
+  assert.deepEqual(parseKPath(''), { id: '', heading: '' });
+});
+
+test('the id is decoded segment by segment, after the heading is cut off', () => {
+  // An encoded slash inside a segment is part of the segment, not a
+  // separator — the same rule idPath writes with.
+  assert.deepEqual(parseKPath('a%20b/c%23d?h=x'), { id: 'a b/c#d', heading: 'x' });
+  // A "?h=" a writer put in a segment travels encoded, so the first one
+  // in the raw path really is the route's own.
+  const raw = 'a/' + encodeURIComponent('q?h=1');
+  assert.deepEqual(parseKPath(raw), { id: 'a/q?h=1', heading: '' });
 });
 
 test('a directory hash tolerates a trailing slash', () => {

--- a/internal/webui/jstest/highlight.test.js
+++ b/internal/webui/jstest/highlight.test.js
@@ -46,6 +46,18 @@ test('a query with no match leaves the text in one piece', () => {
   assert.deepEqual(segments('', terms('sql')), []);
 });
 
+test('a character that grows when lowercased does not shift the marks', () => {
+  // U+0130 lowercases to two code units, so offsets found in the folded
+  // text used to cut the original one character late: the mark landed on
+  // "İs" + "tanbul" instead of on the word that matched, and enough of
+  // them left a <mark> holding nothing at all.
+  assert.deepEqual(segments('İstanbul', terms('stanbul')),
+    [{ text: 'İ', hit: false }, { text: 'stanbul', hit: true }]);
+  const parts = segments('İİİx', terms('x'));
+  assert.deepEqual(parts, [{ text: 'İİİ', hit: false }, { text: 'x', hit: true }]);
+  assert.ok(parts.every(p => p.text));
+});
+
 test('a regular expression in the query is text, not a pattern', () => {
   // Building a pattern out of user input is the bug this avoids: `.*`
   // matches itself here and nothing else.

--- a/internal/webui/jstest/highlight.test.js
+++ b/internal/webui/jstest/highlight.test.js
@@ -1,0 +1,54 @@
+// Marking the query's words in the results: the string half, which is
+// where the matching decisions live.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { segments, terms } from '../static/js/highlight.js';
+
+test('a query is its words, longest first', () => {
+  assert.deepEqual(terms('revenue monthly'), ['revenue', 'monthly']);
+  // An ideographic space separates words as surely as an ASCII one.
+  assert.deepEqual(terms('売上　定義'), ['売上', '定義']);
+  assert.deepEqual(terms('  '), []);
+  // Repeats are one term, and the longer of two sorts first.
+  assert.deepEqual(terms('sql sql select'), ['select', 'sql']);
+});
+
+test('matching ignores case and needs no word boundary', () => {
+  assert.deepEqual(segments('Monthly Revenue', terms('revenue')),
+    [{ text: 'Monthly ', hit: false }, { text: 'Revenue', hit: true }]);
+  // Japanese has no boundaries to find; a substring is the whole rule.
+  assert.deepEqual(segments('月次の売上の定義', terms('売上')),
+    [{ text: '月次の', hit: false }, { text: '売上', hit: true }, { text: 'の定義', hit: false }]);
+});
+
+test('every occurrence marks, not only the first', () => {
+  const parts = segments('sql, more sql', terms('sql'));
+  assert.equal(parts.filter(p => p.hit).length, 2);
+  assert.equal(parts.map(p => p.text).join(''), 'sql, more sql');
+});
+
+test('overlapping terms merge into one mark', () => {
+  // "revenue" and "venue" overlap; the reader sees one run, not a mark
+  // inside a mark.
+  const parts = segments('the revenue', terms('revenue venue'));
+  assert.deepEqual(parts, [{ text: 'the ', hit: false }, { text: 'revenue', hit: true }]);
+});
+
+test('adjacent terms merge too', () => {
+  assert.deepEqual(segments('abcd', terms('ab cd')), [{ text: 'abcd', hit: true }]);
+});
+
+test('a query with no match leaves the text in one piece', () => {
+  assert.deepEqual(segments('nothing here', terms('sql')), [{ text: 'nothing here', hit: false }]);
+  assert.deepEqual(segments('nothing here', []), [{ text: 'nothing here', hit: false }]);
+  assert.deepEqual(segments('', terms('sql')), []);
+});
+
+test('a regular expression in the query is text, not a pattern', () => {
+  // Building a pattern out of user input is the bug this avoids: `.*`
+  // matches itself here and nothing else.
+  assert.deepEqual(segments('a.*b and ab', terms('.*')),
+    [{ text: 'a', hit: false }, { text: '.*', hit: true }, { text: 'b and ab', hit: false }]);
+});

--- a/internal/webui/jstest/links.test.js
+++ b/internal/webui/jstest/links.test.js
@@ -1,0 +1,53 @@
+// Which links point at nothing — and, just as much, which failures are
+// not evidence that they do.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { checkTargets } from '../static/js/links.js';
+
+const notFound = () => Object.assign(new Error('not found'), { code: 'not_found' });
+
+test('a missing concept is dead and a present one is not', async () => {
+  const dead = await checkTargets(['a', 'b'], id => {
+    if (id === 'b') throw notFound();
+    return Promise.resolve({ id });
+  });
+  assert.deepEqual([...dead], ['b']);
+});
+
+test('a failure that is not a missing concept never marks a link', async () => {
+  // A 500, a refused read, a dropped connection: none of these say the
+  // concept is gone, and a red link claims exactly that.
+  const dead = await checkTargets(['a', 'b', 'c'], id => {
+    if (id === 'a') throw Object.assign(new Error('boom'), { code: 'internal' });
+    if (id === 'b') throw new Error('network');
+    if (id === 'c') throw Object.assign(new Error('no'), { code: 'forbidden' });
+    return Promise.resolve({});
+  });
+  assert.deepEqual([...dead], []);
+});
+
+test('each id is asked about once', async () => {
+  const asked = [];
+  await checkTargets(['a', 'b', 'a', '', 'b'], id => { asked.push(id); return Promise.resolve({}); });
+  assert.deepEqual(asked.sort(), ['a', 'b']);
+});
+
+test('no more than the limit are in flight at once', async () => {
+  let live = 0, peak = 0;
+  const ids = Array.from({ length: 12 }, (_, i) => 'id' + i);
+  await checkTargets(ids, () => {
+    live++;
+    peak = Math.max(peak, live);
+    return new Promise(resolve => setTimeout(() => { live--; resolve({}); }, 1));
+  }, 3);
+  assert.ok(peak <= 3, `${peak} probes were in flight at once`);
+});
+
+test('nothing to check asks nothing', async () => {
+  let asked = 0;
+  const dead = await checkTargets([], () => { asked++; return Promise.resolve({}); });
+  assert.equal(asked, 0);
+  assert.equal(dead.size, 0);
+});

--- a/internal/webui/jstest/links.test.js
+++ b/internal/webui/jstest/links.test.js
@@ -8,24 +8,28 @@ import { checkTargets } from '../static/js/links.js';
 
 const notFound = () => Object.assign(new Error('not found'), { code: 'not_found' });
 
-test('a missing concept is dead and a present one is not', async () => {
-  const dead = await checkTargets(['a', 'b'], id => {
+test('a missing concept is dead and a present one is found', async () => {
+  const { found, dead } = await checkTargets(['a', 'b'], id => {
     if (id === 'b') throw notFound();
     return Promise.resolve({ id });
   });
+  assert.deepEqual([...found], ['a']);
   assert.deepEqual([...dead], ['b']);
 });
 
-test('a failure that is not a missing concept never marks a link', async () => {
+test('a failure that is not a missing concept answers neither way', async () => {
   // A 500, a refused read, a dropped connection: none of these say the
-  // concept is gone, and a red link claims exactly that.
-  const dead = await checkTargets(['a', 'b', 'c'], id => {
+  // concept is gone, and a red link claims exactly that — but none of
+  // them says it is there either, and a caller that remembered them as
+  // present would stop asking about a concept it never saw.
+  const { found, dead } = await checkTargets(['a', 'b', 'c'], id => {
     if (id === 'a') throw Object.assign(new Error('boom'), { code: 'internal' });
     if (id === 'b') throw new Error('network');
     if (id === 'c') throw Object.assign(new Error('no'), { code: 'forbidden' });
     return Promise.resolve({});
   });
   assert.deepEqual([...dead], []);
+  assert.deepEqual([...found], []);
 });
 
 test('each id is asked about once', async () => {
@@ -47,7 +51,18 @@ test('no more than the limit are in flight at once', async () => {
 
 test('nothing to check asks nothing', async () => {
   let asked = 0;
-  const dead = await checkTargets([], () => { asked++; return Promise.resolve({}); });
+  const { found, dead } = await checkTargets([], () => { asked++; return Promise.resolve({}); });
   assert.equal(asked, 0);
   assert.equal(dead.size, 0);
+  assert.equal(found.size, 0);
+});
+
+test('a pool of none would answer without asking, so there is no such pool', async () => {
+  // Array.from({length: 0}) is the empty array, so a cap of zero used to
+  // resolve instantly having probed nothing — an empty dead set, which
+  // reads as "every link is fine".
+  let asked = 0;
+  const { dead } = await checkTargets(['a'], id => { asked++; throw notFound(); }, 0);
+  assert.equal(asked, 1);
+  assert.deepEqual([...dead], ['a']);
 });

--- a/internal/webui/jstest/outline.test.js
+++ b/internal/webui/jstest/outline.test.js
@@ -4,7 +4,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { headingAnchor, headingAnchors, TOC_MIN, tocHTML } from '../static/js/outline.js';
+import { headingAnchor, headingAnchors, permalinks, TOC_MIN, tocHTML } from '../static/js/outline.js';
 import { md } from '../static/js/markdown.js';
 
 test('an anchor is the heading in the URL, Japanese included', () => {
@@ -50,6 +50,22 @@ test('the outline waits for a document long enough to need one', () => {
   // Levels indent relative to the shallowest heading present.
   assert.match(html, /<li class="lv0"><a href="#a">a<\/a><\/li>/);
   assert.match(html, /<li class="lv1"><a href="#c">c<\/a><\/li>/);
+});
+
+test('a heading links to itself, within the concept', () => {
+  const { html } = headingAnchors(md('## 検証の順番\n\nprose'));
+  const linked = permalinks(html, 'insights/how-to-read');
+  // The route carries the concept and the heading together: an anchor
+  // alone would lose the concept it is inside.
+  assert.match(linked, /<a class="hlink" href="#\/k\/insights\/how-to-read\?h=%E6%A4%9C%E8%A8%BC%E3%81%AE%E9%A0%86%E7%95%AA"/);
+  // The heading keeps its own text and id.
+  assert.match(linked, /<h2 id="検証の順番">検証の順番<a class="hlink"/);
+});
+
+test('a heading with no id gets no permalink', () => {
+  // headingAnchors leaves an empty heading alone; so does this.
+  const { html } = headingAnchors('<h2></h2>');
+  assert.equal(permalinks(html, 'a/b'), '<h2></h2>');
 });
 
 test('the outline stops at h3', () => {

--- a/internal/webui/static/app.css
+++ b/internal/webui/static/app.css
@@ -20,6 +20,10 @@
   --verified-fg: #1e6b43; --verified-bg: #e3f4e9; --verified-bd: #7cc39a;
   --deprecated-fg: #9a4e12; --deprecated-bg: #fcebdd; --deprecated-bd: #e3a370;
   --rejected-fg: #a03434; --rejected-bg: #fbe7e7; --rejected-bd: #dd9494;
+  /* A searched word where it matched. Its own pair rather than
+     --accent-weak: that tint is a surface behind whole panels, and at
+     the size of one word inside a sentence it does not read as marked. */
+  --mark-bg: #cfeadb; --mark-fg: #10301f;
 }
 @media (prefers-color-scheme: dark) {
   :root {
@@ -38,6 +42,7 @@
     --verified-fg: #82d2a5; --verified-bg: #1e3327; --verified-bd: #35624a;
     --deprecated-fg: #e8a465; --deprecated-bg: #382a1d; --deprecated-bd: #6d4d2e;
     --rejected-fg: #e08e8e; --rejected-bg: #382020; --rejected-bd: #6d3535;
+    --mark-bg: #3c6a51; --mark-fg: #f2fbf6;
   }
 }
 * { box-sizing: border-box; }
@@ -51,9 +56,33 @@ code, pre, .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, m
 pre {
   background: var(--code-bg); border: 1px solid var(--border); border-radius: 8px;
   padding: .7rem .9rem; overflow-x: auto; font-size: .86em; line-height: 1.5; margin: .6rem 0;
+  position: relative; /* the copy button sits in the corner of the block */
 }
 code { background: var(--code-bg); border-radius: 4px; padding: .1em .35em; font-size: .88em; }
 pre code { background: none; padding: 0; }
+
+/* ---- copy buttons ----
+   Quiet until the block is under the pointer, and always there where
+   there is no pointer to hover with. */
+/* Room for the button, kept only where there is one: the first line of
+   a block would otherwise run underneath it. */
+pre[data-copy-wired] { padding-right: 2.4rem; }
+.copy-btn {
+  position: absolute; top: .3rem; right: .3rem;
+  background: var(--surface); color: var(--muted);
+  border: 1px solid var(--border); border-radius: 6px;
+  padding: .1rem .4rem; font-size: .8rem; line-height: 1.4; cursor: pointer;
+  opacity: 0; transition: opacity .12s ease;
+}
+pre:hover .copy-btn, .copy-btn:focus-visible { opacity: 1; }
+.copy-btn:hover { color: var(--text); }
+/* Inline: the ochakai:// address beside a concept's breadcrumb, which
+   belongs to the line rather than to a corner. */
+.copy-btn.inline {
+  position: static; opacity: 1; font-size: .72rem; padding: 0 .35rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+@media (hover: none) { .copy-btn { opacity: 1; } }
 
 /* ---- top bar ---- */
 .topbar {
@@ -434,6 +463,18 @@ table.rules.edit tr.invalid > td { background: var(--rejected-bg); }
 .md h1, .md h2, .md h3, .md h4, .md h5, .md h6 { line-height: 1.3; margin: 1.1em 0 .4em; }
 /* An anchored heading lands below the sticky top bar, not under it. */
 .md [id] { scroll-margin-top: 4.2rem; }
+/* The link a heading has to itself: in the margin of the heading, and
+   out of the way until the heading is under the pointer. */
+.md .hlink {
+  margin-left: .35rem; color: var(--muted); font-size: .8em; font-weight: normal;
+  opacity: 0; transition: opacity .12s ease; text-decoration: none;
+}
+.md :is(h1, h2, h3, h4, h5, h6):hover .hlink, .md .hlink:focus-visible { opacity: 1; }
+@media (hover: none) { .md .hlink { opacity: .55; } }
+/* A link to knowledge nobody has written, drawn as what it is. */
+a.dead { color: var(--rejected-fg); border-bottom: 1px dashed var(--rejected-bd); }
+/* The words a reader searched for, where they matched. */
+mark { background: var(--mark-bg); color: var(--mark-fg); border-radius: 3px; padding: 0 .08em; }
 /* The outline (outline.js): the document's own shape, above the body,
    for the documents long enough to need a map. */
 .toc {

--- a/internal/webui/static/js/clipboard.js
+++ b/internal/webui/static/js/clipboard.js
@@ -1,0 +1,80 @@
+// Copying what a reader came for. The knowledge here is written to be
+// used somewhere else — a verified query pasted into a console, an id
+// handed to an agent — and a page that renders it without a way to take
+// it makes every reader select it by hand.
+//
+// The decoration is one observer rather than a call in every view: the
+// page redraws whole regions by innerHTML (a view, a tab body, a result
+// list), so a rendered <pre> appears in places that share no code, and
+// asking each of them to remember is asking one of them to forget. The
+// click is one delegated listener for the same reason — an injected
+// button carries no listener of its own and can be thrown away with the
+// markup around it.
+
+import { toast } from './api.js';
+import { view } from './dom.js';
+
+// copyText puts one string on the clipboard and says so. The API needs a
+// secure context, which localhost (`ochakai ui`) and https (`serve-ui`)
+// both are; anywhere else it is refused, and a button that did nothing
+// silently would read as a broken page rather than an unavailable one.
+export async function copyText(text, doneMsg) {
+  try {
+    await navigator.clipboard.writeText(text);
+    toast(doneMsg || 'コピーしました。');
+    return true;
+  } catch {
+    toast('コピーできませんでした。お使いのブラウザで選択してコピーしてください。');
+    return false;
+  }
+}
+
+const BUTTON = 'copy-btn';
+
+// decorate puts a button in every code block that has none. It is
+// idempotent because it must be: appending the button is itself a
+// mutation, so the observer sees its own work and comes straight back.
+function decorate(root) {
+  for (const pre of root.querySelectorAll('pre:not([data-copy-wired])')) {
+    pre.dataset.copyWired = '1';
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = BUTTON;
+    btn.title = 'コピー';
+    btn.setAttribute('aria-label', 'コピー');
+    btn.textContent = '⧉';
+    pre.appendChild(btn);
+  }
+}
+
+export function initCopyButtons() {
+  decorate(view);
+  new MutationObserver(records => {
+    for (const r of records) {
+      for (const node of r.addedNodes) {
+        if (node.nodeType !== 1) continue;
+        if (node.matches && node.matches('pre')) decorate(node.parentNode || view);
+        else if (node.querySelector) decorate(node);
+      }
+    }
+  }).observe(view, { childList: true, subtree: true });
+
+  // One listener for every button there will ever be, including the ones
+  // written into a view's own markup with a data-copy of their own.
+  document.addEventListener('click', e => {
+    const btn = e.target.closest && e.target.closest('.' + BUTTON);
+    if (!btn) return;
+    e.preventDefault();
+    if (btn.dataset.copy !== undefined) {
+      copyText(btn.dataset.copy, btn.dataset.copyDone);
+      return;
+    }
+    const pre = btn.closest('pre');
+    if (!pre) return;
+    // The block's text without the button's own glyph: a copy of the
+    // element, minus what this module put in it.
+    const clone = pre.cloneNode(true);
+    clone.querySelectorAll('.' + BUTTON).forEach(b => b.remove());
+    copyText(clone.textContent, 'コードをコピーしました。');
+  });
+}

--- a/internal/webui/static/js/format.js
+++ b/internal/webui/static/js/format.js
@@ -75,8 +75,20 @@ export function parseKPath(raw) {
   const s = String(raw ?? '');
   const at = s.indexOf('?h=');
   const idPart = at === -1 ? s : s.slice(0, at);
-  const heading = at === -1 ? '' : decodeURIComponent(s.slice(at + 3));
-  return { id: idPart.split('/').map(decodeURIComponent).join('/'), heading };
+  const heading = at === -1 ? '' : dec(s.slice(at + 3));
+  return { id: idPart.split('/').map(dec).join('/'), heading };
+}
+// A half-typed or truncated address — "%zz", or a "%E3%81" a chat client
+// cut in two — is a bad address, not an exception. Throwing out of the
+// router leaves the page showing the concept the reader was on while the
+// bar names another one; the raw text finds nothing, which says what
+// happened.
+function dec(s) {
+  try {
+    return decodeURIComponent(s);
+  } catch {
+    return s;
+  }
 }
 // API path for a concept: it lives in the bundle at its id plus `.md`,
 // which is the only address it has (design doc 0046 §3.5).

--- a/internal/webui/static/js/format.js
+++ b/internal/webui/static/js/format.js
@@ -61,6 +61,23 @@ export function idPath(id) {
   return String(id).split('/').map(encodeURIComponent).join('/');
 }
 export const entryHash = e => '#/k/' + idPath(e.id);
+// A link to one section of one concept. A bare "#anchor" cannot do this
+// job: the page routes on the hash, so an address holding only an anchor
+// has lost the concept it was an anchor within — reloading it lands on
+// the home page. The heading rides in the route instead, as a query
+// suffix an anchor can never contain (headingAnchor drops `#%?`), which
+// is what makes the split below unambiguous.
+export const headingHash = (id, anchor) => '#/k/' + idPath(id) + '?h=' + encodeURIComponent(anchor);
+// The inverse, run on the still-encoded path so that a `?h=` a writer
+// put inside a segment survives as text: the route's own separator is
+// the first one, and the id is decoded segment by segment after the cut.
+export function parseKPath(raw) {
+  const s = String(raw ?? '');
+  const at = s.indexOf('?h=');
+  const idPart = at === -1 ? s : s.slice(0, at);
+  const heading = at === -1 ? '' : decodeURIComponent(s.slice(at + 3));
+  return { id: idPart.split('/').map(decodeURIComponent).join('/'), heading };
+}
 // API path for a concept: it lives in the bundle at its id plus `.md`,
 // which is the only address it has (design doc 0046 §3.5).
 export const conceptURL = id => '/api/v1/bundle/' + idPath(id) + '.md';

--- a/internal/webui/static/js/highlight.js
+++ b/internal/webui/static/js/highlight.js
@@ -24,15 +24,33 @@ export function terms(q) {
 // a query is user input, and building a pattern out of it is where the
 // escaping bugs live. Substring also means Japanese needs no word
 // boundaries, which it does not have.
+// Lowercased without changing where anything is. `toLowerCase` is not
+// length-preserving — U+0130 (İ) lowercases to two code units — and the
+// offsets found in the folded text are used to cut the original, so one
+// such character shifts every mark after it by one. A character whose
+// lowercase is not one unit keeps its own form here: it stops matching
+// case-insensitively, which is a smaller loss than marking the wrong
+// word (and than the empty <mark> the shift could leave behind).
+function fold(s) {
+  const lower = s.toLowerCase();
+  if (lower.length === s.length) return lower;
+  let out = '';
+  for (const ch of s) {
+    const c = ch.toLowerCase();
+    out += c.length === ch.length ? c : ch;
+  }
+  return out;
+}
+
 export function segments(text, ts) {
   const s = String(text ?? '');
   if (!s || !ts || !ts.length) return s ? [{ text: s, hit: false }] : [];
-  const hay = s.toLowerCase();
+  const hay = fold(s);
   // Every match from every term, then merged: two terms overlapping in
   // one place is one mark, not two nested ones.
   const spans = [];
   for (const t of ts) {
-    const needle = t.toLowerCase();
+    const needle = fold(t);
     if (!needle) continue;
     for (let i = hay.indexOf(needle); i !== -1; i = hay.indexOf(needle, i + 1)) {
       spans.push([i, i + needle.length]);

--- a/internal/webui/static/js/highlight.js
+++ b/internal/webui/static/js/highlight.js
@@ -1,0 +1,86 @@
+// Marking the words a reader searched for, in the results they came
+// back to. A hit list where nothing says why a card matched leaves the
+// reader to re-run the query with their eyes.
+//
+// The matching half is a string function so it can be tested without a
+// DOM, and the DOM half walks text nodes only — it runs after a card is
+// rendered, so it cannot corrupt markup or turn prose into a tag.
+
+// The words a query holds. Whitespace-separated, U+3000 included, since
+// a Japanese query typed with an ideographic space is one a person meant
+// as two words. Longest first, so an overlapping pair marks the longer
+// run rather than stopping at the shorter one.
+export function terms(q) {
+  const seen = new Set();
+  for (const w of String(q ?? '').split(/\s+/u)) {
+    const t = w.trim();
+    if (t) seen.add(t);
+  }
+  return [...seen].sort((a, b) => b.length - a.length);
+}
+
+// The text cut into runs, each saying whether it matched. Matching is a
+// case-insensitive substring scan rather than a regular expression:
+// a query is user input, and building a pattern out of it is where the
+// escaping bugs live. Substring also means Japanese needs no word
+// boundaries, which it does not have.
+export function segments(text, ts) {
+  const s = String(text ?? '');
+  if (!s || !ts || !ts.length) return s ? [{ text: s, hit: false }] : [];
+  const hay = s.toLowerCase();
+  // Every match from every term, then merged: two terms overlapping in
+  // one place is one mark, not two nested ones.
+  const spans = [];
+  for (const t of ts) {
+    const needle = t.toLowerCase();
+    if (!needle) continue;
+    for (let i = hay.indexOf(needle); i !== -1; i = hay.indexOf(needle, i + 1)) {
+      spans.push([i, i + needle.length]);
+    }
+  }
+  if (!spans.length) return [{ text: s, hit: false }];
+  spans.sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+  const merged = [spans[0].slice()];
+  for (const [from, to] of spans.slice(1)) {
+    const last = merged[merged.length - 1];
+    if (from <= last[1]) last[1] = Math.max(last[1], to);
+    else merged.push([from, to]);
+  }
+  const out = [];
+  let at = 0;
+  for (const [from, to] of merged) {
+    if (from > at) out.push({ text: s.slice(at, from), hit: false });
+    out.push({ text: s.slice(from, to), hit: true });
+    at = to;
+  }
+  if (at < s.length) out.push({ text: s.slice(at), hit: false });
+  return out;
+}
+
+// highlightIn marks the terms inside one element, in place. It walks
+// text nodes, so an attribute — a title, an href — is never touched, and
+// a node already inside a <mark> is left alone rather than nested.
+export function highlightIn(el, ts) {
+  if (!el || !ts || !ts.length) return;
+  const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+  const todo = [];
+  for (let n = walker.nextNode(); n; n = walker.nextNode()) {
+    if (n.parentElement && n.parentElement.closest('mark')) continue;
+    if (n.nodeValue && n.nodeValue.trim()) todo.push(n);
+  }
+  for (const node of todo) {
+    const parts = segments(node.nodeValue, ts);
+    if (!parts.some(p => p.hit)) continue;
+    const frag = document.createDocumentFragment();
+    for (const p of parts) {
+      if (p.hit) {
+        const mark = document.createElement('mark');
+        mark.textContent = p.text;
+        frag.appendChild(mark);
+      } else {
+        frag.appendChild(document.createTextNode(p.text));
+      }
+    }
+    node.replaceWith(frag);
+  }
+}

--- a/internal/webui/static/js/links.js
+++ b/internal/webui/static/js/links.js
@@ -1,0 +1,34 @@
+// Which of a body's links point at something that is there. A wiki
+// draws the ones that do not in red, and the reason is not decoration:
+// a concept that names a neighbour which was deleted or moved is a
+// concept that is quietly wrong, and only the reader following the link
+// ever finds out.
+//
+// The probe is injected rather than imported, so the walk can be tested
+// without a network — and so the caller decides what a read costs.
+
+// checkTargets asks about each id at most once, a few at a time, and
+// answers with the ones that are not there.
+//
+// Only a not_found is dead. A network failure, a 500, a read the policy
+// refuses — none of those say the concept is missing, and marking a link
+// red because the server hiccuped would put a permanent-looking verdict
+// on a temporary condition (the page keeps no record either way, so the
+// next render asks again).
+export async function checkTargets(ids, probe, limit = 4) {
+  const queue = [...new Set(ids)].filter(Boolean);
+  const dead = new Set();
+  let at = 0;
+  const worker = async () => {
+    while (at < queue.length) {
+      const id = queue[at++];
+      try {
+        await probe(id);
+      } catch (e) {
+        if (e && e.code === 'not_found') dead.add(id);
+      }
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(limit, queue.length) }, worker));
+  return dead;
+}

--- a/internal/webui/static/js/links.js
+++ b/internal/webui/static/js/links.js
@@ -8,15 +8,18 @@
 // without a network — and so the caller decides what a read costs.
 
 // checkTargets asks about each id at most once, a few at a time, and
-// answers with the ones that are not there.
+// answers with what it learned: which ids are there, and which are not.
 //
-// Only a not_found is dead. A network failure, a 500, a read the policy
-// refuses — none of those say the concept is missing, and marking a link
-// red because the server hiccuped would put a permanent-looking verdict
-// on a temporary condition (the page keeps no record either way, so the
-// next render asks again).
+// **An id can come back in neither.** Only a read that says the concept
+// is missing makes it dead, and only a read that succeeds makes it
+// found; a network failure, a 500, a read the policy refuses are none of
+// those, and the caller must be able to tell "not there" from "did not
+// find out". Returning the dead set alone cannot say that — every
+// answer that was not a 404 would read as "present", and a caller
+// remembering that would stop asking about a concept it never saw.
 export async function checkTargets(ids, probe, limit = 4) {
   const queue = [...new Set(ids)].filter(Boolean);
+  const found = new Set();
   const dead = new Set();
   let at = 0;
   const worker = async () => {
@@ -24,11 +27,16 @@ export async function checkTargets(ids, probe, limit = 4) {
       const id = queue[at++];
       try {
         await probe(id);
+        found.add(id);
       } catch (e) {
         if (e && e.code === 'not_found') dead.add(id);
       }
     }
   };
-  await Promise.all(Array.from({ length: Math.min(limit, queue.length) }, worker));
-  return dead;
+  // At least one worker, however the caller spelled the cap: a pool of
+  // none finishes instantly having asked nothing, which is the one
+  // outcome that looks like a clean answer while carrying no answer.
+  const workers = Math.min(Math.max(1, limit | 0), queue.length);
+  await Promise.all(Array.from({ length: workers }, worker));
+  return { found, dead };
 }

--- a/internal/webui/static/js/main.js
+++ b/internal/webui/static/js/main.js
@@ -1,6 +1,7 @@
 // Boot: the chrome that belongs to no view, then the first render.
 
 import { markPosture } from './api.js';
+import { initCopyButtons } from './clipboard.js';
 import { $ } from './dom.js';
 import { initPalette } from './palette.js';
 import { refreshQueues } from './queues.js';
@@ -27,4 +28,5 @@ refreshQueues();
 markPosture();
 markAccessTab();
 initPalette();
+initCopyButtons();
 route();

--- a/internal/webui/static/js/outline.js
+++ b/internal/webui/static/js/outline.js
@@ -11,6 +11,7 @@
 // writer typed can match it: a `<h2>` in their prose arrives escaped.
 
 import { esc } from './escape.js';
+import { headingHash } from './format.js';
 
 // The entities esc() writes, undone for the anchor only: a heading
 // "A & B" should anchor as A-B, not A-amp-B. The visible text keeps the
@@ -50,6 +51,22 @@ export function headingAnchors(html) {
     return `<h${level} id="${esc(id)}">${inner}</h${level}>`;
   });
   return { html: out, headings };
+}
+
+// permalinks gives each heading a link to itself — the ¶ every
+// documentation service puts in the margin, so that "the part about
+// re-verification" can be sent as an address rather than described.
+//
+// It runs on the html headingAnchors returned, matching the same shape
+// that function wrote, and leaves a heading without an id alone: an
+// empty heading anchors nowhere, and a heading in a code fence arrived
+// escaped and was never an <hN> to begin with.
+export function permalinks(html, id) {
+  return String(html ?? '').replace(/<h([1-6]) id="([^"]*)">([\s\S]*?)<\/h\1>/g,
+    (m, level, anchor, inner) =>
+      `<h${level} id="${anchor}">${inner}` +
+      `<a class="hlink" href="${esc(headingHash(id, anchor))}" title="この見出しへのリンクをコピーします" aria-label="この見出しへのリンク">¶</a>` +
+      `</h${level}>`);
 }
 
 // How many headings make an outline worth its height: below this a

--- a/internal/webui/static/js/palette.js
+++ b/internal/webui/static/js/palette.js
@@ -13,6 +13,7 @@ import { api } from './api.js';
 import { $ } from './dom.js';
 import { esc } from './escape.js';
 import { displayTitle, entryHash } from './format.js';
+import { highlightIn, terms } from './highlight.js';
 import { icon } from './vocab.js';
 import { debounce, explore, viewExplore } from './views/explore.js';
 
@@ -34,13 +35,21 @@ function render() {
          <span class="type-ico" aria-hidden="true">🔍</span>
          <span class="palette-title">「${esc(q)}」を検索</span><span class="palette-id">結果の一覧と絞り込みを開きます</span>
        </div>`
-    : `<div ${attrs(i)}>
+    : `<div ${attrs(i)} data-hit>
          <span class="type-ico" aria-hidden="true">${icon(r.hit.type)}</span>
          <span class="palette-title">${esc(displayTitle(r.hit))}</span>
          <span class="palette-id mono">${esc(r.hit.id)}</span>
          <span class="badge ${esc(r.hit.status)}">${esc(r.hit.status)}</span>
        </div>`).join('');
   list.innerHTML = items || `<div class="empty">${q ? '一致するナレッジが見つかりません。' : 'まだナレッジがありません。'}</div>`;
+  // The typed words, marked in the titles and ids they matched. The
+  // synthetic search row is skipped: it quotes the query already, and
+  // marking a quotation of itself says nothing.
+  if (q) {
+    const ts = terms(q);
+    list.querySelectorAll('.palette-row[data-hit] .palette-title, .palette-row[data-hit] .palette-id')
+      .forEach(el => highlightIn(el, ts));
+  }
   list.querySelectorAll('.palette-row').forEach(el => {
     el.addEventListener('click', () => go(Number(el.dataset.i)));
     // Hover moves the selection the way the arrows do, so the keyboard

--- a/internal/webui/static/js/router.js
+++ b/internal/webui/static/js/router.js
@@ -4,6 +4,7 @@
 // modules have finished evaluating.
 
 import { $, view } from './dom.js';
+import { parseKPath } from './format.js';
 import { markTreeSelection } from './tree.js';
 import { viewAccess } from './views/access.js';
 import { viewDetail } from './views/detail.js';
@@ -55,7 +56,11 @@ export function route() {
     if (a) { a.classList.add('active'); a.setAttribute('aria-current', 'page'); }
   };
   if (head === 'k' && rest.length >= 1) {
-    viewDetail(rest.map(decodeURIComponent).join('/'));
+    // A concept, and optionally one heading inside it: the route is
+    // split before anything is decoded, because the separator is the
+    // route's and an encoded one inside a segment is the writer's.
+    const { id, heading } = parseKPath(rest.join('/'));
+    viewDetail(id, heading);
   } else if (head === 'dir') {
     // A directory's index page — the web rendering of the index.md the
     // OKF export generates at every level. #/dir/ (the root) shows the

--- a/internal/webui/static/js/views/detail.js
+++ b/internal/webui/static/js/views/detail.js
@@ -507,8 +507,12 @@ export async function viewDetail(id, heading = '') {
     targets.delete(entry.id);
     const ask = [...targets].filter(t => t && !found.has(t)).slice(0, MAX_PROBES);
     if (!ask.length) return;
-    const dead = await checkTargets(ask, t => api(conceptURL(t)), 4);
-    for (const t of ask) (dead.has(t) ? missing : found).add(t);
+    // Whatever the probes did not find out about is left in neither set,
+    // so a server that was briefly unreachable teaches this session
+    // nothing rather than teaching it that every neighbour is fine.
+    const seen = await checkTargets(ask, t => api(conceptURL(t)), 4);
+    for (const t of seen.found) found.add(t);
+    for (const t of seen.dead) missing.add(t);
     // The reader may have walked on while the probes were out; the view
     // holding this body is the one that asked.
     if (body.isConnected) markDead();

--- a/internal/webui/static/js/views/detail.js
+++ b/internal/webui/static/js/views/detail.js
@@ -4,14 +4,17 @@
 import { applyStatus, liftRejection, moveEntry, rejectEntry, verifyEntry } from '../actions.js';
 import { BASE, api, toast } from '../api.js';
 import { hitCard } from '../cards.js';
+import { copyText } from '../clipboard.js';
 import { diffHTML, diffLines, diffStats } from '../diff.js';
 import { $, view } from '../dom.js';
 import { esc } from '../escape.js';
-import { actorStr, conceptURL, crumbTrail, displayTitle, fmtDate, fmtSize, idPath, isVerified, lastVerification, trustOf } from '../format.js';
+import { actorStr, conceptURL, crumbTrail, displayTitle, fmtDate, fmtSize, idPath, isVerified, lastVerification, parseKPath, trustOf } from '../format.js';
+import { checkTargets } from '../links.js';
 import { descHTML, md } from '../markdown.js';
-import { headingAnchors, tocHTML } from '../outline.js';
+import { headingAnchors, permalinks, tocHTML } from '../outline.js';
 import { knownDirs, refreshTree, revealInTree } from '../tree.js';
 import { STATUSES, icon } from '../vocab.js';
+import { explore, viewExplore } from './explore.js';
 
 // A resource is whatever the writer put there: an external URL, a
 // bundle-relative path, a scope descriptor. Only http(s) becomes a real
@@ -44,7 +47,64 @@ export const TAB_LABELS = {
 // signals as the writer recorded them and scores nothing: §5.1 leaves
 // weighing them to whoever is reading.
 
-export async function viewDetail(id) {
+// What the page already knows about whether a concept is there, kept
+// for the session: a body that links to a neighbour is usually one of
+// several that do, and the answer does not change while a reader walks
+// between them. Nothing negative is remembered about a failure that was
+// not a 404 — links.js never reports those, so they are simply asked
+// again on the next render.
+const known = new Map();
+
+// The links a body draws are routes, so the ids come back out of them
+// the same way the router reads them.
+const idFromHash = href => parseKPath(String(href).replace(/^#\/k\//, '')).id;
+
+// A page asks about no more than this many neighbours. A probe is a
+// whole concept read — the contract has no lighter way to ask whether
+// something exists (design doc 0107 froze the core) — and a body citing
+// dozens of others is a body whose reader is not waiting on the colour
+// of the thirty-first link.
+const MAX_PROBES = 30;
+
+// The page behind a link to knowledge nobody has written. A wiki has
+// always answered this address with a page rather than an error, and for
+// the reason that matters here: the reader arrived holding a name, which
+// is the most useful thing anyone has about the concept that is missing.
+// So the name is offered back to them twice — as a search over what does
+// exist, and, for whoever may write, as the id of a new document.
+export async function viewMissing(id) {
+  const segs = String(id).split('/');
+  const name = segs.at(-1) || id;
+  view.innerHTML = `
+    <nav class="crumbs mono">${crumbTrail(segs.slice(0, -1))}</nav>
+    <div class="detail-head"><h1>${esc(name)}</h1></div>
+    <p class="provenance"><code>${esc(id)}</code></p>
+    <div class="status-note">このナレッジはまだありません。リンクをたどってここに来た場合は、リンク元が古いか、まだ誰も書いていません。</div>
+    <div class="toolbar">
+      <button class="btn small" id="missing-search" title="この名前で検索します">🔍「${esc(name)}」を検索</button>
+      <a class="btn small write-only" href="#/new/${idPath(id)}" title="この id でナレッジを作成します">＋ ここに作成</a>
+    </div>
+    <div id="missing-near" style="margin-top:1.2rem"></div>`;
+  $('#missing-search').addEventListener('click', () => {
+    explore.q = name;
+    explore.ageFeed = explore.failedFeed = explore.expiredFeed = false;
+    explore.source = '';
+    if (location.hash === '#/search') viewExplore();
+    else location.hash = '#/search';
+  });
+  // Whatever the base does have under that name, in place. A search that
+  // fails says nothing here: the page's answer is already given above,
+  // and an error banner under it would describe a second problem the
+  // reader did not have.
+  const near = $('#missing-near');
+  try {
+    const { hits = [] } = await api('/api/v1/search?q=' + encodeURIComponent(name) + '&limit=5');
+    if (!near.isConnected || !hits.length) return;
+    near.innerHTML = `<div class="section-title">近い名前のナレッジ</div>` + hits.map(hitCard).join('');
+  } catch { /* the page stands without it */ }
+}
+
+export async function viewDetail(id, heading = '') {
   revealInTree(id); // in parallel with the entry fetch; harmless on 404
   view.innerHTML = '<div class="empty">…</div>';
   let entry, observed, document_;
@@ -57,6 +117,12 @@ export async function viewDetail(id) {
     observed = v.observed || {};
     document_ = v.document || '';
   } catch (e) {
+    // A concept that is not there is not an error the reader caused, and
+    // an error banner is what a page says when something went wrong.
+    // What went wrong here is that somebody followed a link to knowledge
+    // nobody has written — which is a page of its own, with the two ways
+    // on: find what does exist, or write it.
+    if (e.code === 'not_found') { viewMissing(id); return; }
     view.innerHTML = `<div class="error-banner" role="alert">${esc(id)} を読み込めませんでした: ${esc(e.message)}</div>`;
     return;
   }
@@ -96,7 +162,10 @@ export async function viewDetail(id) {
   const atts = entry.files || [];
 
   view.innerHTML = `
-    <nav class="crumbs mono">${crumbTrail(entry.id.split('/').slice(0, -1))} <span class="badge">${esc(entry.type)}</span></nav>
+    <nav class="crumbs mono">${crumbTrail(entry.id.split('/').slice(0, -1))} <span class="badge">${esc(entry.type)}</span>
+      <button type="button" class="copy-btn inline" data-copy="ochakai://${esc(entry.id)}"
+              data-copy-done="ochakai:// のアドレスをコピーしました。"
+              title="このナレッジのアドレスをコピーします" aria-label="このナレッジのアドレスをコピー">ochakai://</button></nav>
     <div class="detail-head">
       <span class="type-ico" style="font-size:1.4rem">${icon(entry.type)}</span>
       <h1>${esc(displayTitle(entry))}</h1>
@@ -210,10 +279,13 @@ export async function viewDetail(id) {
       // description stays out of both — its headings describe, they do
       // not structure the document.
       const body_ = docBody ? headingAnchors(md(docBody, resolveFile, resolveEntry)) : { html: '', headings: [] };
+      // Each heading also gains a link to itself, so a section can be
+      // sent as an address rather than described.
+      const bodyHTML = body_.html ? permalinks(body_.html, entry.id) : '';
       return `
       ${entry.description ? descHTML(entry.description, 'lead') : ''}
       ${tocHTML(body_.headings)}
-      ${docBody ? `<div class="md">${body_.html}</div>` : ''}
+      ${docBody ? `<div class="md">${bodyHTML}</div>` : ''}
       ${!entry.description && !docBody ? '<div class="empty">description も本文もありません。</div>' : ''}`;
     },
     // The document, whole and unrendered. It replaced tabs that each
@@ -359,6 +431,19 @@ export async function viewDetail(id) {
         <table class="kv">${rows}</table>`;
     },
   };
+  // Links to concepts that are not there, drawn as what they are. The
+  // verdicts live in `known`, so this runs after every tab render — the
+  // tab bodies are redrawn from their templates each time they open,
+  // which throws the classes away with the markup.
+  function markDead() {
+    for (const a of body.querySelectorAll('a[href^="#/k/"]')) {
+      if (known.get(idFromHash(a.getAttribute('href'))) === false) {
+        a.classList.add('dead');
+        a.title = 'リンク先のナレッジがありません';
+      }
+    }
+  }
+
   async function showTab(name) {
     document.querySelectorAll('#tabs button').forEach(b => b.classList.toggle('active', b.dataset.tab === name));
     body.innerHTML = tabs[name]();
@@ -374,9 +459,55 @@ export async function viewDetail(id) {
         }
       }
     }
+    markDead();
   }
   document.querySelectorAll('#tabs button').forEach(b => b.addEventListener('click', () => showTab(b.dataset.tab)));
   showTab('overview');
+
+  // A heading named by the route: the overview renders synchronously
+  // above, so the element is there to scroll to. getElementById rather
+  // than a selector, because an anchor is the heading's own words and a
+  // Japanese one would have to be escaped to sit in a selector.
+  if (heading) document.getElementById(heading)?.scrollIntoView();
+
+  // ¶ — the reader gets the address in the bar and on the clipboard,
+  // and the view is not redrawn to give it to them. replaceState leaves
+  // route._current holding the previous hash until the next navigation;
+  // its only reader is the editor's unsaved-changes restore, which
+  // cannot be open behind this view.
+  //
+  // The listener sits on the tab body rather than on the view, because
+  // the view outlives every render and would collect one of these per
+  // concept opened.
+  body.addEventListener('click', e => {
+    const a = e.target.closest && e.target.closest('a.hlink');
+    if (!a) return;
+    e.preventDefault();
+    const href = a.getAttribute('href');
+    history.replaceState(null, '', href);
+    document.getElementById(parseKPath(href.replace(/^#\/k\//, '')).heading)?.scrollIntoView();
+    copyText(location.href, '見出しへのリンクをコピーしました。');
+  });
+
+  // Ask about the neighbours this body names, once per session each.
+  (async () => {
+    const targets = new Set();
+    for (const l of entry.links || []) {
+      const t = String(l.target || '').replace(/^ochakai:\/\//, '');
+      if (t) targets.add(t);
+    }
+    for (const a of body.querySelectorAll('a[href^="#/k/"]')) targets.add(idFromHash(a.getAttribute('href')));
+    // A heading's own ¶ is a link to this concept, which is the one
+    // concept on the page already known to be there.
+    targets.delete(entry.id);
+    const ask = [...targets].filter(t => t && !known.has(t)).slice(0, MAX_PROBES);
+    if (!ask.length) { markDead(); return; }
+    const dead = await checkTargets(ask, t => api(conceptURL(t)), 4);
+    for (const t of ask) known.set(t, !dead.has(t));
+    // The reader may have walked on while the probes were out; the view
+    // holding this body is the one that asked.
+    if (body.isConnected) markDead();
+  })();
 
   // Status is a picker, not a row of transition buttons: any transition
   // the API allows is offered (provenance over authorization, design doc

--- a/internal/webui/static/js/views/detail.js
+++ b/internal/webui/static/js/views/detail.js
@@ -47,13 +47,16 @@ export const TAB_LABELS = {
 // signals as the writer recorded them and scores nothing: §5.1 leaves
 // weighing them to whoever is reading.
 
-// What the page already knows about whether a concept is there, kept
-// for the session: a body that links to a neighbour is usually one of
-// several that do, and the answer does not change while a reader walks
-// between them. Nothing negative is remembered about a failure that was
-// not a 404 — links.js never reports those, so they are simply asked
-// again on the next render.
-const known = new Map();
+// The concepts this session has already found: a body that links to a
+// neighbour is usually one of several that do, and a concept that is
+// there does not stop being there while a reader walks between them.
+//
+// Only the positive answer is kept. A missing one is asked again on
+// every render, because it is the answer that can change under the
+// reader — the page they are looking at offers to write the concept the
+// link is missing, and coming back to find the link still red would
+// have the page contradicting what it just did.
+const found = new Set();
 
 // The links a body draws are routes, so the ids come back out of them
 // the same way the router reads them.
@@ -432,12 +435,13 @@ export async function viewDetail(id, heading = '') {
     },
   };
   // Links to concepts that are not there, drawn as what they are. The
-  // verdicts live in `known`, so this runs after every tab render — the
-  // tab bodies are redrawn from their templates each time they open,
+  // verdict is this render's, and the marking runs after every tab
+  // render — a tab body is redrawn from its template each time it opens,
   // which throws the classes away with the markup.
+  const missing = new Set();
   function markDead() {
     for (const a of body.querySelectorAll('a[href^="#/k/"]')) {
-      if (known.get(idFromHash(a.getAttribute('href'))) === false) {
+      if (missing.has(idFromHash(a.getAttribute('href')))) {
         a.classList.add('dead');
         a.title = 'リンク先のナレッジがありません';
       }
@@ -489,7 +493,8 @@ export async function viewDetail(id, heading = '') {
     copyText(location.href, '見出しへのリンクをコピーしました。');
   });
 
-  // Ask about the neighbours this body names, once per session each.
+  // Ask about the neighbours this body names — the ones this session has
+  // not already found.
   (async () => {
     const targets = new Set();
     for (const l of entry.links || []) {
@@ -500,10 +505,10 @@ export async function viewDetail(id, heading = '') {
     // A heading's own ¶ is a link to this concept, which is the one
     // concept on the page already known to be there.
     targets.delete(entry.id);
-    const ask = [...targets].filter(t => t && !known.has(t)).slice(0, MAX_PROBES);
-    if (!ask.length) { markDead(); return; }
+    const ask = [...targets].filter(t => t && !found.has(t)).slice(0, MAX_PROBES);
+    if (!ask.length) return;
     const dead = await checkTargets(ask, t => api(conceptURL(t)), 4);
-    for (const t of ask) known.set(t, !dead.has(t));
+    for (const t of ask) (dead.has(t) ? missing : found).add(t);
     // The reader may have walked on while the probes were out; the view
     // holding this body is the one that asked.
     if (body.isConnected) markDead();

--- a/internal/webui/static/js/views/explore.js
+++ b/internal/webui/static/js/views/explore.js
@@ -4,6 +4,7 @@ import { api } from '../api.js';
 import { hitCard } from '../cards.js';
 import { $, view } from '../dom.js';
 import { esc } from '../escape.js';
+import { highlightIn, terms } from '../highlight.js';
 import { KNOWN_TYPES, STATUSES, icon } from '../vocab.js';
 
 // Filter state survives navigation within the session.
@@ -233,6 +234,15 @@ export async function runSearch(append = false) {
       html += `<div class="truncation-note">先頭 ${limit} 件を表示しています(サーバー側の上限)。絞り込むか、より具体的な問いで範囲を狭めてください。</div>`;
     }
     out.innerHTML = scopeNote + html;
+    // The words that were typed, marked in the text they matched. It
+    // runs on the rendered cards rather than on the strings above,
+    // because a mark inserted into markup is a mark that can break it —
+    // here it can only ever replace a text node. A feed answers no
+    // query, so there is nothing to mark in one.
+    if (q && !isFeed) {
+      const ts = terms(q);
+      out.querySelectorAll('.card .title, .card .desc, .card .snippet').forEach(el => highlightIn(el, ts));
+    }
     wireScope();
     $('#feed-more')?.addEventListener('click', e => { e.preventDefault(); runSearch(true); });
   } catch (e) {

--- a/internal/webui/webui_test.go
+++ b/internal/webui/webui_test.go
@@ -408,10 +408,11 @@ func TestWriteAffordancesAreHiddenOnAReadOnlyDeployment(t *testing.T) {
 	}
 
 	// Controls that carry the class themselves. Every link into the editor
-	// counts: the sidebar ＋, the tree's per-directory ＋, and the two the
-	// search view offers.
-	if n := strings.Count(page, `href="#/new`); n != 4 {
-		t.Errorf("the page has %d literal links to the editor, not the 4 this guard knows; gate the new one and update the count", n)
+	// counts: the sidebar ＋, the tree's per-directory ＋, the two the
+	// search view offers, and the one on the page for a concept that does
+	// not exist ("ここに作成").
+	if n := strings.Count(page, `href="#/new`); n != 5 {
+		t.Errorf("the page has %d literal links to the editor, not the 5 this guard knows; gate the new one and update the count", n)
 	}
 	for _, i := range indexesOf(page, `href="#/new`) {
 		if _, tag := tagAt(t, page, i); !hidesOnReadOnly(tag) {


### PR DESCRIPTION
## What and why

Four affordances every documentation service keeps, for whoever is
**reading** — where [#774](https://github.com/na0fu3y/ochakai/pull/774)
(palette, outline, revision diffs) served the reviewer. All four are
clients of endpoints that already exist: **no REST operation, parameter,
header, MCP tool, CLI command or environment variable is added, and no
dimension of `docs/surface.md` moves.** Design doc
[0067 §1](docs/design/0067-four-faces-and-what-they-decline.md) puts
search, browse, rulings and history on this face, and each of these is
one of those four doing its job better rather than a fifth thing.

- **Copy on every code block, and on the address.** A fenced block in a
  body, the SQL on a result card, the whole stored document, a past
  revision — each gains a copy button, and the concept header copies its
  `ochakai://` address. Knowledge here is written to be used somewhere
  else, and selecting a verified query by hand was the last step of
  reading it. One `MutationObserver` on `#view` decorates and one
  delegated click copies: the page redraws whole regions by `innerHTML`
  in places that share no code, so asking each of them to remember is
  asking one of them to forget.

- **Heading permalinks**, at `#/k/<id>?h=<heading>`. A bare `#anchor`
  cannot do this job — the page routes on the hash, so an address
  holding only an anchor has lost the concept it was inside, and
  reloading it lands on the home page (the latent half of #774's
  anchors). `headingAnchor` already drops `#%?`, so the route's own
  separator is unambiguous. Clicking ¶ replaces the address without a
  refetch and copies it; the `href` is real, so open-in-new-tab and
  copy-link-address work as they read.

- **The query's words marked** in a result's title, description and
  snippet, and in the palette, so a hit says why it is one. Matching is
  a case-folded substring scan rather than a regular expression built
  out of user input — that is where the escaping bugs are, and Japanese
  needs no word boundaries. The DOM half walks text nodes *after* the
  cards render, so it cannot corrupt markup.

- **Dead links, and a page behind them.** A link to a concept that is
  not there is drawn as one, and the page it points at says the concept
  is missing, offers a search for its last segment, and — write-only —
  the editor with that id already filled in. Only a `not_found` marks a
  link: a network failure or a refused read says nothing about whether a
  concept exists. Each neighbour is asked about once per session, four
  at a time, thirty per body, since the frozen contract has no lighter
  way to ask than a concept read.

The last two commits are a sweep of the new code before review, each fix
with the test that fails without it (verified by stashing the fixes: six
assertions go red). The one worth reading is `checkTargets` answering
with the dead set alone — every outcome that was not a 404, *including a
fetch that never reached the server*, arrived as "not dead" and was
remembered as "present", so one page opened while the server restarted
taught the session that up to thirty neighbours exist and a genuinely
deleted one stayed black until a reload. It now answers `{found, dead}`
and leaves what it did not learn in neither. The others: `segments()`
cut the original string with offsets found in the lowercased one, which
`toLowerCase` does not keep the length of (U+0130); `checkTargets` with
a cap of zero built a pool of no workers and reported every link fine;
and `parseKPath` let `decodeURIComponent` throw out of `route()` on a
malformed escape, leaving the previous concept on screen under an
address naming another one.

No new design doc: nothing here alters an accepted decision — 0067 §1
already says what this face is for, and design doc
[0130](docs/design/0130-the-web-ui-and-the-fields-of-a-document.md) is
untouched (the page still reads and writes documents the same way).
Under [0128](docs/design/0128-a-number-is-for-an-area-not-a-rule-inside-it.md),
these are rules inside an area whose record already exists.

One test expectation moved: `TestWriteAffordancesAreHiddenOnAReadOnlyDeployment`
counts literal links to the editor, and the missing-concept page's
「ここに作成」 is a fifth. It carries `write-only` like the other four,
and the guard checks that for each of them.

### Verified

`scripts/check --db` is clean. The pure halves are held by `node --test`
(113 assertions; `highlight`, `links`, and new cases in `outline` and
`format`), and the whole page was driven in a real browser — against the
dogfood instance for the ordinary paths, and against a stub `/api/v1`
for the ones real data cannot produce, since every link in `kb/` is
alive:

- marks in both colour schemes, on a Japanese and an ASCII query, weak
  matches included
- a ¶ deep link reloaded, landing on its heading; the address bar
  showing `#/k/<id>?h=…` after a click
- copy on four kinds of block, and the `ochakai://` address — with
  `navigator.clipboard` stubbed to read what is handed over, because the
  automation pane denies the permission even in a focused secure context
- a red link followed to the missing-concept page, and 「ここに作成」
  opening the editor with the id filled in
- an unreachable server giving the ordinary error banner rather than the
  missing-concept page, and the verdicts correct again on the same
  session once it is back
- mobile width and touch emulation (buttons always visible), and no CSP
  violation in the console

## Checks

- [x] `scripts/check` is clean — add `--db` when the change touches the store
- [x] Behavior changes come with tests
- [x] Behavior changes have a line under `## [Unreleased]` in `CHANGELOG.md`

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — none of them is touched
- [x] The change lands on every surface it belongs on — Web UI only, on
      purpose: 0067 §1 makes this the human curation face, and every one
      of these four is that face reading better. None is a capability
      another face lacks
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens a surface? **No** — `docs/surface.md` does not move: no
      operation, parameter, header, tool, command, flag, variable or
      vocabulary word is added. The three questions are the reason there
      is nothing to answer here

## Design docs

- [x] Alters an accepted decision? No — not applicable (0128: a rule
      inside an area whose record exists)
- [x] Commit messages and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)
