### PR TITLE
Prepare release 0.28.5

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Version
       description: Output of `ochakai version`, or the image tag you deployed.
-      placeholder: "0.28.4"
+      placeholder: "0.28.5"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ last entry.
 
 ## [Unreleased]
 
+## [0.28.5] - 2026-09-12
+
 ### Added
 
 - **The deployment says which build it is.** `GET /api/v1/stats` carries
@@ -6963,7 +6965,8 @@ worth naming: SQL injection in `compile_sql` through undeclared field
 pass-through, fixed in 0.8.0 — v0.7.0 and earlier are affected. Details
 are in git history.
 
-[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.28.4...HEAD
+[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.28.5...HEAD
+[0.28.5]: https://github.com/na0fu3y/ochakai/compare/v0.28.4...v0.28.5
 [0.28.4]: https://github.com/na0fu3y/ochakai/compare/v0.28.3...v0.28.4
 [0.28.3]: https://github.com/na0fu3y/ochakai/compare/v0.28.2...v0.28.3
 [0.28.2]: https://github.com/na0fu3y/ochakai/compare/v0.28.1...v0.28.2

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -82,7 +82,7 @@ info:
     is a security defect, shipped in the next release with no deprecation
     window (SECURITY.md). MCP, the CLI and the stored shape stay unstable
     while the major version is 0 and may still change in a minor release.
-  version: 0.28.4
+  version: 0.28.5
   license:
     name: MIT
 servers:
@@ -3193,7 +3193,6 @@ components:
         window_days: { type: integer, description: How far back the flow numbers reach. }
         version:
           type: string
-          example: v0.28.4
           description: >
             The build answering — a release tag, or `dev` for a binary
             built in the tree. It is here for design doc 0087 §4's

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -77,7 +77,7 @@ export IMAGE=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:$VERSION
 `:latest` ではなくバージョンを固定し、再デプロイを意識的な判断にする。
 `gh` CLI が無ければ
 [リリースページ](https://github.com/na0fu3y/ochakai/releases)から番号
-を読み、手で設定する — `export VERSION=0.28.4`。
+を読み、手で設定する — `export VERSION=0.28.5`。
 
 (このガイドは 0.9.0 以降を前提にしている。それより前のリリースは
 [retract](https://go.dev/ref/mod#go-mod-file-retract) 済みでサポート外

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -5,7 +5,7 @@ region     = "us-central1"
 
 # Pin a released version, not "latest", so a redeploy is a decision:
 # https://github.com/na0fu3y/ochakai/releases
-image_tag = "0.28.4"
+image_tag = "0.28.5"
 
 # Who can reach ochakai. This is the whole access-control surface — whoever
 # reaches it can read and write everything. Never allUsers.

--- a/internal/domain/stats.go
+++ b/internal/domain/stats.go
@@ -43,8 +43,8 @@ type Stats struct {
 	// WindowDays is how far back the flow numbers reach.
 	WindowDays int `json:"window_days"`
 
-	// Version is the build answering — "v0.28.4", or "dev" for a binary
-	// built in the tree. It travels here for design doc 0087 §4's
+	// Version is the build answering — the tag it was built at, or "dev"
+	// for a binary built in the tree. It travels here for design doc 0087 §4's
 	// reason, applied to the question a reader asks before every other
 	// one on this response: what a deployment is is answered on `stats`,
 	// because the wire is frozen against a header of its own and a


### PR DESCRIPTION
v0.28.4 から二つの追加と一つの修正。**BREAKING は無いので patch** である。

## この版に入るもの

- **デプロイが自分の版を言う**(#844)— `GET /api/v1/stats` の `version`、
  web UI のトップバー、`ochakai whoami` の `version:` 行。
- **`ochakai get` が concept だけでなくファイルも読む**(#842、設計記録
  [0140](docs/design/0140-one-address-reads-as-well-as-writes.md) が 0077 を差し替え)。
- **Web UI のファイル選択が、サーバーが受け取るものを拒まなくなった**(0140 §4)。

`git log v0.28.4..origin/main --first-parent` はこの二本の PR だけで、
どちらも CHANGELOG に載っている。タグ済みの節に紛れ込んだエントリも無い。

## 版番号を持つファイル

`CHANGELOG.md` / `api/openapi.yaml` (`info.version`) /
`.github/ISSUE_TEMPLATE/bug_report.yml` / `deploy/cloudrun/README.md` /
`deploy/terraform/terraform.tfvars.example` の五つ。

**改名の窓は閉じるものが無い** — `mcpserver.RetiredToolNames` も
`retiredCommands` も空で、この版が終わらせる窓は無い(0088)。

## grep が拾った二件は、自分で撒いたものだった

`grep -rn '0.28.4'` が **#844 で入れたばかりの二箇所**を拾った:
`internal/domain/stats.go` のコメントと `api/openapi.yaml` の
`example: v0.28.4`。どちらも真として読まれる宣言ではなく**例**だが、
このままだと**以後のリリースで毎回「これは直すのか」と判断させる行**に
なる。手順に増えた一行は、いつか誰かが落とす一行である。

なので版を名指すのをやめた。コメントは「ビルドされたときのタグ」と形を
言い、スキーマのほうは `example:` を落とした — description が既に
「リリースタグ、またはツリー内ビルドなら `dev`」と両方の形を言っている。
このファイルの他の `example:` はハッシュ・パス・principal で、**どれも
古びない**。これで一つも古びない。

## 版を上げた以外に動かしていないもの

`scripts/check` 緑。表面(`docs/surface.md`)の見出しは v0.28.4 と完全一致で、
この版は面を一つも増減していない。

マージ後にタグ `v0.28.5` を打つ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)