### PR TITLE
Draw the MCP connection rule on identity, not on location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,46 @@ last entry.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Connecting an MCP client is decided by identity, not by location.**
+  [docs/guides/mcp-clients.md](docs/guides/mcp-clients.md) drew its rule
+  as "local server → URL, otherwise the bridge", which used the
+  deployment's address as a stand-in for whether it demands a Google ID
+  token. That stand-in stopped being true when design doc
+  [0066](docs/design/0066-four-postures-one-word.md) put the posture in
+  one word: `public` and sandbox deployments read no identity and take
+  the URL wherever they live, so the old table sent everyone who
+  published one to install gcloud and a binary they did not need. The
+  rule, the table and the `ochakai ui` section are now drawn on the axis
+  that actually decides, and `ochakai whoami`'s `posture:` line is named
+  as the way to read it. **The consequence users see**: trying ochakai
+  from Claude Code is one command with nothing installed —
+  `claude mcp add --transport http ochakai https://demo.ochak.ai/mcp` —
+  which worked all along and was written down for Claude Desktop only,
+  through the `.mcpb` bundle's default.
+- **What expires against Cloud Run is the gcloud session, not the
+  token.** The guide listed `gcloud auth login` as a prerequisite and
+  said nothing about the day it lapses. The bridge reads each ID token's
+  `exp` and mints the next one itself, so the hourly expiry needs
+  nobody; a lapsed gcloud session is recovered by `gcloud auth login`
+  alone, without restarting the client, and only a bridge that could not
+  resolve an identity *at startup* needs a reconnect. The same section
+  now says that a service-account key would be the only more durable
+  form, and that holding one is what design doc
+  [0065](docs/design/0065-identity-and-provenance.md) declines.
+- **The header this repository's own `.mcp.json` carries is documented.**
+  Against a `dev` server every caller is recorded as `human:anonymous`,
+  so an agent writing back through a plain URL connection is
+  indistinguishable from the human who reviews it —
+  `Ochakai-On-Behalf-Of: process:claude-code` is what keeps both halves
+  in the ledger, and the guide had shown the file without it.
+- README said MCP clients see "seven tools"; there have been six since
+  design doc [0076](docs/design/0076-two-tools-leave-mcp.md) took two
+  off. The `MCP: 6` ceiling in [docs/surface.md](docs/surface.md) is
+  checked against the build, but a count spelled out in prose is not —
+  which is the blind spot, not the typo.
+
 ## [0.27.6] - 2026-08-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -230,8 +230,12 @@ you install anything.
 
 MCP is for the clients that cannot shell out: Claude Desktop, and your
 own services calling ochakai under their own identity. Both take one of
-two forms — a URL, or the `ochakai mcp-stdio` bridge against Cloud Run —
-and see the same seven tools. An assistant hosted by a vendor opens the
+two forms — a URL, or the `ochakai mcp-stdio` bridge against a deployment
+that reads identity — and see the same six tools. A deployment that reads
+no identity takes the URL wherever it lives, so trying the public demo
+from Claude Code is one command and no install:
+`claude mcp add --transport http ochakai https://demo.ochak.ai/mcp`.
+An assistant hosted by a vendor opens the
 connection from that vendor's infrastructure rather than from your
 machine, so an IAM-restricted deployment is out of its reach by design:
 [connecting an MCP client](docs/guides/mcp-clients.md) (Japanese).

--- a/docs/guides/mcp-clients.md
+++ b/docs/guides/mcp-clients.md
@@ -3,32 +3,44 @@
 ochakai は `/mcp` で streamable HTTP による MCP を提供する。クライアント
 の設定に何を書くかは二つの事実だけが決め、どちらも好みの問題ではない:
 
-**サーバーがどこにあるか。** Cloud Run に対しては、すべてのリクエスト
-が MCP クライアントの誰も発行できない Google ID トークンを運ばなければ
-ならないので、接続は `ochakai mcp-stdio` を通す — stdin/stdout で MCP
-を話し、他のクライアントコマンドと同じ方法で identity を解決し、
-JSON-RPC メッセージをそのまま転送する(設計ドキュメント
-[0067](../design/0067-four-faces-and-what-they-decline.md) §3)。クライアント側の設定に
-資格情報は要らない、そもそも設定するものが無いからである。ローカル
-ではこの要件が消え、URL がそのまま使える。
+**サーバーが identity を読むか。** 読むデプロイに対しては、すべての
+リクエストが MCP クライアントの誰も発行できない Google ID トークンを
+運ばなければならないので、接続は `ochakai mcp-stdio` を通す —
+stdin/stdout で MCP を話し、他のクライアントコマンドと同じ方法で
+identity を解決し、JSON-RPC メッセージをそのまま転送する(設計
+ドキュメント [0067](../design/0067-four-faces-and-what-they-decline.md) §3)。
+クライアント側の設定に資格情報は要らない、そもそも設定するものが無い
+からである。**読まないデプロイではこの要件が消え、URL がそのまま
+使える** — ローカルの `dev` だけでなく、公開された `public` や
+サンドボックスも同じで、これは所在ではなく posture の問題である
+(設計ドキュメント [0066](../design/0066-four-postures-one-word.md))。
+どちらかは `ochakai whoami` の `posture:` 行が答える。
 
 **クライアントが何を開けるか。** コマンドを起動して stdio で話すこと
 しかできないクライアントもある。そうしたクライアントには、サーバーが
 どちらであってもブリッジが答えになる。
 
