### PR TITLE
Run the module that writes, so the status picker cannot go quiet again

### DIFF
--- a/internal/webui/jstest/actions.test.js
+++ b/internal/webui/jstest/actions.test.js
@@ -1,0 +1,102 @@
+// The writes the page makes on somebody's behalf, held to the calls they
+// turn into. `documents.test.js` covers the edit itself; this covers the
+// module that carries it to the server — which is the half a pure test
+// cannot reach, and the half that shipped broken from v0.21.0 to
+// v0.27.4: applyStatus called conceptURL without importing it, so every
+// status change threw a ReferenceError, the PUT never left the browser,
+// and the page put the old value back. Nothing caught it, because the
+// only checks on this module read its source rather than run it.
+//
+// So it is run. The page's three globals are stubbed just enough for the
+// module graph to load — a document that answers querySelector, a
+// location for the origin, and a fetch that records what it was asked
+// for — and the assertions are about the requests, not the DOM.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+globalThis.location = { protocol: 'http:', origin: 'http://ui.test' };
+const stubEl = () => ({
+  textContent: '', hidden: false, title: '', innerHTML: '',
+  addEventListener() {}, querySelectorAll: () => [],
+  classList: { add() {}, remove() {}, toggle() {}, contains: () => false },
+});
+globalThis.document = {
+  querySelector: stubEl, querySelectorAll: () => [], addEventListener() {}, body: stubEl(),
+};
+
+const calls = [];
+let stored = '';
+globalThis.fetch = async (url, init = {}) => {
+  const method = init.method || 'GET';
+  calls.push({ url, method, body: init.body, headers: init.headers || {} });
+  if (method === 'PUT') {
+    stored = init.body;
+    return new Response(JSON.stringify({ id: 'metrics/revenue' }), { status: 200 });
+  }
+  if (url.endsWith('/api/v1/stats')) {
+    return new Response(JSON.stringify({ queues: { drafts: 1, failed: 0, stale_after: 0 } }), { status: 200 });
+  }
+  if (method === 'POST') return new Response(JSON.stringify({}), { status: 200 });
+  return new Response(JSON.stringify({ id: 'metrics/revenue', document: stored }), { status: 200 });
+};
+
+const { applyStatus, verifyEntry } = await import('../static/js/actions.js');
+
+const DOC = `---
+type: Metric
+title: "Revenue"
+description: "売上"
+status: draft
+sources:
+  - id: handbook
+    resource: https://example.com/handbook
+---
+
+本文。ここは投影が持っていない。
+`;
+
+test('a status change reads the document and writes the same one back, one line changed', async () => {
+  calls.length = 0;
+  stored = DOC;
+  await applyStatus('metrics/revenue', 'stable');
+
+  assert.deepEqual(calls.map(c => c.method), ['GET', 'PUT']);
+  // The document's own address, which is what makes this a full
+  // replacement of what the writer wrote rather than a patch of the
+  // projection the page happens to hold.
+  for (const c of calls) {
+    assert.equal(c.url, 'http://ui.test/api/v1/bundle/metrics/revenue.md');
+  }
+  assert.equal(calls[1].headers['Content-Type'], 'text/markdown');
+  assert.match(stored, /^status: stable$/m);
+  // Everything the projection does not carry survived the round trip —
+  // the body, the sources, the description (design doc 0035 §4 is the
+  // same bug with fewer fields).
+  assert.match(stored, /本文。ここは投影が持っていない。/);
+  assert.match(stored, /resource: https:\/\/example\.com\/handbook/);
+  assert.match(stored, /^description: "売上"$/m);
+});
+
+test('a refused write reaches the caller, which is what puts the badge back', async () => {
+  const ok = globalThis.fetch;
+  globalThis.fetch = async () =>
+    new Response(JSON.stringify({ code: 'read_only', error: '読み取り専用です' }), { status: 403 });
+  // Restored even when the assertion below throws: a stub left in place
+  // fails the next test for the wrong reason, and the log then names a
+  // test that is fine.
+  try {
+    await assert.rejects(() => applyStatus('metrics/revenue', 'stable'), /読み取り専用です/);
+  } finally {
+    globalThis.fetch = ok;
+  }
+});
+
+test('verifying is a ruling on the review face, not an edit of the document', async () => {
+  calls.length = 0;
+  await verifyEntry('metrics/revenue');
+  const ruling = calls.find(c => c.method === 'POST');
+  assert.equal(ruling.url, 'http://ui.test/api/v1/review/metrics/revenue');
+  assert.deepEqual(JSON.parse(ruling.body), { ruling: 'verified' });
+  assert.equal(calls.filter(c => c.method === 'PUT').length, 0);
+});

--- a/internal/webui/jstest/smoke.mjs
+++ b/internal/webui/jstest/smoke.mjs
@@ -316,6 +316,52 @@ try {
     await waitFor(`location.hash.startsWith('#fn-')
       && !!document.querySelector('#view .md:not(.desc) .footnotes')`), shown);
 
