### PR TITLE
Release 0.27.6

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Version
       description: Output of `ochakai version`, or the image tag you deployed.
-      placeholder: "0.27.5"
+      placeholder: "0.27.6"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ last entry.
 
 ## [Unreleased]
 
+## [0.27.6] - 2026-08-27
+
 ### Added
 
 - **A directory moves whole or not at all** (design doc
@@ -5898,7 +5900,8 @@ worth naming: SQL injection in `compile_sql` through undeclared field
 pass-through, fixed in 0.8.0 — v0.7.0 and earlier are affected. Details
 are in git history.
 
-[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.27.5...HEAD
+[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.27.6...HEAD
+[0.27.6]: https://github.com/na0fu3y/ochakai/compare/v0.27.5...v0.27.6
 [0.27.5]: https://github.com/na0fu3y/ochakai/compare/v0.27.4...v0.27.5
 [0.27.4]: https://github.com/na0fu3y/ochakai/compare/v0.27.3...v0.27.4
 [0.27.3]: https://github.com/na0fu3y/ochakai/compare/v0.27.2...v0.27.3

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -82,7 +82,7 @@ info:
     is a security defect, shipped in the next release with no deprecation
     window (SECURITY.md). MCP, the CLI and the stored shape stay unstable
     while the major version is 0 and may still change in a minor release.
-  version: 0.27.5
+  version: 0.27.6
   license:
     name: MIT
 servers:

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -77,7 +77,7 @@ export IMAGE=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:$VERSION
 `:latest` ではなくバージョンを固定し、再デプロイを意識的な判断にする。
 `gh` CLI が無ければ
 [リリースページ](https://github.com/na0fu3y/ochakai/releases)から番号
-を読み、手で設定する — `export VERSION=0.27.5`。
+を読み、手で設定する — `export VERSION=0.27.6`。
 
 (このガイドは 0.9.0 以降を前提にしている。それより前のリリースは
 [retract](https://go.dev/ref/mod#go-mod-file-retract) 済みでサポート外

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -5,7 +5,7 @@ region     = "us-central1"
 
 # Pin a released version, not "latest", so a redeploy is a decision:
 # https://github.com/na0fu3y/ochakai/releases
-image_tag = "0.27.5"
+image_tag = "0.27.6"
 
 # Who can reach ochakai. This is the whole access-control surface — whoever
 # reaches it can read and write everything. Never allUsers.


### PR DESCRIPTION
Cuts 0.27.6. Two user-observable changes landed since v0.27.5, neither
**BREAKING**, so this is a patch bump.

- **A directory moves whole or not at all** (#784, design doc 0132) —
  `ochakai move --directory`, `from_prefix`/`to_prefix` on
  `POST /api/v1/move`, draggable directory nodes in the tree.
- **A listing with no feed is the plain enumeration** (#781) —
  `ochakai list --prefix …` and `GET /api/v1/search` with neither `q`
  nor `sort` now list in address order instead of refusing.

#782 (ROADMAP) and #783 (a JS test that was not being run) widen no
surface and correctly carry no changelog entry.

## What this PR touches

The five files that carry a version number the tag does not update:
`CHANGELOG.md` (heading, fresh `## [Unreleased]`, compare links),
`api/openapi.yaml`, `.github/ISSUE_TEMPLATE/bug_report.yml`,
`deploy/cloudrun/README.md`, `deploy/terraform/terraform.tfvars.example`.

`mcpserver.RetiredToolNames` and `retiredCommands` are both empty — no
rename window closes with this release.

Checked that nothing landed below `## [Unreleased]`, and that every PR
since v0.27.5 touching a non-test file under `internal/` is accounted
for above. `scripts/check` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)