### PR TITLE
Pare the web UI's copy down and make its controls do the work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,36 @@ last entry.
   it to return to the default. The width persists per browser next to
   the collapsed choice. Web UI only — no API, CLI or MCP change.
 
+### Changed
+
+- **The web UI says less, and its review queue empties by verifying.**
+  A curation pass driven by field feedback pared every page's copy down:
+  the long explainers (review queue, access policy, editor hints, the
+  per-tab notes on a concept) are gone or cut to a line, the dev-mode
+  and sandbox banners are one sentence each, and the "cannot store
+  files" setup note moved off the page top onto the files tab it is
+  about. The editor draws only the frontmatter fields the document's
+  type asks for — the Attested Computation contract appears on its own
+  type, and a key a document already carries always keeps its editor —
+  and the fields pane flows with the page instead of scrolling inside
+  itself, with the document pane sticky beside it. On the review page,
+  ✓ 検証 now records the verification *and* promotes the draft to
+  stable, so the queue a ruling resolves visibly shrinks (the two acts
+  stay separate on the wire, design doc 0043 §3.2); the scope input
+  narrows the draft list and the queue chips along with the loop's
+  numbers, and the stale-drafts toggle is gone (sort order and the
+  未使用 badge already carry it). The access page opens directly on its
+  row editor; its JSON textarea is gone — `ochakai access --json` /
+  `-f` remain the JSON surface. Web UI only — no API, CLI or MCP
+  change.
+
+### Fixed
+
+- **The web UI's status picker changes a status again.** The concept
+  page's status dropdown called a helper the module never imported, so
+  every change threw and nothing was saved; the ruling actions beside
+  it were unaffected.
+
 ## [0.27.4] - 2026-08-26
 
 ### Added

--- a/internal/webui/jstest/frontmatter.test.js
+++ b/internal/webui/jstest/frontmatter.test.js
@@ -102,10 +102,27 @@ test('a date the control cannot hold is shown as text rather than erased', () =>
   assert.match(odd, /type="text"[^>]*value="2026-12-31T09:00:00Z"/);
 });
 
