### PR TITLE
Prepare release 0.28.6

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Version
       description: Output of `ochakai version`, or the image tag you deployed.
-      placeholder: "0.28.5"
+      placeholder: "0.28.6"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ last entry.
 
 ## [Unreleased]
 
+## [0.28.6] - 2026-09-13
+
 ### Added
 
 - **A file's card says what points at it, and shows the head of it.** The
@@ -72,6 +74,23 @@ last entry.
   `internal/webui` cannot be answered out of a browser's cache. No
   surface count moves (docs/surface.md): no endpoint, no header, no
   command, no flag.
+
+### Security
+
+- **go-jose moves to 4.1.5**, which fixes GHSA-6mp9-8xrw-74r4: deeply
+  nested JSON could exhaust the stack, and CBC-HMAC decryption could panic
+  on untrusted input. ochakai reaches go-jose only through the OIDC
+  verifier (design doc
+  [0086](docs/design/0086-a-second-way-to-say-who-is-calling.md)), which
+  parses a bearer token with `jwt.ParseSigned` before checking its
+  signature. The CBC-HMAC half never applies there, because ochakai accepts
+  signed tokens only and decrypts nothing. The nesting half was tried
+  against 4.1.4 in that exact call, with tokens up to the 1 MiB header limit
+  and the nesting placed in an unknown header key, in `jwk`, in `jwk.x5c`
+  and in `crit`; every one returned without crashing. That is a list of
+  shapes rather than a proof, so the dependency moves anyway. `govulncheck`
+  said nothing about it only because the Go vulnerability database had not
+  yet listed the advisory.
 
 ## [0.28.5] - 2026-09-12
 
@@ -7017,7 +7036,8 @@ worth naming: SQL injection in `compile_sql` through undeclared field
 pass-through, fixed in 0.8.0 — v0.7.0 and earlier are affected. Details
 are in git history.
 
-[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.28.5...HEAD
+[Unreleased]: https://github.com/na0fu3y/ochakai/compare/v0.28.6...HEAD
+[0.28.6]: https://github.com/na0fu3y/ochakai/compare/v0.28.5...v0.28.6
 [0.28.5]: https://github.com/na0fu3y/ochakai/compare/v0.28.4...v0.28.5
 [0.28.4]: https://github.com/na0fu3y/ochakai/compare/v0.28.3...v0.28.4
 [0.28.3]: https://github.com/na0fu3y/ochakai/compare/v0.28.2...v0.28.3

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -82,7 +82,7 @@ info:
     is a security defect, shipped in the next release with no deprecation
     window (SECURITY.md). MCP, the CLI and the stored shape stay unstable
     while the major version is 0 and may still change in a minor release.
-  version: 0.28.5
+  version: 0.28.6
   license:
     name: MIT
 servers:

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -77,7 +77,7 @@ export IMAGE=$REGION-docker.pkg.dev/$PROJECT_ID/ghcr/na0fu3y/ochakai:$VERSION
 `:latest` ではなくバージョンを固定し、再デプロイを意識的な判断にする。
 `gh` CLI が無ければ
 [リリースページ](https://github.com/na0fu3y/ochakai/releases)から番号
-を読み、手で設定する — `export VERSION=0.28.5`。
+を読み、手で設定する — `export VERSION=0.28.6`。
 
 (このガイドは 0.9.0 以降を前提にしている。それより前のリリースは
 [retract](https://go.dev/ref/mod#go-mod-file-retract) 済みでサポート外

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -5,7 +5,7 @@ region     = "us-central1"
 
 # Pin a released version, not "latest", so a redeploy is a decision:
 # https://github.com/na0fu3y/ochakai/releases
-image_tag = "0.28.5"
+image_tag = "0.28.6"
 
 # Who can reach ochakai. This is the whole access-control surface — whoever
 # reaches it can read and write everything. Never allUsers.


### PR DESCRIPTION
## What

0.28.6 の準備。Unreleased を `## [0.28.6] - 2026-09-13` として閉じ、版を持つ五つのファイルを動かす。

- `CHANGELOG.md` — 節を閉じ、空の Unreleased を開き、比較リンクを付け替え
- `api/openapi.yaml` — `info.version`
- `.github/ISSUE_TEMPLATE/bug_report.yml` — 版の placeholder
- `deploy/cloudrun/README.md` — 手で設定する `export VERSION=`
- `deploy/terraform/terraform.tfvars.example` — `image_tag`

## 版番号

**patch**。節に BREAKING が無い。

## 中身

| 節 | エントリ |
|---|---|
| Added | ファイルのカードが、それを指す frontmatter のキーと先頭 10 行を見せる |
| Changed | web UI と API の版がずれたとき、トップバーが両方を言う |
| Security | go-jose を 4.1.5 に上げる(GHSA-6mp9-8xrw-74r4) |

**マージの順序に注意。** Security のエントリが書いている go-jose の更新は、この PR を作った時点ではまだ dependabot の PR 856 として開いている。**856 がマージされてから、この PR をマージする。** 逆にすると、main の CHANGELOG が入っていない依存の更新を「入った」と言う。

## 確認したこと

- **Unreleased は実際に入ったものと一致する。** v0.28.5 以降に `internal/` と `cmd/` のテスト以外を触ったのは PR 843 と PR 846 の二本だけで、どちらもエントリを持つ。
- **公開済みの 0.28.5 節に何も紛れていない。** タグ時点の節と main の節がバイト一致。
- **削る退役名は無い。** `mcpserver.RetiredToolNames` と `retiredCommands` はどちらも空。
- **表面は動いていない。** `docs/surface.md` の見出しは v0.28.5 と同じ。
- 残る `0.28.5` の文字列は、CHANGELOG の散文と `cmd/ochakai/ui_test.go` のテストデータで、どちらも正当。
- `TestReleaseVersionsAgree` と `TestARetiredNameLastsOneRelease` 通過。`scripts/check core` 通過。

## go-jose の件を緊急にしなかった理由

advisory は high だが、ochakai がこれに触れるのは OIDC 検証の `jwt.ParseSigned` だけで、CBC-HMAC の復号は通らない。深いネストの側は 4.1.4 に対して同じ呼び出しを、1 MiB のヘッダ上限までのトークンで四通り試し、どれも落ちなかった。`govulncheck` が黙っていたのは Go の脆弱性 DB に未登録だったから(OSV にも無い)。だから通常の束で出す。

## マージ後

タグ `v0.28.6` を annotated で、`--cleanup=verbatim` で打ち、release skill §4 の検証をする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
