### PR TITLE
Prepare release 0.28.4

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Version
       description: Output of `ochakai version`, or the image tag you deployed.
-      placeholder: "0.28.3"
+      placeholder: "0.28.4"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ last entry.
 
 ## [Unreleased]
 
+## [0.28.4] - 2026-09-07
+
 ### Fixed
 
 - **The MCP server declares only the capabilities it has.** The
@@ -6904,7 +6906,8 @@ worth naming: SQL injection in `compile_sql` through undeclared field
 pass-through, fixed in 0.8.0 — v0.7.0 and earlier are affected. Details
 are in git history.
 
-[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.28.3...HEAD
+[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.28.4...HEAD
+[0.28.4]: https://github.com/na0fu3y/ochakai/compare/v0.28.3...v0.28.4
 [0.28.3]: https://github.com/na0fu3y/ochakai/compare/v0.28.2...v0.28.3
 [0.28.2]: https://github.com/na0fu3y/ochakai/compare/v0.28.1...v0.28.2
 [0.28.1]: https://github.com/na0fu3y/ochakai/compare/v0.28.0...v0.28.1

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -82,7 +82,7 @@ info:
     is a security defect, shipped in the next release with no deprecation
     window (SECURITY.md). MCP, the CLI and the stored shape stay unstable
     while the major version is 0 and may still change in a minor release.
-  version: 0.28.3
+  version: 0.28.4
   license:
     name: MIT
 servers:

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -77,7 +77,7 @@ export IMAGE=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:$VERSION
 `:latest` ではなくバージョンを固定し、再デプロイを意識的な判断にする。
 `gh` CLI が無ければ
 [リリースページ](https://github.com/na0fu3y/ochakai/releases)から番号
-を読み、手で設定する — `export VERSION=0.28.3`。
+を読み、手で設定する — `export VERSION=0.28.4`。
 
 (このガイドは 0.9.0 以降を前提にしている。それより前のリリースは
 [retract](https://go.dev/ref/mod#go-mod-file-retract) 済みでサポート外

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -5,7 +5,7 @@ region     = "us-central1"
 
 # Pin a released version, not "latest", so a redeploy is a decision:
 # https://github.com/na0fu3y/ochakai/releases
-image_tag = "0.28.3"
+image_tag = "0.28.4"
 
 # Who can reach ochakai. This is the whole access-control surface — whoever
 # reaches it can read and write everything. Never allUsers.


### PR DESCRIPTION
Closes `## [Unreleased]` as **0.28.4** (2026-09-07, JST) and moves the
four placeholders that carry a version but are not the tag:
`api/openapi.yaml`, `.github/ISSUE_TEMPLATE/bug_report.yml`,
`deploy/cloudrun/README.md` and `deploy/terraform/terraform.tfvars.example`.

**Patch, not minor**: no **BREAKING** entry stands in the section.

## What was checked

- **Nothing fell below the line.** The `[0.28.3]` section is byte-identical
  to `git show v0.28.3:CHANGELOG.md`, so no PR branched before the tag
  dropped an entry — whole or appended — into the section that was
  already published.
- **Nothing landed without an entry.** No merged PR in this cycle carries
  the `no-changelog` label; the five labeled ones are dependabot's, and
  none of them touches `internal/` or `cmd/`.
- **The section does not contradict itself.** The "Knowledge Catalog had
  not been tried" claim from #813 already carries its parenthetical
  correction from the later `kcmd push` measurement, and the MCP byte
  count carries its re-measurement the same way.
- **No rename window closes.** `mcpserver.RetiredToolNames` and
  `retiredCommands` are both empty.
- **No migration lands**, and `docs/surface.md`'s headings are unchanged
  from v0.28.3 — nothing counted moved in either direction.

## What an operator gets

23 PRs. The two that change what a caller sees:

- **`stale_after` reads back as an RFC 3339 datetime, always** (0139,
  superseding 0133). A bundle exported before this carried a bare
  `YYYY-MM-DD` for a UTC midnight, which is a spelling OKF v0.2 stopped
  defining on 2026-08-21 and which a conformant consumer drops without a
  word. Input is unchanged; a client parsing only dates must widen.
- **The MCP server declares only `tools` and `resources`** — `logging`
  and `listChanged: true` were the SDK's defaults and were untrue. No tool
  or list moves, and the surface holds 10,485 resident bytes instead of
  12,290.

`scripts/check --db` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)