### PR TITLE
Pin the non-BMP frontier where the provider is controlled, report it elsewhere

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,9 +37,11 @@ jobs:
     # What that test actually reads is not only PostgreSQL. Above the BMP
     # the default parser asks the C library whether a character is a
     # letter, so the answer belongs to the image's glibc as much as to
-    # the server: on glibc 2.39 the extension-I characters Unicode 17
-    # added are letters and the test fails, on bookworm's 2.36 they are
-    # not and it passes. Both plain tags below resolve to bookworm today
+    # the server: on glibc 2.39 the extension-I characters (Unicode 15.1,
+    # not 17 — what 17 added is extension J) are letters and the pin does
+    # not hold, on bookworm's 2.36 they are not and it does. The test pins
+    # the frontier only here, where the image makes the provider a
+    # controlled variable; off CI it reports what it found. Both plain tags below resolve to bookworm today
     # — pg17 is pg17-bookworm and pg18 is pg18-bookworm — which is what
     # makes this matrix vary one thing. If upstream ever repoints one of
     # them at trixie, that test is the one that will say so, and its

--- a/internal/store/migrations/0044_the_index_knows_the_characters_go_knows.sql
+++ b/internal/store/migrations/0044_the_index_knows_the_characters_go_knows.sql
@@ -22,16 +22,28 @@
 --
 -- **This does not make the new characters findable, and no class would.**
 -- All 645 of them live above the BMP, and what becomes a lexeme up there
--- is decided by PostgreSQL's own Unicode knowledge rather than by this
--- class: a non-BMP character the parser knows becomes a token (mangled,
--- but mangled the same way on both sides, so a query reproduces it), and
--- one it does not know becomes `blank` — nothing, on both sides. On
--- PostgreSQL 17, extension I is the second case.
--- TestWhatPostgresCanIndexAboveTheBMP holds both halves of that, so the
--- day a PostgreSQL lifts the limit is a day ochakai finds out rather
--- than a day it keeps a stale sentence. What this migration settles is
--- the agreement, which is what the pin asks for and what lets ochakai be
--- built on Go 1.27 at all.
+-- is decided outside this class: a non-BMP character the text-search
+-- parser reads as a word character becomes a token (mangled, but mangled
+-- the same way on both sides, so a query reproduces it), and one it does
+-- not becomes `blank` — nothing, on both sides.
+--
+-- **What decides it is the database's ctype provider, not PostgreSQL's
+-- version**, and this sentence used to say otherwise. Above the BMP the
+-- parser asks the C library whether a character is a letter, so the
+-- frontier moves with glibc: 2.36 (bookworm) reads extension I as blank,
+-- 2.39 reads it as a word character — same PostgreSQL, opposite answers —
+-- and a cluster in the C locale reads every non-ASCII character as a word
+-- character, so it has no frontier at all. The same sentence also called
+-- extension I a Unicode 17 addition; it is **Unicode 15.1**, and what 17
+-- added is extension J at U+323B0.
+--
+-- TestWhatPostgresCanIndexAboveTheBMP pins the frontier where the
+-- provider is a controlled variable — in CI, whose images are bookworm
+-- (.github/workflows/ci.yaml says so beside its matrix), so a red row
+-- there means the image was repointed. Off CI it reports instead, the
+-- provider being whatever the developer has. What this migration settles
+-- is the agreement between the class and the binary, which is what the
+-- pin asks for and what lets ochakai be built on Go 1.27 at all.
 --
 -- The class below is generated, not edited: it is what
 -- store.scriptWithoutSpaces answers over the whole code space. The test

--- a/internal/store/unicode17_integration_test.go
+++ b/internal/store/unicode17_integration_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"os"
 	"testing"
 )
 