+  // The status picker, driven end to end. It is here because this is the
+  // check that would have caught what the picker shipped broken from
+  // v0.21.0 to v0.27.4: applyStatus threw a ReferenceError on its first
+  // line, its own handler caught it and turned it into a toast, and so
+  // there was no console error and no blank panel — every check above
+  // this line passed while the one control that writes changed nothing.
+  //
+  // It is the only write the smoke makes, and it is put back: flipped to
+  // the other value and flipped again, asserting the badge each way,
+  // because a picker that always redraws the same pill would pass a
+  // one-way check. The concept keeps an explicit `status:` line it may
+  // not have had (the value it names is the one it started with), which
+  // is what a throwaway database is for.
+  const status0 = await waitFor(`(document.querySelector('#act-status') || {}).value`);
+  // A native <select> opens no popup under CDP, so the picker is driven
+  // the way the page hears it: set the value, then say it changed.
+  const flip = t => evalJS(`(() => { const s = document.querySelector('#act-status');
+    if (!s) return false;
+    s.value = ${json(t)};
+    s.dispatchEvent(new Event('change', { bubbles: true }));
+    return true; })()`);
+  // Asserted on the pill's class rather than its text: the transparent
+  // select over it puts every option's label in textContent, so the text
+  // says draft, stable and deprecated whatever the concept is.
+  const shows = t => `!!document.querySelector('.badge.status-pick.' + ${json(t)})`;
+  // A failure here is reported by the page, not by the console, so the
+  // toast is what the log should carry: it is where "conceptURL is not
+  // defined" was, all along, for anybody who had thought to look.
+  const toasted = async () =>
+    (await evalJS(`(document.querySelector('#toast') || {}).textContent || ''`)) || await shown();
+  if (await evalJS(`document.body.classList.contains('read-only')`)) {
+    console.log('skip the status picker: this deployment is read-only');
+  } else {
+    const other = status0 === 'draft' ? 'stable' : 'draft';
+    await flip(other);
+    const changed = await waitFor(shows(other));
+    await check('the status picker writes the change', changed, toasted);
+    await flip(status0);
+    // Only asked when the first flip landed: against a picker that
+    // changes nothing, "it went back" is true of a badge that never
+    // left, and a hollow ok under a FAIL reads as a partial success.
+    if (changed) {
+      await check('and the change can be put back', await waitFor(shows(status0)), toasted);
+    }
+  }
+
   await go('#/review');
   await check('the review queue renders', await waitFor(`${textOf('#view')}.length > 100`), shown);
   // Only a route the top nav names has a current item — a directory page


### PR DESCRIPTION
## What and why

A field report: on a concept's detail page, changing the status from `draft`
to `stable` did nothing. It reproduces, and it is already fixed — but nothing
would have stopped it from coming back, which is what this PR is about.

The picker called `applyStatus`, which called `conceptURL` without importing
it. Every status change threw a `ReferenceError` on its first line, the PUT
never left the browser, and the page put the old value back. `git log -S` and
`git tag --contains` put it between `89fc07f` (the module split) and `4a15a33`
(#779, which restored the import): **shipped in v0.21.0 through v0.27.4**,
fixed in v0.27.5. The review queue's ✓ composes the same call, so its
promotion to `stable` went the same way.

What let it ship for seventeen releases is that nothing ran the module. The
only checks on it read its source — `webui_test.go` greps the body of
`applyStatus` and asserts `id="act-status"` is in the page — and the browser
smoke never touched the one control on the page that writes. The failure was
invisible from outside besides: the handler caught its own `ReferenceError`
and turned it into a toast, so there was no console error and no blank panel,
and every existing check passed while the picker changed nothing.

So the module is run, at the two altitudes the bug passed through.

- **`jstest/actions.test.js`** (new) loads `actions.js` with the page's three
  globals stubbed just enough for the module graph to resolve, and asserts on
  the requests: a status change reads the document and writes the same one
  back with one line changed — so the body and the sources the projection does
  not carry survive the round trip (design doc 0035 §4 is that bug with fewer
  fields); a refused write reaches the caller, which is what puts the badge
  back; verifying is a ruling on the review face and not an edit of the
  document. No browser and no database: it runs in `scripts/check ui`.
- **`smoke.mjs`** drives the picker end to end. The value is flipped to the
  other one and flipped back, asserting the pill each way — a one-way check
  passes against a picker that always redraws the same pill. On failure the
  log carries the toast, which is where `conceptURL is not defined` was all
  along, for anybody who had thought to look.

Both were checked in both directions. With the import removed, the unit test
fails on the `ReferenceError` and the smoke prints
`FAIL the status picker writes the change / ステータスを変更できませんでした: conceptURL is not defined`;
with it in place, `scripts/check ui` and the full smoke are green.

### For a reviewer

- **The smoke now writes.** It was read-only until this PR — it types into the
  editor and the access rows without saving. There is no way to tell a status
  change that worked from one that threw without letting the PUT happen, so
  this one writes and puts it back. The fixture keeps an explicit `status:`
  line naming the value it started with, which a throwaway CI database does
  not mind; a read-only deployment skips the pair.
- **The Go grep checks are left alone.** `webui_test.go:131` now overlaps the
  unit test. Removing it is reasonable and is not in this PR.
- No CHANGELOG entry: `internal/webui/jstest/` is excluded from the changelog
  workflow's idea of behavior, and nothing outside it moved.

## Checks

- [x] `scripts/check` is clean — `--db` not needed, the store is untouched
- [x] Behavior changes come with tests — this PR *is* the tests
- [x] Behavior changes have a line under `## [Unreleased]` in `CHANGELOG.md` —
      n/a, tests only (and excluded by the changelog workflow's own filter)

Verified the way CI does it: a throwaway PostgreSQL, `serve`, `examples/demo`
imported, `metrics/revenue` verified, `ochakai ui`, then the smoke — run once
against a UI built from the pre-fix source and once against this branch.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`,
      `internal/apiclient` — untouched
- [x] Lands on every surface it belongs on — tests only; no surface moves
- [x] `api/openapi.frozen.txt` untouched
- [x] Widens no surface, so `docs/surface.md` is unchanged

## Design docs

- [x] Alters no accepted decision
- [x] Commit messages and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)