### PR TITLE
Show a concept's sources, and fold its two link tabs into one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,36 @@ last entry.
 
 ### Added
 
+- **The web UI shows what a concept derives from, and its two link tabs
+  became one.** A `sources` row is the material behind the prose (OKF
+  SPEC §5.1) — an address, who wrote it, when it last moved, how often it
+  was exercised — and the only place the page showed one was as YAML in
+  the ドキュメント tab. The body cites a source by `sources[].id` in a
+  footnote whose text is the writer's own line, so `examples/demo`'s
+  `metrics/revenue` drew 「売上計上ポリシー (FY2026)」 under the body and
+  left the wiki address that line stands on, and the day somebody last
+  touched it, on the page and unreadable.
+
+  There is a **出典 tab** now, drawing those rows. It reads them through
+  `POST /api/v1/frontmatter` — the face [design doc
+  0130](docs/design/0130-the-web-ui-and-the-fields-of-a-document.md) §3.3
+  added so the editor could have fields — so the browser still parses no
+  YAML, no read's default shape is widened, and a read-only deployment
+  answers it. A key the row has no word for is drawn under its own name
+  rather than dropped, and `usage_count: 0` is drawn where an absent
+  count is not: the two say different things.
+
+  **リンク and 参照元 are one リンク tab**, with 「リンク先」 and
+  「参照元」 as its headings. They are one graph read in two directions,
+  and having them apart meant a reader had to know which of the two words
+  named the direction they wanted before they could look; each heading
+  now carries the count the tab bar used to. The tab bar is still seven
+  tabs — the fold is what the 出典 tab is paid for. Nothing else moved:
+  no endpoint, command, tool or variable, and
+  [docs/surface.md](docs/surface.md) does not count the Web UI, which
+  has no address space of its own and is a client of `/api/v1`
+  (0130 §2).
+
 - **A failure report's note is readable.** `--note` on `ochakai report`
   has been writable since outcomes existed and **no surface ever read it
   back** — `POST /api/v1/usage/{id}` took up to 2,000 bytes, wrote them

--- a/internal/webui/jstest/smoke.mjs
+++ b/internal/webui/jstest/smoke.mjs
@@ -316,6 +316,35 @@ try {
     await waitFor(`location.hash.startsWith('#fn-')
       && !!document.querySelector('#view .md:not(.desc) .footnotes')`), shown);
 
+  // The other half of that citation. The footnote above carries the
+  // writer's own line; what the line stands on — the address, and when
+  // anybody last touched it — is `sources[].id`'s row, and the tab is
+  // where it is legible rather than as YAML in the document tab.
+  //
+  // Asserted on the address, because that is the part no other tab
+  // shows: the title is also the footnote's text, so a check on it would
+  // pass against a tab that drew nothing of its own. The row is read out
+  // of the document by POST /api/v1/frontmatter (design doc 0130 §3.3),
+  // so this is also the assertion that the page never parses YAML and
+  // still shows the fields.
+  const tab = t => `document.querySelector('#tabs button[data-tab=${json(t)}]').click()`;
+  await evalJS(tab('sources'));
+  await check('a source is drawn as a row, not as YAML',
+    await waitFor(`${textOf('#tab-body')}.includes('wiki.example.co.jp/finance/revenue-recognition')
+      && ${textOf('#tab-body')}.includes('[^rev-policy]')`), shown);
+
+  // Both directions of the graph under one tab: what this body points at
+  // (in hand, from the read that drew the page) and what points at it (a
+  // request, made when the tab is opened). A tab that lost one of them
+  // would still render, which is why each is asserted by its own row.
+  await evalJS(tab('links'));
+  await check('the links tab draws what this concept points at',
+    await waitFor(`!!document.querySelector('#tab-body table.kv a[href$="/insights/reading-revenue"]')`), shown);
+  await check('and, under its own heading, what points at it',
+    await waitFor(`${textOf('#linked-sec')}.includes('参照元')
+      && ${countOf('#linked-sec .card')} > 0`), shown);
+  await evalJS(tab('overview'));
+
   // The status picker, driven end to end. It is here because this is the
   // check that would have caught what the picker shipped broken from
   // v0.21.0 to v0.27.4: applyStatus threw a ReferenceError on its first

--- a/internal/webui/static/app.css
+++ b/internal/webui/static/app.css
@@ -409,6 +409,11 @@ input[type=date]:not(:focus):invalid, input[type=date]:not(:focus):placeholder-s
 }
 .tabs button:hover { color: var(--text); }
 .tabs button.active { color: var(--accent-strong); border-bottom-color: var(--accent); }