+test('a field appears when its type asks for it or its key is present', () => {
+  // The Attested Computation contract (SPEC §10.2) is noise on every
+  // other type, and usage_window earns its place only when a document
+  // brings it. A key the document carries always gets its editor —
+  // hiding one would make it uneditable without saying so.
+  const base = fieldsMarkup({ type: 'Insight' });
+  assert.ok(!base.includes('data-fm-key="runtime"'), 'runtime drawn for a type with no contract');
+  assert.ok(!base.includes('data-fm-key="usage_window"'), 'usage_window drawn with no key to edit');
+  const ac = fieldsMarkup({ type: 'Attested Computation' });
+  assert.ok(ac.includes('data-fm-key="runtime"'), 'the contract is missing from its own type');
+  const carried = fieldsMarkup({ type: 'Insight', runtime: 'bigquery', usage_window: { from: '2026-01-01' } });
+  assert.ok(carried.includes('data-fm-key="runtime"'), 'a carried key lost its editor');
+  assert.ok(carried.includes('data-fm-key="usage_window"'), 'a carried usage_window lost its editor');
+});
+
 test('every control says which key and column it belongs to', () => {
   // The editor reads the form back by walking these markers; a control
-  // without them is a value that never reaches the document.
-  const html = fieldsMarkup({});
+  // without them is a value that never reaches the document. Rendered
+  // from a document that draws every field: the Attested Computation
+  // contract by its type, usage_window by being present.
+  const html = fieldsMarkup({ type: 'Attested Computation', usage_window: { from: '2026-01-01' } });
   for (const f of FIELDS) {
     assert.ok(html.includes(`data-fm-key="${f.key}"`) || html.includes(`data-fm-rows="${f.key}"`)
       || html.includes(`data-fm-list="${f.key}"`), `${f.key} has no marker`);

--- a/internal/webui/jstest/policy.test.js
+++ b/internal/webui/jstest/policy.test.js
@@ -1,8 +1,6 @@
-// The access policy's round trip: the rules the server sends, the
-// document an operator edits, and the rules that go back (design doc
-// 0109 §5). Every bug here is a bug in a boundary somebody is drawing,
-// and the two directions are held together because a document that does
-// not parse back to what it rendered from is a policy nobody can review.
+// The access policy's normalization: the rows the form builds and the
+// rules that go to the wire (design doc 0109 §5). Every bug here is a
+// bug in a boundary somebody is drawing.
 //
 // Outside static/, so it is not embedded and not served.
 
@@ -10,80 +8,47 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
-  joinPrincipal, parsePolicyDocument, policyDocument, splitPrincipal,
-  validPrincipal, validateRules,
+  joinPrincipal, splitPrincipal, validPrincipal, validateRules,
 } from '../static/js/policy.js';
 
-const RULES = [
-  { prefix: '', principal: 'human:na0@example.co.jp', may_write: true, granted_at: '2026-08-17T00:00:00Z', granted_by: 'human:na0@example.co.jp' },
-  { prefix: 'sales', principal: '*', may_write: false },
-  { prefix: 'sales/sample', principal: 'human:tanaka@example.co.jp', may_write: true },
-];
-
-test('the document parses back to the rules it was rendered from', () => {
-  const back = parsePolicyDocument(policyDocument(RULES));
-  assert.deepEqual(back, [
-    { prefix: '', principal: 'human:na0@example.co.jp', may_write: true },
-    { prefix: 'sales', principal: '*', may_write: false },
-    { prefix: 'sales/sample', principal: 'human:tanaka@example.co.jp', may_write: true },
-  ]);
-});
-
-// The server records these and ignores them on write. A document that
-// carried them would invite an edit that silently does nothing — the
-// worst answer a boundary editor can give.
-test('the document leaves out what the server records', () => {
-  const text = policyDocument(RULES);
-  assert.doesNotMatch(text, /granted_at/);
-  assert.doesNotMatch(text, /granted_by/);
-});
-
-test('an empty policy is a document, not an empty box', () => {
-  assert.deepEqual(parsePolicyDocument(policyDocument([])), []);
-  assert.match(policyDocument([]), /"rules": \[\]/);
-});
-
 test('a prefix is trimmed the way the server trims it', () => {
-  const [rule] = parsePolicyDocument('{"rules":[{"prefix":" /sales/orders/ ","principal":"*","may_write":false}]}');
+  const [rule] = validateRules([{ prefix: ' /sales/orders/ ', principal: '*', may_write: false }]);
   assert.equal(rule.prefix, 'sales/orders');
 });
 
 // "sales/" and "sales" are one grant once the server has them, so the
 // duplicate has to be caught against the row as it will be kept.
 test('two rows for one grant are refused, however they are spelled', () => {
-  assert.throws(() => parsePolicyDocument(
-    '{"rules":[{"prefix":"sales","principal":"*"},{"prefix":"sales/","principal":"*"}]}'),
+  assert.throws(() => validateRules(
+    [{ prefix: 'sales', principal: '*' }, { prefix: 'sales/', principal: '*' }]),
   /二行/);
 });
 
 test('a nested prefix is not a duplicate of the one above it', () => {
-  const rules = parsePolicyDocument(
-    '{"rules":[{"prefix":"sales","principal":"*"},{"prefix":"sales/sample","principal":"*"}]}');
+  const rules = validateRules(
+    [{ prefix: 'sales', principal: '*' }, { prefix: 'sales/sample', principal: '*' }]);
   assert.equal(rules.length, 2);
 });
 
 test('may_write defaults to false and refuses anything but a boolean', () => {
-  const [rule] = parsePolicyDocument('{"rules":[{"prefix":"sales","principal":"*"}]}');
+  const [rule] = validateRules([{ prefix: 'sales', principal: '*' }]);
   assert.equal(rule.may_write, false);
-  assert.throws(() => parsePolicyDocument('{"rules":[{"prefix":"s","principal":"*","may_write":"yes"}]}'),
+  assert.throws(() => validateRules([{ prefix: 's', principal: '*', may_write: 'yes' }]),
     /may_write/);
 });
 
 // Which row is wrong is the whole reason this check exists in the page
-// at all: the server validates it again, but the textarea is the thing
-// with rows in it.
+// at all: the server validates it again, but the form is the thing with
+// rows in it.
 test('a bad row is named by its position', () => {
-  assert.throws(() => parsePolicyDocument(
-    '{"rules":[{"prefix":"a","principal":"*"},{"prefix":"b","principal":"tanaka@example.co.jp"}]}'),
+  assert.throws(() => validateRules(
+    [{ prefix: 'a', principal: '*' }, { prefix: 'b', principal: 'tanaka@example.co.jp' }]),
   /^Error: 2 番目の principal/);
 });
 
-test('the shapes that are not a policy say so', () => {
-  assert.throws(() => parsePolicyDocument('{'), /JSON として読めません/);
-  assert.throws(() => parsePolicyDocument('[]'), /rules/);
-  assert.throws(() => parsePolicyDocument('{"rules":{}}'), /rules/);
-  assert.throws(() => parsePolicyDocument('{"rules":[null]}'), /1 番目/);
-  assert.throws(() => parsePolicyDocument('{"rules":[{"prefix":2,"principal":"*"}]}'), /prefix/);
+test('the shapes that are not a rule say so', () => {
+  assert.throws(() => validateRules([null]), /1 番目/);
+  assert.throws(() => validateRules([{ prefix: 2, principal: '*' }]), /prefix/);
 });
 
 test('a principal is the wildcard or an actor the ledger can spell', () => {
@@ -98,27 +63,26 @@ test('a principal is the wildcard or an actor the ledger can spell', () => {
 test('may_admin implies may_write, and the root refuses it', () => {
   // The page sends what the server would infer anyway, so a rule read
   // back matches the one that was typed (design doc 0124).
-  const [rule] = parsePolicyDocument(
-    '{"rules":[{"prefix":"teams/growth","principal":"human:lead@example.co.jp","may_admin":true}]}');
+  const [rule] = validateRules(
+    [{ prefix: 'teams/growth', principal: 'human:lead@example.co.jp', may_admin: true }]);
   assert.equal(rule.may_admin, true);
   assert.equal(rule.may_write, true, 'may_admin implies may_write');
 
   // Who may edit the whole policy is the one answer the policy cannot
   // carry, and the refusal names where it lives instead.
   assert.throws(
-    () => parsePolicyDocument('{"rules":[{"prefix":"","principal":"human:x@example.co.jp","may_admin":true}]}'),
+    () => validateRules([{ prefix: '', principal: 'human:x@example.co.jp', may_admin: true }]),
     /OCHAKAI_ADMINS/);
   assert.throws(
-    () => parsePolicyDocument('{"rules":[{"prefix":"a","principal":"*","may_admin":"yes"}]}'),
+    () => validateRules([{ prefix: 'a', principal: '*', may_admin: 'yes' }]),
     /may_admin/);
 });
 
-test('a policy that delegates nothing reads as it did before may_admin', () => {
-  const doc = policyDocument([{ prefix: 'sales', principal: '*', may_write: false }]);
-  assert.equal(doc.includes('may_admin'), false);
-  const withAdmin = policyDocument([
-    { prefix: 'sales', principal: 'human:lead@example.co.jp', may_write: true, may_admin: true }]);
-  assert.equal(withAdmin.includes('"may_admin": true'), true);
+// A rule that delegates nothing must not grow the key: a policy read
+// back matches the one that was typed (design doc 0124).
+test('may_admin is carried only where it is set', () => {
+  const [plain] = validateRules([{ prefix: 'sales', principal: '*', may_write: false }]);
+  assert.equal('may_admin' in plain, false);
 });
 
 // The row editor holds a principal as two controls and the wire carries
@@ -142,18 +106,17 @@ test('a principal the ledger cannot spell keeps its text and is still refused', 
   assert.throws(() => validateRules([{ prefix: 'a', principal: 'tanaka@example.co.jp' }]), /principal/);
 });
 
-// The rows and the document go through one check, so neither shape can
-// send what the other would have refused.
-test('the rows the form builds are checked exactly as a pasted document is', () => {
+// What the form builds is normalized once, so what is sent is what a
+// second pass would send again.
+test('normalization is idempotent', () => {
   const rows = [{ prefix: ' /sales/ ', principal: joinPrincipal('human', ' tanaka@example.co.jp '), may_write: true }];
-  assert.deepEqual(validateRules(rows), parsePolicyDocument(policyDocument(validateRules(rows))));
+  assert.deepEqual(validateRules(rows), validateRules(validateRules(rows)));
   assert.deepEqual(validateRules(rows), [
     { prefix: 'sales', principal: 'human:tanaka@example.co.jp', may_write: true }]);
 });
 
-// The form can point at the row it is about; a document can only say it.
-// The position rides on the error so that both surfaces get their own
-// half of the same sentence.
+// The form can point at the row it is about, so the position rides on
+// the error beside the sentence.
 test('a refusal carries the row it is about', () => {
   const bad = [{ prefix: 'a', principal: '*' }, { prefix: 'b', principal: 'nobody' }];
   assert.throws(() => validateRules(bad), e => e.row === 2 && /2 番目/.test(e.message));

--- a/internal/webui/jstest/smoke.mjs
+++ b/internal/webui/jstest/smoke.mjs
@@ -347,15 +347,14 @@ try {
     await waitFor(`${textOf('#loop-stats')}.includes('直近 7 日に起きたこと')`), shown);
 
   // examples/demo keeps its metrics under metrics/, and a scope the base
-  // does not have would draw the same note over nothing at all.
+  // does not have would change nothing at all.
   await evalJS(`(() => { const p = document.querySelector('#loop-prefix'); if (!p) return;
     p.value = 'metrics'; p.dispatchEvent(new Event('input', { bubbles: true })); })()`);
   // Scoped, the misses beside the other numbers are still the whole
-  // instance's and cannot be anything else (design doc 0069 §5.1) — so
-  // the reading says which of its numbers did not narrow.
-  await check('a scoped reading says what it could not scope',
-    await waitFor(`(() => { const t = ${textOf('#loop-stats')};
-      return t.includes('該当なしの検索だけは絞れません') && t.includes('/metrics'); })()`), shown);
+  // instance's and cannot be anything else (design doc 0069 §5.1) — the
+  // one number that did not narrow says so on its tile.
+  await check('a scoped reading marks the number it could not scope',
+    await waitFor(`${textOf('#loop-stats')}.includes('該当なしの検索(全体)')`), shown);
 
   // The access policy (design doc 0109 §5). The tab is absent until the
   // server answers for it, so this is also the check that the probe ran
@@ -365,26 +364,18 @@ try {
     await waitFor(`(() => { const a = document.querySelector('#nav-access');
       return !!a && !a.hidden && getComputedStyle(a).display !== 'none'; })()`), shown);
   await go('#/access');
-  await check('the access policy renders', await waitFor(`${textOf('#view')}.includes('境界はまだありません')`), shown);
-  // The document the CLI's -f takes is still there, seeded from what the
-  // server just sent — behind two disclosures now, which is why this
-  // asks the textarea's value rather than what is on screen.
-  await check('the policy is offered as the document `ochakai access -f` takes',
-    await waitFor(`(() => { const t = document.querySelector('#access-doc');
-      return !!t && t.value.includes('"rules"'); })()`), shown);
-  // A grant is added as a row of controls, and the document is written
-  // from the rows — so what an operator would copy into git is what the
-  // save would send, never a snapshot of how the rows started.
-  await evalJS(`(() => { document.querySelector('#access-edit').open = true;
-    document.querySelector('#access-add').click();
+  // CI's deployment has no policy, so the page opens straight on the
+  // editor with the sentence that says what no grants means.
+  await check('the access policy renders', await waitFor(`${textOf('#view')}.includes('付与が 1 件も無い')`), shown);
+  // A grant is added as a row of controls, and the "no grants yet" line
+  // yields to it.
+  await evalJS(`(() => { document.querySelector('#access-add').click();
     const tr = document.querySelector('#access-rows tbody tr');
     tr.querySelector('[data-f="prefix"]').value = 'metrics';
-    tr.querySelector('[data-f="name"]').value = 'tanaka@example.co.jp';
-    document.querySelector('#access-json').open = true; })()`);
-  await check('a grant typed as a row is the document the CLI takes',
-    await waitFor(`(() => { const t = document.querySelector('#access-doc');
-      return !!t && t.value.includes('"metrics"')
-        && t.value.includes('human:tanaka@example.co.jp'); })()`), shown);
+    tr.querySelector('[data-f="name"]').value = 'tanaka@example.co.jp'; })()`);
+  await check('a grant is typed as a row of controls',
+    await waitFor(`(() => { const tr = document.querySelector('#access-rows tbody tr');
+      return !!tr && document.querySelector('#access-empty').hidden; })()`), shown);
 
   await go('#/new');
   await check('the editor renders', await waitFor(`!!document.querySelector('#view textarea')`), shown);

--- a/internal/webui/static/app.css
+++ b/internal/webui/static/app.css
@@ -458,12 +458,6 @@ table.rules.edit td.who { white-space: nowrap; }
 table.rules.edit td.who select { width: 10rem; }
 table.rules.edit td.who input[type=text] { width: 12rem; margin-left: .35rem; }
 table.rules.edit tr.invalid > td { background: var(--rejected-bg); }
-/* A warning no server field turns on or off: the page cannot know which
-   way it is being served (design doc 0130 §1), so it names both. */
-.caution {
-  background: var(--rejected-bg); border: 1px solid var(--rejected-bd); color: var(--rejected-fg);
-  border-radius: 8px; padding: .6rem .9rem; margin: .8rem 0; font-size: .92rem; max-width: 48rem;
-}
 .stat-tiles { display: grid; grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr)); gap: .8rem; max-width: 42rem; }
 .stat-tiles .tile { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: .9rem 1rem; }
 .tile .num { font-size: 1.7rem; font-weight: 700; }
@@ -661,9 +655,10 @@ mark { background: var(--mark-bg); color: var(--mark-fg); border-radius: 3px; pa
   text-transform: none; margin-bottom: .5rem;
   padding-bottom: .3rem; border-bottom: 1px solid var(--border);
 }
-/* The fields are the taller pane on anything real, so it scrolls inside
-   itself rather than dragging the textarea off the screen. */
-@media (min-width: 901px) { #fm-fields { max-height: 68vh; overflow-y: auto; padding-right: .4rem; } }
+/* The fields flow with the page — an inner scrollbar hid most of the
+   form. The document pane sticks instead, so the text the fields are
+   writing stays in view while the page scrolls. */
+@media (min-width: 901px) { .editor-panes .pane:last-child { position: sticky; top: 3.8rem; } }
 #fm-fields .fieldset { margin-bottom: .9rem; }
 /* The frontmatter's groups hold one to six columns, not three, and a
    fixed trio left an attester's single path a third of the width with
@@ -717,7 +712,7 @@ body.read-only .read-only-note {
    so they take the view's text column: 62rem less the 1.2rem <main>
    insets its text by, which puts a banner's edge where the first line
    of the page starts. */
-.dev-note, .sandbox-note, .setup-note {
+.dev-note, .sandbox-note {
   max-width: calc(min(62rem, 100%) - 2.4rem); margin: 1.4rem auto 0;
 }
 /* A sandbox is writable, so nothing is hidden — what it needs is to
@@ -740,20 +735,6 @@ body.sandbox .sandbox-note {
   border-radius: 8px; padding: .6rem .9rem;
   font-size: .92rem;
 }
-/* What the deployment cannot do because a variable is unset, shown to
-   whoever may set it (design doc 0131). Quieter than both of its
-   neighbours: nothing here is being lost or misrecorded — something is
-   simply not switched on — and the caller reading it is the one person
-   who can end it. Hidden until api.js fills it, since an administrator
-   is not something the page can tell on its own. */
-.setup-note {
-  background: var(--surface); border: 1px dashed var(--border);
-  border-radius: 8px; padding: .6rem .9rem;
-  font-size: .92rem; color: var(--muted);
-}
-.setup-note code { font-size: .92em; }
-.setup-note .who { display: block; margin-top: .3rem; font-size: .88em; }
-
 /* A deployment with no bucket stores markdown concepts only (design doc
    0075 §1), so every affordance that would write or read a file can only
    be refused. Hidden rather than disabled, for the reason the read-only

--- a/internal/webui/static/index.html
+++ b/internal/webui/static/index.html
@@ -77,17 +77,11 @@
          not to deploy it, which is why the page says it too — the
          deployments that need telling are the ones that did it anyway. -->
     <div class="dev-note" role="status">
-      <strong>認証が無効になっています(<code>OCHAKAI_MODE=dev</code>)。</strong>この URL に届いた人は、誰の名前でも名乗れます。検証も却下も名乗ったとおりに記録されるため、<strong>このベースでは「人が確認した」という記録に意味がありません</strong>。開発専用の設定です。共有された URL でこれをご覧になっている場合は、意図しない公開です。
+      <strong>認証が無効です(<code>OCHAKAI_MODE=dev</code>)。</strong>開発専用です。
     </div>
     <div class="sandbox-note" role="status">
-      <strong>ここはサンドボックスです。</strong>誰でも書き込めて、誰も識別されず、ナレッジベース全体が定期的に初期化されます。ここに書いたものは、すべて消えます。試すための場所ですので、ナレッジを下書きし、検証し、結果を報告してみてください。<strong>失って困るものは置かないでください。</strong>
+      <strong>ここはサンドボックスです。</strong>誰でも書き込めて、全体が定期的に初期化されます。<strong>失って困るものは置かないでください。</strong>
     </div>
-    <!-- What this deployment cannot do because a variable is unset, for
-         the caller who could set it (design doc 0131). Written by
-         api.js from the server's own answer and empty otherwise: the
-         page does not know who is an administrator and never decides it
-         — the variable is on the answer or it is not. -->
-    <div class="setup-note" id="setup-note" role="status" hidden></div>
     <!-- tabindex="-1" so the router can move focus here after a
        navigation: the view is replaced in place, and without it a
        keyboard or screen-reader user stays where the last click left

--- a/internal/webui/static/js/actions.js
+++ b/internal/webui/static/js/actions.js
@@ -5,7 +5,7 @@
 import { READ_ONLY, api, toast } from './api.js';
 import { withStatus } from './documents.js';
 import { $ } from './dom.js';
-import { idPath } from './format.js';
+import { conceptURL, idPath } from './format.js';
 import { refreshQueues } from './queues.js';
 import { refreshTree } from './tree.js';
 

--- a/internal/webui/static/js/api.js
+++ b/internal/webui/static/js/api.js
@@ -2,7 +2,6 @@
 // it turns responses into, the read-only banner, and the toast.
 
 import { $ } from './dom.js';
-import { esc } from './escape.js';
 
 // The page always talks to its own origin — both serving paths
 // (`ochakai ui`, `ochakai serve-ui`) proxy /api/v1 with the right
@@ -43,13 +42,16 @@ export async function markPosture() {
 // What this deployment cannot do, and who gets told how to change it
 // (design doc 0131).
 //
-// Two sentences out of one answer. The capability is everybody's,
-// because everybody is who a button that can only fail would have lied
-// to — so the affordance goes away for every caller, the way the write
-// affordances go away on a read-only deployment. The variable that turns
-// it on is an operator's sentence, and it arrives only for a caller the
-// server considers an administrator: **the page never decides who is
-// who**, it renders what the answer carried (design doc 0130 §1).
+// The capability is everybody's, because everybody is who a button that
+// can only fail would have lied to — so the affordance goes away for
+// every caller, the way the write affordances go away on a read-only
+// deployment. The variable that turns it on is an operator's sentence,
+// and it arrives only for a caller the server considers an
+// administrator: **the page never decides who is who**, it renders what
+// the answer carried (design doc 0130 §1). It is kept here and drawn on
+// the files tab — the one place somebody meets the refusal — rather
+// than as a page-wide banner.
+export let FILES_VARIABLE = '';
 function markCapabilities(s) {
   // Absent is not "off". A server that predates the field answers
   // nothing here, and the page goes on offering what it always offered
@@ -57,13 +59,7 @@ function markCapabilities(s) {
   const files = s.files;
   if (!files || files.enabled !== false) return;
   document.body.classList.add('no-files');
-  if (!files.variable) return;
-  const note = $('#setup-note');
-  note.innerHTML = `<strong>このデプロイはファイルを保存できません。</strong>`
-    + `<code>${esc(files.variable)}</code> にバケットを設定すると、ナレッジに画像・PDF・テキストを添付できるようになります。`
-    + `設定するまで、ファイルの追加はどの面からも断られます。`
-    + `<span class="who">この案内は、このデプロイの管理者にだけ表示されています。</span>`;
-  note.hidden = false;
+  FILES_VARIABLE = files.variable || '';
 }
 
 // The archive is a representation of the bundle root, asked for with an

--- a/internal/webui/static/js/frontmatter.js
+++ b/internal/webui/static/js/frontmatter.js
@@ -34,55 +34,45 @@ const RUNTIMES = ['bigquery', 'postgres', 'dbt', 'python', 'looker'];
 // generated. A producer's own key is not here either — it has no field,
 // and it is not lost: the document keeps it, and the form says so.
 export const FIELDS = [
-  {
-    key: 'type', kind: 'combo', label: '型', options: KNOWN_TYPES, required: true,
-    hint: 'OKF が必須にする唯一のキーです。一覧は推奨の語彙で、どんな文字列でも書けます。',
-  },
-  {
-    key: 'title', kind: 'text', label: 'タイトル',
-    hint: '空のままなら、ID の最後の区切りが名前になります。',
-  },
+  { key: 'type', kind: 'combo', label: '型', options: KNOWN_TYPES, required: true },
+  { key: 'title', kind: 'text', label: 'タイトル' },
   { key: 'description', kind: 'prose', label: '説明', hint: '一文で。検索結果と一覧に出ます。' },
   {
     key: 'resource', kind: 'text', label: '実体の場所',
     placeholder: 'bigquery://project/dataset/table',
-    hint: 'この知識が指している物の正準 URI です。テーブル、ダッシュボード、外部ページなど。',
+    hint: 'この知識が指している物の URI。テーブル、ダッシュボード、外部ページなど。',
   },
   { key: 'tags', kind: 'list', label: 'タグ', placeholder: 'sales' },
   {
     key: 'sources', kind: 'rows', label: '出典', addLabel: '出典を足す',
-    hint: 'この知識が何から導かれたかです。書いた人しか知らないので、ochakai は埋められません。',
+    hint: 'この知識が何から導かれたかです。',
     columns: [
       { name: 'resource', label: '場所', placeholder: 'bigquery://project/dataset/table' },
       { name: 'title', label: '見出し' },
-      { name: 'id', label: '識別子', hint: '本文から個別に引くときの鍵です。' },
+      { name: 'id', label: '識別子' },
       { name: 'author', label: '作成者', placeholder: 'human:tanaka@example.co.jp' },
       { name: 'usage_count', label: '参照回数', kind: 'number' },
       { name: 'last_modified', label: '最終更新', kind: 'date' },
     ],
   },
   {
-    key: 'usage_window', kind: 'object', label: '参照回数を数えた期間',
+    key: 'usage_window', kind: 'object', label: '参照回数を数えた期間', onlyIfPresent: true,
     hint: '上の参照回数が、いつからいつまでを数えたものかです。',
     columns: [
       { name: 'from', label: '開始', kind: 'date' },
       { name: 'to', label: '終了', kind: 'date' },
     ],
   },
-  {
-    key: 'status', kind: 'enum', label: '状態', options: STATUSES,
-    hint: '書かなければ stable として読まれます(SPEC §5.4)。誰が確認したかは別の台帳で、ここでは決まりません。',
-  },
-  {
-    key: 'stale_after', kind: 'date', label: '再確認日',
-    hint: 'この日を過ぎたら見直す、という日付です。過ぎても隠れません。',
-  },
+  { key: 'status', kind: 'enum', label: '状態', options: STATUSES },
+  { key: 'stale_after', kind: 'date', label: '再確認日' },
   {
     key: 'runtime', kind: 'combo', label: '実行環境', options: RUNTIMES,
+    types: ['Attested Computation'],
     hint: '計算を約束する型では必須です(SPEC §10.2)。ochakai は記録するだけで、実行はしません。',
   },
   {
     key: 'parameters', kind: 'rows', label: 'パラメータ', addLabel: 'パラメータを足す',
+    types: ['Attested Computation'],
     hint: 'エージェントが埋める穴です。',
     columns: [
       { name: 'name', label: '名前', placeholder: 'year' },
@@ -92,10 +82,12 @@ export const FIELDS = [
   },
   {
     key: 'computation', kind: 'text', label: '計算の置き場所',
+    types: ['Attested Computation'],
     hint: '空のままなら、本文の <code># Computation</code> のコードブロックが計算です。',
   },
   {
     key: 'executor', kind: 'object', label: '実行のしかた',
+    types: ['Attested Computation'],
     columns: [
       { name: 'resource', label: '手順・コードの場所' },
       { name: 'receipt', label: '実行が返すべき項目', kind: 'list' },
@@ -103,6 +95,7 @@ export const FIELDS = [
   },
   {
     key: 'attester', kind: 'object', label: '検証のしかた',
+    types: ['Attested Computation'],
     hint: '実行が正しく行われたかを機械的に確かめるコードの場所です。',
     columns: [{ name: 'resource', label: 'コードの場所' }],
   },
@@ -179,12 +172,28 @@ function scalarValue(col, raw) {
 
 // ---- markup -----------------------------------------------------------
 
-// fieldsMarkup renders every field from the frontmatter's values. The
-// values come from the server's read of the document, so what is drawn
-// here is the document — not a second store the page keeps beside it.
+// visibleFields picks the fields worth drawing for this document. A key
+// the document carries always gets its editor — hiding one would make it
+// uneditable without saying so. A field tied to types (the Attested
+// Computation contract, SPEC §10.2) appears only when the type asks for
+// it, and one marked onlyIfPresent stays away until a document brings
+// the key: every field at once was a form nobody could see whole.
+export function visibleFields(values) {
+  const v = values || {};
+  return FIELDS.filter(f => {
+    if (v[f.key] !== undefined) return true;
+    if (f.types) return f.types.includes(v.type);
+    return !f.onlyIfPresent;
+  });
+}
+
+// fieldsMarkup renders the visible fields from the frontmatter's values.
+// The values come from the server's read of the document, so what is
+// drawn here is the document — not a second store the page keeps beside
+// it.
 export function fieldsMarkup(values) {
   const v = values || {};
-  return FIELDS.map(f => fieldMarkup(f, v[f.key])).join('');
+  return visibleFields(v).map(f => fieldMarkup(f, v[f.key])).join('');
 }
 
 export function fieldMarkup(field, value) {

--- a/internal/webui/static/js/policy.js
+++ b/internal/webui/static/js/policy.js
@@ -1,9 +1,8 @@
-// The access policy as rows and as a document (design doc 0109 §5): the
-// grants an operator edits, the text the CLI takes, and the validation
-// both go through before either is sent.
+// The access policy as rows (design doc 0109 §5): the grants an operator
+// edits, and the validation they go through before being sent.
 //
 // A module of its own, importing nothing a browser has to provide, for
-// the reason documents.js is one — the round trip is what a test can
+// the reason documents.js is one — the normalization is what a test can
 // hold, and this is the half of the access view worth holding.
 
 // The spellings a grant can name, mirroring domain.ValidPrincipal.
@@ -13,61 +12,14 @@
 export const ACTOR_KINDS = ['human', 'process'];
 export const ANY_PRINCIPAL = '*';
 
-// policyDocument renders the rules as the document the API takes back —
-// the same one `ochakai access --json` prints and `-f` reads, so an
-// operator can move a policy between the two surfaces by copying it.
-//
-// granted_at and granted_by are left out. The server records them and
-// ignores them on write, so a document that carried them would invite an
-// edit that silently does nothing; who granted what belongs in the table
-// above the editor, where nothing looks editable.
-//
-// Nothing here validates: the rows in front of the operator are allowed
-// to be half-typed, and this is what shows them the document they are
-// building out of them. The save is the one place that refuses.
-export function policyDocument(rules) {
-  const body = (rules || []).map(r => ({
-    prefix: r.prefix || '',
-    principal: r.principal || '',
-    may_write: r.may_write === true,
-    // Carried only where it is set, so a policy that delegates nothing
-    // reads exactly as it did before this field existed (design doc 0124).
-    ...(r.may_admin === true ? { may_admin: true } : {}),
-  }));
-  return JSON.stringify({ rules: body }, null, 2) + '\n';
-}
-
-// parsePolicyDocument turns the document back into rules, or throws a
-// sentence naming the row that is wrong.
-//
-// The server validates all of this again and stays the only judge — this
-// is here because it can say *which row*, and what is in front of the
-// operator is a thing with rows. The same division the concept editor
-// draws with its frontmatter check (design doc 0044 §2.3).
-export function parsePolicyDocument(text) {
-  let doc;
-  try {
-    doc = JSON.parse(text);
-  } catch (e) {
-    throw new Error('JSON として読めません: ' + e.message);
-  }
-  if (!doc || typeof doc !== 'object' || Array.isArray(doc)) {
-    throw new Error('rules を一つ持つオブジェクトにしてください。');
-  }
-  if (!Array.isArray(doc.rules)) {
-    throw new Error('rules の配列がありません。付与を全部消すなら {"rules": []} です。');
-  }
-  return validateRules(doc.rules);
-}
-
-// validateRules is the check both editors share: the rows the form holds
-// and the rows a pasted document parses to are one thing by the time
-// they arrive here, so neither shape can send what the other would have
-// refused.
+// validateRules normalizes the rows the form holds into the rules the
+// wire takes, or throws a sentence naming the row that is wrong. The
+// server validates all of this again and stays the only judge — this is
+// here because it can say *which row*, and what is in front of the
+// operator is a thing with rows.
 //
 // The error carries the position it is about (`row`, 1-based) as well as
-// naming it in the sentence, because the form can point at the row and a
-// document cannot.
+// naming it in the sentence.
 export function validateRules(list) {
   const seen = new Set();
   return (list || []).map((r, i) => {

--- a/internal/webui/static/js/queues.js
+++ b/internal/webui/static/js/queues.js
@@ -27,20 +27,22 @@ export async function refreshQueues() {
   badge.textContent = total;
   badge.hidden = !total;
   badge.title = total ? `未処理 ${total} 件(draft ${waiting.drafts}・再検証 ${waiting.failed}・期限切れ ${waiting.stale_after})` : '';
-  const strip = $('#queue-strip');
-  if (strip) strip.innerHTML = queueStrip();
 }
 
 // The same three numbers as links into the feed each one counts. Zero is
 // worth printing here (unlike on the tab): on the review page it is the
 // answer to "is there anything else", and it is an answer nothing gave
 // before.
-export function queueStrip() {
-  if (!waiting) return '';
+//
+// counts defaults to the whole instance's; the review page passes the
+// queues from its own scoped stats call, so the strip narrows with the
+// numbers and the draft list around it.
+export function queueStrip(counts = waiting) {
+  if (!counts) return '';
   return [
-    ['#/review', waiting.drafts, 'draft'],
-    ['#/search/reported-wrong', waiting.failed, '再検証'],
-    ['#/search/stale', waiting.stale_after, '期限切れ'],
+    ['#/review', counts.drafts, 'draft'],
+    ['#/search/reported-wrong', counts.failed, '再検証'],
+    ['#/search/stale', counts.stale_after, '期限切れ'],
   ].map(([href, n, label]) =>
     `<a class="badge${n ? ' draft' : ''}" href="${href}">${label} ${n}</a>`).join(' ');
 }

--- a/internal/webui/static/js/views/access.js
+++ b/internal/webui/static/js/views/access.js
@@ -1,26 +1,24 @@
 // Who may read and write under which directory (design doc 0109), on
 // the surface the person who decides it already uses.
 //
-// One table to read and one table to edit, and behind both the same
-// document. The policy is read as a set, because that is how the
-// question arrives — "who can see personnel/" is answered by reading all
-// of it — and it is sent as a set too: the save replaces the whole
-// document the way `ochakai access -f` does, which is what §5 decided
-// and what keeps the wire at one verb instead of three.
+// One table to read and one table to edit. The policy is read as a set,
+// because that is how the question arrives — "who can see personnel/" is
+// answered by reading all of it — and it is sent as a set too: the save
+// replaces the whole policy the way `ochakai access -f` does, which is
+// what §5 decided and what keeps the wire at one verb instead of three.
 //
-// What the rows are is the *editing* of that document. Spelling
-// `human:` and a pair of booleans into JSON by hand is not what deciding
-// a boundary is, and a JSON syntax error is the worst thing to meet
-// while doing it. The document stays one disclosure away, because it is
-// the form the CLI takes and the form that goes into git.
+// The rows are the whole editor. Spelling `human:` and a pair of
+// booleans into JSON by hand is not what deciding a boundary is, and a
+// JSON syntax error is the worst thing to meet while doing it — the
+// JSON form stays on the CLI (`ochakai access --json` / `-f`), which is
+// where git and automation take it from.
 
 import { api, toast } from '../api.js';
 import { $, view } from '../dom.js';
 import { esc } from '../escape.js';
 import { fmtDate } from '../format.js';
 import {
-  ACTOR_KINDS, ANY_PRINCIPAL, joinPrincipal, parsePolicyDocument, policyDocument,
-  splitPrincipal, validateRules,
+  ACTOR_KINDS, ANY_PRINCIPAL, joinPrincipal, splitPrincipal, validateRules,
 } from '../policy.js';
 import { knownDirs } from '../tree.js';
 
@@ -50,7 +48,7 @@ export async function viewAccess() {
       : `<div class="error-banner" role="alert">アクセスポリシーを読み込めませんでした: ${esc(e.message)}</div>`);
     return;
   }
-  renderAccess(rules, false, version);
+  renderAccess(rules, version);
 }
 
 function ruleRow(r) {
@@ -117,13 +115,10 @@ function editRow(r) {
   </tr>`;
 }
 
-// open keeps the editor open across the re-render a save causes, so the
-// operator reads back the policy they just sent — which is the whole of
-// the advice `ochakai access` gives at the terminal.
 // version is what the editor sends back as If-Match: the page saves the
 // policy it read, and refuses rather than dropping the rules somebody
 // else added in between (design doc 0120).
-export function renderAccess(rules, open = false, version = '') {
+export function renderAccess(rules, version = '') {
   const table = rules.length ? `
     <div class="scroll-x">
       <table class="rules">
@@ -137,22 +132,13 @@ export function renderAccess(rules, open = false, version = '') {
     <code>sales/sample</code> も書けます。表に無いところは、その人には <strong>404</strong> です。見えないのではなく、無いものとして答えます。</p>
     <p style="color:var(--muted);max-width:48rem;font-size:.9rem">バンドル全体にまたがる操作
     (統計・エクスポート・<code>move</code>・再埋め込み・このポリシー自身)は管理者のものです。塞げないものが一つあります。読めるナレッジの本文が、隠した id を名指していれば、その id は本文の中で読めてしまいます。この表が約束するのは、一覧・検索・取得・エクスポート・履歴から<em>出てこない</em>ことまでです。</p>`
-    : `<div class="empty" style="padding:1.5rem 0">境界はまだありません。</div>
-    <p style="color:var(--muted);max-width:48rem;font-size:.9rem">付与が一行も無いデプロイでは、ここに届いた人が全部を読み書きします。<strong>最初の一行が、全員に対して同時に境界を入れます。</strong>段階的に効かせる仕組みはありません。部門ごとに秘匿しながら全社の用語集は検証済みのまま共有する、といった、デプロイを分けるだけでは実現できない要件のための機構です。</p>`;
+    : '';
 
   view.innerHTML = `
     <div class="section-title">アクセス</div>
     ${table}
     <div class="read-only-note">この ochakai は read-only のため、ポリシーは表示のみです。知識の側だけが凍結されて境界は動かせる、という状態を作らないためです。</div>
-    <details class="write-only" id="access-edit"${open ? ' open' : ''}>
-      <summary style="cursor:pointer">編集する</summary>
-      <div class="caution">
-        <strong>保存が誰として記録されるかは、この UI の配り方で決まります。</strong>
-        <code>ochakai ui</code> なら、あなた自身(<code>human:…</code>)です。
-        <code>ochakai serve-ui</code> を IAP 無しで置いた場合は、全員が同じサービスアカウント
-        (<code>process:…</code>)に畳まれるため、<strong>この URL に届く全員がこのポリシーを編集できます</strong>。ポリシーに履歴はありません。残るのは、いまの表と、それを設定した人だけです。
-      </div>
-      <p style="color:var(--muted);max-width:48rem;font-size:.9rem">この表が<strong>ポリシーの全部</strong>です。保存すると、いまサーバーにあるものが、ここに並んでいる行で丸ごと置き換わります。行を消して保存すれば、その付与は無くなります。「ディレクトリ」を空にするとバンドル全体で、入力欄には読み込み済みのディレクトリが候補として出ます。</p>
+    <div class="write-only" id="access-edit">
       <div class="scroll-x">
         <table class="rules edit" id="access-rows">
           <thead><tr><th>ディレクトリ</th><th>対象</th><th>できること</th><th></th></tr></thead>
@@ -160,24 +146,13 @@ export function renderAccess(rules, open = false, version = '') {
         </table>
       </div>
       <datalist id="access-dirs">${knownDirs().map(p => `<option value="${esc(p)}">`).join('')}</datalist>
-      <div id="access-empty" class="empty" style="padding:.8rem 0"${rules.length ? ' hidden' : ''}>付与はまだ一行もありません。</div>
+      <div id="access-empty" class="empty" style="padding:.8rem 0"${rules.length ? ' hidden' : ''}>付与が 1 件も無いあいだは、誰でもすべてを読み書きできます。1 件でも付与すると、全員に同時にアクセス権限境界が入ります。</div>
       <div class="toolbar"><button class="btn small" id="access-add" type="button">＋ 行を追加</button></div>
       <div id="access-error"></div>
-      <details id="access-json">
-        <summary style="cursor:pointer;color:var(--muted);font-size:.9rem">JSON として扱う</summary>
-        <p style="color:var(--muted);max-width:48rem;font-size:.9rem"><code>ochakai access --json</code> が出力するもの、<code>-f</code> が受け取るものと同じ形式です。上の表をそのまま写しているので、git に入れる文書はここからコピーします。貼り付けたものを表に入れるには「行に取り込む」を押してください — 保存が送るのは、いつでも上の表です。</p>
-        <textarea id="access-doc" rows="12" class="mono" spellcheck="false"
-          aria-label="アクセスポリシーの文書">${esc(policyDocument(rules))}</textarea>
-        <div id="access-json-error"></div>
-        <div class="toolbar" style="justify-content:flex-end">
-          <button class="btn small" id="access-import" type="button">行に取り込む</button>
-        </div>
-      </details>
       <div class="toolbar" style="justify-content:flex-end">
-        <button class="btn" id="access-reset" type="button">サーバーの内容に戻す</button>
         <button class="btn primary" id="access-save" type="button">保存</button>
       </div>
-    </details>`;
+    </div>`;
 
   const rowsBody = $('#access-rows tbody');
   if (!rowsBody) return; // read-only: the editor is not on the page
@@ -215,46 +190,12 @@ export function renderAccess(rules, open = false, version = '') {
     afterRowsChanged();
     rowsBody.lastElementChild.querySelector('[data-f="prefix"]').focus();
   });
-  $('#access-reset').addEventListener('click', () => {
-    rowsBody.innerHTML = rules.map(editRow).join('');
-    $('#access-error').innerHTML = '';
-    afterRowsChanged();
-  });
   $('#access-save').addEventListener('click', () => saveAccess(rules, version));
-  // The document is written from the rows every time it is opened, so
-  // what is copied out of it is what would be saved — never a stale
-  // snapshot of the rows as they were rendered.
-  $('#access-json').addEventListener('toggle', e => {
-    if (e.target.open) syncDocument();
-  });
-  $('#access-import').addEventListener('click', () => importDocument());
 }
 
-// afterRowsChanged keeps the two things that describe the rows honest:
-// the "nothing here yet" line and the document behind the disclosure.
+// afterRowsChanged keeps the "nothing here yet" line honest.
 function afterRowsChanged() {
   $('#access-empty').hidden = !!$('#access-rows tbody').children.length;
-  if ($('#access-json').open) syncDocument();
-}
-
-function syncDocument() {
-  $('#access-doc').value = policyDocument(currentRules());
-}
-
-function importDocument() {
-  const errBox = $('#access-json-error');
-  errBox.innerHTML = '';
-  let next;
-  try {
-    next = parsePolicyDocument($('#access-doc').value);
-  } catch (e) {
-    errBox.innerHTML = `<div class="error-banner" role="alert">${esc(e.message)}</div>`;
-    return;
-  }
-  $('#access-rows tbody').innerHTML = next.map(editRow).join('');
-  $('#access-error').innerHTML = '';
-  afterRowsChanged();
-  toast(`${next.length} 行を表に取り込みました。まだ保存していません。`);
 }
 
 // currentRules reads the rows as they stand, without judging them: the
@@ -303,7 +244,7 @@ async function saveAccess(rules, version) {
     const saved = await api('/api/v1/access',
       { method: 'PUT', body: { rules: next }, ifMatch: version ? `"${version}"` : undefined });
     toast('アクセスポリシーを保存しました。');
-    renderAccess(saved.rules || [], true, saved.version);
+    renderAccess(saved.rules || [], saved.version);
   } catch (e) {
     // The precondition failed: somebody replaced the policy while this
     // page held it. Saying so is the whole point — the alternative was

--- a/internal/webui/static/js/views/detail.js
+++ b/internal/webui/static/js/views/detail.js
@@ -2,7 +2,7 @@
 // history, and the actions a reader can take on it.
 
 import { applyStatus, liftRejection, moveEntry, rejectEntry, verifyEntry } from '../actions.js';
-import { BASE, api, toast } from '../api.js';
+import { BASE, FILES_VARIABLE, api, toast } from '../api.js';
 import { hitCard } from '../cards.js';
 import { copyText } from '../clipboard.js';
 import { diffHTML, diffLines, diffStats } from '../diff.js';
@@ -154,11 +154,11 @@ export async function viewDetail(id, heading = '') {
   ].filter(Boolean).join(' · ');
 
   // A passed stale_after is a prompt to re-check, never a claim the entry
-  // is wrong (OKF SPEC §5.5) — the comparison is a plain date one.
-  const staleNote = entry.stale_after
-    ? (entry.stale_after <= new Date().toISOString().slice(0, 10)
-        ? `<div class="status-note">${esc(entry.stale_after)} から期限切れです。内容を確かめ直してください。</div>`
-        : `<div class="provenance">${esc(entry.stale_after)} まで(stale_after)</div>`)
+  // is wrong (OKF SPEC §5.5) — the comparison is a plain date one. A
+  // date still in the future says nothing a reader needs yet, so nothing
+  // is drawn until it passes.
+  const staleNote = entry.stale_after && entry.stale_after <= new Date().toISOString().slice(0, 10)
+    ? `<div class="status-note">${esc(entry.stale_after)} から期限切れです。内容を確かめ直してください。</div>`
     : '';
 
   const tags = (entry.tags || []).map(t => `<span class="tag">${esc(t)}</span>`).join(' ');
@@ -295,17 +295,13 @@ export async function viewDetail(id, heading = '') {
     // redrew a slice of the frontmatter in some other shape — which is
     // the duplication document-first exists to remove, and the reason
     // design doc 0044 puts the format itself in front of the reader.
-    document: () => `
-      <p class="provenance" style="margin:0 0 .8rem">ochakai が保存しているままのドキュメントです。
-      OKF の frontmatter と markdown で、「編集」が開くのも export が書き出すのも、このテキストです。</p>
-      <pre class="mono">${esc(document_)}</pre>`,
+    document: () => `<pre class="mono">${esc(document_)}</pre>`,
     // Read-only: links come from the body's markdown links (design doc
     // 0024), so the body editor is where they are changed.
     links: () => {
       const links = entry.links || [];
       if (!links.length) return '<div class="empty">本文はまだ他のナレッジを指していません。</div>';
-      return `<p class="provenance" style="margin:0 0 .8rem">本文の markdown リンクから取り出しています。変更するには本文を編集してください。</p>`
-        + '<table class="kv">' + links.map(l => {
+      return '<table class="kv">' + links.map(l => {
         const target = String(l.target || '').replace(/^ochakai:\/\//, '');
         const href = target ? '#/k/' + idPath(target) : null;
         const text = l.text || target.split('/').pop() || target;
@@ -340,15 +336,17 @@ export async function viewDetail(id, heading = '') {
       }).join('');
       return `
         ${cards || '<div class="empty files-only">ファイルはありません。</div>'}
-        <div class="empty files-off">このデプロイはファイルを保存しません。ナレッジは markdown だけです。</div>
+        <div class="empty files-off">このデプロイはファイルを保存しません。${FILES_VARIABLE
+          ? `<br><code>${esc(FILES_VARIABLE)}</code> にバケットを設定すると添付できるようになります。`
+          : ''}</div>
         <div class="toolbar write-only files-only" style="margin-top:1rem">
           <input type="file" id="att-file" accept="image/png,image/jpeg,image/webp,application/pdf,text/plain,.txt,.csv,.json" multiple hidden>
           <button class="btn small" id="att-choose">ファイルを選択…</button>
           <span class="provenance" id="att-chosen" style="margin:0"></span>
           <button class="btn small primary" id="att-upload">ファイルを追加</button>
         </div>
-        <p class="provenance write-only files-only">形式は問わず、1 ファイル 5 MiB までです。本文から参照しておくと
-        (<code>![alt](${esc(lastSeg)}/name.png)</code> または <code>[name](${esc(lastSeg)}/name.txt)</code>)、検索で見つかるようになり、OKF export にも残ります。</p>`;
+        <p class="provenance write-only files-only">本文から参照しておくと
+        (<code>![alt](${esc(lastSeg)}/name.png)</code> または <code>[name](${esc(lastSeg)}/name.txt)</code>)、埋め込みできるようになります。</p>`;
     },
     linked: () => '<div class="empty">…</div>',
     usage: () => '<div class="empty">…</div>',
@@ -396,13 +394,12 @@ export async function viewDetail(id, heading = '') {
           <div class="tile"><div class="num">${u.worked ?? 0}</div><div class="lbl">成功</div></div>
           <div class="tile"><div class="num">${u.failed ?? 0}</div><div class="lbl">失敗</div></div>
         </div>
-        <p class="provenance">${u.last_used_at ? '最終利用: ' + esc(fmtDate(u.last_used_at)) : 'まだ使われていません'}</p>`;
+        <p class="provenance">${u.last_used_at ? '最終利用日: ' + esc(fmtDate(u.last_used_at)) : 'まだ使われていません'}</p>`;
     },
     linked: async () => {
       const { hits: entries = [] } = await api('/api/v1/search?links_to=' + encodeURIComponent(entry.id) + '&limit=100');
       return () => (entries && entries.length)
-        ? `<p class="provenance" style="margin:0 0 .8rem">このナレッジを指しているナレッジです。このナレッジ自身のリンクは「リンク」タブにあります。</p>`
-          + entries.map(hitCard).join('')
+        ? entries.map(hitCard).join('')
         : '<div class="empty">このナレッジを指しているものは、まだありません。</div>';
     },
     history: async () => {
@@ -429,9 +426,7 @@ export async function viewDetail(id, heading = '') {
           </td>
         </tr>`;
       }).join('');
-      return () => `
-        <p class="provenance" style="margin:0 0 .8rem">すべての変更を新しい順に並べています。誰が何を変えたのかを差分で、そのときの全文をドキュメントで確かめられます。</p>
-        <table class="kv">${rows}</table>`;
+      return () => `<table class="kv">${rows}</table>`;
     },
   };
   // Links to concepts that are not there, drawn as what they are. The

--- a/internal/webui/static/js/views/editor.js
+++ b/internal/webui/static/js/views/editor.js
@@ -63,9 +63,6 @@ export async function viewEditor(id, prefix = '') {
           <input type="text" id="e-id" class="mono" value="${esc(entryID)}"
                  placeholder="sales/monthly-revenue"
                  ${editing ? 'disabled' : 'required'}>
-          <div class="hint">${editing
-            ? 'ナレッジの置き場所です(移動はナレッジのページから行います)。'
-            : 'ディレクトリを「/」で区切ったフルパスです。最後の区切りがナレッジの名前になります(例: 売上、monthly-revenue)。一緒に読まれるべきものは、一緒に置いてください。'}</div>
         </div>`;
 
   view.innerHTML = `
@@ -82,7 +79,7 @@ export async function viewEditor(id, prefix = '') {
         <div class="pane">
           <div class="pane-head">ドキュメント</div>
           <textarea id="e-doc" rows="30" class="mono" spellcheck="false" required>${esc(doc)}</textarea>
-          <div class="hint"><code>---</code> の行にはさまれた OKF frontmatter、そのあとに markdown を書きます。左の欄はこの本文を読んで描かれ、左で直すとここが書き換わります。どちらで書いても、保存されるのはこのドキュメントです。他のナレッジへは、そのパスへの markdown リンク(<code>[revenue](/metrics/revenue.md)</code>)で結ぶと、両方向のリンクになります。ochakai が定義していないキーは書いたまま保たれます。サーバーが持つキー(<code>generated</code>・<code>verified</code>・<code>created_by</code>)は、あなたが決めるものではないため、書いてあっても無視されます。</div>
+          <div class="hint">他のナレッジへは、そのパスへの markdown リンク(<code>[revenue](/metrics/revenue.md)</code>)で結びます。</div>
         </div>
       </div>
       <div id="editor-error"></div>
@@ -248,12 +245,16 @@ export async function viewEditor(id, prefix = '') {
       }
     }
     await push(sets, value === undefined ? [field.key] : null);
-    // Only the seeding branch redraws, so a key the type change added
-    // has to reach its own field by hand.
-    for (const k of Object.keys(sets)) {
-      if (k === field.key) continue;
-      const input = fields.querySelector(`[data-fm-key="${k}"]:not([data-fm-path])`);
-      if (input && !input.value) input.value = sets[k];
+    // A type change decides which fields are drawn (frontmatter.js
+    // filters on it), so it is the one non-seeding edit that redraws the
+    // form — the keys it added reach their fields in the same stroke.
+    // Safe here where push's no-redraw rule is not: the change fired
+    // because its writer left the type field.
+    if (field.key === 'type') {
+      await inOrder(async () => {
+        const out = await frontmatter({ document: docEl.value });
+        if (out) draw(out);
+      });
     }
   });
 

--- a/internal/webui/static/js/views/review.js
+++ b/internal/webui/static/js/views/review.js
@@ -1,7 +1,7 @@
 // The review queue: what agents drafted, what was reported wrong, what
 // is past its expiry — and the loop's own numbers above them.
 
-import { rejectEntry, verifyEntry } from '../actions.js';
+import { applyStatus, rejectEntry, verifyEntry } from '../actions.js';
 import { api, toast } from '../api.js';
 import { cardThumbs } from '../cards.js';
 import { $, view } from '../dom.js';
@@ -15,7 +15,7 @@ import { debounce, explore } from './explore.js';
 
 // A draft with zero search hits, older than this, is flagged stale — the
 // inventory case (nobody's finding it; a candidate to drop). Sort=usage
-// already sinks these to the bottom; the toggle isolates them.
+// already sinks these to the bottom; the badge names them there.
 export const STALE_DAYS = 14;
 // The windows the flow numbers can be asked about — `days` on the stats
 // call, whose default is the 30 this page opens with. 180 is the
@@ -26,16 +26,15 @@ export const STALE_DAYS = 14;
 export const STATS_WINDOWS = [7, 30, 90, 180];
 // loaded and cursor walk the draft queue a page at a time (design doc
 // 0050 §2.1): the queue is a ledger, so it has an end rather than a cap.
-// days and prefix are what the loop's numbers above it are asked about;
-// both are parameters the stats call already takes.
-export const review = { staleOnly: false, loaded: [], cursor: '', days: 30, prefix: '' };
+// days is what the loop's numbers are asked about; prefix scopes both
+// the numbers and the draft queue below them, so one control answers
+// "how is my subtree doing, and what of it is waiting on me".
+export const review = { loaded: [], cursor: '', days: 30, prefix: '' };
 
 export function viewReview() {
   view.innerHTML = `
     <div class="section-title">draft のレビューキュー</div>
     <div class="read-only-note">この ochakai は read-only のため、レビューの操作は表示されません。キューそのものは本物です。書き込めるデプロイのレビュアーが解消していくのは、これと同じ列です。</div>
-    <p style="color:var(--muted);max-width:48rem">エージェントが書き戻した draft を、求められている順に並べています。順位を決めるのは検索に出た回数ではなく、実際に読み込まれた回数です。直近の期間を先に見て、同じなら通算で比べます。正しいものは検証し、そうでないものは却下してください(理由が <code>status_note</code> として残るため、エージェントは同じ提案を繰り返さなくなります)。一度も読まれていない draft は下に並ぶので、<em>放置されたものだけ</em>に切り替えると仕分けができます。</p>
-    <p style="color:var(--muted);font-size:.9rem;max-width:48rem">検証済みのナレッジには、それ自身のキューが二つあります。<a href="#/search/reported-wrong">再検証</a>(失敗の報告にまだ応えていないナレッジ)と、<a href="#/search/verification-age">検証の古さ</a>(検証の古いものから順)です。検証し直すと、前者からは消え、後者では最後尾に回ります。三つ目の<a href="#/search/stale">期限切れ</a>は、書き手が宣言した期限を過ぎたナレッジを並べます。こちらは検証では解消せず、ナレッジを編集して期限を宣言し直すと消えます。</p>
     <div class="toolbar" style="margin:.2rem 0 .5rem">
       <label class="check" style="white-space:nowrap">期間
         <select id="loop-days" aria-label="集計期間">${STATS_WINDOWS.map(d =>
@@ -48,13 +47,10 @@ export function viewReview() {
     </div>
     <div id="loop-stats"></div>
     <div class="toolbar">
-      <label class="check"><input type="checkbox" id="r-stale" ${review.staleOnly ? 'checked' : ''}>
-        放置されたものだけ(検索ヒット 0 件・作成から ${STALE_DAYS} 日以上)</label>
       <span class="grow"></span>
       <span id="queue-strip" style="display:flex;gap:.35rem">${queueStrip()}</span>
     </div>
     <div id="review-results"><div class="empty">…</div></div>`;
-  $('#r-stale').addEventListener('change', () => { review.staleOnly = $('#r-stale').checked; runReview(); });
   // The directories the tree has loaded, offered as completions — the
   // same list the move dialog completes against, and the reason the
   // scope is typed as a path rather than picked from a fixed menu:
@@ -63,7 +59,7 @@ export function viewReview() {
   $('#loop-days').addEventListener('change', e => { review.days = Number(e.target.value); loadLoopStats(); });
   $('#loop-prefix').addEventListener('input', e => {
     review.prefix = e.target.value.replace(/^\/+|\/+$/g, '').trim();
-    debounce(loadLoopStats, 250);
+    debounce(() => { loadLoopStats(); runReview(); }, 250);
   });
   refreshQueues();
   runReview();
@@ -107,7 +103,7 @@ function sparkline(weeks) {
     <svg viewBox="0 0 ${weeks.length * (w + gap) - gap} ${h}" width="${weeks.length * (w + gap) - gap}"
          height="${h}" role="img" aria-label="直近 ${weeks.length} 週の検証数、古い順: ${
       weeks.map(week => week.verifications).join('、')}">${bars}</svg>
-    <figcaption>直近 ${weeks.length} 週の検証(計 ${total} 件)。左が古い順です</figcaption>
+    <figcaption>週ごとの検証数(直近 ${weeks.length} 週・計 ${total} 件)</figcaption>
   </figure>`;
 }
 
@@ -154,14 +150,9 @@ export async function loadLoopStats() {
   // request: a caller whose grants cover part of the bundle gets their
   // own numbers whether or not they picked a prefix here (design doc
   // 0123). `scope` absent means the whole bundle.
-  const scope = Array.isArray(s.scope) ? s.scope : null;
-  const scoped = scope !== null;
+  const scoped = Array.isArray(s.scope);
   const withheld = !!s.misses?.withheld;
-  const scopeText = scoped
-    ? (scope.length ? scope.map(p => `<code>/${esc(p)}</code>`).join('、') : 'あなたに見えている範囲')
-    : '';
-  out.innerHTML = (scoped ? `
-    <p style="max-width:48rem;margin:0 0 .8rem;color:var(--muted);font-size:.9rem">${scopeText} の下だけを数えています。<strong>該当なしの検索だけは絞れません。</strong>何も返さなかった検索にはナレッジの id が無いため、どこで尋ねられたかを言えないからです。${withheld ? 'そのため、範囲を持つ利用者には出していません — 全体の数は管理者に尋ねてください。' : 'その数と一覧はインスタンス全体のものです。'}下のキューの帯と draft の一覧も絞っていません。</p>` : '') + `
+  out.innerHTML = `
     <div class="tile-band">いまの姿</div>
     <div class="stat-tiles band" style="max-width:52rem;margin:0 0 1rem">
       <div class="tile"><div class="num">${s.concepts?.total ?? 0}</div><div class="lbl">ナレッジ</div></div>
@@ -183,12 +174,24 @@ export async function loadLoopStats() {
     <p style="max-width:48rem;margin:0 0 1.2rem;color:var(--muted);font-size:.9rem">
       ${truncated} 件のナレッジが、埋め込みモデルの入力窓に収まらず<strong>前半だけ</strong>ベクトル検索に載っています(全 ${s.embedding.vectors} 件中)。後半に書かれた内容では見つかりません。語句そのものが含まれていれば字句検索では見つかります。長すぎるナレッジを分けるか、より広い窓のモデルに移すかのどちらかが必要です。</p>` : '') + (gaps.length ? `
     <details style="max-width:48rem;margin:0 0 1.2rem">
-      <summary style="cursor:pointer;color:var(--muted)">該当なしの検索(${scoped ? '全体・' : ''}次に書くもの)</summary>
-      <p style="color:var(--muted);font-size:.9rem;margin:.5rem 0">直近 ${s.window_days} 日で何も返さなかった検索を、多く尋ねられた順に並べています。誰かが解消するキューではありません。答えになるナレッジが書かれれば、この一覧からは自然に消えます。${scoped ? 'この一覧だけは範囲の指定を受けません。何も返さなかった検索は、どこで尋ねられたかを言えないからです。' : ''}</p>
+      <summary style="cursor:pointer;color:var(--muted)">該当なしの検索(次に書くべきもの)</summary>
+      <p style="color:var(--muted);font-size:.9rem;margin:.5rem 0">直近 ${s.window_days} 日で何も返さなかった検索を、多く尋ねられた順に並べています。</p>
       ${gaps.map(g => `<div style="display:flex;gap:.6rem;align-items:baseline;padding:.25rem 0">
         <span class="badge">${g.count}×</span>
         <a href="#/search" class="mono" data-gap="${esc(g.query)}">${esc(g.query)}</a></div>`).join('')}
     </details>` : '');
+  // The strip is drawn from this same answer, so its depths narrow with
+  // the band and the draft list around it (QueueCounts takes the same
+  // filter the feeds take, design doc 0049). A scoped count has to lead
+  // to a scoped feed, so the links carry the prefix into the search view.
+  const strip = $('#queue-strip');
+  if (strip) {
+    strip.innerHTML = queueStrip(s.queues);
+    if (review.prefix) {
+      strip.querySelectorAll('a[href^="#/search/"]').forEach(a =>
+        a.addEventListener('click', () => { explore.prefix = review.prefix; }));
+    }
+  }
   // A gap is a question; clicking it asks it again, which is how a
   // curator sees what is there before writing what is not.
   out.querySelectorAll('[data-gap]').forEach(a => a.addEventListener('click', () => {
@@ -210,17 +213,18 @@ export async function runReview(append = false) {
   const my = runReview._seq = (runReview._seq || 0) + 1;
   const limit = 100;
   let url = '/api/v1/search?sort=usage&status=draft&limit=' + limit;
+  // The scope control above narrows this queue too, so the numbers and
+  // the cards under them answer about the same subtree.
+  if (review.prefix) url += '&prefix=' + encodeURIComponent(review.prefix);
   if (append && review.cursor) url += '&cursor=' + encodeURIComponent(review.cursor);
   else { review.loaded = []; review.cursor = ''; }
   try {
     const page = await api(url);
     if (my !== runReview._seq || out !== $('#review-results')) return; // stale response
-    const hits = review.loaded = review.loaded.concat(page.hits || []);
+    const list = review.loaded = review.loaded.concat(page.hits || []);
     review.cursor = page.cursor || '';
-    let list = hits;
-    if (review.staleOnly) list = list.filter(isStaleDraft);
     if (!list.length) {
-      out.innerHTML = `<div class="empty">${review.staleOnly ? '放置された draft はありません。' : 'レビュー待ちの draft はありません。'}</div>`;
+      out.innerHTML = `<div class="empty">レビュー待ちの draft はありません。</div>`;
       return;
     }
     out.innerHTML = list.map(reviewCard).join('')
@@ -264,10 +268,10 @@ export function reviewCard(h) {
       <span class="type-ico" title="${esc(h.type)}">${icon(h.type)}</span>
       <a class="title" href="${entryHash(h)}" title="ochakai://${esc(h.id)}">${esc(displayTitle(h))}</a>
       <span class="badge draft">draft</span>
-      ${isStaleDraft(h) ? '<span class="badge" title="検索ヒット 0 件で動きもありません(削除の候補)">🕸️ 放置</span>' : ''}
+      ${isStaleDraft(h) ? '<span class="badge" title="作成から日が経っても検索ヒットがありません(削除の候補)">🕸️ 未使用</span>' : ''}
       ${tags}
       <span class="actions write-only" style="margin-left:auto;display:flex;gap:.45rem">
-        <button class="btn small primary" data-act="verify">✓ 検証</button>
+        <button class="btn small primary" data-act="verify" title="検証として記録し、stable にします">✓ 検証</button>
         <button class="btn small danger" data-act="reject">却下</button>
       </span>
     </div>
@@ -281,13 +285,19 @@ export function wireReviewActions(container) {
   container.querySelectorAll('[data-act]').forEach(btn => btn.addEventListener('click', async () => {
     const card = btn.closest('[data-id]');
     const id = card.dataset.id;
-    // Both are rulings against the entry as it stands, so neither needs
-    // the entry's current content — there is no full-replacement PUT here
-    // to clobber a body edited since the queue loaded.
     try {
       if (btn.dataset.act === 'verify') {
         await verifyEntry(id);
-        toast('検証しました。');
+        // This queue lists drafts, so a verified card that stayed made ✓
+        // look like a no-op. The ruling and the promotion stay separate
+        // acts on the wire (design doc 0043 §3.2); the queue composes
+        // them because accepting a draft is what its ✓ means here.
+        try {
+          await applyStatus(id, 'stable');
+          toast('検証し、stable にしました。');
+        } catch (e) {
+          toast('検証しました(stable への変更には失敗: ' + e.message + ')');
+        }
       } else {
         const note = prompt('却下の理由をご記入ください。裁定として残るため、エージェントは同じ提案を繰り返さなくなります。', '');
         if (note === null) return;
@@ -296,6 +306,7 @@ export function wireReviewActions(container) {
       }
       refreshTree(); // the tree shows status badges (and hides rejected)
       runReview();
+      loadLoopStats(); // the band and the strip count what the ruling moved
     } catch (e) {
       toast((btn.dataset.act === 'verify' ? '検証' : '却下') + 'できませんでした: ' + e.message);
     }

--- a/internal/webui/webui_test.go
+++ b/internal/webui/webui_test.go
@@ -315,11 +315,13 @@ func TestTheUploadIsHiddenWhereFilesAreUnsupported(t *testing.T) {
 	// The variable that would turn files on is the server's to send or
 	// withhold. A page that decided this for itself would be deciding
 	// who is an administrator, which it cannot know (design doc 0130 §1).
-	if !strings.Contains(body, "if (!files.variable) return;") {
-		t.Errorf("the setup banner is not gated on the server having sent the variable:\n%s", body)
+	// It is drawn on the files tab — where the refusal is met — not as a
+	// page-wide banner.
+	if !strings.Contains(body, "FILES_VARIABLE = files.variable") {
+		t.Errorf("the page no longer keeps the variable the server sent for the files tab to draw:\n%s", body)
 	}
-	if tag := section(t, asset(t, "index.html"), `id="setup-note"`, ">"); !strings.Contains(tag, "hidden") {
-		t.Errorf("the setup banner ships visible: %s", tag)
+	if !strings.Contains(detail, "FILES_VARIABLE") {
+		t.Error("the files tab no longer tells an administrator which variable turns files on")
 	}
 }
 


### PR DESCRIPTION
## What

A field-feedback pass over the web UI (na0 reviewed every page against the sandbox): the long explainers are gone or cut to a line, and the behavior the prose was compensating for is fixed instead.

**Copy pared down**
- Review queue, access policy, editor hints, the per-tab notes on a concept page, the dev-mode and sandbox banners — removed or cut to one sentence.
- The "cannot store files" setup note moved off the page top onto the files tab it is about (still drawn only from the server's own answer, design doc 0131).
- A future `stale_after` draws nothing on the concept page; only a passed one shows the re-check notice. Usage shows a structured `最終利用日:`.

**Controls doing the work**
- Review queue: ✓ 検証 records the verification **and** promotes the draft to stable, so the queue empties by verifying — reject was the only ruling that visibly shrank it before. The two acts stay separate calls on the wire (design doc 0043 §3.2); the queue composes them because accepting a draft is what its ✓ means there.
- The review scope input now narrows the draft list and the queue chips along with the loop's numbers (`QueueCounts` already takes the same filter, design doc 0049), and chip links carry the scope into the feeds they count. The stale-drafts toggle is gone — sort order and the 未使用 badge already say it.
- Editor: only the frontmatter fields the document's type asks for are drawn — the Attested Computation contract on its own type, `usage_window` only when a document carries it, and a carried key always keeps its editor. A type change redraws the form. The fields pane flows with the page (no inner scrollbar); the document pane is sticky beside it.
- Access: opens directly on the flat row editor; the JSON textarea is gone (`ochakai access --json` / `-f` remain the JSON surface), and `policyDocument`/`parsePolicyDocument` went with it. The empty-policy sentence shows only while there are no grants.

**Fixed in passing**
- The concept page's status picker called `conceptURL` without importing it, so every status change threw a `ReferenceError` and nothing was saved.

## Surface questions (docs/surface.md)

Who got stuck: the operator reviewing the UI — the prose was the cost. Existing surface covers everything here (no new endpoint, tool, command or variable; the Web UI is deliberately uncounted in surface.md). Folded away in exchange: the JSON policy editor, the stale-only toggle, the page-top setup banner, and ~10 explainer paragraphs.

## Tests

- `scripts/check` (core + ui + lint) green; jstest rewritten where it exercised the removed JSON policy round trip, smoke updated to assert the scoped tile marker and the flat access editor.
- Verified in a real browser against the dogfood instance: scoped queue chips (26 → 7 under `skills`), type-driven field redraw, verify-promotes flow, files-tab note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)