### PR TITLE
Say when the dogfood instance is older than the tree

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -60,6 +60,31 @@ concepts() {
 	curl -sf -m 3 "$OCHAKAI_URL/api/v1/stats" 2>/dev/null | jq -r '.concepts.total // empty' 2>/dev/null
 }
 
+# stale_note prints one sentence when the running dogfood image was built
+# before the last change to code in this tree, and nothing otherwise —
+# including whenever it cannot tell. The instance answering is not the
+# instance being current: `up -d` reuses the image it already has and
+# neither pulls nor rebuilds, so a stack started weeks ago keeps serving
+# that build while the tree moves on. /api/v1/stats cannot say so, because
+# a build from the tree reports `dev` as its version; the image's build
+# time against the tree's last code change can. 2026-09-12 found an
+# instance built on 08-26 still reporting a trust tier that design doc 0138
+# had lapsed, sixteen days after 0138 landed.
+stale_note() {
+	command -v docker >/dev/null 2>&1 || return 0
+	command -v git >/dev/null 2>&1 || return 0
+	cid=$(docker compose -f "$2" ps -q ochakai 2>/dev/null | head -n 1) || return 0
+	[ -n "$cid" ] || return 0
+	img=$(docker inspect "$cid" --format '{{.Image}}' 2>/dev/null) || return 0
+	created=$(docker image inspect "$img" --format '{{.Created}}' 2>/dev/null) || return 0
+	built=$(printf '%s\n' "$created" | jq -Rr 'sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601' 2>/dev/null) || return 0
+	code=$(git -C "$1" log -1 --format=%ct -- internal cmd go.mod go.sum 2>/dev/null) || return 0
+	[ -n "$built" ] && [ -n "$code" ] || return 0
+	[ "$built" -lt "$code" ] || return 0
+	code_day=$(git -C "$1" log -1 --format=%cs -- internal cmd go.mod go.sum 2>/dev/null) || return 0
+	printf ' It is older than the code in this tree — the running image was built %s and the code last changed %s — so what it recalls and the trust tiers it reports can predate what the tree implements. Rebuild it with `docker compose -f deploy/compose.yaml up -d --build`.' "$(printf '%s' "$created" | cut -c1-10)" "$code_day"
+}
+
 dogfood_local() {
 	root=$(cd "$(dirname "$0")/../.." && pwd)
 	compose="$root/deploy/compose.yaml"
@@ -102,7 +127,8 @@ dogfood_local() {
 		n=$(concepts) || n=0
 		verb="$verb and was loaded from kb/bundle as drafts (nothing verified, so nothing ruled on)"
 	fi
-	say "The dogfood ochakai instance $verb at $OCHAKAI_URL: $n concepts (kb/README.md). Recall runs on each prompt; fetch with the ochakai MCP get_concept tool, never the CLI."
+	stale=$(stale_note "$root" "$compose") || stale=
+	say "The dogfood ochakai instance $verb at $OCHAKAI_URL: $n concepts (kb/README.md).$stale Recall runs on each prompt; fetch with the ochakai MCP get_concept tool, never the CLI."
 }
 
 [ "${CLAUDE_CODE_REMOTE:-}" = "true" ] || dogfood_local

--- a/kb/README.md
+++ b/kb/README.md
@@ -21,6 +21,19 @@ Claude Code のセッションでは `.claude/hooks/session-start.sh` がこれ�
 する(draft しか無いバンドルの読み込みは何も裁定しない)。バンドルが
 検証を運ぶようになったら、import は下の規則どおり人の手に戻る。
 
+**立っていることと、いまのコードであることは別である。** `up -d` は手元に
+ある image をそのまま使い、pull も再ビルドもしない — 数週間前に上げた
+インスタンスは、ツリーが先へ進んでもその時のビルドを返し続ける。フックは
+動いている image のビルド時刻とツリーのコードの最終変更を比べ、古ければ
+そう言う。そのときは上げ直す:
+
+```sh
+docker compose -f deploy/compose.yaml up -d --build
+```
+
+データベースは名前付き volume(`pgdata`)にあるので、concept も台帳も
+消えない。
+
 そこから先 — 誰がどの identity で書くか、レビューの回し方、ここへの
 書き戻し — は
 [skills/run-the-dogfood-loop](bundle/skills/run-the-dogfood-loop.md) と


### PR DESCRIPTION
## What

SessionStart フックが dogfood インスタンスの**概念数だけ**を見ていたので、インスタンスがツリーのコードより古くても誰も気づけなかった。動いている image のビルド時刻とツリーのコードの最終変更を比べ、古ければ最初の一文にそう書き、上げ直すコマンドを添える。kb/README.md にも同じことを一段落足した。

**製品の面は動かない** — `.claude/hooks/` と `kb/README.md` だけで、REST・CLI・MCP・ENV・surface.md の数はどれも変わらない。CHANGELOG の check が見る `internal/` と `cmd/` にも触れていない。

## 誰が詰まったか

2026-09-12 のセッションで、`ochakai export` を第三者の OKF 読み手(okf-agent-memory)に通したところ、唯一の意味のある警告が「`verified.at` が `generated.at` より前」だった。これは設計記録 0138 §0.1 が決めた規則そのもので、**その concept は dogfood で human-reviewed のまま立っていた**。原因はインスタンスが 0138 より古いことだった。

| | |
|---|---|
| 動いていた image のビルド | 2026-08-26 |
| ツリーのコードの最終変更 | 2026-09-12 |
| コンテナの稼働 | 2 週間 |

同じ形の詰まりは既に一度 KB に書かれている(dogfood インスタンスがコードより古いと新しい面が 404 になる)。二度目である。

## 既存の面で回避できるか

できなかった。

- **`/api/v1/stats` の `version` では判定できない。** 0.28.5 から入った欄だが、ツリーからビルドした image は `dev` を返す。compose はまさにツリーからビルドするので、`dev` と `dev` を比べても何も言えない。
- **`docker compose up -d` は古さを直さない。** 手元の image をそのまま使い、pull も再ビルドもしない。

使えるのは image のビルド時刻とコードのコミット時刻で、どちらも既にある道具(docker と git)で読める。

## 何が畳めるか

何も畳めない。一文を足すだけで、畳む対象になる機構が無い。単調に増えてよい理由は、**フックの目的(セッションの中からループが動いているか分かるようにする)の、既にある半分の続き**だから — 冒頭のコメントが言う「インストールされていて動いていないことを誰もセッションの中から分からなかった」の、「動いているが古い」版である。

## 失敗しても黙る

ヘッダが言う「フックがセッションを拒ませる理由になってはいけない」を守る。docker・git が無い、コンテナが無い、inspect や日付の解析が失敗する — どれも警告を出さずに抜ける。

## 確認

`sh`(macOS の bash 3.2)と `dash` の両方で、実物の dogfood インスタンスに対して走らせた。

| 経路 | シェル | 終了コード | 警告 |
|---|---|---|---|
| 実物の古いインスタンス | sh | 0 | 出る |
| 実物の古いインスタンス | dash | 0 | 出る |
| docker が常に失敗する偽物 | dash | 0 | 出ない |
| ビルド時刻が 2099 年の偽物 | dash | 0 | 出ない |

`sh -n` と `dash -n` も通る。shellcheck はこの環境に無く、CI も hook を shellcheck していない。`scripts/check core` 通過。

実際に出る文:

> The dogfood ochakai instance is up at http://localhost:8080: 76 concepts (kb/README.md). It is older than the code in this tree — the running image was built 2026-08-26 and the code last changed 2026-09-13 — so what it recalls and the trust tiers it reports can predate what the tree implements. Rebuild it with `docker compose -f deploy/compose.yaml up -d --build`. Recall runs on each prompt; …

(「2026-09-13」はコミットのタイムゾーン(+09:00)での日付で、比較そのものは epoch で行っている。)

**このセッションの dogfood インスタンスは上げ直していない。** ローカルの Docker の状態を変える操作なので、マージ後に人が打つ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
