### PR TITLE
Move codeql-action's four steps together, because one alone cannot pass

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,17 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
+    groups:
+      # codeql-action's steps are one dependency wearing four names.
+      # init, autobuild and analyze must run the same version — a run
+      # that mixes them dies with "Loaded a configuration file for
+      # version X, but running version Y" — so a pull request moving one
+      # of them alone can never go green, and three such pull requests
+      # sat red until they were merged by hand as one commit. Grouped,
+      # they arrive as the single bump they always were.
+      codeql-action:
+        patterns:
+          - github/codeql-action*
   - package-ecosystem: docker
     directory: /
     schedule:

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -46,12 +46,12 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false # same shared-key problem as in ci.yaml
-      - uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+      - uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: go
           # `security-extended` over the default `security`: this is not a
           # merge gate, so a lower-confidence finding costs a read rather
           # than a blocked pull request.
           queries: security-extended
-      - uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
-      - uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+      - uses: github/codeql-action/autobuild@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+      - uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9


### PR DESCRIPTION
## What got stuck

Three dependabot pull requests — #836 (`init`), #835 (`autobuild`), #832
(`analyze`) — all sat red on the same error:

```
##[error]We were unable to automatically build your code.
Loaded a configuration file for version '4.37.9', but running version '4.37.6'
```

`codeql.yaml` pins three steps of `github/codeql-action`, and dependabot
treats each as its own dependency. The steps are one action wearing
several names: a run whose `init` and `analyze` disagree dies with a
configuration error. **None of the three could go green alone** — only
all of them, in one commit.

## The change

Both halves of that:

- `codeql.yaml` names digest `cdf488f` (v4.37.9) in all three places.
  This is exactly the union of #836, #835 and #832, so merging it closes
  them. `scorecard.yaml`'s `upload-sarif` is already on that digest from
  #833.
- `dependabot.yml` gets a `codeql-action` group, so the next bump arrives
  as the one pull request it always was rather than three that have to be
  merged by hand as one commit.

## Surface

None. No REST, MCP, CLI or Web UI change, nothing under `internal/` or
`cmd/`, no design record (this is not a decision a user can observe,
[0048](docs/design/0048-decision-records-for-wire-contracts.md)) and no
CHANGELOG entry — `docs/surface.md` is untouched.

`scripts/check actions` (zizmor 1.29.0) is clean; the proof is the
`analyze` job on this pull request going green where the three it
replaces could not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)