### PR TITLE
Let the reader drag the tree's width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ last entry.
 
 ## [Unreleased]
 
+### Added
+
+- **The web UI's tree sidebar is resizable.** The tree holds names the
+  user chose, so no fixed width suits every bundle: drag the divider
+  (bounded both ways, so a drag can never wedge the page), double-click
+  it to return to the default. The width persists per browser next to
+  the collapsed choice. Web UI only — no API, CLI or MCP change.
+
 ## [0.27.4] - 2026-08-26
 
 ### Added

--- a/internal/webui/static/app.css
+++ b/internal/webui/static/app.css
@@ -166,12 +166,32 @@ pre:hover .copy-btn, .copy-btn:focus-visible { opacity: 1; }
 }
 
 /* ---- layout: persistent tree sidebar + content pane ---- */
-.shell { display: grid; grid-template-columns: 17rem minmax(0, 1fr); }
+/* The tree column is the dragged width when the user set one (--side-w,
+   written by main.js), the default otherwise. Clamped where it is used,
+   not where it is set, so a stale stored value can never wedge the page:
+   the floor keeps the tree readable, the ceiling keeps the content pane
+   the wider half on any viewport. */
+.shell {
+  display: grid;
+  --side-col: clamp(12rem, var(--side-w, 17rem), min(34rem, 45vw));
+  grid-template-columns: var(--side-col) minmax(0, 1fr);
+  position: relative; /* anchors the drag handle to the column edge */
+}
 /* The topbar toggle collapses the sidebar for reading room; the choice
    persists per browser. Narrow screens have their own disclosure, so
    the toggle is desktop-only. */
 .shell.side-collapsed { grid-template-columns: minmax(0, 1fr); }
 .shell.side-collapsed .sidebar { display: none; }
+/* The handle rides the sidebar's right border for the shell's full
+   height. Wider than the border so it can be grabbed; visible only on
+   hover or mid-drag so the border stays a border. */
+.side-resize {
+  position: absolute; top: 0; bottom: 0; left: calc(var(--side-col) - .3rem);
+  width: .6rem; cursor: col-resize; touch-action: none;
+}
+.side-resize:hover, .side-resize.dragging { background: var(--accent-weak); }
+.shell.side-collapsed .side-resize { display: none; }
+@media (max-width: 800px) { .side-resize { display: none; } }
 /* The second cell holds the view and whatever banner sits above it, so
    the grid has exactly two children however many banners are shown. A
    grid item's floor is its own content, which an unbreakable line — a

--- a/internal/webui/static/index.html
+++ b/internal/webui/static/index.html
@@ -60,6 +60,12 @@
       <div id="tree" class="browse"><div class="empty">…</div></div>
     </details>
   </aside>
+  <!-- The divider between tree and content is draggable: the tree holds
+       names the user chose, so no fixed width can be right for every
+       bundle. Absolutely positioned, so the grid still has exactly two
+       cells. Pointer-only by design — the default width needs no
+       adjustment to use the page, so it carries no keyboard surface. -->
+  <div class="side-resize" id="side-resize" aria-hidden="true" title="ドラッグで幅を調整、ダブルクリックで元に戻します"></div>
   <!-- The banners are content, not a column. Left as siblings of <main>
        they were grid items of their own: a displayed one took the
        content cell and pushed the view into the second row of the

--- a/internal/webui/static/js/main.js
+++ b/internal/webui/static/js/main.js
@@ -23,6 +23,33 @@ $('#side-toggle').addEventListener('click', () => {
   localStorage.setItem('ochakai.sidebar', collapsed ? 'collapsed' : 'open');
 });
 
+// The divider drags: the raw pointer x is the width, and app.css clamps
+// it where it is used, so nothing here needs to know the bounds. The
+// width persists per browser like the collapsed choice; double-click
+// forgets it, which is the default width again.
+const sideResize = $('#side-resize');
+const storedW = localStorage.getItem('ochakai.sidebar-width');
+if (storedW) shell.style.setProperty('--side-w', storedW);
+sideResize.addEventListener('pointerdown', e => {
+  e.preventDefault(); // a drag, not a text selection
+  sideResize.setPointerCapture(e.pointerId);
+  sideResize.classList.add('dragging');
+});
+sideResize.addEventListener('pointermove', e => {
+  if (!sideResize.hasPointerCapture(e.pointerId)) return;
+  shell.style.setProperty('--side-w', `${e.clientX}px`);
+});
+// lostpointercapture covers both the release and a cancelled drag.
+sideResize.addEventListener('lostpointercapture', () => {
+  sideResize.classList.remove('dragging');
+  const w = shell.style.getPropertyValue('--side-w');
+  if (w) localStorage.setItem('ochakai.sidebar-width', w);
+});
+sideResize.addEventListener('dblclick', () => {
+  shell.style.removeProperty('--side-w');
+  localStorage.removeItem('ochakai.sidebar-width');
+});
+
 refreshTree();
 refreshQueues();
 markPosture();


### PR DESCRIPTION
## What

The sidebar's divider now drags. The tree holds names the user chose, so no fixed width is right for every bundle: a long concept title was ellipsized into its tooltip at 17rem. Every explorer pane over a user-named tree hands the divider to the user (Finder, VS Code, BigQuery Studio's Explorer — the closest neighbour a Google Cloud user knows); navigation menus with fixed vocabularies stay fixed, and this sidebar is the former kind.

## How

- The grid column becomes `clamp(12rem, var(--side-w, 17rem), min(34rem, 45vw))` — clamped **where it is used**, not where it is set, so a stale stored value can never wedge the page.
- A 0.6rem-wide handle rides the sidebar's right border; `main.js` writes the raw pointer x to `--side-w` (~25 lines, pointer capture). Absolutely positioned, so the shell grid keeps exactly two cells.
- The width persists per browser (`ochakai.sidebar-width`, next to the collapsed choice); double-click forgets it, which is the default again. The handle disappears with the sidebar — collapsed, and on narrow screens where the tree is a disclosure.

## Surface

Who got stuck: a curator whose concept titles outgrow 17rem — the ellipsis-plus-tooltip fallback makes the tree unscannable. Does an existing surface cover it: no; the tooltip shows one row at a time. What widens: nothing counted — no endpoint, no flag, no manual line; direct manipulation that explains itself. Deliberately pointer-only: the default width needs no adjustment to use the page, so the handle carries no keyboard surface.

## Verified

Dragged in a real browser: 272→480px, restored after reload, clamps at 192px/544px, double-click resets and clears storage, collapsing hides the handle. `scripts/check core` green; the jstest smoke's failures against the local dogfood instance are the known demo-data/older-server mismatches, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)