### PR TITLE
Take the live-attachment lock where the files are written, and check it

### DIFF
--- a/internal/store/attachment_search_integration_test.go
+++ b/internal/store/attachment_search_integration_test.go
@@ -2,6 +2,9 @@ package store
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
@@ -290,5 +293,66 @@ func TestIntegrationAttachmentVectorsAreKeyedByPath(t *testing.T) {
 	}
 	if !got[one.ID] || !got[two.ID] {
 		t.Errorf("the shared file ranked %v, want both %s and %s", hits, one.ID, two.ID)
+	}
+}
+
+// The lock above is a convention until something checks it, and the
+// restapi package learned that once already: issue #546 was one archive
+// test out of five that did not take it, so a guard there now reads that
+// rule back off the source. That guard can only see its own file, and
+// this is the other end of the same rule — the side that *holds* a live
+// attachment rather than the side that scans for one. A test here that
+// writes a file against this package's blob fake and skips the lock is
+// invisible to restapi's guard, and it flakes restapi rather than store,
+// which is a long way from where anyone would then look.
+//
+// So the holders are read back here too: a function that calls PutFile
+// takes the lock, itself or through a helper that does (several tests
+// share one store constructor, and the lock belongs with the blob fake
+// that constructor installs).
+func TestEveryLiveAttachmentTestTakesTheLock(t *testing.T) {
+	names, err := filepath.Glob("*_test.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Function bodies, split on the column-0 brace that ends each one.
+	// Crude, and enough: this package's test functions are all
+	// top-level, which is the assumption restapi's guard makes too.
+	type fn struct{ file, name, body string }
+	var fns []fn
+	locks := map[string]bool{} // functions that take the lock, for the helper hop
+	for _, name := range names {
+		src, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, body := range strings.Split(string(src), "\nfunc ")[1:] {
+			f, _, _ := strings.Cut(body, "(")
+			fns = append(fns, fn{name, f, body})
+			if strings.Contains(body, "lockLiveAttachments(t") {
+				locks[f] = true
+			}
+		}
+	}
+	checked := 0
+	for _, f := range fns {
+		if f.name == "lockLiveAttachments" || !strings.Contains(f.body, "PutFile(") {
+			continue
+		}
+		checked++
+		locked := locks[f.name]
+		for helper := range locks {
+			if strings.Contains(f.body, helper+"(t") {
+				locked = true
+			}
+		}
+		if !locked {
+			t.Errorf("%s in %s writes a file without lockLiveAttachments(t, ...): "+
+				"its bytes live in a blob fake only this package can read, so a "+
+				"whole-bundle scan in another package fails on it (#546)", f.name, f.file)
+		}
+	}
+	if checked < 8 {
+		t.Errorf("only %d live-attachment tests found; the guard stopped matching them", checked)
 	}
 }

--- a/internal/store/moveprefix_integration_test.go
+++ b/internal/store/moveprefix_integration_test.go
@@ -20,6 +20,7 @@ import (
 // can list — which is the whole reason this operation exists rather than
 // being a loop somebody writes in shell.
 func TestMovePrefixMovesTheWholeDirectoryIntegration(t *testing.T) {
+	lockLiveAttachments(t, testdb.URL(t)) // loose.markdown rides a fake blob store other packages' export scans can't read
 	ctx, s := movePrefixStore(t)
 	run := testdb.Unique(t, "stit-moveprefix-")
 	actor := domain.Actor{Kind: domain.ActorHuman, Name: "test"}


### PR DESCRIPTION
## What and why

`TestRESTIntegrationTheArchiveCarriesAFileNothingOwns` failed on CI with
`unexpected EOF` while reading the archive's tar — the gzip header parsed, then
the stream stopped ([the run](https://github.com/na0fu3y/ochakai/actions/runs/33094807261/job/98596799783)).
pg18 passed on the same commit and a rerun of pg17 passed, so it is a flake;
this is where it comes from.

**It is issue #546 again, from the other end.** Tests sharing the test database
serialize on `pg_advisory_lock(0x0c8a1a77)` whenever one holds a live
attachment or scans all of them, because a file's bytes resolve against the
fake blob store of whichever package wrote it and no other package can read
them. `internal/store/moveprefix_integration_test.go`, added with `MovePrefix`
in #784, writes `old/loose.markdown` through `memPrefixBlobs` and does not take
the lock. Its comment says markdown lives in the database — true of the OKF
bundle layout, not of these bytes: `PutFile` routes **every** media type
through `s.blobs.Put` ([attachment.go:167](https://github.com/na0fu3y/ochakai/blob/main/internal/store/attachment.go#L167)),
which is also why the test installs a blob fake at all. While that file is
live, a whole-bundle export in `internal/restapi` can fail on it mid-stream —
after the response has begun, which is why the symptom is a truncated tar
rather than #546's original `gzip: invalid header`.

Of the seven test files that call `PutFile`, it is the only one that did not
take the lock:

```
internal/store/store_integration_test.go              lock=6
internal/store/attachment_search_integration_test.go  lock=4
internal/service/attachment_integration_test.go       lock=4
internal/store/objectpath_integration_test.go         lock=1  (in its shared constructor)
internal/store/sweep_integration_test.go              lock=1
internal/store/blob_integration_test.go               lock=1
internal/store/moveprefix_integration_test.go         lock=0  ← this
```

**Why it arrived green.** `TestEveryArchiveTestSerializesAgainstLiveFiles`
reads only `restapi_integration_test.go`. It guards the *scanners* and cannot
see a *holder* appear in another package — and when one does, the failure
surfaces in `internal/restapi`, a long way from where anyone would look. That
guard's own comment says the lock "is a convention until something checks it",
so this PR adds the check on the holder side rather than only fixing the
instance: every function in `internal/store` that calls `PutFile` takes the
lock, itself or through a helper that does (several tests share a store
constructor, and the lock belongs beside the blob fake it installs).

Deleting the one-line fix makes the new guard name the test:

```
TestMovePrefixMovesTheWholeDirectoryIntegration in moveprefix_integration_test.go
writes a file without lockLiveAttachments(t, ...) ... (#546)
```

**Reviewer's call:** the guard is the larger half of the diff and could be left
out, shipping the one-line fix alone. I included it because the same hole
reopens with the next test that writes a file, and this failure mode does not
point at its own cause.

## Checks

- [x] `scripts/check --db` is clean — the change is in store tests, so the
      store integration tests ran
- [x] Behavior changes come with tests — no behavior changed; the change *is*
      tests. The new guard is verified by removing the fix and watching it fail
- [x] Behavior changes have a line under `## [Unreleased]` in `CHANGELOG.md` —
      not applicable and not added: no non-test file moved, nothing an operator
      upgrading would see. Label `no-changelog` if the workflow disagrees

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`,
      `internal/apiclient` say the same thing — untouched
- [x] The change lands on every surface it belongs on — no surface involved
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens a surface? **No** — test files only, `docs/surface.md` unchanged

## Design docs

- [x] Alters an accepted decision? **No** — a test convention that already
      exists, applied where it was missing and checked where it is held
- [x] Commit messages and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)
