### PR TITLE
Declare only the MCP capabilities the server has

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,21 @@ last entry.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The MCP server declares only the capabilities it has.** The
+  capabilities a client reads at `initialize` were the SDK's defaults, and
+  two of them were untrue: `logging`, a feature ochakai has never used
+  and the protocol deprecated at 2026-07-28 (design doc
+  [0118](docs/design/0118-a-call-carries-everything-it-needs.md) §2), and
+  `listChanged: true` on the tool and resource lists, promising a
+  notification for lists that are fixed when the process is built (0118
+  §7) and that a stateless transport has no session to send anyway. The
+  declaration is now `tools` and `resources` and nothing else, written
+  by hand so a later SDK default cannot change what ochakai says;
+  `subscribe` stays out because a subscription lives on a session and
+  there is none. No tool, list or surface moves.
+
 ### Changed
 
 - **A recall pointer says when a concept is past its re-check date.** The

--- a/internal/mcpserver/capabilities_test.go
+++ b/internal/mcpserver/capabilities_test.go
@@ -1,0 +1,59 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"maps"
+	"slices"
+	"testing"
+)
+
+// The declaration a client reads at initialize says what this server
+// can do and nothing it cannot. Left to the SDK it said two untrue
+// things — `logging`, never used and deprecated at 2026-07-28, and
+// `listChanged` on lists a process cannot change (design doc 0118 §7)
+// and a stateless transport could not notify about (0118 §2) — so each
+// half is pinned: what is declared because it is offered, and what is
+// absent because it is not.
+func TestTheServerDeclaresOnlyWhatItDoes(t *testing.T) {
+	caps := connect(t).InitializeResult().Capabilities
+	if caps == nil {
+		t.Fatal("initialize carried no capabilities")
+	}
+
+	// Offered.
+	if caps.Tools == nil {
+		t.Error("tools is not declared, and six are served")
+	}
+	if caps.Resources == nil {
+		t.Error("resources is not declared, and a template is served")
+	}
+
+	// Not offered. A list fixed at build time changes on a release, which
+	// a running process cannot announce; a subscription needs a session,
+	// and there is none.
+	if caps.Tools != nil && caps.Tools.ListChanged {
+		t.Error("tools.listChanged promises a notification the tool list never sends")
+	}
+	if caps.Resources != nil && caps.Resources.ListChanged {
+		t.Error("resources.listChanged promises a notification the resource list never sends")
+	}
+	if caps.Resources != nil && caps.Resources.Subscribe {
+		t.Error("resources.subscribe is declared on a transport with no session to hold one")
+	}
+	// Read off the wire form rather than the struct's fields: `logging`'s
+	// field is deprecated with the feature, and what matters is which
+	// keys a client sees. Exactly the two offered, and no `logging` among
+	// them (0118 §2: ochakai has never sent a log message).
+	raw, err := json.Marshal(caps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var keys map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &keys); err != nil {
+		t.Fatal(err)
+	}
+	got := slices.Sorted(maps.Keys(keys))
+	if want := []string{"resources", "tools"}; !slices.Equal(got, want) {
+		t.Errorf("initialize declares %v, want exactly %v", got, want)
+	}
+}

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -242,6 +242,20 @@ func instructionsFor(cfg *config.Config) string {
 func newServer(svc *service.Service, version string, retired []RetiredToolName) *mcp.Server {
 	s := mcp.NewServer(&mcp.Implementation{Name: serverName, Version: version}, &mcp.ServerOptions{
 		Instructions: instructionsFor(svc.Config),
+		// What this server can do, said in the protocol's own vocabulary
+		// and nothing it cannot. Left to the SDK, the declaration said two
+		// untrue things: `logging`, a feature ochakai never used and the
+		// protocol has deprecated (design doc 0118 §2), and `listChanged`
+		// on both lists, promising a notification for lists that are fixed
+		// when the process is built (0118 §7) — and that a stateless
+		// transport has no session to send one on anyway. `subscribe`
+		// stays absent for the same reason: a subscription lives on a
+		// session, and there is none. Written down rather than inferred so
+		// that a later SDK default cannot change what ochakai says.
+		Capabilities: &mcp.ServerCapabilities{
+			Tools:     &mcp.ToolCapabilities{},
+			Resources: &mcp.ResourceCapabilities{},
+		},
 	})
 
 	// A name this release renamed still answers, for this release only


### PR DESCRIPTION
## What and why

The capabilities a client reads at `initialize` were the SDK's defaults, and two of them were untrue:

- `logging`, a feature ochakai has never used and the protocol deprecated at 2026-07-28 (design doc [0118](docs/design/0118-a-call-carries-everything-it-needs.md) §2).
- `listChanged: true` on the tool and resource lists, promising a notification for lists that are fixed when the process is built (0118 §7) and that a stateless transport has no session to send anyway.

The declaration is now `tools` and `resources` and nothing else, written by hand so a later SDK default cannot change what ochakai says. `subscribe` stays out because a subscription lives on a session and there is none. No tool, list or surface moves.

This PR was first opened with `completion/complete` for the concept template and one prompt beside this fix; the owner ruled to ship the capabilities fix alone, and the branch was rebuilt from `main` with only that. Neither addition had a person who got stuck behind it, which is the first of `docs/surface.md`'s three questions.

## Checks

- [x] `scripts/check` — `go test ./internal/mcpserver/ ./cmd/ochakai/` and `scripts/check lint` (0 issues) pass locally; the earlier full `--db` run covered the same server change
- [x] Behavior changes come with tests: `capabilities_test.go` reads the declaration off the wire form and pins the key set to exactly `tools` and `resources`, with `listChanged` and `subscribe` false
- [x] `CHANGELOG.md` has an entry under `## [Unreleased]`

## Surfaces and contract

- [x] `api/openapi.yaml`, `internal/restapi`, `internal/apiclient` are untouched — nothing here is on REST
- [x] Lands on MCP only; it is a correction of what MCP already says about itself
- [x] `api/openapi.frozen.txt` untouched
- [x] Widens no surface: `docs/surface.md` is unchanged and every count stays

## Design docs

- [x] No new record: the rule is inside 0118's area (§2 says no notification is needed, §7 says the lists are fixed at build time), and the parent plus this CHANGELOG entry answer it (0128)
- [x] Commit messages and code comments are in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CT1KuRMnFEPkqopDmqzAhf