### PR TITLE
Keep the outcome notes off MCP, which 0137 said they were

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,12 @@ last entry.
   and `failed` are, since most reports carry no note. A listing never
   carries them: a feed row's `usage` comes from the listing's own
   aggregate, so the feed answers which concept to look at and the read it
-  opens answers what was written about it. MCP does not carry them
-  ([design doc 0137](docs/design/0137-a-report-says-what-it-saw.md)).
+  opens answers what was written about it. MCP does not carry them:
+  `report_outcome` answers with the totals alone, because an agent
+  filing a report is not the reviewer who reads them and handing it up
+  to ten other callers' paragraphs would spend the context window that
+  tool is paid from ([design doc
+  0137](docs/design/0137-a-report-says-what-it-saw.md) §5).
 
   Two things the record states rather than leaves to be discovered.
   **The 180-day pruning of raw events becomes visible here** — until now

--- a/docs/guides/golden-query-canary.md
+++ b/docs/guides/golden-query-canary.md
@@ -99,6 +99,13 @@ ochakai は関与しない。
   か"`(REST: `POST /api/v1/usage/queries/<id>`、MCP:
   `report_outcome`)。worked と failed の合計は `/usage` に出るので、
   失敗が積み上がった検証済み concept を優先して再検証できる。
+  **`--note` に書いた内容もそこに出る** — `ochakai usage <id>` の
+  `report` 行、Web UI なら詳細ページの「利用」タブで、新しい順に最大
+  10 件。数は「どれを先に見るか」を決め、この一文が「何を直すか」を
+  決めるので、**次に読むのは人である**つもりで書く(設計ドキュメント
+  [0137](../design/0137-a-report-says-what-it-saw.md))。スタックトレース
+  ではなく、何を走らせて何が合わなかったかを一文で。生の報告は 180 日で
+  消えるので、それより古い note は残らない。
   **`sort=failed` の再検証フィード**(`ochakai list failed --trust
   human-reviewed`、REST: `GET /api/v1/search?sort=failed`、MCP:
   `list_concepts` に `sort: "failed"`)は、間違いだと報告された

--- a/docs/guides/mcp-clients.md
+++ b/docs/guides/mcp-clients.md
@@ -59,7 +59,7 @@ JSON のキー名が違うだけなので、[その他のクライアント](#�
 | `get_concept` | concept を一件、OKF ドキュメントとして取得する。ファイルのメタデータと、この concept を本文から指す concept の行(`linked_from` — metric の読み方を言う insight はここに出る)が付く |
 | `get_file` | concept に添付されたファイルを取得する(ダッシュボードのスクリーンショット、ER 図、seeds ファイルなど) |
 | `put_concept` | 学びを書き戻す — id が空いていれば作成し、埋まっていれば置き換える。変更はすべてリビジョンとして残る |
-| `report_outcome` | ナレッジをもとに行動した後、worked/failed を報告する — failed の報告は verified な concept を再検証フィードに乗せる |
+| `report_outcome` | ナレッジをもとに行動した後、worked/failed を報告する — failed の報告は verified な concept を再検証フィードに乗せる。`note` に何が起きたかを書けば、フィードを読む人がそれを読む(設計ドキュメント [0137](../design/0137-a-report-says-what-it-saw.md))。**返ってくるのは合計だけで、note の一覧は返らない** — 読むのは REST・CLI・Web UI の側である |
 
 これらはすべて知識に関する操作である。ochakai は SQL を実行せず、LLM も
 呼ばない。`compile_sql` — セマンティックモデルからの決定的な SQL 生成 —

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -514,7 +514,7 @@ func newServer(svc *service.Service, version string, retired []RetiredToolName) 
 		if err != nil {
 			return nil, usageOut{}, err
 		}
-		return nil, usageOut{Usage: *u}, nil
+		return nil, newUsageOut(u), nil
 	}))
 
 	// A read-only deployment does not offer the write tools at all
