### PR TITLE
Prepare release 0.28.3

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Version
       description: Output of `ochakai version`, or the image tag you deployed.
-      placeholder: "0.28.2"
+      placeholder: "0.28.3"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ last entry.
 
 ## [Unreleased]
 
+## [0.28.3] - 2026-09-03
+
 ### Added
 
 - **A fourth review queue, `edited`: concepts confirmed once but edited
@@ -6377,7 +6379,8 @@ worth naming: SQL injection in `compile_sql` through undeclared field
 pass-through, fixed in 0.8.0 — v0.7.0 and earlier are affected. Details
 are in git history.
 
-[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.28.2...HEAD
+[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.28.3...HEAD
+[0.28.3]: https://github.com/na0fu3y/ochakai/compare/v0.28.2...v0.28.3
 [0.28.2]: https://github.com/na0fu3y/ochakai/compare/v0.28.1...v0.28.2
 [0.28.1]: https://github.com/na0fu3y/ochakai/compare/v0.28.0...v0.28.1
 [0.28.0]: https://github.com/na0fu3y/ochakai/compare/v0.27.6...v0.28.0

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -82,7 +82,7 @@ info:
     is a security defect, shipped in the next release with no deprecation
     window (SECURITY.md). MCP, the CLI and the stored shape stay unstable
     while the major version is 0 and may still change in a minor release.
-  version: 0.28.2
+  version: 0.28.3
   license:
     name: MIT
 servers:

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -77,7 +77,7 @@ export IMAGE=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:$VERSION
 `:latest` ではなくバージョンを固定し、再デプロイを意識的な判断にする。
 `gh` CLI が無ければ
 [リリースページ](https://github.com/na0fu3y/ochakai/releases)から番号
-を読み、手で設定する — `export VERSION=0.28.2`。
+を読み、手で設定する — `export VERSION=0.28.3`。
 
 (このガイドは 0.9.0 以降を前提にしている。それより前のリリースは
 [retract](https://go.dev/ref/mod#go-mod-file-retract) 済みでサポート外

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -5,7 +5,7 @@ region     = "us-central1"
 
 # Pin a released version, not "latest", so a redeploy is a decision:
 # https://github.com/na0fu3y/ochakai/releases
-image_tag = "0.28.2"
+image_tag = "0.28.3"
 
 # Who can reach ochakai. This is the whole access-control surface — whoever
 # reaches it can read and write everything. Never allUsers.


### PR DESCRIPTION
v0.28.2 から4本入り、うち `no-changelog` は dependabot の grpc bump 1本だけ。
Unreleased に **BREAKING** はないのでパッチ、`0.28.3`。

版を持つ5ファイルを揃えた:

- `CHANGELOG.md` — Unreleased を `## [0.28.3] - 2026-09-03` にし、空の
  Unreleased と compare リンクを足した
- `api/openapi.yaml` の `info.version`
- `.github/ISSUE_TEMPLATE/bug_report.yml` の placeholder
- `deploy/cloudrun/README.md` の手書き `export VERSION=`
- `deploy/terraform/terraform.tfvars.example` の `image_tag`

`mcpserver.RetiredToolNames` と `retiredCommands` はどちらも既に空で、
この版で閉じる窓はない。リリース済みセクションに後から落ちた項目が
ないことも `git diff v0.28.2..main -- CHANGELOG.md` で確認済み。

`scripts/check` green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)