@@ -10,47 +11,91 @@ import (
 // It buys the agreement the pin demands: the class in the database and
 // the tables the binary reads answer the same for every code point, so
 // ochakai can be built on the toolchain carrying Unicode 17 at all.
+// That half is ochakai's own, it holds under every server, and it is
+// asserted unconditionally below.
 //
-// It does not, on its own, make the characters Unicode 17 added
-// findable, and no class could. They are all outside the BMP, and what
-// decides a lexeme there is **PostgreSQL's own Unicode knowledge, not
-// ochakai's**: a non-BMP character the parser knows becomes a token
-// (mangled, but mangled identically on both sides, so a query
-// reproduces it), and one it does not know becomes `blank` — nothing at
-// all, on both sides, so nothing can be asked for.
+// It does not, on its own, make the characters above the BMP findable,
+// and no class would. What becomes a lexeme up there is decided outside
+// ochakai: a character the text-search parser reads as a word character
+// becomes a token (mangled, but mangled identically in the document and
+// in the query, so a query reproduces it), and one it does not becomes
+// `blank` — nothing at all, on both sides, so nothing can be asked for.
 //
-// The line between the two cases is the server's Unicode version, and it
-// moves when PostgreSQL moves. That is why it is a test: the limit is
-// invisible from the Go side, it belongs to a component ochakai does not
-// ship, and the day it lifts is a day ochakai can promise something it
-// cannot promise now.
+// **The decider is the database's ctype provider, not PostgreSQL.** Above
+// the BMP the default parser asks the C library whether a character is a
+// letter, so the frontier moves with glibc: 2.36 (bookworm) reads
+// extension I as blank, 2.39 reads it as a word character. The CI
+// workflow says this too, beside the matrix it explains, because both
+// images resolve to bookworm today and that is what makes the pin below
+// meaningful there.
+//
+// **So the pin is CI's, and only CI's.** In CI the ctype provider is a
+// controlled variable, and a red row means the image was repointed —
+// which is the signal `.github/workflows/ci.yaml` says this test exists
+// to give. Anywhere else the provider is whatever the developer has, and
+// the row would be reporting the machine rather than the code: glibc 2.39
+// reads extension I as a word character, and a cluster in the **C locale**
+// — which `scripts/check` builds when Docker cannot serve the CI image —
+// has no frontier at all, since the parser reads every non-ASCII
+// character as one. Both of those made this test fail locally while CI
+// was green. Outside CI the frontier is reported instead.
+//
+// One thing is asserted wherever the probe runs, because it is nobody's
+// Unicode version: **the document and the query agree.** A character that
+// produces no lexeme is the limit honestly reached; one that produces a
+// lexeme the query cannot reproduce would be a term stored and
+// unreachable.
 func TestWhatPostgresCanIndexAboveTheBMP(t *testing.T) {
 	ctx := context.Background()
 	s := newSearchStore(t, ctx)
 
+	// GitHub Actions sets CI, and the workflow is where the image — and
+	// so the ctype provider — is pinned. Outside it, nothing here is
+	// controlled.
+	pinned := os.Getenv("CI") != ""
+
+	var ctype string
+	if err := s.pool.QueryRow(ctx,
+		`SELECT datctype FROM pg_database WHERE datname = current_database()`).Scan(&ctype); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("ctype provider locale: %s (frontier %s)", ctype,
+		map[bool]string{true: "pinned, this is CI", false: "reported, this is not CI"}[pinned])
+
 	for _, tc := range []struct {
 		name      string
 		term      string
-		indexable bool
+		unicode   string
+		indexable bool // what bookworm's glibc 2.36 answers, which is CI's
 		note      string
 	}{
 		{
-			name: "extension B, old enough for this PostgreSQL to know",
-			// In the class since 0036, and it round-trips: the parser
-			// makes the same odd token of the document and of the query.
-			term: "\U00020000\U00020001", indexable: true,
+			name: "extension B, old enough for every provider to know",
+			// It round-trips: the parser makes the same odd token of the
+			// document and of the query.
+			term: "\U00020000\U00020001", unicode: "3.1", indexable: true,
 		},
 		{
-			name: "extension I, which Unicode 17 added",
-			// In the class since 0044, and it does not round-trip: this
-			// PostgreSQL reads it as blank, so neither side has a lexeme.
-			term: "\U0002EBF0\U0002EBF1", indexable: false,
+			name: "extension I, which bookworm's glibc does not know",
+			// In the class since 0044, and blank under Unicode 15.0.
+			// **Extension I is Unicode 15.1, not Unicode 17** — it was
+			// already assigned when Go 1.27's tables gained it, and this
+			// row used to say otherwise.
+			term: "\U0002EBF0\U0002EBF1", unicode: "15.1", indexable: false,
+			note: "a term written in these characters is findable by nothing here, whatever the class says",
+		},
+		{
+			name: "extension J, which Unicode 17 added",
+			// The newest range Go 1.27's Han holds, and blank under every
+			// glibc shipping today.
+			term: "\U000323B0\U000323B1", unicode: "17.0", indexable: false,
 			note: "a term written in these characters is findable by nothing here, whatever the class says",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			// ochakai's half, which is right either way: these are
-			// characters of a script that does not space its words.
+			// characters of a script that does not space its words, so
+			// the class has to hold them however the server reads them.
 			var inClass bool
 			if err := s.pool.QueryRow(ctx,
 				`SELECT $1 ~ ('[' || ochakai_cjk_class() || ']')`,
@@ -60,21 +105,40 @@ func TestWhatPostgresCanIndexAboveTheBMP(t *testing.T) {
 			if !inClass {
 				t.Errorf("%q is outside ochakai_cjk_class(): the class and Go disagree, which is the pin's business", tc.term)
 			}
-			// PostgreSQL's half, which is where the answer is decided.
-			var indexed bool
+
+			// The provider's half. lexed says the document produced a
+			// lexeme at all; found says the query reproduced it.
+			var lexed, found bool
 			if err := s.pool.QueryRow(ctx,
-				`SELECT to_tsvector('simple', $1) @@ plainto_tsquery('simple', $1)`,
-				tc.term).Scan(&indexed); err != nil {
+				`SELECT to_tsvector('simple', $1) != '',
+				        to_tsvector('simple', $1) @@ plainto_tsquery('simple', $1)`,
+				tc.term).Scan(&lexed, &found); err != nil {
 				t.Fatal(err)
 			}
+			if lexed && !found {
+				t.Errorf("%q is indexed but not findable: the document produced a lexeme and "+
+					"the query did not reproduce it, so a term written in these characters is "+
+					"stored and unreachable. This one is not a Unicode version — it is the two "+
+					"sides of one parser disagreeing", tc.term)
+			}
+			if !pinned {
+				t.Logf("Unicode %s: %s", tc.unicode, map[bool]string{
+					true:  "a word character on this server",
+					false: "blank on this server",
+				}[lexed])
+				return
+			}
 			switch {
-			case tc.indexable && !indexed:
+			case tc.indexable && !lexed:
 				t.Errorf("%q stopped round-tripping through to_tsvector: a term that used to be findable is not", tc.term)
-			case !tc.indexable && indexed:
-				t.Errorf("PostgreSQL now indexes %q.\n\n"+
-					"That is good news and it makes this row wrong: %s no longer holds, "+
-					"so replace it with the recall test it was standing in for, and correct "+
-					"migration 0044's prose, which says the same thing.", tc.term, tc.note)
+			case !tc.indexable && lexed:
+				t.Errorf("PostgreSQL now indexes %q (Unicode %s).\n\n"+
+					"That is good news and it makes this row wrong: %s no longer holds. "+
+					"The likeliest cause is the pgvector image being repointed off bookworm, "+
+					"which is what .github/workflows/ci.yaml says this row is here to catch — "+
+					"check the image's glibc, then replace this row with the recall test it "+
+					"was standing in for and correct migration 0044's prose, which says the "+
+					"same thing.", tc.term, tc.unicode, tc.note)
 			}
 		})
 	}


### PR DESCRIPTION
## What and why

`TestWhatPostgresCanIndexAboveTheBMP` failed on a developer machine while CI was green — it surfaced during #789. **Two independent causes**, both measured rather than reasoned about: the same PostgreSQL 16.13, two clusters, one query.

| locale | ext B (U+20000) | ext I (U+2EBF0) | ext J (U+323B0) |
|---|---|---|---|
| `C` | lexes | **lexes** | **lexes** |
| `C.utf8` (glibc 2.39) | lexes | **lexes** | blank |
| CI (`en_US.utf8`, glibc 2.36) | lexes | blank | blank |

1. Above the BMP the parser asks the C library whether a character is a letter, so the frontier moves with **glibc**: 2.36 (bookworm, which both pgvector images resolve to) reads extension I as blank, 2.39 reads it as a word character.
2. A cluster in the **`C` locale has no frontier at all** — every non-ASCII character is a word character. `scripts/check` builds exactly such a cluster when Docker cannot serve the CI image.

### The tripwire is kept

**`ci.yaml` already documents the glibc half and pins deliberately**: a red row means the image was repointed off bookworm. I nearly removed that — an earlier revision of this PR turned the row into a pure report, which would have traded the signal away. It is kept.

What changes is *where the pin applies*: **in CI**, where the image makes the ctype provider a controlled variable, and nowhere else, because off CI the row reports the developer's machine rather than the code.

**Verified in both regimes** against a `C.utf8` cluster:

- off CI — reports and passes, logging the locale and which side of the line each probe fell on;
- with `CI` set — the extension I row **fires**, naming a repointed image as the likely cause. That is the tripwire working, exercised rather than assumed.

One assertion is unconditional, because it is nobody's Unicode version: **the document and the query agree.** A character that produces no lexeme is the limit honestly reached; one that produces a lexeme the query cannot reproduce would be a term stored and unreachable. The class-agrees-with-Go half, which is ochakai's own, is asserted as before.

### One factual correction

**Extension I is Unicode 15.1, not Unicode 17.** It was already assigned when Go 1.27's tables gained it — the 645-character delta 0044 describes is measured from Unicode 15.0, which is correct, but the test, 0044's prose and `ci.yaml`'s comment all turned that into "the extension-I characters Unicode 17 added". What Unicode 17 added is **extension J at U+323B0**, which is a third probe now.

0044's SQL is untouched, and migrations are tracked by filename rather than by checksum (`internal/store/migrate.go`), so an already-migrated database is unaffected.

## Checks

- [x] `scripts/check --db` is clean — green on this machine's `C`-locale fallback cluster, where the old row failed. The only step that does not complete here is `govulncheck`, which cannot reach `vuln.go.dev` through this environment's proxy; it passed in CI on the previous push
- [x] Behavior changes come with tests — this *is* the test change, and both of its branches were exercised (above)
- [ ] Behavior changes have a line under `## [Unreleased]` in `CHANGELOG.md` — **not applicable; the PR is labelled `no-changelog`.** Nothing a user can observe moves: one test file, a workflow comment, and a comment in an applied migration whose SQL is unchanged. The changelog job counts the `.sql` because it is a non-test file under `internal/`

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and `internal/apiclient` — untouched
- [x] The change lands on every surface it belongs on — none. It is a test and two comments
- [x] `api/openapi.frozen.txt` is untouched
- [x] Widens a surface? No

## Design docs

- [x] Alters an accepted decision? **No.** 0044's decision is the class, and the class is byte-for-byte what it was; `ci.yaml`'s decision is the matrix and the tripwire, and both stand. What changes is a sentence of reasoning that was factually wrong, and the scope of a pin. Per [0128](docs/design/0128-a-number-is-for-an-area-not-a-rule-inside-it.md) §2.1 that is PR-description territory, which is what this is
- [x] Commit messages and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CNWXz54Ao4tyWUvLT9aBM