-つまり: **ローカルサーバー、かつ対応できるクライアントなら URL。それ
-以外はブリッジ** — ブリッジには独自の前提条件があり、どの設定より前に
-[下](#what-the-bridge-needs)で挙げる。
+つまり: **identity を読まないサーバー、かつ対応できるクライアントなら
+URL。それ以外はブリッジ** — ブリッジには独自の前提条件があり、どの設定
+より前に[下](#what-the-bridge-needs)で挙げる。
 
-| クライアント | ローカル `docker compose` | Cloud Run | 設定の置き場所 |
+| クライアント | identity を読まないサーバー | identity を読むサーバー | 設定の置き場所 |
 |---|---|---|---|
 | [Claude Code](#claude-code)* | URL | ブリッジ | `.mcp.json`、または `claude mcp add` |
-| [Claude Desktop](#claude-desktop) | ブリッジ | ブリッジ | `claude_desktop_config.json` |
+| [Claude Desktop](#claude-desktop) | ブリッジ(または [`.mcpb`](#claude-desktop)) | ブリッジ | `claude_desktop_config.json` |
 | [その他のクライアント](#その他のクライアント) | URL | ブリッジ | クライアントごと(下の表) |
-| [ホスト型アシスタント](#clients-that-cannot-reach-your-deployment) | — | — | 設計上、届かない |
+| [ホスト型アシスタント](#clients-that-cannot-reach-your-deployment) | 公開デプロイなら届く | 設計上、届かない | 製品ごと |
 
-下にあるローカル URL は `http://localhost:8080/mcp` で、
-`deploy/compose.yaml` が渡すものそのものである。
+**何もインストールせずに一番速く繋ぐ**なら、公開デモが URL をそのまま
+取る — Claude Code なら一コマンドで、Go も gcloud も要らない:
+
+```sh
+claude mcp add --transport http ochakai https://demo.ochak.ai/mcp
+```
+
+自分のサーバーに対する URL は、ローカルの `docker compose` なら
+`http://localhost:8080/mcp` で、`deploy/compose.yaml` が渡すものその
+ものである。
 
 \* Claude Code はこの表の唯一の例外である: シェルを持っているので、
 [推奨される経路は CLI](#claude-code) であって MCP ではない。
@@ -89,8 +101,8 @@ JSON のキー名が違うだけなので、[その他のクライアント](#�
 ## ブリッジが必要とするもの
 
 下の設定のうちコマンドを起動するものはどれも、クライアントの `PATH`
-上に `ochakai` を必要とする。Cloud Run に対してはさらに二つ必要で、
-どちらもマシンに既定では入っていない:
+上に `ochakai` を必要とする。identity を読むデプロイに対してはさらに
+二つ必要で、どちらもマシンに既定では入っていない:
 
 - **`gcloud` CLI。** ID トークンの出どころである。ブリッジはまず
   サービスアカウントの ADC を試し、それが無ければ
@@ -119,8 +131,28 @@ https://your-service.run.app`)にも同じ方法で同じトークンを解決�
 クライアントは、たいてい「サーバーにツールが無い」という形でそれを
 報告するからである。
 
-これはすべて Cloud Run に対する話で、トークンを一切要求しないローカル
-の `docker compose` サーバーには当てはまらない。
+### 切れるのはトークンではなくセッションである
+
+ID トークンは一時間で失効するが、**それは誰も触らずに回る**: ブリッジ
+はトークンの `exp` を読んで期限を知り、切れていれば次のリクエストの
+ために発行し直す。設定を書いたあと繰り返し打つコマンドは無い。
+
+切れるのはその下の **gcloud のセッション**のほうで、いつ切れるかを
+決めるのは ochakai ではなくあなたの組織である — Google Workspace の
+セッション長ポリシー、パスワードの変更、長い無活動、`gcloud auth
+revoke`。復旧は端末で `gcloud auth login` を打ち直すことだけで、
+**動いているクライアントを再起動する必要は無い**: 次の呼び出しが新しい
+セッションからトークンを取る。例外は起動時で、ブリッジは identity を
+解決できないと即座に終了するため(それを「ツールが無い」として黙らせ
+ないためである)、その場合だけクライアント側の再接続が要る。
+
+これより永続的な形はサービスアカウントの ADC だが、それは鍵をディスク
+に置くことを意味する。ochakai が secret を一つも持たない姿勢
+([0065](../design/0065-identity-and-provenance.md))で到達できる永続性の
+上限が、この gcloud セッションである。
+
+以上は identity を読むデプロイに対する話で、トークンを一切要求しない
+`dev` や `public` のサーバーには当てはまらない。
 
 ## Claude Code
 
@@ -132,13 +164,14 @@ https://your-service.run.app`)にも同じ方法で同じトークンを解決�
 
 ### それでも MCP のツールが欲しい場合
 
-ローカルサーバーに対して:
+identity を読まないサーバー(ローカルの `docker compose`、公開デモ)に
+対して:
 
 ```sh
 claude mcp add --transport http ochakai http://localhost:8080/mcp
 ```
 
-Cloud Run に対して、ブリッジ経由:
+identity を読むサーバーに対して、ブリッジ経由:
 
 ```sh
 claude mcp add ochakai -- ochakai mcp-stdio
@@ -149,6 +182,31 @@ claude mcp add ochakai -- ochakai mcp-stdio
 `.mcp.json` に書き込む — これはコミットされる形で、このリポジトリ自身
 の `.mcp.json` はローカルの `docker compose` サーバーを指し、それが
 動いていれば自動的に繋がる。
+
+その `.mcp.json` は `Ochakai-On-Behalf-Of` ヘッダも載せている:
+
+```json
+{
+  "mcpServers": {
+    "ochakai": {
+      "type": "http",
+      "url": "http://localhost:8080/mcp",
+      "headers": { "Ochakai-On-Behalf-Of": "process:claude-code" }
+    }
+  }
+}
+```
+
+**`dev` のサーバーに書き戻すつもりなら、これを省いてはならない。**
+`dev` は呼び出し元を全員 `human:anonymous` として記録するので、ヘッダの
+無い接続から書かれた concept は人が書いたものと区別が付かなくなる —
+エージェントの下書きを人の裁定と取り違えないための区別が、台帳から
+消える。ヘッダを付ければ `process:claude-code via human:anonymous` と
+両方が残る。`dev` では誰でも委譲できるので
+`OCHAKAI_DELEGATING_CALLERS` を設定する必要は無く、本番ではそれが
+呼び出し元を許していることが要る([設定](../configuration.md#environment-variables))。
+identity を読むデプロイでは呼び出し元が本物の Google の身元を運ぶので、
+自分を名乗らせるためにこのヘッダを足す理由は無い。
 
 ## Claude Desktop
 
@@ -239,10 +297,10 @@ Cloud Run に対しては、この設定だけではマシンに gcloud とロ�
 誰も気づかない(設計ドキュメント
 [0068](../design/0068-how-a-face-is-added-and-removed.md) §3)。
 
-## Cloud Run に対して機能する URL
+## identity を読むサーバーに対して機能する URL
 
-クライアントが URL を要求し、サーバーが Cloud Run 上にあるなら、
-`ochakai ui` がそれを与えるローカルのプロキシである。あなたの identity
+クライアントが URL しか取らず、サーバーが identity を読むなら、
+`ochakai ui` がその URL を与えるローカルのプロキシである。あなたの identity
 で認証し、web UI と並べて `/mcp` を、ループバックに束縛して公開する:
 
 ```sh
@@ -268,11 +326,18 @@ ChatGPT のコネクタ、OpenAI の Responses API、Claude Desktop のカスタ
 これはギャップではなく、アクセスモデルが働いている証拠である:
 到達できることそのものが認可である(設計ドキュメント
 [0065](../design/0065-identity-and-provenance.md) §1)ので、デプロイを第三者のサーバー
-から届くようにすることは、そのまま公開到達可能にすることを意味する —
-ochakai を公開で呼び出せる状態にすることは、デプロイの一形態ではなく
+から届くようにすることは、そのまま公開到達可能にすることを意味する。
+チームの知識を持つデプロイをそこへ置くのは、デプロイの一形態ではなく
 設定ミスである。ローカルコードも動かせるホスト型アシスタント
 (ブリッジ越しの Claude Desktop、Claude Code、Cursor)が、サポートされる
 経路である。
+
+**例外は、公開することが決定であるデプロイだけである** — `public` と
+サンドボックス([0066](../design/0066-four-postures-one-word.md) §3・
+[0087](../design/0087-a-sandbox-says-it-is-one.md))は、誰から届くかを
+選んでいないのだから、ベンダーのインフラから届いても失うものが無い。
+公開デモがその形で、ここでは誰も動かしていないので、各アシスタントの
+コネクタ UI がそれを受け入れるかどうかは、それぞれの製品の話である。
 
 ## 繋がらないとき
 


### PR DESCRIPTION
## What and why

Someone asked which of the many ways to reach ochakai from Claude Code and
Claude Desktop is the easiest, and whether the manual supports them. Walking
all of them turned up one wrong rule and three loose ends.

**The rule was drawn on the wrong axis.** `docs/guides/mcp-clients.md` chose
between a URL and the `mcp-stdio` bridge by asking where the server is —
*"local → URL, otherwise the bridge"* — which uses the address as a stand-in
for whether the deployment demands a Google ID token. Design doc
[0066](../blob/main/docs/design/0066-four-postures-one-word.md) retired that
stand-in when it put the posture in one word: `public` and sandbox deployments
read no identity and take a URL wherever they live. So the old table sent
everyone who published one to install gcloud and a binary they did not need.

It also hid the shortest route into the project. This works today, and works
with nothing installed:

```sh
claude mcp add --transport http ochakai https://demo.ochak.ai/mcp
```

`demo.ochak.ai` appeared in `README.md` and in the `.mcpb` manifest's default
and nowhere else — so **Claude Desktop users were handed the one-step path
through the bundle, and Claude Code users were not.** The rule, the client
table, the Claude Code examples and the `ochakai ui` section are now drawn on
the axis that decides, with `ochakai whoami`'s `posture:` line named as the way
to read it.

**Three things found while checking the routes:**

- *What expires against Cloud Run is the gcloud session, not the token.* The
  guide listed `gcloud auth login` as a prerequisite and said nothing about the
  day it lapses. `internal/apiclient/token.go` reads each ID token's `exp` into
  `oauth2.ReuseTokenSource`, so the hourly expiry needs nobody, and a lapsed
  session is recovered by `gcloud auth login` alone **without restarting the
  client** — only a bridge that could not resolve an identity *at startup*
  needs a reconnect, since `cmdMCPStdio` fails fast on purpose. A
  service-account key is the only more durable form, and holding one is what
  design doc 0065 declines. New subsection saying so.
- *The header this repository's own `.mcp.json` carries was undocumented.*
  Against a `dev` server every caller is recorded as `human:anonymous`, so an
  agent writing back through a plain URL connection is indistinguishable from
  the human who reviews it. `Ochakai-On-Behalf-Of: process:claude-code` keeps
  both halves in the ledger. The guide had described that file without it.
  (`dev` needs no `OCHAKAI_DELEGATING_CALLERS` — `authenticated()` passes
  `["*"]` there; I had written the opposite before reading the code.)
- *README said MCP clients see "seven tools".* There have been six since design
  doc 0076 took two off. The `MCP: 6` ceiling is checked against the build, but
  **a count spelled out in prose is not** — that is the blind spot, not the
  typo.

**One sentence narrowed.** "Making ochakai publicly callable is a
misconfiguration, not a form of deployment" denied the very posture 0066 §3 and
0087 sanction — and the public demo is one, so the page contradicted itself. It
now says that of a deployment holding a team's knowledge, and states the
deliberate exception. Whether any given vendor's connector UI accepts the demo
URL is left unasserted: nobody here runs those, which is the same reason
0068 §3 gives for not printing other clients' configs in full.

**Not in this PR:** collapsing the four-step hooks install into a Claude Code
plugin. It would serve C5, but it widens a surface, and the case for it needs
somebody who actually got stuck — not the fact that it is possible.

## Checks

- [x] `scripts/check` is clean — docs only, the store is untouched
- [x] Behavior changes come with tests — n/a, no behavior changed
- [x] Behavior changes have a line under `## [Unreleased]` in `CHANGELOG.md` —
      four of them, though the workflow would not have asked: nothing under
      `internal/` or `cmd/` moved. They are there because a reader upgrading
      wants to know the connection rule they were given was wrong

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`,
      `internal/apiclient` say the same thing — untouched
- [x] The change lands on every surface it belongs on — no surface moved
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens a surface? **No.** `docs/surface.md` is unchanged: no operation,
      tool, command or variable was added, and the manual grew 7,617 → 7,686
      lines, inside `DOC-LINES: 8000` with its 500 slack — the grid absorbed it,
      which is what the grid is for

## Design docs

- [x] Alters an accepted decision? **No** — 0066 already decided this; the
      manual had not caught up. Per
      [0128](../blob/main/docs/design/0128-a-number-is-for-an-area-not-a-rule-inside-it.md),
      the parent record plus the CHANGELOG answer the question somebody reopens
      in three months, so this is PR-and-CHANGELOG work, not a new number
- [x] Commit messages and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)
