### PR TITLE
Name an actor once on the web UI's provenance line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,26 @@ last entry.
 
 ## [Unreleased]
 
+### Changed
+
+- **The web UI names an actor once on a concept's provenance line.** A
+  delegated identity is two identities wide — the caller that acted is
+  kept beside the person it acted for, never dropped, because a
+  delegation nobody can tell apart from a direct write is a forgery
+  (design doc 0065 §3) — so a concept created and later edited through
+  the same embedded application printed that whole pair twice. On the
+  deployed web UI, whose service account is the caller for every edit
+  anybody makes through it, that filled two of the header's lines on a
+  desktop and six on a phone with one name repeated.
+
+  The line now groups the events under whoever did them, in the order
+  each actor first appears:
+  `👤 tanaka@example.co.jp(process:ui@proj.iam.gserviceaccount.com 経由)
+  が作成 2026年8月25日・更新 2026年8月31日`. Nothing is dropped and no
+  identity is abbreviated — two actors still print two names, and the
+  same header on a phone is three lines instead of six. `ochakai get`'s
+  provenance line on stderr is unchanged.
+
 ## [0.28.2] - 2026-09-01
 
 ### Added

--- a/internal/webui/jstest/format.test.js
+++ b/internal/webui/jstest/format.test.js
@@ -6,7 +6,7 @@ import assert from 'node:assert/strict';
 import {
   actorStr, conceptURL, crumbTrail, daysSince, dirHash, displayTitle,
   editedSinceVerified, entryHash, fmtAge, fmtDateTime, fmtSize, headingHash,
-  isVerified, lastVerification, parseKPath, trustOf,
+  isVerified, lastVerification, parseKPath, provenanceLine, trustOf,
 } from '../static/js/format.js';
 import { esc } from '../static/js/escape.js';
 
