### PR TITLE
Prepare 0.28.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Version
       description: Output of `ochakai version`, or the image tag you deployed.
-      placeholder: "0.27.6"
+      placeholder: "0.28.0"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ last entry.
 
 ## [Unreleased]
 
+## [0.28.0] - 2026-08-30
+
 ### Changed
 
 - **BREAKING: a top-level `id` in frontmatter is a producer's key, not
@@ -6076,7 +6078,8 @@ worth naming: SQL injection in `compile_sql` through undeclared field
 pass-through, fixed in 0.8.0 — v0.7.0 and earlier are affected. Details
 are in git history.
 
-[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.27.6...HEAD
+[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.28.0...HEAD
+[0.28.0]: https://github.com/na0fu3y/ochakai/compare/v0.27.6...v0.28.0
 [0.27.6]: https://github.com/na0fu3y/ochakai/compare/v0.27.5...v0.27.6
 [0.27.5]: https://github.com/na0fu3y/ochakai/compare/v0.27.4...v0.27.5
 [0.27.4]: https://github.com/na0fu3y/ochakai/compare/v0.27.3...v0.27.4

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -82,7 +82,7 @@ info:
     is a security defect, shipped in the next release with no deprecation
     window (SECURITY.md). MCP, the CLI and the stored shape stay unstable
     while the major version is 0 and may still change in a minor release.
-  version: 0.27.6
+  version: 0.28.0
   license:
     name: MIT
 servers:

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -77,7 +77,7 @@ export IMAGE=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:$VERSION
 `:latest` ではなくバージョンを固定し、再デプロイを意識的な判断にする。
 `gh` CLI が無ければ
 [リリースページ](https://github.com/na0fu3y/ochakai/releases)から番号
-を読み、手で設定する — `export VERSION=0.27.6`。
+を読み、手で設定する — `export VERSION=0.28.0`。
 
 (このガイドは 0.9.0 以降を前提にしている。それより前のリリースは
 [retract](https://go.dev/ref/mod#go-mod-file-retract) 済みでサポート外

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -5,7 +5,7 @@ region     = "us-central1"
 
 # Pin a released version, not "latest", so a redeploy is a decision:
 # https://github.com/na0fu3y/ochakai/releases
-image_tag = "0.27.6"
+image_tag = "0.28.0"
 
 # Who can reach ochakai. This is the whole access-control surface — whoever
 # reaches it can read and write everything. Never allUsers.


### PR DESCRIPTION
0.28.0 の準備 PR。タグは別。

**なぜ minor か。** Unreleased に **BREAKING** が二つある — 冒頭の
`id` が producer の鍵になったこと(0136)と、却下が削除になったこと
(0135)。0.x では BREAKING があれば minor を上げる。

**版を持つ五つのファイル。** タグが更新しないもの全部:

| ファイル | 何 |
| --- | --- |
| `CHANGELOG.md` | `## [Unreleased]` を `## [0.28.0] - 2026-08-30` にし、空の Unreleased を上に開き、末尾のリンクを張り替え |
| `api/openapi.yaml` | `info.version` |
| `.github/ISSUE_TEMPLATE/bug_report.yml` | placeholder |
| `deploy/cloudrun/README.md` | 手で設定する `export VERSION=` の例 |
| `deploy/terraform/terraform.tfvars.example` | `image_tag` — 上の四つと違い版についての文ではなく適用される値なので、古いままだと古いイメージが出る |

`TestReleaseVersionsAgree` が四つを見ている。

**改名の窓は空。** `mcpserver.RetiredToolNames` も `retiredCommands`
も空のままで、消すものが無い。0088 の一リリースの窓を使った改名は
今回無かった — `ochakai reject` は別名にはなっておらず、0135 が
消して `ochakai delete --note` を綴りにした。それを読む場所は
CHANGELOG のほうである。

**取りこぼしの掃除。** v0.27.6 以降の PR を全部当たった:

- #798 / #790 / #789 — Unreleased に入っている(BREAKING 二つと Fixed 二つ)
- #792 — `api/openapi.yaml` の散文が 0134 を指し直しただけで、0134 の項目に乗っている
- #787 — MCP クライアント案内の四項目として入っている
- #788 — テストのみ
- #791 — マイグレーション 0044 の散文と CI の pin。SQL は無傷で、マイグレーションはファイル名で追跡されるから適用済みの DB は動かない。`no-changelog` は正しい
- #786 — スクリーンショット、#793 / #796 — dependabot

`## [Unreleased]` の下に落ちたものも無い: 0.27.6 の節はタグが公開した
ものとバイト一致する(`git show v0.27.6:CHANGELOG.md` と突き合わせ済み)。

**面は減っている。** REST 13 と PARAM 18 は据え置き、CLI は 25 から
24 へ、`FLAG` は 29 から 27 へ、`VOCAB` は 49 から 45 へ。0135 が
`reject` とその周りを畳んだぶんである。

`scripts/check` と `scripts/check --db` がどちらも緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
