### PR TITLE
Point the archive prose at design doc 0134, which exists

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -591,7 +591,7 @@ paths:
 
 
         **An archive of a subtree says it is one**, in the two places
-        its reader meets it (design doc 0135): the root `index.md` names
+        its reader meets it (design doc 0134): the root `index.md` names
         the subtree in its heading and in a sentence saying what is
         missing, and the `Content-Disposition` filename is
         `ochakai-okf-<subtree>.tar.gz` rather than `ochakai-okf.tar.gz`.
@@ -605,7 +605,7 @@ paths:
 
         **Who may take it**: the whole bundle (the root) is an
         administrator's, and a subtree belongs to whoever may read it
-        (design docs 0109 §3, 0135). A path outside the caller's read
+        (design docs 0109 §3, 0134). A path outside the caller's read
         scope answers 404, as every other read of it does. Refusing a
         subtree bought nothing once the archive stopped being mistakable
         for a backup of the base: it carries what its caller could


### PR DESCRIPTION
## What and why

A review of the unreleased OKF v0.2 alignment changes (#789) against the spec found one defect: `api/openapi.yaml`'s bundle-archive prose cites **design doc 0135** in two places for the rule that a subtree archive names itself in its root `index.md` heading and filename. The record that says so is **0134** — 0135 does not exist — and `internal/apiclient` already cites 0134. This fixes the two references before the release ships a contract file pointing at a record nobody can find.

Prose only; no behavior moves. (The rest of the review confirmed #789's claims against the spec verbatim — §5's "Every timestamp-valued key in OKF is an ISO 8601 datetime with an explicit UTC offset", §5.5's absolute instant, §8's `okf_version`-only index frontmatter, and §11's conformance rule 3 — with nothing to roll back.)

## Checks

- [x] `scripts/check --db core` is clean apart from `TestWhatPostgresCanIndexAboveTheBMP`, which fails on this machine's newer Unicode data (pre-existing, environment-dependent, unrelated to this change)
- [x] Behavior changes come with tests — not applicable: prose-only
- [x] Changelog — not applicable: no behavior change (`no-changelog`; only `api/openapi.yaml` description text moves)

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and `internal/apiclient` say the same thing — all four now cite 0134
- [x] No surface is added or removed
- [x] `api/openapi.frozen.txt` is untouched — prose is outside the frozen wire by design, and `TestFrozenWireHasNotMoved` passes
- [x] Widens no surface

## Design docs

- [x] Alters no accepted decision; `TestDesignDocs` passes
- [x] Commit messages and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JNbkhB8vXzBTKXpxdPZHi

---
_Generated by [Claude Code](https://claude.ai/code/session_016JNbkhB8vXzBTKXpxdPZHi)_