@@ -704,6 +704,22 @@ type fileOut struct {
 
 type usageOut struct {
 	Usage domain.Usage `json:"usage"`
+}
+
+// newUsageOut is the totals without what the reports said (design doc
+// 0137 §5). The notes are the loop's human side: a reviewer working the
+// failed feed reads them, and an agent that just filed a report does not
+// — it would be handed up to ten other callers' paragraphs, and their
+// names, out of the context window it pays this tool from (0103), which
+// is also the reverse lookup by reporter 0137 §6 declined.
+//
+// Stripping here rather than giving this a shape of its own keeps one
+// definition of the totals; TestReportOutcomeCarriesNoNotes fails if a
+// later field arrives on Usage and reaches this surface unconsidered.
+func newUsageOut(u *domain.Usage) usageOut {
+	out := usageOut{Usage: *u}
+	out.Usage.Reports = nil
+	return out
 }
 
 type outcomeIn struct {

--- a/internal/mcpserver/mcpserver_integration_test.go
+++ b/internal/mcpserver/mcpserver_integration_test.go
@@ -2,6 +2,7 @@ package mcpserver
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -121,6 +122,18 @@ func TestIntegrationDelegatedActorFollowsEachCall(t *testing.T) {
 	}
 	if res.IsError {
 		t.Fatalf("report_outcome failed: %+v", res.Content)
+	}
+	// The result carries the totals and not what the reports said
+	// (design doc 0137 §5). The note this call just wrote is readable —
+	// on REST, the CLI and the web UI, where a reviewer works — and an
+	// agent filing a report is not that reviewer: handing it back up to
+	// ten callers' paragraphs and their names spends the context window
+	// this tool is paid from on the reverse lookup 0137 §6 declined.
+	if body := fmt.Sprint(res.Content); strings.Contains(body, "did not run") {
+		t.Errorf("report_outcome echoed the notes back to MCP: %s", body)
+	}
+	if strings.Contains(fmt.Sprint(res.Content), "reports") {
+		t.Errorf("report_outcome carries a reports field: %v", res.Content)
 	}
 	conn, err := pgx.Connect(context.Background(), dbURL)
 	if err != nil {

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -833,3 +833,52 @@ func TestOneWriteFace(t *testing.T) {
 		t.Errorf("tools = %d, want %d: %v", len(names), len(want), names)
 	}
 }
+
+// TestReportOutcomeCarriesNoNotes holds the line design doc 0137 §5 drew:
+// the notes callers write with their outcome reports are read on REST,
+// the CLI and the web UI, and never here.
+//
+// The tool answers with the concept's totals, and 0137 §5 keeps this
+// surface off the notes for two reasons at once — an agent that just
+// filed a report is not the reviewer who reads them, and handing one up
+// to ten other callers' paragraphs, with their names, spends the context
+// window this tool is paid from (0103) on the reverse lookup by reporter
+// that 0137 §6 declined.
+//
+// It is written against newUsageOut rather than the field, so a later
+// field arriving on domain.Usage does not reach MCP unconsidered: that
+// is the way this leaked in the first place, the tool result being built
+// from the shared totals with nothing asking what had grown on them.
+func TestReportOutcomeCarriesNoNotes(t *testing.T) {
+	full := &domain.Usage{
+		Worked: 3,
+		Failed: 1,
+		Reports: []domain.OutcomeReport{{
+			Outcome: domain.EventFailed,
+			By:      domain.Actor{Kind: "human", Name: "tanaka@example.co.jp"},
+			Note:    "double-counts split shipments",
+		}},
+	}
+	out := newUsageOut(full)
+	if out.Usage.Reports != nil {
+		t.Errorf("MCP result carries the notes: %+v", out.Usage.Reports)
+	}
+	// The totals it does answer with are untouched: this drops one field,
+	// it does not narrow the answer.
+	if out.Usage.Worked != full.Worked || out.Usage.Failed != full.Failed {
+		t.Errorf("totals = %+v, want worked %d failed %d", out.Usage, full.Worked, full.Failed)
+	}
+	// The caller's own value is not modified — the tool is handed the
+	// service's Usage, and clearing it in place would take the notes off
+	// a value the service may still be holding.
+	if full.Reports == nil {
+		t.Error("newUsageOut cleared its argument's reports rather than its copy's")
+	}
+	body, err := json.Marshal(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(body), "reports") {
+		t.Errorf("the marshalled result names reports: %s", body)
+	}
+}


### PR DESCRIPTION
## What and why

Follow-up to [#802](https://github.com/na0fu3y/ochakai/pull/802), fixing a defect it shipped. **Not released** — 0137 is still under `## [Unreleased]`, so no deployment ever answered this way.

[0137](docs/design/0137-a-report-says-what-it-saw.md) §5 put the notes on REST, the CLI and the web UI and kept them off MCP, for two reasons at once: an agent that just filed a report is not the reviewer who reads them, and handing it up to ten other callers' paragraphs — and their names — spends the context window that tool is paid from ([0103](docs/design/0103-the-tool-result-travels-once.md)) on the reverse lookup by reporter that §6 declined.

**The code did not do that.** `report_outcome` answered with `usageOut{Usage: *u}`, built straight from the service's totals, so the moment `domain.Usage` grew a `Reports` field the tool started returning **up to 20 KB of other callers' free text on every call**. The record was right; the surface was not. That is the failure mode of a shared response type — nothing at the boundary asks what has grown on it since — and it is the same shape as the drift #800 and #801 were cleaning up, one layer down.

### The fix

`newUsageOut` drops the field with the reason written beside it, and **`TestReportOutcomeCarriesNoNotes` pins the boundary rather than the field**, so a later addition to `domain.Usage` cannot reach this surface unnoticed the way this one did. It copies rather than clearing in place, since the service may still hold that value — the test covers that too.

**Nothing else moves.** `report_outcome` publishes no output schema (probed: `OutputSchema == nil`), so `MCP-BYTES` is untouched at **12,126 / 12,500** — the leak was in the returned value, never in the advertised schema. The fix costs nothing from the agent's budget and removes the payload.

### Two manual pages the merge left incomplete

Both are places that tell somebody to write a note without saying who reads it:

- **`docs/guides/golden-query-canary.md`** — the page that actually types `--note "何が起きたか"` in its workflow, and then said only *the totals* reach `/usage`. It now says where the note surfaces (`ochakai usage` の `report` 行 / Web UI の「利用」タブ, newest first, at most 10), that **the next reader is a person** so write a sentence rather than a stack trace, and that the raw reports are pruned at 180 days.
- **`docs/guides/mcp-clients.md`** — described `report_outcome` without the note at all, and without the boundary above. One row, now naming both.

I updated `docs/loop.md` in #802 and missed these; the canary guide is the more instructive of the two, since it is where the flag gets typed.

## Checks

- [x] `scripts/check` is clean — `scripts/check --db core` passes with `internal/store`, `internal/service`, `internal/restapi` and `internal/mcpserver` against PostgreSQL 16.13 (not the pgvector/pgvector:pg17 CI uses); `scripts/check lint` reports 0 issues. `govulncheck` cannot reach `vuln.go.dev` from this environment (`Forbidden` from the egress proxy) — unverified here, not failing; CI runs it.
- [x] Behavior changes come with tests — a unit test on the boundary (`newUsageOut` drops the reports, keeps the totals, does not mutate its argument, and the marshalled result never names the field) and an assertion on the real wire in the MCP integration test, that the tool result echoes back neither the note just written nor a `reports` field.
- [x] Behavior changes have a line under `## [Unreleased]` — the existing `### Added` bullet already claimed MCP does not carry them; it now also says what `report_outcome` answers with instead, which was the half a reader could not check.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver` and `internal/apiclient` say the same thing — the first, third and fourth are unchanged; `internal/mcpserver` is what moves, to match what the other three and 0137 §5 already said.
- [x] The change lands on every surface it belongs on — this **removes** something from one surface. REST, the CLI and the web UI keep the notes; MCP is the deliberate omission 0137 §5 named and this makes true.
- [x] `api/openapi.frozen.txt` is untouched.
- [x] Widens a surface? **No** — it narrows one. No counted name moves and `MCP-BYTES` does not change, since the tool has no output schema.

## Design docs

- [x] Alters an accepted decision? **No.** 0137 §5 already decided this; the code disagreed with it. Per [0128](docs/design/0128-a-number-is-for-an-area-not-a-rule-inside-it.md) a number is for an area's decision, not a correction inside one — the record plus the CHANGELOG answer this in three months, and here the record needed no change at all.
- [x] Commit messages and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqNsKPWQ51NyeaDQZN4ST1

---
_Generated by [Claude Code](https://claude.ai/code/session_01NqNsKPWQ51NyeaDQZN4ST1)_