+/* The links tab holds both directions of one graph, so its second
+   heading follows the first section's own last rule. The gap is the
+   heading's, not the table's: what separates the two is that the reader
+   has finished one question and is starting the other. */
+#linked-sec { display: block; margin-top: 1.7rem; }
 /* A revision's diff (diff.js): a line each, colored the way the page
    already colors states — additions in verified's green, deletions in
    rejected's red — and the elisions quiet, because they are the part

--- a/internal/webui/static/js/views/detail.js
+++ b/internal/webui/static/js/views/detail.js
@@ -36,16 +36,34 @@ export const windowText = w => w && (w.from || w.to) ? `${w.from || '…'} → $
 export const TAB_LABELS = {
   overview: '概要',
   document: 'ドキュメント',
+  sources: '出典',
   links: 'リンク',
   files: 'ファイル',
-  linked: '参照元',
   usage: '利用状況',
   history: '履歴',
 };
 
-// The material an entry derives from (OKF SPEC §5.1). ochakai shows the
-// signals as the writer recorded them and scores nothing: §5.1 leaves
-// weighing them to whoever is reading.
+// A source row's plain labelled pairs (OKF SPEC §5.1). The other keys
+// the spec gives a source are not here because each has a place of its
+// own: `resource` is the address the row leads with, `title` and `id`
+// name it, and `usage_count` carries the window it was counted over.
+//
+// SOURCE_KNOWN is every key that has one of those places, so that what
+// is left is a producer's own (SPEC §4.1) and can be drawn under its own
+// name rather than dropped — a reading of the document that showed less
+// than the document says would be worth less than the document.
+const SOURCE_FIELDS = [
+  ['author', '作成者'],
+  ['last_modified', '最終更新'],
+];
+const SOURCE_KNOWN = new Set(['resource', 'id', 'title', 'usage_count', 'usage_window',
+  ...SOURCE_FIELDS.map(([k]) => k)]);
+
+// A producer's own value, drawn as text. A scalar is what it says; a
+// nested shape is JSON, which is at least the shape it has — the
+// alternative is `[object Object]`, which is a value the reader cannot
+// tell from a bug.
+const scalarText = v => (v !== null && typeof v === 'object') ? JSON.stringify(v) : String(v);
 
 // The concepts this session has already found: a body that links to a
 // neighbour is usually one of several that do, and a concept that is
@@ -217,9 +235,9 @@ export async function viewDetail(id, heading = '') {
     <div class="tabs" id="tabs">
       <button data-tab="overview" class="active">${TAB_LABELS.overview}</button>
       <button data-tab="document">${TAB_LABELS.document}</button>
-      <button data-tab="links">${TAB_LABELS.links}${entry.links && entry.links.length ? ' (' + entry.links.length + ')' : ''}</button>
+      <button data-tab="sources">${TAB_LABELS.sources}</button>
+      <button data-tab="links">${TAB_LABELS.links}</button>
       <button data-tab="files">${TAB_LABELS.files}${atts.length ? ' (' + atts.length + ')' : ''}</button>
-      <button data-tab="linked">${TAB_LABELS.linked}</button>
       <button data-tab="usage">${TAB_LABELS.usage}</button>
       <button data-tab="history">${TAB_LABELS.history}</button>
     </div>
@@ -273,9 +291,6 @@ export async function viewDetail(id, heading = '') {
   };
 
   const tabs = {
-    // Sources sit under the prose they support rather than in a tab of
-    // their own: OKF's own model is body footnotes keyed to source ids, so
-    // whoever is reading the body is exactly who needs the list.
     overview: () => {
       // The body with its outline: ids on the headings, and a table of
       // contents when there are enough of them to need a map. The
@@ -296,18 +311,40 @@ export async function viewDetail(id, heading = '') {
     // the duplication document-first exists to remove, and the reason
     // design doc 0044 puts the format itself in front of the reader.
     document: () => `<pre class="mono">${esc(document_)}</pre>`,
-    // Read-only: links come from the body's markdown links (design doc
-    // 0024), so the body editor is where they are changed.
+    // What the document derives from (OKF SPEC §5.1), read out of the
+    // document by the server rather than by the page: the browser parses
+    // no YAML (design doc 0130 §3.3), and this is the same face the
+    // editor draws its fields from. The rows are shown as the writer
+    // recorded them and nothing is scored — §5.1 leaves weighing them to
+    // whoever is reading.
+    //
+    // They had been visible only as YAML in the document tab, while the
+    // body cites them by `sources[].id` in a footnote whose text is the
+    // writer's own line — so the address the citation stands on, and when
+    // anybody last touched it, were on the page and unreadable.
+    sources: () => '<div class="empty">…</div>',
+    // Both directions of one graph, in one tab. They were two, and the
+    // reader who wanted "what is this connected to" had to know which of
+    // two words named the direction they meant before they could look;
+    // the rows answer the same question and only the arrow differs, which
+    // a heading can say for a third of the tab bar's width.
+    //
+    // Outgoing is in hand: links come from the body's markdown links
+    // (design doc 0024), so the body editor is where they are changed.
+    // Incoming is a request, made when the tab is first opened.
     links: () => {
       const links = entry.links || [];
-      if (!links.length) return '<div class="empty">本文はまだ他のナレッジを指していません。</div>';
-      return '<table class="kv">' + links.map(l => {
+      const rows = links.map(l => {
         const target = String(l.target || '').replace(/^ochakai:\/\//, '');
         const href = target ? '#/k/' + idPath(target) : null;
         const text = l.text || target.split('/').pop() || target;
         return `<tr><td class="k">${esc(text)}</td>
           <td>${href ? `<a class="mono" href="${href}">${esc(target)}</a>` : `<span class="mono">${esc(target)}</span>`}</td></tr>`;
-      }).join('') + '</table>';
+      }).join('');
+      return `
+        <div class="section-title">リンク先${links.length ? ` (${links.length})` : ''}</div>
+        ${rows ? `<table class="kv">${rows}</table>` : '<div class="empty">本文はまだ他のナレッジを指していません。</div>'}
+        <div id="linked-sec">${linkedHTML || '<div class="section-title">参照元</div><div class="empty">…</div>'}</div>`;
     },
     // A deployment with no bucket holds markdown concepts only (design
     // doc 0075 §1), so everything that would add a file can only be
@@ -348,7 +385,6 @@ export async function viewDetail(id, heading = '') {
         <p class="provenance write-only files-only">本文から参照しておくと
         (<code>![alt](${esc(lastSeg)}/name.png)</code> または <code>[name](${esc(lastSeg)}/name.txt)</code>)、埋め込みできるようになります。</p>`;
     },
-    linked: () => '<div class="empty">…</div>',
     usage: () => '<div class="empty">…</div>',
     history: () => '<div class="empty">…</div>',
   };
@@ -407,6 +443,13 @@ export async function viewDetail(id, heading = '') {
       <p class="provenance">note の付いた報告だけを新しい順に最大 10 件。報告の件数は上の成功・失敗です。生の報告は 180 日で消えるので、それより古いものは残っていません。</p>`;
   };
 
+  // The incoming half of the links tab, once it has been fetched. It is
+  // held here rather than in the lazy table below because it is half of a
+  // tab: what the two directions cost is not the same, and a failure to
+  // reach the server about the backlinks must not take the outgoing links
+  // — which are already in hand, and are right — off the page with it.
+  let linkedHTML = '';
+  let asking = false;
   const body = $('#tab-body');
   // Lazily loaded tabs: fetch once on first open, then re-render from the
   // cached template. A failed fetch shows in place and retries next open.
@@ -423,11 +466,46 @@ export async function viewDetail(id, heading = '') {
         <p class="provenance">${u.last_used_at ? '最終利用日: ' + esc(fmtDate(u.last_used_at)) : 'まだ使われていません'}</p>
         ${reportsHTML(u.reports)}`;
     },
-    linked: async () => {
-      const { hits: entries = [] } = await api('/api/v1/search?links_to=' + encodeURIComponent(entry.id) + '&limit=100');
-      return () => (entries && entries.length)
-        ? entries.map(hitCard).join('')
-        : '<div class="empty">このナレッジを指しているものは、まだありません。</div>';
+    // The frontmatter as structure, from the one face that reads it
+    // (design doc 0130 §3.3). The document is already in hand, so this
+    // posts the bytes this page drew rather than naming the concept:
+    // there is no id, no ETag and nothing stored, and a read-only
+    // deployment answers it.
+    sources: async () => {
+      const { values = {} } = await api('/api/v1/frontmatter', { method: 'POST', body: { document: document_ } });
+      const rows = Array.isArray(values.sources) ? values.sources.filter(r => r && typeof r === 'object') : [];
+      // The window the counts were counted over is the entry's, and a
+      // source may name its own for itself — so the one below the table
+      // is the entry's and a row that overrides it says so in place.
+      const window_ = windowText(values.usage_window);
+      return () => {
+        if (!rows.length) return '<div class="empty">この文書は出典を挙げていません。</div>';
+        const trs = rows.map(r => {
+          const meta = [];
+          for (const [key, label] of SOURCE_FIELDS) {
+            if (r[key] !== undefined && r[key] !== null && r[key] !== '') meta.push(`${label} ${scalarText(r[key])}`);
+          }
+          if (r.usage_count !== undefined && r.usage_count !== null) {
+            const own = windowText(r.usage_window);
+            meta.push(`参照回数 ${scalarText(r.usage_count)}${own ? `(${own})` : ''}`);
+          }
+          for (const [key, v] of Object.entries(r)) {
+            if (!SOURCE_KNOWN.has(key)) meta.push(`${key} ${scalarText(v)}`);
+          }
+          // The name is the writer's title, and the id behind it when
+          // there is none: a source with neither is its address, which
+          // the value cell is already showing.
+          const name = r.title || r.id || '';
+          return `<tr>
+            <td class="k">${esc(name)}</td>
+            <td>${r.resource ? resourceHTML(r.resource) : '<span class="provenance">場所がありません</span>'}
+              ${meta.length ? `<div class="provenance">${esc(meta.join(' · '))}</div>` : ''}
+              ${r.id ? `<div class="provenance">本文からの参照: <code>[^${esc(r.id)}]</code></div>` : ''}
+            </td></tr>`;
+        }).join('');
+        return `<table class="kv">${trs}</table>
+          ${window_ ? `<p class="provenance">参照回数を数えた期間: ${esc(window_)}</p>` : ''}`;
+      };
     },
     history: async () => {
       // ?history is the object's own ledger, at the object's own address
@@ -457,6 +535,34 @@ export async function viewDetail(id, heading = '') {
       return () => `<table class="kv">${rows}</table>`;
     },
   };
+  // What links at this concept — the one question its own document cannot
+  // answer (design doc 0106). The read that drew this page carries the
+  // first rows of it; this asks search for the whole set, which is what a
+  // curator following an edge is after, and it asks once.
+  async function fillLinked() {
+    if (linkedHTML || asking) return;
+    asking = true;
+    let html;
+    try {
+      const { hits = [] } = await api('/api/v1/search?links_to=' + encodeURIComponent(entry.id) + '&limit=100');
+      html = linkedHTML = `<div class="section-title">参照元${hits.length ? ` (${hits.length})` : ''}</div>`
+        + (hits.length ? hits.map(hitCard).join('') : '<div class="empty">このナレッジを指しているものは、まだありません。</div>');
+    } catch (e) {
+      // Nothing is cached, so opening the tab again asks again.
+      html = `<div class="section-title">参照元</div>
+        <div class="error-banner" role="alert">参照元を読み込めませんでした: ${esc(e.message)}</div>`;
+    } finally {
+      asking = false;
+    }
+    // The reader may have walked on while the request was out; the
+    // section this answers is the one that asked.
+    const sec = $('#linked-sec');
+    if (sec) {
+      sec.innerHTML = html;
+      markDead();
+    }
+  }
+
   // Links to concepts that are not there, drawn as what they are. The
   // verdict is this render's, and the marking runs after every tab
   // render — a tab body is redrawn from its template each time it opens,
@@ -475,6 +581,7 @@ export async function viewDetail(id, heading = '') {
     document.querySelectorAll('#tabs button').forEach(b => b.classList.toggle('active', b.dataset.tab === name));
     body.innerHTML = tabs[name]();
     if (name === 'files') wireFiles();
+    if (name === 'links') fillLinked();
     if (lazy[name]) {
       try {
         tabs[name] = await lazy[name]();


### PR DESCRIPTION
## What and why

Two requests, and they pay for each other. The tab bar is still seven tabs.

**「sources を見るタブが欲しい」.** A `sources` row is the material behind the prose (OKF SPEC §5.1) — an address, who wrote it, when it last moved, how often it was exercised — and the only place the detail page showed one was as YAML in the ドキュメント tab. The body cites a source by `sources[].id` in a footnote whose text is the writer's own line, so `examples/demo`'s own `metrics/revenue` drew 「売上計上ポリシー (FY2026)」 under the body and left the wiki address that name stands on, and the day somebody last touched it, on the page and unreadable. The editor could put a source *in* (0130 §3.2); nothing could read one back except in raw frontmatter.

The 出典 tab reads them through **`POST /api/v1/frontmatter`** — the face 0130 §3.2 added for exactly this shape of problem, and §3.3 opened to any caller that says it needs structure. So the browser still parses no YAML, no read's default shape is widened, and a read-only deployment answers it. Widening `Summary` instead is what [0072](https://github.com/na0fu3y/ochakai/blob/main/docs/design/0072-the-web-ui-serves-and-edits-documents.md) §3.1 refused for a reason that outlived it: a curation surface that runs the envelope's structure alongside the read teaches a shape the format does not have.

Two details it gets right on purpose, both testable in the screenshots below: a key the row has no word for is drawn under its own name rather than dropped (SPEC §4.1 — the same promise the editor's 「この欄に無いキー」 note makes), and `usage_count: 0` is drawn where an absent count is not, which is why that field is a pointer in `domain.Source`. A source's own `usage_window` overrides the entry's in place; the entry's is the line under the table. `windowText` had been exported and called by nothing since the module split — this is its caller.

**「リンクと参照元は統合してもよいのではないか」** — yes, and it is what the new tab is paid for. They are one graph read in two directions, and having them under two words in the tab bar meant a reader had to know which of the two named the direction they wanted before they could look. One リンク tab now, 「リンク先」 and 「参照元」 as its headings, each carrying the count the tab bar used to.

The incoming half is still the complete set from search's `links_to` rather than the read's first twenty `linked_from` rows ([0106](https://github.com/na0fu3y/ochakai/blob/main/docs/design/0106-what-links-at-this-entry.md)) — using the read's rows would have put `maxBacklinks`, a server constant, in the page. It is filled in place rather than through the lazy table, because a failure to reach the server about the backlinks must not take the outgoing links — already in hand, and right — off the page with it.

### The three questions

Asked because the Web UI has a default too (0067 §1: 「人の curation に要るときだけ」), even though `docs/surface.md` counts no dimension here.

1. **Who got stuck.** Somebody reading a concept to decide whether to trust it. The footnote gives them the source's *name*; the address it stands on and its `last_modified` — the two things that say whether the citation is still good — were only in the raw document.
2. **Does an existing surface cover it.** The ドキュメント tab does, in the sense that YAML is on the page. That is the same "it is technically visible" that 0130 §3.2 rejected on the write side, and this is its read side.
3. **What is folded.** リンク and 参照元, into one tab. Net zero.

## Checks

- [x] `scripts/check` is clean — `core`, `ui` and `lint` all green. Not run with `--db`: this change touches no Go, and no store.
- [x] Behavior changes come with tests — three added to the browser smoke (0130 §4's layer for a claim about the whole page): a source is drawn as a row rather than as YAML, the links tab draws what the concept points at, and, under its own heading, what points at it. Verified green against `examples/demo` with `ochakai ui`. The renderers live inside `viewDetail`, which is not a pure module, so there is nothing for `node --test` to hold — the same reason the links tab has always been smoke-covered rather than unit-covered.
- [x] Behavior changes have a line under `## [Unreleased]` in `CHANGELOG.md`

Read at 1280px and 500px against a source carrying a per-source window, a producer's own key, `usage_count: 0`, no title, and no `resource` at all, and against a concept that lists no sources: no horizontal overflow, no console errors.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, `internal/apiclient` — untouched. No endpoint moved; the page calls one that has existed since 0.27.2.
- [x] The change lands on every surface it belongs on — **Web UI only, deliberately.** `POST /api/v1/frontmatter` is deliberately absent from CLI and MCP (0130 §6), and this is a reader for the same reason: a terminal reader already has the document open, and an agent reads the frontmatter it was handed.
- [x] `api/openapi.frozen.txt` is untouched.
- [x] Widens a surface? **No.** `docs/surface.md` counts no Web UI dimension — the page has no address space of its own and is a client of `/api/v1` (0130 §2) — and no REST, MCP, CLI, FLAG, ENV, PARAM, HEADER or VOCAB entry moves.

## Design docs

- [x] Alters an accepted decision? **No.** The Web UI is [0130](https://github.com/na0fu3y/ochakai/blob/main/docs/design/0130-the-web-ui-and-the-fields-of-a-document.md)'s area, and §2 already rules that what the page follows the API into is decided case by case on whether a person's curation needs it — so which tabs the detail page has is a rule inside that area, not an area of its own ([0128](https://github.com/na0fu3y/ochakai/blob/main/docs/design/0128-a-number-is-for-an-area-not-a-rule-inside-it.md) §2). It is on 0067 §5.4's list of what the Web UI declines in neither direction: `sources` was never declined, only never drawn.
- [x] Commit messages and code comments are in English.

## One thing seen and not fixed

The smoke's access-policy check clicks `#access-add` with no `waitFor` guard, and it failed once in five local runs on a `null` there before passing on the next run. It is unrelated to this diff — that view is untouched — so it is left alone rather than folded in here, but it is a real race and worth its own line.

---
_Generated by [Claude Code](https://claude.ai/code/session_012k8PQKmri7NLRSnnWoMgHo)_