### PR TITLE
Release 0.27.5

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Version
       description: Output of `ochakai version`, or the image tag you deployed.
-      placeholder: "0.27.4"
+      placeholder: "0.27.5"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ last entry.
 
 ## [Unreleased]
 
+## [0.27.5] - 2026-08-27
+
 ### Added
 
 - **The web UI's tree sidebar is resizable.** The tree holds names the
@@ -5845,7 +5847,8 @@ worth naming: SQL injection in `compile_sql` through undeclared field
 pass-through, fixed in 0.8.0 — v0.7.0 and earlier are affected. Details
 are in git history.
 
-[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.27.4...HEAD
+[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.27.5...HEAD
+[0.27.5]: https://github.com/na0fu3y/ochakai/compare/v0.27.4...v0.27.5
 [0.27.4]: https://github.com/na0fu3y/ochakai/compare/v0.27.3...v0.27.4
 [0.27.3]: https://github.com/na0fu3y/ochakai/compare/v0.27.2...v0.27.3
 [0.27.2]: https://github.com/na0fu3y/ochakai/compare/v0.27.1...v0.27.2

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -82,7 +82,7 @@ info:
     is a security defect, shipped in the next release with no deprecation
     window (SECURITY.md). MCP, the CLI and the stored shape stay unstable
     while the major version is 0 and may still change in a minor release.
-  version: 0.27.4
+  version: 0.27.5
   license:
     name: MIT
 servers:

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -77,7 +77,7 @@ export IMAGE=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:$VERSION
 `:latest` ではなくバージョンを固定し、再デプロイを意識的な判断にする。
 `gh` CLI が無ければ
 [リリースページ](https://github.com/na0fu3y/ochakai/releases)から番号
-を読み、手で設定する — `export VERSION=0.27.4`。
+を読み、手で設定する — `export VERSION=0.27.5`。
 
 (このガイドは 0.9.0 以降を前提にしている。それより前のリリースは
 [retract](https://go.dev/ref/mod#go-mod-file-retract) 済みでサポート外

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -5,7 +5,7 @@ region     = "us-central1"
 
 # Pin a released version, not "latest", so a redeploy is a decision:
 # https://github.com/na0fu3y/ochakai/releases
-image_tag = "0.27.4"
+image_tag = "0.27.5"
 
 # Who can reach ochakai. This is the whole access-control surface — whoever
 # reaches it can read and write everything. Never allUsers.


### PR DESCRIPTION
Cut v0.27.5. A patch release — nothing unreleased is marked **BREAKING**, and everything that landed since v0.27.4 is web UI only.

## What is in it

- The tree sidebar is resizable and remembers its width per browser (#778).
- A curation pass over the web UI's copy: the long explainers are gone or cut to a line, the editor draws only the frontmatter fields a document's type asks for, ✓ 検証 on the review page both records the verification and promotes the draft, and the access page opens on its row editor (#779).
- The concept page's status dropdown works again — it called a helper the module never imported (#779).

Dependabot's three bumps (#734, #735, #736) move no user-visible surface.

## The window this closes

- `CHANGELOG.md`: `## [Unreleased]` becomes `## [0.27.5] - 2026-08-27`, a fresh empty Unreleased above it, compare links repointed. Nothing had landed *below* the Unreleased heading — checked against `git show v0.27.4:CHANGELOG.md`.
- `api/openapi.yaml`, `.github/ISSUE_TEMPLATE/bug_report.yml`, `deploy/cloudrun/README.md`, `deploy/terraform/terraform.tfvars.example` all take 0.27.5.
- `mcpserver.RetiredToolNames` and `retiredCommands` are both empty — no rename's one-release window ends here.

No new surface, so `docs/surface.md` is unchanged.

`scripts/check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)