### PR TITLE
Mark a recalled concept past its re-check date, and date the memory-layer claims

### DIFF
--- a/.claude/hooks/ochakai-recall.sh
+++ b/.claude/hooks/ochakai-recall.sh
@@ -50,8 +50,14 @@ if [ -n "$session" ]; then
 	: >"${TMPDIR:-/tmp}/ochakai-up-$session" 2>/dev/null || true
 fi
 
-rows=$(printf '%s' "$hits" | jq -r '.hits[]? |
-	"- ochakai://\(.id) [\(.type), \(.trust)]\(if .description and .description != "" then " — " + .description elif .snippet and .snippet != "" then " — " + .snippet else "" end)"' 2>/dev/null) || exit 0
+# A row says whether the writer's re-check date has passed, because the
+# ranking does not: an expired concept is due for re-checking, not wrong,
+# so it is neither hidden nor demoted (design doc 0069 §7). Date
+# granularity, so both spellings of an OKF instant work (0139), and today
+# counts as passed: the date names the UTC midnight that opens it (0133).
+today=$(date -u +%Y-%m-%d)
+rows=$(printf '%s' "$hits" | jq -r --arg today "$today" '.hits[]? |
+	"- ochakai://\(.id) [\(.type), \(.trust)\(if (.stale_after // "") == "" then "" elif (.stale_after[:10] <= $today) then ", past stale_after" else "" end)]\(if .description and .description != "" then " — " + .description elif .snippet and .snippet != "" then " — " + .snippet else "" end)"' 2>/dev/null) || exit 0
 [ -z "$rows" ] && exit 0
 
 if [ -n "$session" ]; then
@@ -59,4 +65,4 @@ if [ -n "$session" ]; then
 		>>"${TMPDIR:-/tmp}/ochakai-recalled-$session"; } 2>/dev/null || true
 fi
 
-printf 'Knowledge in this repository'"'"'s ochakai instance that may bear on this request — pointers, not the knowledge itself. Fetch what you rely on with the ochakai MCP get_concept tool (never the CLI, per the identity policy); a fetched concept lists what links at it under linked_from. Trust verified concepts; judge drafts by created_by:\n\n%s\n' "$rows"
+printf 'Knowledge in this repository'"'"'s ochakai instance that may bear on this request — pointers, not the knowledge itself. Fetch what you rely on with the ochakai MCP get_concept tool (never the CLI, per the identity policy); a fetched concept lists what links at it under linked_from. Trust verified concepts; judge drafts by created_by. A row marked `past stale_after` is due for re-checking, not wrong:\n\n%s\n' "$rows"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,49 @@ last entry.
 
 ### Changed
 
+- **A recall pointer says when a concept is past its re-check date.** The
+  bundled `UserPromptSubmit` hook
+  ([examples/claude-code](examples/claude-code)) printed each hit's type
+  and trust but never `stale_after`, so an agent choosing what to fetch
+  could not see that a row's own writer had declared it due for
+  re-checking — search had carried the field all along. The row now says
+  `past stale_after`, and the injected prose says in one clause what the
+  mark means. **It is a mark, not a filter and not a demotion**: an
+  expired concept is due for re-checking, not wrong, which is the answer
+  [0069](docs/design/0069-the-loop-and-what-measures-it.md) §7 already
+  gave — and the answer a memory layer gives differently, mem0 hiding an
+  expired memory from search by default. Compared at date granularity, so
+  both spellings of an OKF instant work
+  ([0139](docs/design/0139-ochakai-does-not-choose-a-spelling.md)) and the
+  declared day itself counts as passed
+  ([0133](docs/design/0133-an-okf-moment-is-an-instant.md)). No surface
+  moves: the field was already in the response, and the hook is an
+  example.
+
+- **The positioning page stops arguing against memory layers from three
+  premises that expired.** All three were checked against the sources on
+  2026-09-05. *"They extract with an LLM"* is not a claim about the
+  category: MemPalace makes zero LLM calls at write time and publishes
+  96.6% R@5 on LongMemEval, and the critique paper reproduces the number
+  while attributing it to verbatim storage rather than to the spatial
+  metaphor ([arXiv:2604.21284](https://arxiv.org/abs/2604.21284)).
+  *"Memory belongs to one agent"* is not either: MemPalace ships a shared
+  hub, Letta has shared memory and a git remote, mem0 has `app_id` /
+  `org_id`. Neither is *"nobody reviews"*: Letta's dreaming has an
+  optional gate before a proposal applies, and Zep sells ABAC, retention
+  and an audit trail. **What is left is one axis** — that the ruling is a
+  human the instance authenticated and observed into a ledger
+  ([0075](docs/design/0075-the-bundle-is-the-address-space.md) §3.1) —
+  and the page says that instead. Not having an LLM stays the *reason*
+  human verification can be trusted
+  ([0081](docs/design/0081-what-ochakai-is-and-what-it-refuses-to-hold.md));
+  it has stopped being the difference.
+
+  The same section also claimed a rejection is something an agent reads
+  before re-proposing. **It is not, and deliberately so**:
+  [0135](docs/design/0135-a-rejection-is-a-deletion.md) §3 decided a
+  ruling blocks nothing, and that sentence had outlived it.
+
 - **Three pages said an agent cannot verify. The wire has always let one,
   and a fourth page documents the practice.** Nothing in the build
   changes: `Service.Verify` does not branch on the actor's kind, so a

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -65,7 +65,7 @@ semantic layer は revenue = `SUM(price)` だと教えてくれる。100 とい�
 | **[Google Cloud Knowledge Catalog](https://cloud.google.com/products/knowledge-catalog)(旧 Dataplex)** | 同じ Google Cloud の IAM、立てるものが無いこと、自動収集、lineage、品質、用語集、Gemini が生成する説明と example query、Context API と remote MCP | 人の裁定が中核であること、却下の理由が履歴に残ること、OKF での丸ごとの出口、収集ではなくキュレーションであること、**一つのテーブルに二つ目の読み方を並べられること** | 同じ雲で正面から重なる — 下記参照 |
 | ウェアハウス native の semantic layer(dbt MCP、Cube、Lightdash、Snowflake Semantic Views、Databricks Metric Views)と、その標準([Apache Ossie](https://github.com/apache/ossie) — 旧 OSI) | メトリクス定義、ディメンション、コンパイルされた SQL | 解釈、用語集、書き戻し、ウェアハウスをまたぐもの、そして誰が確認したか | 両立 — 下記参照 |
 | 「コンテキスト層」になったカタログ(OpenMetadata、DataHub、Atlan) | 技術メタデータ、リネージ、オーナーシップ、大規模な収集 | キュレーションされた側が OSS であること — 解釈とレビューループは商用ティアに置かれがち | 両立、あるいは既に運用しているなら ochakai の代わりになる |
-| エージェントのメモリ層(mem0、Zep、Letta、[remnic](https://github.com/joshuaswarren/remnic)) | ユーザーごと・エージェントごとの記憶、自動抽出・自動注入。**remnic は人の承認の門と provenance と訂正ループとサーバーを持つ** | チームの所有、認証された呼び出し元を観測する台帳、secret を置かないこと(remnic は bearer token) | 両立 — 下記参照 |
+| エージェントのメモリ層(mem0、Zep / Graphiti、Letta、[MemPalace](https://github.com/mempalace/mempalace)、[remnic](https://github.com/joshuaswarren/remnic)) | ユーザーごと・エージェントごとの記憶、自動抽出・自動注入、チームで共有する形。**MemPalace は書き込みに LLM を使わず、Letta はメモリが git 管理の markdown + frontmatter、remnic は人の承認の門と provenance と訂正ループを持つ** | 認証された呼び出し元を観測する台帳としての裁定、secret を置かないこと(remnic は bearer token) | 両立 — 下記参照 |
 | 自分の文書に対する RAG | 他の理由で書かれた文書からの断片 | 単位としてのレビュー済みの主張、provenance、著者の向き | 両立 |
 | AI アナリスト製品に内蔵された検証済みクエリストア(Cortex Analyst の VQR、Genie) | 問い + 検証済み SQL、一つのベンダーのチャットの中で | 他のクライアント、出口 | 重なる、そしてロックインする |
 | FDE 型オントロジー([Palantir Foundry Ontology](https://www.palantir.com/docs/foundry/ontology/overview)) | 組織のデジタルツイン — オブジェクトとリンク、Action と write-back、ライブデータへの接続、プラットフォーム内のガバナンス | 出口(オントロジーはプラットフォームのもの)、FDE 無しの立ち上げ、テナントごとの安価なセルフホスト | 約束は同じ、買い方を拒む — 下記参照 |
@@ -218,17 +218,51 @@ ochakai が持つ資格情報では決してない。
 ### エージェントのメモリ層
 
 *メモリ層は起きたことを覚え、ochakai は正しいことをキュレーションする。*
-あちらは LLM で抽出し、監査を経ずに注入する: 何が記憶されたかを誰も
-レビューせず、間違った記憶は静かに残り続ける。データ分析において
-間違った記憶は間違った意思決定であり、監査されない想起の品質の天井は
-低い。ochakai は人の裁定の後ろにあるチーム共有のナレッジであり、却下は
-その理由を履歴に残すので、同じ提案をする前にエージェントが読めるものが
-ある。
+一行目は今も立つ。**その下にこの節が長く書いていた三つの前提は、崩れた**
+(2026-09-05 に原典を開いて確認)。
+
+- **「あちらは LLM で抽出する」はカテゴリ全体には言えない。** MemPalace は
+  書き込み時の LLM 呼び出しがゼロで — 分類も分割も正規表現と語彙スコア、
+  本文は逐語で保存する — その姿勢のまま LongMemEval R@5 96.6% を公表して
+  いる。批判論文はその数字を再現できるとしたうえで、効いているのは逐語
+  保存と既定の埋め込みであって階層の比喩ではないと書く
+  ([arXiv:2604.21284](https://arxiv.org/abs/2604.21284))。**LLM を持たない
+  ことは、もうこの節の差別化ではない。** ochakai がそれを持たない理由 —
+  人の検証への信頼の根拠
+  ([0081](design/0081-what-ochakai-is-and-what-it-refuses-to-hold.md))— は
+  変わらないが、理由と差別化は同じものではない。
+- **「記憶は個体に属する」も言えない。** MemPalace は共有ハブを、Letta は
+  クラウドの共有メモリと git のリモートを、mem0 は `app_id` / `org_id` の
+  スコープを持つ。
+- **「誰もレビューしない」も一律には言えない。** Letta の dreaming は提案を
+  適用前に見せる門を任意で持ち、Zep は ABAC と保持期限と全リクエストの
+  監査証跡を売っている。
+
+**残る差は一つに絞れる**: 裁定するのが**認証された人**であり、その裁定を
+**インスタンス自身が観測して台帳に持つ**こと
+([0075](design/0075-the-bundle-is-the-address-space.md) §3.1)。mem0 の
+history は old / new と `user_id` を持つが行為者の名前を持たず、feedback
+(POSITIVE / NEGATIVE / VERY_NEGATIVE と理由)は蓄えて自社のチューニングに
+使うもので、人が読む面が無い。**mem0 自身の 2026 年の報告が、誰が記憶を
+検査できて・いつ消えるかは application-layer の未解決事項だと書いている。**
+ochakai は人の裁定の後ろにあるチーム共有のナレッジであり、却下は理由ごと
+リビジョンと `log.md` に残る — ただし**それが次の提案を止めるわけではない**。
+却下を削除にしたとき、塞ぐことはしないと決めている
+([0135](design/0135-a-rejection-is-a-deletion.md) §3)。
+
+**形も近づいた。** Letta は 2026-02 にメモリを git 管理の markdown +
+YAML frontmatter に作り直した(MemFS)— `system/` の下だけが毎ターン
+system prompt に載り、残りはファイル木だけ見せて必要なときに読ませる。
+OKF バンドルと同じ形であり、この節と下の vault 節の境目は消えつつある。
 
 あちらから学ぶ価値があるのは記憶の品質ではなく人間工学のほうである:
 本当の強みは、エージェントが覚えようと*決める*必要が無いことである。
 ochakai は Claude Code の[フック](../examples/claude-code)でそれに
 答える — 想起も書き戻しも習慣ではなく仕組みとして、しかも LLM 無しで。
+**期限切れの扱いは、そこで分かれる。** mem0 は期限の切れた記憶を検索から
+隠すが、ochakai の期限切れは「間違い」ではなく「再確認が要る」なので
+([0069](design/0069-the-loop-and-what-measures-it.md) §7)、隠さず、順位も
+動かさず、想起のポインタ行に印として出す。
 
 ### 自分の文書に対する RAG
 

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -238,9 +238,12 @@ ochakai が持つ資格情報では決してない。
   適用前に見せる門を任意で持ち、Zep は ABAC と保持期限と全リクエストの
   監査証跡を売っている。
 
-**残る差は一つに絞れる**: 裁定するのが**認証された人**であり、その裁定を
-**インスタンス自身が観測して台帳に持つ**こと
-([0075](design/0075-the-bundle-is-the-address-space.md) §3.1)。mem0 の
+**残る差は一つに絞れる**: 裁定が**インスタンス自身の観測**として台帳に残り、
+その行が**認証された呼び出し元**を名指すこと
+([0075](design/0075-the-bundle-is-the-address-space.md) §3.1)。人が確かめた
+のか機械かは、その台帳から導かれる tier が言い分ける — 中核に置いているのは
+`human-reviewed` の側である
+([0138](design/0138-a-verification-stands-until-the-content-moves.md))。mem0 の
 history は old / new と `user_id` を持つが行為者の名前を持たず、feedback
 (POSITIVE / NEGATIVE / VERY_NEGATIVE と理由)は蓄えて自社のチューニングに
 使うもので、人が読む面が無い。**mem0 自身の 2026 年の報告が、誰が記憶を

--- a/examples/claude-code/README.md
+++ b/examples/claude-code/README.md
@@ -10,13 +10,18 @@
    Claude Code 自身なので毎回必ず発火し、エージェントの判断は挟まらない
    — メモリ層が使っているのと同じ手を、LLM 抜きでやる:
    - `ochakai-recall.sh`(**UserPromptSubmit**)は `ochakai search
-     "<prompt>" --json` を実行し、返ってきた順位 — id・型・trust・説明の
-     ポインタ行 — をエージェントが作業を始める前にコンテキストへ差し込み、
+     "<prompt>" --json` を実行し、返ってきた順位 — id・型・trust・書き手が
+     宣言した期限を過ぎていればその印・説明のポインタ行 —
+     をエージェントが作業を始める前にコンテキストへ差し込み、
      何を指したかを下の Stop フックのために記録する。自動の想起である。
      ナレッジ本体は注入しない(設計ドキュメント
      [0108](../../docs/design/0108-the-context-pack-retires.md)):
      fetch はエージェント自身の選択で、`ochakai get` で取った concept は
-     自分を指す concept を `linked_from` として連れてくる。
+     自分を指す concept を `linked_from` として連れてくる。期限の印は
+     隠しも減点もしない — 期限切れは「間違い」ではなく「再確認が要る」
+     なので(設計ドキュメント
+     [0069](../../docs/design/0069-the-loop-and-what-measures-it.md) §7)、
+     順位を動かさずに伝えるのがこの一語である。
    - `ochakai-write-back.sh`(**Stop**)はデータ作業のセッションごとに
      一度、エージェントが止まる直前に割り込み、再利用できるクエリと
      メトリクスの気づきを保存するか(書き戻し)、想起で指された concept が

--- a/examples/claude-code/hooks/ochakai-recall.sh
+++ b/examples/claude-code/hooks/ochakai-recall.sh
@@ -31,8 +31,15 @@ case $prompt in
 esac
 
 hits=$(ochakai search "$prompt" --limit "${OCHAKAI_RECALL_LIMIT:-8}" --json 2>/dev/null) || exit 0
-rows=$(printf '%s' "$hits" | jq -r '.hits[]? |
-	"- ochakai://\(.id) [\(.type), \(.trust)]\(if .description and .description != "" then " — " + .description elif .snippet and .snippet != "" then " — " + .snippet else "" end)"' 2>/dev/null) || exit 0
+# A row says whether the writer's re-check date has passed, because the
+# ranking does not: an expired concept is due for re-checking, not wrong,
+# so it is neither hidden nor demoted (design doc 0069 §7) — the agent is
+# told, and chooses. Compared at date granularity so both spellings of an
+# OKF instant work (0139), and today counts as passed: the date names the
+# UTC midnight that opens it (0133).
+today=$(date -u +%Y-%m-%d)
+rows=$(printf '%s' "$hits" | jq -r --arg today "$today" '.hits[]? |
+	"- ochakai://\(.id) [\(.type), \(.trust)\(if (.stale_after // "") == "" then "" elif (.stale_after[:10] <= $today) then ", past stale_after" else "" end)]\(if .description and .description != "" then " — " + .description elif .snippet and .snippet != "" then " — " + .snippet else "" end)"' 2>/dev/null) || exit 0
 [ -z "$rows" ] && exit 0
 
 session=$(printf '%s' "$input" | jq -r '.session_id // empty' 2>/dev/null) || session=""
@@ -41,4 +48,4 @@ if [ -n "$session" ]; then
 		>>"${TMPDIR:-/tmp}/ochakai-recalled-$session"; } 2>/dev/null || true
 fi
 
-printf 'Team knowledge in ochakai that may bear on this request — pointers, not the knowledge itself. Fetch what you rely on before answering (`ochakai get <id>`); a fetched concept lists the concepts that link at it under linked_from, which is where the caveat that says how to read a number lives. Trust verified concepts; `ochakai get` prints who wrote and who confirmed one on stderr, which is how a draft is judged. Cite what you use: name the concept id and whether a human confirmed it, so the reader can check the answer and knows which concept to fix:\n\n%s\n' "$rows"
+printf 'Team knowledge in ochakai that may bear on this request — pointers, not the knowledge itself. Fetch what you rely on before answering (`ochakai get <id>`); a fetched concept lists the concepts that link at it under linked_from, which is where the caveat that says how to read a number lives. Trust verified concepts; `ochakai get` prints who wrote and who confirmed one on stderr, which is how a draft is judged. A row marked `past stale_after` is due for re-checking, not wrong — prefer a fresh concept when both answer, and say which you used. Cite what you use: name the concept id and whether a human confirmed it, so the reader can check the answer and knows which concept to fix:\n\n%s\n' "$rows"


### PR DESCRIPTION
## What and why

A competitive re-check of the agent memory layers (Mem0, Graphiti/Zep, Letta, MemPalace), read against `docs/positioning.md`. **Three of that section's premises had stopped being true, and one of its sentences had outlived [0135](https://github.com/na0fu3y/ochakai/blob/main/docs/design/0135-a-rejection-is-a-deletion.md).** One idea out of the review was worth building; the other two are recorded here as declined, with the reason.

No code under `internal/` or `cmd/` moves. **No surface widens** — see below.

### 1. A recall pointer says when a concept is past its re-check date

The bundled `UserPromptSubmit` hook printed `[type, trust]` and nothing else. `stale_after` was in the search response the whole time (`domain.Summary`), so the one thing the row could not say was the thing its own writer had declared: *this is due for re-checking*. An agent picking what to fetch could not see it until after the fetch.

The row now carries `past stale_after`, and the injected prose says in one clause what it means.

**It is a mark, not a filter and not a demotion.** That is the whole design question, and [0069](https://github.com/na0fu3y/ochakai/blob/main/docs/design/0069-the-loop-and-what-measures-it.md) §7 already answered it — an expired concept is due for re-checking, not wrong, so it is neither hidden nor ranked down. It is also **exactly where the memory layers answer differently**: mem0 hides an expired memory from search by default. The mark is that disagreement made visible to the agent.

Compared at date granularity, which is what makes both spellings of an OKF instant work ([0139](https://github.com/na0fu3y/ochakai/blob/main/docs/design/0139-ochakai-does-not-choose-a-spelling.md)), and the declared day itself counts as passed — the date names the UTC midnight that opens it ([0133](https://github.com/na0fu3y/ochakai/blob/main/docs/design/0133-an-okf-moment-is-an-instant.md)).

Four cases, run through the real jq:

```
today=2026-09-05
- ochakai://a [Metric, human-reviewed] — fresh, no date
- ochakai://b [Insight, unverified] — future date
- ochakai://c [Metric, human-reviewed, past stale_after] — past, rfc3339
- ochakai://d [Policy, unverified, past stale_after] — expires today
```

And end to end against the dogfood instance, with `today` moved forward so real rows trip it:

```
- insights/knowledge-catalog-now-ingests-okf-but-does-not-rule [unverified, past stale_after] stale_after=2026-12-03
- insights/a-validator-passes-where-a-real-consumer-rejects    [unverified, past stale_after] stale_after=2026-12-05
- insights/prose-should-not-count-its-own-table                [unverified]                   stale_after=none
```

Both copies of the hook move together — the shipped example and this repository's own dogfood one under `.claude/hooks/`.

### 2. The memory-layer section was arguing from expired premises

All three re-checked against the sources on 2026-09-05.

| the page said | what is true |
|---|---|
| *"they extract with an LLM"* | not a claim about the category: **MemPalace makes zero LLM calls at write time** — regex and lexical scoring for classification and chunking, verbatim bodies — and publishes 96.6% R@5 on LongMemEval. The critique paper ([arXiv:2604.21284](https://arxiv.org/abs/2604.21284)) reproduces the number and attributes it to verbatim storage rather than to the spatial metaphor |
| *"memory belongs to one agent"* | MemPalace ships a shared hub, Letta has shared memory and a git remote, mem0 has `app_id` / `org_id` |
| *"nobody reviews"* | Letta's dreaming has an optional gate before a proposal applies; Zep sells ABAC, retention and an audit trail |

**What is left is one axis**: the ruling is a human *the instance authenticated and observed into a ledger* ([0075](https://github.com/na0fu3y/ochakai/blob/main/docs/design/0075-the-bundle-is-the-address-space.md) §3.1). None of the four has it. mem0's history carries `old_memory`/`new_memory` and a `user_id` but no actor name, and its feedback (`POSITIVE` / `NEGATIVE` / `VERY_NEGATIVE` with a reason) is stored to tune the vendor's own retrieval — there is no surface a person reads it on. **mem0's own 2026 report lists who may inspect a memory, and when it is deleted, as unsolved application-layer questions.**

Not having an LLM stays the *reason* human verification can be trusted ([0081](https://github.com/na0fu3y/ochakai/blob/main/docs/design/0081-what-ochakai-is-and-what-it-refuses-to-hold.md)). It has stopped being the difference. The page now says so.

**The shape converged too**, and that is worth a reader knowing: Letta rebuilt memory in 2026-02 as a git-backed repository of markdown with YAML frontmatter (MemFS), `system/` loaded every turn and the rest shown as a file tree. That is the OKF bundle's shape. **Not measured** — running Letta needs an API key, and "the shape matches" is not "the agent reads it" — so the page claims the shape and nothing more.

### 3. The stale sentence 0135 left behind

The section also said a rejection is something an agent reads before re-proposing. **0135 §3 decided a ruling blocks nothing** — a rejection is a deletion, the reason rides the revision and `log.md`, and `rejected` left `search_concepts`. The code is exactly as 0135 says; only this prose was old. Same family as the sweep the kb records for that record.

### Declined, with reasons

- **A PreCompact write-back nudge — dropped as impossible, not as unwanted.** The mechanism was sound (a long session's early learnings are thin by the time `Stop` fires) but Claude Code has no event that can carry the ask: `PreCompact` can only *block* compaction, its stdout goes to the debug log, and it has neither `additionalContext` nor `decision: block`. Blocking compaction blocks the user, not the agent. If this hole is ever filled it has to be from `UserPromptSubmit`, on the first prompt after a compaction.
- **An always-loaded SessionStart layer of verified `Policy` concepts — declined on the three questions.** `SessionStart` stdout does reach the context, so the mechanism exists; what does not is a reason. Nobody got stuck, search → get already covers it, and nothing folds away in exchange. The default answer is no.

## Checks

- [x] `scripts/check` is clean (`core` too). No code moved, so `--db` exercises nothing new; CI runs it.
- [x] Behavior changes come with tests — n/a for the docs. The hook change is an example script with no Go test harness; it was verified by running both copies against a live instance, output above, plus `sh -n` on both.
- [x] `## [Unreleased]` carries both entries. The `changelog` workflow only demands one when a non-test file under `internal/` or `cmd/` moves; neither did. Following the convention #820 / #821 / #823 / #824 set for a change that lands on the positioning page.

**Conflict note:** #825 also appends under `## [Unreleased]` → `### Changed`. Whichever merges second rebases that one hunk; nothing else overlaps.

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/mcpserver`, `internal/apiclient` — untouched, and still say the same thing.
- [x] Lands on every surface it belongs on: **none**. The mark is an example hook rendering a field the API already returns; REST, MCP, CLI and Web UI are unchanged, deliberately. A server-side "hide the expired" or "rank it down" is the thing 0069 §7 declines.
- [x] `api/openapi.frozen.txt` untouched.
- [x] **Widens no surface**, so `docs/surface.md` does not move: no REST operation, no MCP tool, no CLI command, no environment variable, no vocabulary term. `REST (13)`, `MCP (6)`, `CLI (24)`, `ENV (15)`, `VOCAB (46)`, `DOC (27)` all stand, and no page was added. The three questions therefore do not apply — nothing is being added to pay for.

## Design docs

- [x] Not applicable. No accepted decision is altered: this applies 0069 §7 rather than revising it, and corrects a living page against 0135's shipped decision. `docs/positioning.md` is explicitly the landscape page, not a record — *"landscape は決定ではないので、代わりにここで追う."* By [0128](https://github.com/na0fu3y/ochakai/blob/main/docs/design/0128-a-number-is-for-an-area-not-a-rule-inside-it.md), a hook printing one more field is a rule inside an area, not an area's decision.
- [x] Commit message and code comments are in English.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