@@ -78,6 +78,52 @@ test('an actor never loses who it was acting through', () => {
   assert.equal(actorStr({ kind: 'process', name: 'sa@p', producer: 'claude/1' }), '🤖 sa@p(claude/1 使用)');
   assert.equal(actorStr(null), '');
   assert.equal(actorStr({ kind: 'human' }), '');
+});
+
+test('the provenance line names an actor once, however many events it did', () => {
+  // The case that made the line unreadable: one person, writing through
+  // an embedded application, created a concept and later edited it. The
+  // delegation chain is two identities wide and is never dropped (design
+  // doc 0065 §3), so it filled a phone's header twice over.
+  const na0 = { kind: 'human', name: 'na0@x.jp', via: 'process:ui@p.iam.gserviceaccount.com' };
+  const line = provenanceLine(
+    { created_at: '2026-08-25T00:00:00Z', updated_at: '2026-08-31T00:00:00Z' },
+    { created_by: na0, generated: { by: na0, at: '2026-08-31T00:00:00Z' } });
+  assert.equal(line.split('process:ui@p.iam.gserviceaccount.com').length - 1, 1);
+  assert.match(line, /^👤 na0@x\.jp\(process:ui@p\.iam\.gserviceaccount\.com 経由\) が作成 .+・更新 .+$/);
+
+  // Two actors are two names: the fold is a repeat removed, not an
+  // identity dropped. Each group keeps the order it first appeared in.
+  const agent = { kind: 'process', name: 'sa@p', producer: 'claude/1' };
+  const two = provenanceLine(
+    { created_at: '2026-08-25T00:00:00Z', updated_at: '2026-08-31T00:00:00Z' },
+    {
+      created_by: agent,
+      verified: [{ by: na0, at: '2026-08-26T00:00:00Z' }],
+      generated: { by: agent, at: '2026-08-31T00:00:00Z' },
+    });
+  assert.match(two, /^🤖 sa@p\(claude\/1 使用\) が作成 .+・更新 .+ · 👤 na0@x\.jp\(.+ 経由\) が検証 .+$/);
+});
+
+test('the provenance line says only what the ledgers say', () => {
+  // Nothing was written after the creation, so there is no 更新 — and an
+  // updated_at that only moved for a reformat is not one either, because
+  // the date comes from generated.at (OKF SPEC §5.2).
+  const created = { created_at: '2026-08-25T00:00:00Z', updated_at: '2026-08-31T00:00:00Z' };
+  assert.match(provenanceLine(created, { created_by: { kind: 'human', name: 'a@b' }, generated: { at: '2026-08-25T00:00:00Z' } }),
+    /^👤 a@b が作成 [^·]+$/);
+  // Events nobody recorded an actor for are a group of their own: the
+  // dates still stand, with no name in front of them.
+  assert.match(provenanceLine(created, {}), /^作成 .+・更新 .+$/);
+  // Confirmed more than once, the newest is the one shown, and the line
+  // says how many there were.
+  const twice = provenanceLine(created, {
+    created_by: { kind: 'human', name: 'a@b' },
+    verified: [{ by: { kind: 'human', name: 'a@b' }, at: '2026-08-26T00:00:00Z' },
+      { by: { kind: 'human', name: 'a@b' }, at: '2026-08-27T00:00:00Z' }],
+    generated: { at: '2026-08-25T00:00:00Z' },
+  });
+  assert.match(twice, /^👤 a@b が作成 .+・検証 .+\(計 2 件\)$/);
 });
 
 test('trust defaults to unverified, and the newest verification wins', () => {

--- a/internal/webui/static/js/format.js
+++ b/internal/webui/static/js/format.js
@@ -35,6 +35,49 @@ export function actorStr(a) {
   return (a.kind === 'human' ? '👤 ' : '🤖 ') + a.name +
     (notes.length ? '(' + notes.join('・') + ')' : '');
 }
+// The header's provenance line: when this concept was written,
+// confirmed and last changed, and who each of those was.
+//
+// An actor is named once. A delegated identity is two identities wide —
+// the caller is kept beside the person it acted for, never dropped
+// (design doc 0065 §3) — so a concept somebody created and later edited
+// through the same embedded application printed that pair twice, and
+// filled a phone's header with one name repeated. Nothing is dropped
+// here either: the events are grouped under the actor who did them, in
+// the order that actor first appears, and an event whose actor is
+// unknown groups with the others that have none.
+export function provenanceLine(entry, observed) {
+  const o = observed || {};
+  const lv = lastVerification(o);
+  // The 更新 date is generated.at — when the content last meaningfully
+  // changed (OKF SPEC §5.2) — rather than updated_at, which moves for a
+  // write that only reformatted the document; drawing generated.by
+  // beside updated_at named a date generated never claimed (design doc
+  // 0064 fixed the same mismatch in the JSON).
+  const changedAt = (o.generated || {}).at || entry.updated_at;
+  const events = [
+    { text: `作成 ${fmtDate(entry.created_at)}`, by: o.created_by },
+    lv
+      ? {
+        text: `検証 ${fmtDate(lv.at)}`
+          + ((o.verified || []).length > 1 ? `(計 ${o.verified.length} 件)` : ''),
+        by: lv.by,
+      }
+      : null,
+    changedAt && changedAt !== entry.created_at
+      ? { text: `更新 ${fmtDate(changedAt)}`, by: (o.generated || {}).by }
+      : null,
+  ].filter(Boolean);
+
+  const groups = [];
+  for (const e of events) {
+    const who = actorStr(e.by);
+    const g = groups.find(x => x.who === who);
+    if (g) g.texts.push(e.text);
+    else groups.push({ who, texts: [e.text] });
+  }
+  return groups.map(g => (g.who ? g.who + ' が' : '') + g.texts.join('・')).join(' · ');
+}
 // The ledgers a read carries beside the document (design doc 0043
 // §§3.2-3.3). Verification is plural and stored oldest-first, so the
 // newest is the last one.

--- a/internal/webui/static/js/views/detail.js
+++ b/internal/webui/static/js/views/detail.js
@@ -8,7 +8,7 @@ import { copyText } from '../clipboard.js';
 import { diffHTML, diffLines, diffStats } from '../diff.js';
 import { $, view } from '../dom.js';
 import { esc } from '../escape.js';
-import { actorStr, conceptURL, crumbTrail, displayTitle, editedSinceVerified, fmtDate, fmtDateTime, fmtSize, idPath, isVerified, lastVerification, parseKPath, trustOf } from '../format.js';
+import { actorStr, conceptURL, crumbTrail, displayTitle, editedSinceVerified, fmtDate, fmtDateTime, fmtSize, idPath, isVerified, lastVerification, parseKPath, provenanceLine, trustOf } from '../format.js';
 import { checkTargets } from '../links.js';
 import { descHTML, md } from '../markdown.js';
 import { headingAnchors, permalinks, tocHTML } from '../outline.js';
@@ -157,27 +157,11 @@ export async function viewDetail(id, heading = '') {
 
   // The pair the page is read by: generated is who the content stands by
   // and when it last meaningfully changed (OKF SPEC §5.2), verified is
-  // who confirmed it and when. The 更新 line dates itself from
-  // generated.at rather than updated_at, which moves for a write that
-  // only reformatted the document — it used to draw generated.by beside
-  // a date generated never claimed (design doc 0064 fixed the same
-  // mismatch in the JSON).
-  const changedAt = (observed.generated || {}).at || entry.updated_at;
+  // who confirmed it and when. Both, and the creation, are one line —
+  // grouped under whoever did them, so an actor is named once
+  // (format.js, provenanceLine).
   const edited = editedSinceVerified(observed);
-  const prov = [
-    observed.created_by && observed.created_by.name ? `作成 ${fmtDate(entry.created_at)} ${actorStr(observed.created_by)}` : `作成 ${fmtDate(entry.created_at)}`,
-    lastVerification(observed)
-      ? `検証 ${fmtDate(lastVerification(observed).at)} ${actorStr(lastVerification(observed).by)}`
-        + ((observed.verified || []).length > 1 ? `(計 ${observed.verified.length} 件)` : '')
-      : '',
-    // updated_by is OKF's generated.by: who the content stands by now,
-    // which is not always who created it (design doc 0036 §3.3).
-    changedAt && changedAt !== entry.created_at
-      ? ((observed.generated || {}).by && observed.generated.by.name
-          ? `更新 ${fmtDate(changedAt)} ${actorStr(observed.generated.by)}`
-          : `更新 ${fmtDate(changedAt)}`)
-      : '',
-  ].filter(Boolean).join(' · ');
+  const prov = provenanceLine(entry, observed);
 
   // A passed stale_after is a prompt to re-check, never a claim the entry
   // is wrong (OKF SPEC §5.5) — the comparison is a plain one against now.


### PR DESCRIPTION
## What and why

Feedback on the detail page's header: `ochakai-webui@<project>.iam.gserviceaccount.com`
appears **twice on one line**. It takes two lines on a desktop and six on a
phone, which is most of the header. It is not wrong — it is design doc
[0065](docs/design/0065-identity-and-provenance.md) §3's delegation chain drawn
correctly — but it is a burden to read.

The length is not the identity, it is the repeat. A delegated identity is two
identities wide (the caller is kept beside the person it acted for, because a
delegation nobody can tell apart from a direct write is a forgery), and the line
drew that pair once per event. On a deployed web UI the service account is the
caller for **every** edit anybody makes, so a concept somebody created and later
edited printed the same pair twice.

So the repeat folds, and nothing else does. The line now groups the events under
whoever did them, in the order each actor first appears:

```
👤 tanaka@example.co.jp(process:ui@proj.iam.gserviceaccount.com 経由) が作成 2026年8月25日・更新 2026年8月31日
```

- Two actors still print two names (`🤖 sa@p(claude/1 使用) が作成…・更新… · 👤 tanaka@… が検証…`).
- An event whose actor nobody recorded still stands on its date alone, grouped
  with the others that have none.
- **No identity is abbreviated.** Dropping the constant `.iam.gserviceaccount.com`
  would shorten it further and was declined: the 👤/🤖 icons are derived from
  exactly that suffix (0065 §2), so hiding it takes the evidence for the
  human/process distinction off the screen.

Measured in a browser against the dogfood instance, injecting the reported
strings at the reported widths: **6 lines → 3 at 375px, 2 → 1 on a desktop.**

Composing the line moves out of `views/detail.js` into `format.js` — the half of
the page a test can hold — as `provenanceLine()`.

No surface widens: no endpoint, tool, command, flag or variable, and
`docs/surface.md` counts none of this. `ochakai get`'s provenance line on stderr
has a different shape (creation and confirmation, no 更新) and is deliberately
left alone; say the word and it can follow.

## Checks

- [x] `scripts/check` is clean — `--db` not needed (no store change)
- [x] Behavior changes come with tests — four cases in
      `internal/webui/jstest/format.test.js`: the reported repeat, two actors
      staying two names, several confirmations, and an unrecorded actor
- [x] Behavior changes have a line under `## [Unreleased]` in `CHANGELOG.md`

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, and
      `internal/apiclient` say the same thing — none of them moved
- [x] The change lands on every surface it belongs on: the web UI is the one
      with a header to crowd. REST and MCP carry `observed` unchanged, and the
      CLI's own line is left as noted above
- [x] `api/openapi.frozen.txt` is untouched
- [x] Does not widen a surface

## Design docs

- [x] Not applicable. 0065 §3 is not altered — the chain is still whole and
      still never dropped; what changed is that it is printed once. A rule
      inside an area belongs in the PR and the CHANGELOG, not a number
      ([0128](docs/design/0128-a-number-is-for-an-area-not-a-rule-inside-it.md))
- [x] Commit messages and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)
