### PR TITLE
Release 0.28.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Version
       description: Output of `ochakai version`, or the image tag you deployed.
-      placeholder: "0.28.1"
+      placeholder: "0.28.2"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ last entry.
 
 ## [Unreleased]
 
+## [0.28.2] - 2026-09-01
+
 ### Added
 
 - **A concept edited after it was confirmed says so.** OKF SPEC §5.2
@@ -6252,7 +6254,8 @@ worth naming: SQL injection in `compile_sql` through undeclared field
 pass-through, fixed in 0.8.0 — v0.7.0 and earlier are affected. Details
 are in git history.
 
-[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.28.1...HEAD
+[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.28.2...HEAD
+[0.28.2]: https://github.com/na0fu3y/ochakai/compare/v0.28.1...v0.28.2
 [0.28.1]: https://github.com/na0fu3y/ochakai/compare/v0.28.0...v0.28.1
 [0.28.0]: https://github.com/na0fu3y/ochakai/compare/v0.27.6...v0.28.0
 [0.27.6]: https://github.com/na0fu3y/ochakai/compare/v0.27.5...v0.27.6

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -82,7 +82,7 @@ info:
     is a security defect, shipped in the next release with no deprecation
     window (SECURITY.md). MCP, the CLI and the stored shape stay unstable
     while the major version is 0 and may still change in a minor release.
-  version: 0.28.1
+  version: 0.28.2
   license:
     name: MIT
 servers:

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -77,7 +77,7 @@ export IMAGE=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:$VERSION
 `:latest` ではなくバージョンを固定し、再デプロイを意識的な判断にする。
 `gh` CLI が無ければ
 [リリースページ](https://github.com/na0fu3y/ochakai/releases)から番号
-を読み、手で設定する — `export VERSION=0.28.1`。
+を読み、手で設定する — `export VERSION=0.28.2`。
 
 (このガイドは 0.9.0 以降を前提にしている。それより前のリリースは
 [retract](https://go.dev/ref/mod#go-mod-file-retract) 済みでサポート外

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -5,7 +5,7 @@ region     = "us-central1"
 
 # Pin a released version, not "latest", so a redeploy is a decision:
 # https://github.com/na0fu3y/ochakai/releases
-image_tag = "0.28.1"
+image_tag = "0.28.2"
 
 # Who can reach ochakai. This is the whole access-control surface — whoever
 # reaches it can read and write everything. Never allUsers.


### PR DESCRIPTION
0.28.1 から5本入った。**BREAKING** はないので patch。

## この PR がすること

`## [Unreleased]` を `## [0.28.2] - 2026-09-01` にして空の窓を上に作り、
比較リンクを張り替える。あわせて、タグが更新しない版番号5ファイル:

- `api/openapi.yaml` の `info.version`
- `.github/ISSUE_TEMPLATE/bug_report.yml` の placeholder
- `deploy/cloudrun/README.md` の手で打つ `export VERSION=`
- `deploy/terraform/terraform.tfvars.example` の `image_tag` — これだけは
  文章ではなく適用される値なので、古いままだと古いイメージが出る

`mcpserver.RetiredToolNames` と `retiredCommands` はどちらも既に空で、
この版が閉じる退役窓はない。

## 何が入るか

- 確認後に編集された概念がそう言う (#805)
- Web UI の 出典 タブと、リンク/参照元 の2タブを1つに (#804)
- 失敗レポートの note が読み戻せる (#802) — MCP には載せない (#803)
- 拒否を状態として書いていた5ページの修正 (#801)

`docs/surface.md` の見出しは v0.28.1 から増減なし。

## Surface の三問

新しい surface を広げないので該当しない — 中身は既に main に入っている
機能で、この PR は版番号だけを動かす。

`scripts/check` は緑。