### PR TITLE
Measure what an AIX bundle costs, and give a wrong premise a door

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,54 @@ last entry.
 
 ### Changed
 
+- **The positioning page says what an AIX bundle costs ochakai, and it was
+  measured rather than argued.** `aix-format` calls itself upward
+  compatible with OKF and adds four things, two of which ochakai declined
+  by name: a permanent `id` that is not the path (0075 §2) and typed
+  relations, `rel` having been dropped because no code ever read it (0136
+  §2). On 2026-09-05 its `examples/` went through `ochakai import` and
+  back out through `ochakai export`. Four concepts in, four created, ten
+  files out — `index.md` and `log.md` are reserved names and are not
+  imported (SPEC §3.1). **All four documents came back byte-identical
+  outside provenance**: frontmatter values and bodies alike, the only
+  movement being the one 0009 §3.2 designs, where a document's declared
+  `generated`/`verified` separate under `received` and this instance's own
+  `generated` and `created_by` are appended.
+
+  **All four AIX additions survive verbatim** — the permanent `id`, four
+  `links[].rel` entries with their notes, `provenance.confidence`, and a
+  federation-qualified target — down to the YAML comments. What ochakai
+  declines to *model* it does not lose: OKF §4.1's producer keys already
+  fill that hole, which is what 0043 §3.6 promises. The relations reach a
+  reader the way SPEC and 0136 §2 say they do — all three `linked_from`
+  edges derive from body markdown, and "supersedes" is stated in the
+  prose. `fm.id` is refused, and the refusal's own wording is the
+  position.
+
+  Three small mismatches, recorded: a source written `uri` rather than
+  `resource` (SPEC §5.1) is dropped **from the index** while staying in
+  the document, so C1 holds and the non-conformance is the other side's;
+  `manifest.aix.yaml` is not markdown and needs `OCHAKAI_GCS_BUCKET`
+  (0075 §1); and **AIX's own example writes a bare `stale_after` date**,
+  against SPEC §5 since 2026-08-21 — which is the case 0139 §3.1 keeps
+  taking on input, so it read and returned unchanged. **Both declines
+  stand, now on a measurement rather than on an argument.**
+
+- **CONTRIBUTING.md says what to do when a record's premise turns out to
+  be wrong.** A record states what was decided and what was true when it
+  was decided; there were doors for the first (supersede, or amend by
+  replacing — 0128 §2.2) and none for the second, so a record whose
+  decision still stands had no way to say that one of its reasons does
+  not. 0133 is the case that found it, and the error propagated into the
+  English index summary, the CHANGELOG and `docs/positioning.md` before
+  one of the three was corrected. The rule: the correction is one
+  `Corrected(YYYY-MM-DD):` line in the `Status:` block, **the body is not
+  edited**, and the record's English summary row gets the same
+  correction. Immutability does not object, for the reason the tombstone
+  rule gives — it is a promise about *decisions* somebody could be
+  depending on, and a claim about the outside world is not one. Not a
+  numbered record, by 0128's own rule.
+
 - **`stale_after` reads back as an RFC 3339 datetime, always** — a UTC
   midnight no longer collapses to the bare date it used to (design doc
   [0139](docs/design/0139-ochakai-does-not-choose-a-spelling.md),

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -605,6 +605,52 @@ maintenance than that — extended to the record it summarizes.
 `TOMBSTONE-LINES` and requires the commit link; going over it means the
 record is still carrying prose nobody rereads.
 
+### When a record's premise turns out to be wrong
+
+A record states two kinds of thing: what was decided, and what was true
+about the world when it was decided. There are doors for the first —
+supersede it, or amend it by replacing it (0128 §2.2) — and until now
+none for the second, which meant a record whose decision still stands had
+no way to say that one of its reasons does not.
+
+[0133](docs/design/0133-an-okf-moment-is-an-instant.md) is the case that
+found this. Its §1 read ochakai's old date-only code as having misquoted
+OKF; the code had in fact matched the spec as published, which changed a
+normative rule seven days before 0133 was written without moving its
+version. **The decision 0133 reached was right, and is still right** —
+which is exactly why there was nothing to do about the premise. The error
+then propagated: it was copied into the English index summary, into the
+CHANGELOG, and into `docs/positioning.md`, and the correction reached one
+of the three before the other two were noticed a week later.
+
+So: **a factual premise is corrected in the `Status:` block, and the body
+is not edited.** One line, naming what the body says, what is true, and
+where that was established. Had 0133's decision not also moved — it did,
+so 0139 superseded it and its body is a tombstone now — the line it would
+carry is the shape to copy:
+
+    Corrected(2026-09-05): §1 reads the old date-only rule as a misquote
+    of SPEC §5; it matched the spec as published on 2026-07-24, which
+    changed on 2026-08-21 without moving its version (0139 §1.1).
+
+Then apply the same correction to that record's row in
+[README.en.md](docs/design/README.en.md), which restates the record in the
+present tense and would otherwise keep repeating the error.
+
+**Immutability does not object**, for the reason the tombstone rule gives:
+it is a promise about *decisions* somebody could be depending on, and a
+claim about the outside world is not one. The `Status:` block is already
+the mutable part — 0064's carries a growing list of what later records
+revised in it — and this is that same block being asked one more question.
+
+**Do not reach for supersession here.** It requires restating the whole
+area, and it would then shrink a record that is still the current answer
+to a tombstone. If the decision moves too, that is an ordinary
+supersession and this rule is not needed.
+
+This is not a numbered record, by 0128's own rule: it is a rule inside an
+area, not an area's decision, and nothing a user of ochakai can observe.
+
 ### How many records, and how much
 
 `RECORD-LINES` bounds one record's thickness, and the tombstone rule

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -405,6 +405,44 @@ namespace による federation、`manifest.aix.yaml` を足す。この四つの
 断り自体は今も筋が通っているが、**同じ穴を別の答えで埋める形式が出て
 きたこと**は、次にこの二つを問い直す人が読むべき事実である。
 
+**そこで通した。** 2026-09-05、aix-format の `examples/` を
+`ochakai import` に入れ、`ochakai export` で引き戻した。6 文書のうち
+`index.md` と `log.md` は予約名なので取り込まれず(SPEC §3.1)、4 concept
+が 4/4 で入り、10 ファイルで出た。**4 文書とも、provenance 以外は
+frontmatter も本文もバイト一致で戻った。** 動いたのは 0009 §3.2 の
+とおり — 文書が申告した `generated` / `verified` が `received` の下へ分かれ、
+このインスタンス自身の `generated` と `created_by` が付いた。それだけである。
+
+**AIX が足した四つは、四つとも原文のまま出てきた。** 恒久的な
+`id: payment-service-v2`、4 本の `links[].rel`(`supersedes`・
+`depends-on` ×2・`authored-by`、`note` ごと、4 → 4)、
+`provenance.confidence`、federation で修飾した
+`to: data-eng/orders-events`。**YAML のコメント行(`# AIX additions`)
+まで残っている。** つまり **ochakai がモデル化を断ったものを、失っては
+いない** — OKF §4.1 の producer キーがその穴を既に埋めており、それは
+0043 §3.6 が約束していることである。
+
+**関係は本文から届く。** `linked from` は 3 件とも本文の markdown リンク
+から導出され、「supersedes」は散文が伝えていた — SPEC と 0136 §2 が
+そう言っているとおりである。`fm.id` は 400 で断られ、その文面が立場の
+説明になっている(「a producer's own key is stored and handed back
+exactly as written, not asked for」)。**恒久 id を足すことは、
+[0139](design/0139-ochakai-does-not-choose-a-spelling.md) がちょうど
+畳んだ「規格が綴りを定めているものの二つ目の綴り」を足し直すこと**でも
+ある — 住所を定めているのは SPEC §2 である。
+
+**食い違いは三つ、どれも小さい。** `sources[0]` は `resource` ではなく
+`uri` を書くので(SPEC §5.1)、**索引からは落ちる** — `?source=` で
+引けない。**文書には残っている**ので C1 は無事で、落ちたのは向こうの
+非適合のほうである。`manifest.aix.yaml` は markdown でないので
+`OCHAKAI_GCS_BUCKET` の無いデプロイでは保存できない(0075 §1)。そして
+**AIX 自身の例が `stale_after: 2026-11-20` と裸の日付を書いている** —
+2026-08-21 以降の SPEC §5 に反するが、0139 §3.1 が入りで日付を取り続ける
+と決めた理由がまさにこれで、そのまま読めてそのまま戻った。
+
+**だから断りは、測ったうえで有効である。** 型で分岐するコードが一つ出た
+日に `rel` のモデル化が値段に見合う、という 0136 §2 の反証条件も動かない。
+
 重なりは表面的ではない — **物理的な形が同じ**なのである。`ochakai
 export` のバンドルは YAML frontmatter を持つ markdown ファイルの
 ディレクトリで、その関係は普通の本文リンクである


### PR DESCRIPTION
## What and why

The two items the last round left standing. Docs only — no code, no surface.

### 1. The AIX declines were an argument; now they are a measurement

`docs/positioning.md` said `aix-format` fills two holes ochakai declined by name — a permanent `id` that is not the path ([0075](https://github.com/na0fu3y/ochakai/blob/main/docs/design/0075-the-bundle-is-the-address-space.md) §2) and typed relations, `rel` having been dropped because no code ever read it ([0136](https://github.com/na0fu3y/ochakai/blob/main/docs/design/0136-a-concept-is-addressed-not-labelled.md) §2) — and left it at *"a fact the next person to reopen these should read."* That paragraph asked for evidence and had none. So its `examples/` went through `ochakai import` and back out through `ochakai export`, the same method #820 / #821 / #823 used.

**4 concepts in, 4 created, 10 files out** (`index.md` and `log.md` are reserved and not imported, SPEC §3.1).

**All four documents came back byte-identical outside provenance** — frontmatter values and bodies alike. Checked by parsing both sides, dropping the four provenance keys, and comparing:

```
concepts/payment-service      non-prov frontmatter equal=True  body byte-equal=True
concepts/payment-service-v2   non-prov frontmatter equal=True  body byte-equal=True
concepts/orders-table         non-prov frontmatter equal=True  body byte-equal=True
people/jane-doe               non-prov frontmatter equal=True  body byte-equal=True
```

The only movement is the one 0009 §3.2 designs: a document's declared `generated`/`verified` separate under `received`, and this instance's own `generated` and `created_by` are appended.

**All four AIX additions survive verbatim** — the permanent `id: payment-service-v2`, four `links[].rel` entries with their `note`s (`supersedes`, `depends-on` ×2, `authored-by`; 4 → 4), `provenance.confidence`, and the federation-qualified `to: data-eng/orders-events` — **down to the YAML comment lines** (`# AIX additions`). So **what ochakai declines to *model*, it does not lose**: OKF §4.1's producer keys already fill that hole, which is what 0043 §3.6 promises.

The relations reach a reader the way SPEC and 0136 §2 say they do — all three `linked_from` edges derive from body markdown, and "supersedes" is stated in the prose. `fm.id` is refused, and the refusal's own wording is the position: *"a producer's own key is stored and handed back exactly as written, not asked for."* Worth noting too that **adding a permanent id would be adding back the shape [0139](https://github.com/na0fu3y/ochakai/blob/main/docs/design/0139-ochakai-does-not-choose-a-spelling.md) just folded away** — a second spelling of something the format fixes a spelling for, SPEC §2 fixing the address.

**Three mismatches, recorded rather than hidden:**

| what | where it lands |
|---|---|
| `sources[0]` writes `uri`, not `resource` (SPEC §5.1) | dropped **from the index** (`?source=` → no hits), **kept in the document** — C1 holds and the non-conformance is the other side's |
| `manifest.aix.yaml` | not markdown; needs `OCHAKAI_GCS_BUCKET` (0075 §1) |
| AIX's own example writes `stale_after: 2026-11-20`, a bare date | against SPEC §5 since 2026-08-21 — and exactly the case 0139 §3.1 keeps taking on input, so it read and returned unchanged |

**Both declines stand, now on a measurement.** 0136 §2's falsification condition is unchanged: `rel` earns modelling the day one piece of code branches on a relation type.

### 2. A wrong premise had no door

A record states two kinds of thing: **what was decided**, and **what was true about the world when it was decided**. There are doors for the first — supersede, or amend by replacing (0128 §2.2) — and there were none for the second, so a record whose decision still stands had no way to say that one of its reasons does not.

0133 is the case that found it. Its §1 read ochakai's old date-only code as having misquoted SPEC §5; the code had matched the spec as published, which changed a normative rule seven days before 0133 was written without moving its version. **The decision 0133 reached was right and is still right** — which is precisely why there was nothing to do about the premise. The error then propagated into the English index summary, the CHANGELOG and `docs/positioning.md`; #821 corrected one of the three, and the other two survived until #822 a week later.

The rule added to `CONTRIBUTING.md`:

- The correction is **one `Corrected(YYYY-MM-DD):` line in the `Status:` block**, naming what the body says, what is true, and where that was established.
- **The body is not edited.**
- The record's row in `README.en.md` gets the same correction — it restates the record in the present tense and would otherwise keep repeating the error.
- **Do not reach for supersession**: it requires restating the whole area, and it would shrink a record that is still the current answer to a tombstone. If the decision moves too, that is an ordinary supersession and this rule is not needed.

Immutability does not object, for the reason the tombstone rule already gives: it is a promise about *decisions* somebody could be depending on, and a claim about the outside world is not one. The `Status:` block is already the mutable part — 0064's carries a growing list of what later records revised in it — and this asks that same block one more question.

**Not a numbered record, by 0128's own rule**: a rule inside an area rather than an area's decision, and nothing a user of ochakai can observe.

## Checks

- [x] `scripts/check core` is clean. No code moved, so `--db` has nothing new to exercise; CI runs it anyway.
- [x] Behaviour changes come with tests — n/a, no behaviour changes.
- [x] `## [Unreleased]` carries both entries. (The changelog workflow only requires one when a non-test file under `internal/` or `cmd/` moves; neither did. Following the convention #820 / #821 / #823 set for a measurement that lands on the positioning page.)

## Surfaces and contract

- [x] No surface moves. `api/openapi.yaml`, `internal/`, `cmd/` are untouched — the diff is `docs/positioning.md`, `CONTRIBUTING.md` and `CHANGELOG.md` only.
- [x] `api/openapi.frozen.txt` untouched.
- [x] Nothing widens, so `docs/surface.md`'s counts do not move.

## Design docs

- [x] **No accepted decision is altered**, so no numbered record is in this PR — and that is the deliberate answer to both items, not an omission. The AIX measurement *confirms* 0075 §2 and 0136 §2 rather than changing them; the premise rule is a process rule that 0128 keeps out of the numbering.
- [x] Commit message is in English.

## The throwaway instance this was measured on

A local PostgreSQL 16 + `ochakai serve` in dev mode with embeddings off, built from `bd70a03` (this branch's base, i.e. with #822 in it — which is why the bare `stale_after` round-tripped as written). Torn down after the measurement; nothing from it is in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VLr8SUa4zSRkYR4rkCgqGx

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLr8SUa4zSRkYR4rkCgqGx)_