### PR TITLE
Record the demand feed's rename as 1.0 work

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -79,6 +79,18 @@ current exception, and no design doc is proposed but unlanded. If something you
 need is missing from this list, that is a reason to say so, not a sign it was
 already considered.
 
+- **Spell the demand feed something other than `usage`, at 1.0.** The CLI reads
+  `ochakai usage <id>` for one concept's totals and `ochakai list usage` for
+  the feed ordered by them: one word, two commands, and the reader learns
+  which is which from the shape of the line rather than from the word. It
+  waits for the freeze to lift, and that is the whole of the decision —
+  `sort=usage` is a line in [api/openapi.frozen.txt](api/openapi.frozen.txt),
+  and [0064](docs/design/0064-rest-stops-at-api-v1.md) §11 leaves a security
+  defect as the only reason to move one. Renaming it in the CLI alone would
+  set the client against the contract it is a thin client of
+  ([0067](docs/design/0067-four-faces-and-what-they-decline.md) §2) and pay for
+  the same rename twice.
+
 ## Considered and deliberately not doing
 
 These are decisions, not backlog. Each has a document behind it, and where a


### PR DESCRIPTION
The CLI spells one concept's totals `ochakai usage <id>` and the feed ordered by them `ochakai list usage`, so the same word names two commands. Renaming the feed is not available before the freeze lifts: `sort=usage` is a line in api/openapi.frozen.txt, and design doc 0064 §11 leaves a security defect as the only reason to move one. Renaming it in the CLI alone would set the client against the contract it is a thin client of (0067 §2) and pay for the same rename twice, so the intent is written down rather than half-acted on.

Roadmap only: no surface moves and no behavior changes.


Claude-Session: https://claude.ai/code/session_01M19M37RYBrt11znXZ8pUuE

<!-- Keep PRs small and focused. Link the issue or design doc, if there is one. -->

## What and why

## Checks

CI runs the same script; make it pass locally first (CONTRIBUTING.md has the
context, including the store integration test and the fuzz targets).

- [ ] `scripts/check` is clean — add `--db` when the change touches the store
- [ ] Behavior changes come with tests
- [ ] Behavior changes have a line under `## [Unreleased]` in `CHANGELOG.md`
      — the `changelog` workflow checks for one when a non-test file under
      `internal/` or `cmd/` moves; if this change is not behavior, label the
      PR `no-changelog` and say why above

## Surfaces and contract

- [ ] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing; a new endpoint has an
      integration test, which is what puts it under the OpenAPI contract check
- [ ] The change lands on every surface it belongs on — REST / MCP / CLI /
      Web UI — and what it stays off is deliberate (design doc 0067)
- [ ] `api/openapi.frozen.txt` is untouched. REST is frozen at `/api/v1`
      (design doc 0064), and `cmd/ochakai/frozenwire_test.go` fails on any
      wire change; regenerating that file is a decision, and §11 leaves a
      security defect as the only reason — say which one, here
- [ ] Widens a surface — a REST operation, an MCP tool, a CLI command, an
      environment variable? `docs/surface.md` is updated
      (`cmd/ochakai/surface_test.go` says so), the description names which of
      its eight conditions the addition serves, and the three questions are
      answered under *What and why*: who actually got stuck, why an existing
      surface does not already cover it, and what is folded away in exchange.
      The default answer is no

## Design docs

- [ ] Alters an accepted decision? A new numbered doc under `docs/design` is in
      this PR — or: it does not, and this box is not applicable. The index
      entries, the `Status:` headers at both ends and the two indexes agreeing
      about them are checked by `cmd/ochakai/designdocs_test.go`; what is left
      for a human is whether the index's opening table still points at the doc
      to read now, and whether the English summary says what was decided
- [ ] Commit messages and code comments are in English
